### PR TITLE
Run benchmarks using python library

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ target/
 !target/release/ballista-scheduler
 !target/release/ballista-executor
 !target/release/tpch
+!python/target/wheels/

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -23,5 +23,5 @@ set -x
 
 for query in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 17 18 21
 do
-  python3 tpch.py --host ballista-scheduler --port 50050 --query $query --path /data --ext tbl 
+  python3 tpch.py --host ballista-scheduler --query $query --path /data --ext tbl 
 done

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -23,5 +23,5 @@ set -x
 
 for query in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 17 18 21
 do
-  /root/tpch benchmark ballista --host ballista-scheduler --port 50050 --query $query --path /data --format tbl --iterations 1 --debug
+  python3 tpch.py --host ballista-scheduler --port 50050 --query $query --path /data --ext tbl 
 done

--- a/benchmarks/tpch.py
+++ b/benchmarks/tpch.py
@@ -140,9 +140,10 @@ import time
 start = time.time()
 
 df = ctx.sql(sql)
-df.show()
+results = df.collect()
+row_count = sum([record.num_rows for record in results])
 
 end = time.time()
-print("Query", query, "took", end - start, "second(s)")
+print("Query", query, "took", end - start, "second(s) and returned", row_count,"rows")
 
 

--- a/benchmarks/tpch.py
+++ b/benchmarks/tpch.py
@@ -20,29 +20,118 @@ import time
 import argparse
 
 parser = argparse.ArgumentParser(description='Run SQL benchmarks.')
+parser.add_argument('--host', help='Ballista host')
 parser.add_argument('--query', help='query to run, such as q1')
 parser.add_argument('--path', help='path to data files')
 parser.add_argument('--ext', default='', help='optional file extension, such as parquet')
 
 args = parser.parse_args()
 
+host = args.host
 query = args.query
 path = args.path
 table_ext = args.ext
 
+
 import ballista
-ctx = ballista.BallistaContext("localhost", 50050)
+ctx = ballista.BallistaContext(host, 50050)
 
 tables = ["part", "supplier", "partsupp", "customer", "orders", "lineitem", "nation", "region"]
+
+table_schema = { "part": pa.schema([
+    ("p_partkey", pa.int64()),
+    ("p_name", pa.utf8()),
+    ("p_mfgr", pa.utf8()),
+    ("p_brand", pa.utf8()),
+    ("p_type", pa.utf8()),
+    ("p_size", pa.int32()),
+    ("p_container", pa.utf8()),
+    ("p_retailprice", pa.float64()),
+    ("p_comment", pa.utf8()),
+]),
+
+"supplier": pa.schema([
+    ("s_suppkey", pa.int64()),
+    ("s_name", pa.utf8()),
+    ("s_address", pa.utf8()),
+    ("s_nationkey", pa.int64()),
+    ("s_phone", pa.utf8()),
+    ("s_acctbal", pa.float64()),
+    ("s_comment", pa.utf8()),
+]),
+
+"partsupp": pa.schema([
+    ("ps_partkey", pa.int64()),
+    ("ps_suppkey", pa.int64()),
+    ("ps_availqty", pa.int32()),
+    ("ps_supplycost", pa.float64()),
+    ("ps_comment", pa.utf8()),
+]),
+
+"customer": pa.schema([
+    ("c_custkey", pa.int64()),
+    ("c_name", pa.utf8()),
+    ("c_address", pa.utf8()),
+    ("c_nationkey", pa.int64()),
+    ("c_phone", pa.utf8()),
+    ("c_acctbal", pa.float64()),
+    ("c_mktsegment", pa.utf8()),
+    ("c_comment", pa.utf8()),
+]),
+
+"orders": pa.schema([
+    ("o_orderkey", pa.int64()),
+    ("o_custkey", pa.int64()),
+    ("o_orderstatus", pa.utf8()),
+    ("o_totalprice", pa.float64()),
+    ("o_orderdate", pa.date32()),
+    ("o_orderpriority", pa.utf8()),
+    ("o_clerk", pa.utf8()),
+    ("o_shippriority", pa.int32()),
+    ("o_comment", pa.utf8()),
+]),
+
+"lineitem": pa.schema([
+    ("l_orderkey", pa.int64()),
+    ("l_partkey", pa.int64()),
+    ("l_suppkey", pa.int64()),
+    ("l_linenumber", pa.int32()),
+    ("l_quantity", pa.float64()),
+    ("l_extendedprice", pa.float64()),
+    ("l_discount", pa.float64()),
+    ("l_tax", pa.float64()),
+    ("l_returnflag", pa.utf8()),
+    ("l_linestatus", pa.utf8()),
+    ("l_shipdate", pa.date32()),
+    ("l_commitdate", pa.date32()),
+    ("l_receiptdate", pa.date32()),
+    ("l_shipinstruct", pa.utf8()),
+    ("l_shipmode", pa.utf8()),
+    ("l_comment", pa.utf8()),
+]),
+
+"nation": pa.schema([
+    ("n_nationkey", pa.int64()),
+    ("n_name", pa.utf8()),
+    ("n_regionkey", pa.int64()),
+    ("n_comment", pa.utf8()),
+]),
+
+"region": pa.schema([
+    ("r_regionkey", pa.int64()),
+    ("r_name", pa.utf8()),
+    ("r_comment", pa.utf8()),
+]) }
+
 
 for table in tables:
     table_path = path + "/" + table
     if len(table_ext) > 0:
         table_path = table_path + "." + table_ext
     print("Registering table", table, "at path", table_path)
-    ctx.register_parquet(table, table_path)
+    ctx.register_csv(table, table_path, schema=table_schema[table], delimiter="|", has_header=False, file_extension="tbl")
 
-with open("queries/" + query + ".sql", 'r') as file:
+with open("benchmarks/queries/q" + query + ".sql", 'r') as file:
     sql = file.read()
 
 import time

--- a/benchmarks/tpch.py
+++ b/benchmarks/tpch.py
@@ -18,6 +18,7 @@
 import sys
 import time
 import argparse
+import pyarrow as pa
 
 parser = argparse.ArgumentParser(description='Run SQL benchmarks.')
 parser.add_argument('--host', help='Ballista host')

--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -15,19 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:22.04
+FROM rust:1.63.0-bullseye
 
 ARG RELEASE_FLAG=release
 
 ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -y install python3-pip
 
 COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
 COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor
 COPY target/$RELEASE_FLAG/tpch /root/tpch
+COPY python/target/wheels/ballista-*-manylinux*.whl /root/
+RUN pip3 install /root/ballista-*-manylinux*.whl
 
 COPY benchmarks/run.sh /root/run.sh
+COPY benchmarks/tpch.py /root/tpch.py
 COPY benchmarks/queries/ /root/benchmarks/queries
 
 WORKDIR /root

--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.63.0-bullseye
+FROM ubuntu:22.04
 
 ARG RELEASE_FLAG=release
 
@@ -24,7 +24,7 @@ ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get -y install python3-pip
+RUN apt-get update && apt-get -y install python3 python3-pip
 
 COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
 COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor

--- a/dev/docker/ballista-builder.Dockerfile
+++ b/dev/docker/ballista-builder.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.63.0-buster
+FROM rust:1.63.0-bullseye
 
 ARG EXT_UID
 
@@ -25,6 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat curl unzip \
+    python3-venv \
     nodejs npm && \
     npm install -g yarn
 

--- a/dev/docker/builder-entrypoint.sh
+++ b/dev/docker/builder-entrypoint.sh
@@ -27,10 +27,11 @@ cd ballista/ui/scheduler
 yarn install
 yarn build
 
-cd /home/builder/workspace/python
+cd $HOME/workspace/python
 python3 -m venv venv
 source venv/bin/activate
 python3 -m pip install -U pip
 python3 -m pip install -r requirements-310.txt
 maturin build
+
 cd /home/builder/workspace/

--- a/dev/docker/builder-entrypoint.sh
+++ b/dev/docker/builder-entrypoint.sh
@@ -26,3 +26,11 @@ cargo build --features flight-sql "--$RELEASE_FLAG" "$@"
 cd ballista/ui/scheduler
 yarn install
 yarn build
+
+cd /home/builder/workspace/python
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install -U pip
+python3 -m pip install -r requirements-310.txt
+maturin build
+cd /home/builder/workspace/


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-ballista/issues/363

 # Rationale for this change
Ensures testing of python bindings as part of the integration test. 

# What changes are included in this PR?
- Execution of TPCH benchmarks using the python client 
- Build Ballista python library as part of integration tests to enable the above benchmarks

Open points for discussion
- Modified the builder base image from buster to bullseye given buster has python 3.7 as default python and numpy 1.22 has dropped support for 3.7. Bullseye provides 3.9.2 by default
- The wheel generated has the version info and some suffix included (i.e `ballista-0.8.0-cp37-abi3-manylinux_2_31_x86_64.whl`) in the name. Currently using regex to transfer these to docker.  

