### PR TITLE
Automatically register tables if env var specified

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -29,12 +29,12 @@ rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]
-ballista = { path = "../ballista/client", version = "0.9.0", features = [
-    "standalone",
-] }
+ballista = { path = "../ballista/client", version = "0.9.0", features = ["standalone"] }
+ballista-core = { path = "../ballista/core", version = "0.9.0" }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = "14.0.0"
-datafusion-cli = "14.0.0"
+dashmap = "5.4.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
+datafusion-cli = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/ballista-cli/src/main.rs
+++ b/ballista-cli/src/main.rs
@@ -126,7 +126,7 @@ pub async fn main() -> Result<()> {
                 num_cpus::get()
             };
             // In-process execution with Ballista Standalone
-            BallistaContext::standalone(&ballista_config, concurrent_tasks).await?
+            BallistaContext::standalone(&ballista_config, concurrent_tasks, None).await?
         }
     };
 

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -31,8 +31,9 @@ rust-version = "1.59"
 ballista-core = { path = "../core", version = "0.9.0" }
 ballista-executor = { path = "../executor", version = "0.9.0", optional = true }
 ballista-scheduler = { path = "../scheduler", version = "0.9.0", optional = true }
-datafusion = "14.0.0"
-datafusion-proto = "14.0.0"
+dashmap = "5.4.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -41,14 +41,14 @@ simd = ["datafusion/simd"]
 
 [dependencies]
 ahash = { version = "0.8", default-features = false }
-
 arrow-flight = { version = "26.0.0", features = ["flight-sql-experimental"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = "14.0.0"
+dashmap = "5.4.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 datafusion-objectstore-hdfs = { version = "0.1.1", default-features = false, optional = true }
-datafusion-proto = "14.0.0"
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 futures = "0.3"
 hashbrown = "0.13"
 

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -21,7 +21,7 @@
 use clap::ArgEnum;
 use core::fmt;
 use std::collections::HashMap;
-use std::result;
+use std::{env, result};
 
 use crate::error::{BallistaError, Result};
 
@@ -84,6 +84,17 @@ impl BallistaConfigBuilder {
     pub fn set(&self, k: &str, v: &str) -> Self {
         let mut settings = self.settings.clone();
         settings.insert(k.to_owned(), v.to_owned());
+        Self { settings }
+    }
+
+    pub fn load_env(&self) -> Self {
+        let mut settings = self.settings.clone();
+        if let Ok(it) = env::var("DATAFUSION_CATALOG_LOCATION") {
+            settings.insert("datafusion.catalog.location".to_string(), it);
+        }
+        if let Ok(it) = env::var("DATAFUSION_CATALOG_TYPE") {
+            settings.insert("datafusion.catalog.type".to_string(), it);
+        }
         Self { settings }
     }
 

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -392,8 +392,8 @@ mod tests {
             None
         }
 
-        fn required_child_distribution(&self) -> Distribution {
-            Distribution::SinglePartition
+        fn required_input_distribution(&self) -> Vec<Distribution> {
+            vec![Distribution::SinglePartition]
         }
 
         fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/ballista/core/src/serde/physical_plan/mod.rs
+++ b/ballista/core/src/serde/physical_plan/mod.rs
@@ -331,6 +331,8 @@ impl AsExecutionPlan for PhysicalPlanNode {
                     physical_window_expr,
                     input,
                     Arc::new((&input_schema).try_into()?),
+                    vec![],
+                    None,
                 )?))
             }
             PhysicalPlanType::Aggregate(hash_agg) => {

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -62,7 +62,7 @@ uuid = { version = "1.0", features = ["v4"] }
 [dev-dependencies]
 
 [build-dependencies]
-configure_me_codegen = "0.4.0"
+configure_me_codegen = "=0.4.0"
 
 # use libc on unix like platforms to set worker priority in DedicatedExecutor
 [target."cfg(unix)".dependencies.libc]

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -42,8 +42,8 @@ ballista-core = { path = "../core", version = "0.9.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = "14.0.0"
-datafusion-proto = "14.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 futures = "0.3"
 hyper = "0.14.4"
 log = "0.4"

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -47,8 +47,8 @@ base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
 dashmap = "5.4.0"
-datafusion = "14.0.0"
-datafusion-proto = "14.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 etcd-client = { version = "0.10", optional = true }
 flatbuffers = { version = "22.9.29" }
 futures = "0.3"
@@ -75,6 +75,7 @@ tower = { version = "0.4" }
 tracing = "0.1.36"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.15", features = ["fmt", "env-filter", "ansi"] }
+url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 warp = "0.3"
 

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -83,5 +83,5 @@ warp = "0.3"
 ballista-core = { path = "../core", version = "0.9.0" }
 
 [build-dependencies]
-configure_me_codegen = "0.4.1"
+configure_me_codegen = "=0.4.0"
 tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -584,7 +584,7 @@ mod test {
     };
     use ballista_core::serde::scheduler::ExecutorSpecification;
     use ballista_core::serde::BallistaCodec;
-    use ballista_core::utils::default_session_builder;
+    use ballista_core::utils::DefaultSessionBuilder;
 
     use crate::state::executor_manager::DEFAULT_EXECUTOR_TIMEOUT_SECONDS;
     use crate::state::{backend::standalone::StandaloneClient, SchedulerState};
@@ -593,12 +593,14 @@ mod test {
 
     #[tokio::test]
     async fn test_poll_work() -> Result<(), BallistaError> {
+        let session_builder = Arc::new(DefaultSessionBuilder {});
         let state_storage = Arc::new(StandaloneClient::try_new_temporary()?);
         let mut scheduler: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
             SchedulerServer::new(
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                session_builder,
                 SchedulerConfig::default(),
                 default_metrics_collector().unwrap(),
             );
@@ -625,7 +627,7 @@ mod test {
         let state: SchedulerState<LogicalPlanNode, PhysicalPlanNode> =
             SchedulerState::new_with_default_scheduler_name(
                 state_storage.clone(),
-                default_session_builder,
+                Arc::new(DefaultSessionBuilder {}),
                 BallistaCodec::default(),
             );
         state.init().await?;
@@ -658,7 +660,7 @@ mod test {
         let state: SchedulerState<LogicalPlanNode, PhysicalPlanNode> =
             SchedulerState::new_with_default_scheduler_name(
                 state_storage.clone(),
-                default_session_builder,
+                Arc::new(DefaultSessionBuilder {}),
                 BallistaCodec::default(),
             );
         state.init().await?;
@@ -680,12 +682,14 @@ mod test {
 
     #[tokio::test]
     async fn test_stop_executor() -> Result<(), BallistaError> {
+        let session_builder = Arc::new(DefaultSessionBuilder {});
         let state_storage = Arc::new(StandaloneClient::try_new_temporary()?);
         let mut scheduler: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
             SchedulerServer::new(
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                session_builder,
                 SchedulerConfig::default(),
                 default_metrics_collector().unwrap(),
             );
@@ -761,12 +765,14 @@ mod test {
     #[tokio::test]
     #[ignore]
     async fn test_expired_executor() -> Result<(), BallistaError> {
+        let session_builder = Arc::new(DefaultSessionBuilder {});
         let state_storage = Arc::new(StandaloneClient::try_new_temporary()?);
         let mut scheduler: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
             SchedulerServer::new(
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                session_builder,
                 SchedulerConfig::default(),
                 default_metrics_collector().unwrap(),
             );

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -100,13 +100,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         scheduler_name: String,
         config_backend: Arc<dyn StateBackendClient>,
         codec: BallistaCodec<T, U>,
+        session_builder: Arc<dyn SessionBuilder>,
         config: SchedulerConfig,
         metrics_collector: Arc<dyn SchedulerMetricsCollector>,
         task_launcher: Arc<dyn TaskLauncher>,
     ) -> Self {
         let state = Arc::new(SchedulerState::with_task_launcher(
             config_backend,
-            default_session_builder,
+            session_builder,
             codec,
             scheduler_name.clone(),
             config.clone(),

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -614,25 +614,6 @@ mod test {
         Ok(scheduler)
     }
 
-    async fn test_push_staged_scheduler(
-    ) -> Result<SchedulerServer<LogicalPlanNode, PhysicalPlanNode>> {
-        let session_builder = Arc::new(DefaultSessionBuilder {});
-        let state_storage = Arc::new(StandaloneClient::try_new_temporary()?);
-        let config = SchedulerConfig::default()
-            .with_scheduler_policy(TaskSchedulingPolicy::PushStaged);
-        let mut scheduler: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
-            SchedulerServer::new(
-                "localhost:50050".to_owned(),
-                state_storage,
-                BallistaCodec::default(),
-                session_builder,
-                config,
-            );
-        scheduler.init().await?;
-
-        Ok(scheduler)
-    }
-
     fn test_executors(num_partitions: usize) -> Vec<(ExecutorMetadata, ExecutorData)> {
         let task_slots = (num_partitions as u32 + 1) / 2;
 

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -28,8 +28,8 @@ use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 
 use crate::config::SchedulerConfig;
-use ballista_core::utils::SessionBuilder;
 use crate::metrics::SchedulerMetricsCollector;
+use ballista_core::utils::SessionBuilder;
 use log::{error, warn};
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use ballista_core::serde::protobuf::PhysicalPlanNode;
 use ballista_core::serde::BallistaCodec;
-use ballista_core::utils::create_grpc_server;
+use ballista_core::utils::{create_grpc_server, SessionBuilder};
 use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
@@ -32,7 +32,9 @@ use log::info;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
 
-pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
+pub async fn new_standalone_scheduler(
+    session_builder: Arc<dyn SessionBuilder>,
+) -> Result<SocketAddr> {
     let client = StandaloneClient::try_new_temporary()?;
 
     let metrics_collector = default_metrics_collector()?;
@@ -42,6 +44,7 @@ pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
             "localhost:50050".to_owned(),
             Arc::new(client),
             BallistaCodec::default(),
+            session_builder,
             SchedulerConfig::default(),
             metrics_collector,
         );

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -138,7 +138,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
     #[allow(dead_code)]
     pub(crate) fn with_task_launcher(
         config_client: Arc<dyn StateBackendClient>,
-        session_builder: SessionBuilder,
+        session_builder: Arc<dyn SessionBuilder>,
         codec: BallistaCodec<T, U>,
         scheduler_name: String,
         config: SchedulerConfig,
@@ -151,7 +151,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
             ),
             task_manager: TaskManager::with_launcher(
                 config_client.clone(),
-                session_builder,
+                session_builder.clone(),
                 codec.clone(),
                 scheduler_name,
                 dispatcher,

--- a/ballista/scheduler/src/state/session_manager.rs
+++ b/ballista/scheduler/src/state/session_manager.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::scheduler_server::SessionBuilder;
 use crate::state::backend::{Keyspace, StateBackendClient};
 use crate::state::{decode_protobuf, encode_protobuf};
 use ballista_core::config::BallistaConfig;
@@ -23,6 +22,7 @@ use ballista_core::error::Result;
 use ballista_core::serde::protobuf::{self, KeyValuePair};
 use datafusion::prelude::{SessionConfig, SessionContext};
 
+use ballista_core::utils::SessionBuilder;
 use datafusion::common::ScalarValue;
 use log::warn;
 use std::sync::Arc;
@@ -30,13 +30,13 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct SessionManager {
     state: Arc<dyn StateBackendClient>,
-    session_builder: SessionBuilder,
+    session_builder: Arc<dyn SessionBuilder>,
 }
 
 impl SessionManager {
     pub fn new(
         state: Arc<dyn StateBackendClient>,
-        session_builder: SessionBuilder,
+        session_builder: Arc<dyn SessionBuilder>,
     ) -> Self {
         Self {
             state,
@@ -63,7 +63,7 @@ impl SessionManager {
             .put(Keyspace::Sessions, session_id.to_owned(), value)
             .await?;
 
-        Ok(create_datafusion_context(config, self.session_builder))
+        create_datafusion_context(config, self.session_builder.as_ref())
     }
 
     pub async fn create_session(
@@ -85,7 +85,7 @@ impl SessionManager {
         }
         let config = config_builder.build()?;
 
-        let ctx = create_datafusion_context(&config, self.session_builder);
+        let ctx = create_datafusion_context(&config, self.session_builder.as_ref())?;
 
         let value = encode_protobuf(&protobuf::SessionSettings { configs: settings })?;
         self.state
@@ -106,15 +106,15 @@ impl SessionManager {
         }
         let config = config_builder.build()?;
 
-        Ok(create_datafusion_context(&config, self.session_builder))
+        create_datafusion_context(&config, self.session_builder.as_ref())
     }
 }
 
 /// Create a DataFusion session context that is compatible with Ballista Configuration
 pub fn create_datafusion_context(
     ballista_config: &BallistaConfig,
-    session_builder: SessionBuilder,
-) -> Arc<SessionContext> {
+    session_builder: &dyn SessionBuilder,
+) -> Result<Arc<SessionContext>> {
     let config = SessionConfig::new()
         .with_target_partitions(ballista_config.default_shuffle_partitions())
         .with_batch_size(ballista_config.default_batch_size())
@@ -124,8 +124,8 @@ pub fn create_datafusion_context(
         .with_parquet_pruning(ballista_config.parquet_pruning());
     let config = propagate_ballista_configs(config, ballista_config);
 
-    let session_state = session_builder(config);
-    Arc::new(SessionContext::with_state(session_state))
+    let session_state = session_builder.build(config)?;
+    Ok(Arc::new(SessionContext::with_state(session_state)))
 }
 
 /// Update the existing DataFusion session context with Ballista Configuration
@@ -160,6 +160,12 @@ fn propagate_ballista_configs(
     for (k, v) in ballista_config.settings() {
         // see https://arrow.apache.org/datafusion/user-guide/configs.html for explanation of these configs
         match k.as_str() {
+            "datafusion.catalog.location" => {
+                config = config.set(k, ScalarValue::Utf8(Some(v.clone())))
+            }
+            "datafusion.catalog.type" => {
+                config = config.set(k, ScalarValue::Utf8(Some(v.clone())))
+            }
             "datafusion.optimizer.filter_null_join_keys" => {
                 config = config.set(
                     k,

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -162,7 +162,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     #[allow(dead_code)]
     pub(crate) fn with_launcher(
         state: Arc<dyn StateBackendClient>,
-        session_builder: SessionBuilder,
+        session_builder: Arc<dyn SessionBuilder>,
         codec: BallistaCodec<T, U>,
         scheduler_id: String,
         launcher: Arc<dyn TaskLauncher>,

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
-use crate::scheduler_server::SessionBuilder;
 use crate::state::backend::{Keyspace, Operation, StateBackendClient};
 use crate::state::execution_graph::{
     ExecutionGraph, ExecutionStage, RunningTaskInfo, TaskDescription,
@@ -37,6 +36,7 @@ use ballista_core::serde::protobuf::{
 use ballista_core::serde::scheduler::to_proto::hash_partitioning_to_proto;
 use ballista_core::serde::scheduler::ExecutorMetadata;
 use ballista_core::serde::{AsExecutionPlan, BallistaCodec};
+use ballista_core::utils::SessionBuilder;
 use dashmap::DashMap;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
@@ -108,7 +108,7 @@ impl TaskLauncher for DefaultTaskLauncher {
 #[derive(Clone)]
 pub struct TaskManager<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> {
     state: Arc<dyn StateBackendClient>,
-    session_builder: SessionBuilder,
+    session_builder: Arc<dyn SessionBuilder>,
     codec: BallistaCodec<T, U>,
     scheduler_id: String,
     // Cache for active jobs curated by this scheduler
@@ -145,7 +145,7 @@ pub struct UpdatedStages {
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U> {
     pub fn new(
         state: Arc<dyn StateBackendClient>,
-        session_builder: SessionBuilder,
+        session_builder: Arc<dyn SessionBuilder>,
         codec: BallistaCodec<T, U>,
         scheduler_id: String,
     ) -> Self {
@@ -784,7 +784,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         }
         let config = config_builder.build()?;
 
-        Ok(create_datafusion_context(&config, self.session_builder))
+        create_datafusion_context(&config, self.session_builder.as_ref())
     }
 
     async fn decode_execution_graph(&self, value: Vec<u8>) -> Result<ExecutionGraph> {

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -51,6 +51,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::CsvReadOptions;
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
+use ballista_core::utils::DefaultSessionBuilder;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use parking_lot::Mutex;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
@@ -417,6 +418,7 @@ impl SchedulerTest {
                 "localhost:50050".to_owned(),
                 state_storage.clone(),
                 BallistaCodec::default(),
+                Arc::new(DefaultSessionBuilder {}),
                 config,
                 metrics_collector,
                 Arc::new(launcher),

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,8 +34,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.9.0" }
-datafusion = "14.0.0"
-datafusion-proto = "14.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 env_logger = "0.9"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["ballista/standalone"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "0.9.0" }
-datafusion = "14.0.0"
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f" }
 futures = "0.3"
 num_cpus = "1.13.0"
 prost = "0.11"

--- a/examples/examples/standalone-sql.rs
+++ b/examples/examples/standalone-sql.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         .set("ballista.shuffle.partitions", "1")
         .build()?;
 
-    let ctx = BallistaContext::standalone(&config, 2).await?;
+    let ctx = BallistaContext::standalone(&config, 2, None).await?;
 
     // register csv file with the execution context
     ctx.register_csv(

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,7 +36,7 @@ default = ["mimalloc"]
 [dependencies]
 async-trait = "0.1"
 ballista = { path = "../ballista/client", version = "0.9.0" }
-datafusion = { version = "14.0.0", features = ["pyarrow"] }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "7b5842b91ebd00a2c7f894fcad797bea68a56d0f", features = ["pyarrow"] }
 futures = "0.3"
 mimalloc = { version = "*", optional = true, default-features = false }
 pyo3 = { version = "~0.17.1", features = ["extension-module", "abi3", "abi3-py37"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #500.

 # Rationale for this change

Described in issue.

# What changes are included in this PR?

1. upgrade of datafusion & arrow
2. config plumbing
3. conversion of `default_session_builder` to a supserset of functionality (now with state)
4. default table factories
5. a bunch of flight sql work for database introspection (more required in future PRs)
6. 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
