### PR TITLE
Auto-refresh job table

### DIFF
--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -110,11 +110,13 @@ pub(crate) async fn get_jobs<T: AsLogicalPlan, U: AsExecutionPlan>(
     // TODO: Display last seen information in UI
     let state = data_server.state;
 
-    let jobs = state
+    let mut jobs = state
         .task_manager
         .get_jobs()
         .await
         .map_err(|_| warp::reject())?;
+
+    jobs.sort_by(|a, b| b.start_time.cmp(&a.start_time));
 
     let jobs: Vec<JobResponse> = jobs
         .iter()

--- a/ballista/scheduler/ui/src/App.tsx
+++ b/ballista/scheduler/ui/src/App.tsx
@@ -24,6 +24,7 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
+  useInterval,
   VStack,
 } from "@chakra-ui/react";
 import { Header } from "./components/Header";
@@ -32,6 +33,8 @@ import { ExecutorsList } from "./components/ExecutorsList";
 import { QueriesList } from "./components/QueriesList";
 import { Footer } from "./components/Footer";
 import "./App.css";
+
+const REFRESH_TABLE_INTERVAL = 800; // 0.8s
 
 const App: React.FunctionComponent<any> = () => {
   const [schedulerState, setSchedulerState] = useState(undefined);
@@ -70,6 +73,19 @@ const App: React.FunctionComponent<any> = () => {
       .then((res) => res.json())
       .then((res) => setExecutors(res));
   }
+
+  useInterval(async () => {
+    const new_jobs = await fetch(`/api/jobs`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+      },
+    }).then((res) => res.json());
+
+    if (jobs !== new_jobs) {
+      getJobs();
+    }
+  }, REFRESH_TABLE_INTERVAL);
 
   useEffect(() => {
     getSchedulerState();


### PR DESCRIPTION
### Which issue does this PR close?
None

### Rationale for this change
The summary query jobs table is static. One needs to refresh the page to get new jobs that were submitted, finished, etc. 

### What changes are included in this PR?
Simple changes

### Are there any user-facing changes?
The user gets the needed information without additional steps: refreshing the webpage. 

There is a caveat though: the sorting feature of the react-table gets "broken". Need to understand this interaction and fix that. 

### Demo

[![ballista-refresh-interval.gif](https://s4.gifyu.com/images/ballista-refresh-interval.gif)](https://gifyu.com/image/Sh5Om)