### PR TITLE
tpch conversion is failling with ArrowError(CsvError)

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -874,6 +874,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("p_container", DataType::Utf8, false),
             Field::new("p_retailprice", DataType::Decimal128(15, 2), false),
             Field::new("p_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "supplier" => Schema::new(vec![
@@ -884,6 +885,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("s_phone", DataType::Utf8, false),
             Field::new("s_acctbal", DataType::Decimal128(15, 2), false),
             Field::new("s_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "partsupp" => Schema::new(vec![
@@ -892,6 +894,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("ps_availqty", DataType::Int32, false),
             Field::new("ps_supplycost", DataType::Decimal128(15, 2), false),
             Field::new("ps_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "customer" => Schema::new(vec![
@@ -903,6 +906,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("c_acctbal", DataType::Decimal128(15, 2), false),
             Field::new("c_mktsegment", DataType::Utf8, false),
             Field::new("c_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "orders" => Schema::new(vec![
@@ -915,6 +919,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("o_clerk", DataType::Utf8, false),
             Field::new("o_shippriority", DataType::Int32, false),
             Field::new("o_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "lineitem" => Schema::new(vec![
@@ -934,6 +939,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("l_shipinstruct", DataType::Utf8, false),
             Field::new("l_shipmode", DataType::Utf8, false),
             Field::new("l_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "nation" => Schema::new(vec![
@@ -941,12 +947,14 @@ fn get_schema(table: &str) -> Schema {
             Field::new("n_name", DataType::Utf8, false),
             Field::new("n_regionkey", DataType::Int64, false),
             Field::new("n_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         "region" => Schema::new(vec![
             Field::new("r_regionkey", DataType::Int64, false),
             Field::new("r_name", DataType::Utf8, false),
             Field::new("r_comment", DataType::Utf8, false),
+            Field::new("_trailing", DataType::Int8, true),
         ]),
 
         _ => unimplemented!(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
This is - to me - a utility change, so I don't create a bug.
Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
benchmarks/src/bin/tpch.rs is failing to convert TPC-H's tbl file to parquet file.
because there's a tailing '|' in the tbl file like this:
```
1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|
```
So Arrow believes the schema doesn't match CSV itself and throws `Error: ArrowError(CsvError("incorrect number of fields for line 1, expected 9 got more than 9"))`

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Adds an null-able trailing field to the schema so CSV parsing won't fail.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
