### PR TITLE
doc: Fix minor things on `communication` doc

### DIFF
--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -73,11 +73,10 @@ We will send a summary of all sync ups to the dev@arrow.apache.org mailing list.
 ## Contributing
 
 Our source code is hosted on
-[GitHub](https://github.com/apache/arrow-datafusion). More information on contributing is in
-the [Contribution Guide](https://github.com/apache/arrow-datafusion/blob/master/CONTRIBUTING.md)
-, and we have curated a [good-first-issue]
-(https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-list to help you get started. You can find datafusion's major designs in docs/source/specification.
+[GitHub](https://github.com/apache/datafusion-ballista). More information on contributing is in
+the [Contribution Guide](https://github.com/apache/datafusion-ballista/blob/main/CONTRIBUTING.md)
+, and we have curated a [good-first-issue](https://github.com/apache/datafusion-ballista/contribute)
+list to help you get started.
 
 We use GitHub issues for maintaining a queue of development work and as the
 public record. We often use Google docs, Github issues and pull requests for


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Closes NA.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Having correct links on `communication` page is generally helpful and particularly for new contributors

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Changes:
1. `Good first issue` link was broken & was pointing wrongly to `datafusion` repository
2. Update repo links (`datafusion` -> `ballista`)
3. Remove spec reference that was pointing to `datafusion` specification.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
NO
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
NO