### PR TITLE
feat(scheduler): add csv support for get_file_metadata grpc method

### DIFF
--- a/ballista-cli/src/exec.rs
+++ b/ballista-cli/src/exec.rs
@@ -49,11 +49,11 @@ pub async fn exec_from_lines(
                 let line = line.trim_end();
                 query.push_str(line);
                 if line.ends_with(';') {
-                    match exec_and_print(ctx, print_options, query).await {
+                    match exec_and_print(ctx, print_options, query.clone()).await {
                         Ok(_) => {}
                         Err(err) => println!("{err:?}"),
                     }
-                    query = "".to_owned();
+                    "".clone_into(&mut query);
                 } else {
                     query.push('\n');
                 }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -84,6 +84,7 @@ warp = "0.3"
 
 [dev-dependencies]
 ballista-core = { path = "../core", version = "0.12.0" }
+tempfile = "3"
 
 [build-dependencies]
 configure_me_codegen = { workspace = true }

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -33,6 +33,7 @@ struct SchedulerStateResponse {
     version: &'static str,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, serde::Serialize)]
 struct ExecutorsResponse {
     executors: Vec<ExecutorMetaResponse>,

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -653,6 +653,8 @@ mod test {
 
     use datafusion_proto::protobuf::LogicalPlanNode;
     use datafusion_proto::protobuf::PhysicalPlanNode;
+    use object_store::path::Path;
+    use tempfile::NamedTempFile;
     use tonic::{Code, Request};
 
     use crate::config::SchedulerConfig;
@@ -858,17 +860,21 @@ mod test {
             );
         scheduler.init().await?;
 
+        let mut test_file = NamedTempFile::new()?;
+        let source_location_str =
+            Path::from(test_file.as_ref().to_str().unwrap()).to_string();
+
         let requests = vec![
             Request::new(GetFileMetadataParams {
-                path: "/tmp/file.parquet".to_string(),
+                path: source_location_str.clone(),
                 file_type: "parquet".to_string(),
             }),
             Request::new(GetFileMetadataParams {
-                path: "/tmp/file.csv".to_string(),
+                path: source_location_str.clone(),
                 file_type: "csv".to_string(),
             }),
             Request::new(GetFileMetadataParams {
-                path: "/tmp/file.tbl".to_string(),
+                path: source_location_str.clone(),
                 file_type: "tbl".to_string(),
             }),
         ];
@@ -891,7 +897,7 @@ mod test {
 
         let request: Request<GetFileMetadataParams> =
             Request::new(GetFileMetadataParams {
-                path: "/tmp/file.avro".to_string(),
+                path: source_location_str,
                 file_type: "avro".to_string(),
             });
         let avro_response = scheduler

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -860,7 +860,7 @@ mod test {
             );
         scheduler.init().await?;
 
-        let mut test_file = NamedTempFile::new()?;
+        let test_file = NamedTempFile::new()?;
         let source_location_str =
             Path::from(test_file.as_ref().to_str().unwrap()).to_string();
 

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -340,7 +340,7 @@ impl ExecutionGraph {
 
                             match failed_reason {
                                 Some(FailedReason::FetchPartitionError(
-                                    fetch_partiton_error,
+                                    fetch_partition_error,
                                 )) => {
                                     let failed_attempts = failed_stage_attempts
                                         .entry(stage_id)
@@ -348,12 +348,12 @@ impl ExecutionGraph {
                                     failed_attempts.insert(task_stage_attempt_num);
                                     if failed_attempts.len() < max_stage_failures {
                                         let map_stage_id =
-                                            fetch_partiton_error.map_stage_id as usize;
-                                        let map_partition_id = fetch_partiton_error
+                                            fetch_partition_error.map_stage_id as usize;
+                                        let map_partition_id = fetch_partition_error
                                             .map_partition_id
                                             as usize;
                                         let executor_id =
-                                            fetch_partiton_error.executor_id;
+                                            fetch_partition_error.executor_id;
 
                                         if !failed_stages.is_empty() {
                                             let error_msg = format!(
@@ -436,7 +436,7 @@ impl ExecutionGraph {
                             successful_task,
                         )) = task_status.status
                         {
-                            // update task metrics for successfu task
+                            // update task metrics for successful task
                             running_stage
                                 .update_task_metrics(partition_id, operator_metrics)?;
 
@@ -510,30 +510,31 @@ impl ExecutionGraph {
                                         failed_stages.insert(stage_id, failed_task.error);
                                     }
                                     Some(FailedReason::FetchPartitionError(
-                                        fetch_partiton_error,
+                                        fetch_partition_error,
                                     )) if failed_stages.is_empty()
                                         && current_running_stages.contains(
-                                            &(fetch_partiton_error.map_stage_id as usize),
+                                            &(fetch_partition_error.map_stage_id
+                                                as usize),
                                         )
                                         && !unsolved_stage
                                             .last_attempt_failure_reasons
                                             .contains(
-                                                &fetch_partiton_error.executor_id,
+                                                &fetch_partition_error.executor_id,
                                             ) =>
                                     {
                                         should_ignore = false;
                                         unsolved_stage
                                             .last_attempt_failure_reasons
                                             .insert(
-                                                fetch_partiton_error.executor_id.clone(),
+                                                fetch_partition_error.executor_id.clone(),
                                             );
                                         let map_stage_id =
-                                            fetch_partiton_error.map_stage_id as usize;
-                                        let map_partition_id = fetch_partiton_error
+                                            fetch_partition_error.map_stage_id as usize;
+                                        let map_partition_id = fetch_partition_error
                                             .map_partition_id
                                             as usize;
                                         let executor_id =
-                                            fetch_partiton_error.executor_id;
+                                            fetch_partition_error.executor_id;
                                         let removed_map_partitions = unsolved_stage
                                             .remove_input_partitions(
                                                 map_stage_id,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.
I was exploring the code and came across the `TODO` about the `csv` file format support. So decided to address it.


 # Rationale for this change
The functionality extension.

# What changes are included in this PR?
- add `csv` / `tlb` file format support
- fix minor typos

# Are there any user-facing changes?
No

