### PR TITLE
Add rust-toolchain.toml for clarity

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1005 .

 # Rationale for this change

Improves clarity for developers (particularly new ones) about which toolchain to use for Rust development.

# What changes are included in this PR?

Adds a trivial `rust-toolchain.toml` that specifies that this project uses the `stable` toolchain.

# Are there any user-facing changes?

None
