### PR TITLE
[Docs] fix good_first_issue link in the contribution md doc

### DIFF
--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -75,7 +75,7 @@ We will send a summary of all sync ups to the dev@datafusion.apache.org mailing 
 Our source code is hosted on
 [GitHub](https://github.com/apache/arrow-datafusion). More information on contributing is in
 the [Contribution Guide](https://github.com/apache/arrow-datafusion/blob/master/CONTRIBUTING.md)
-, and we have curated a [good-first-issue](https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+, and we have curated a [good-first-issue](https://github.com/apache/datafusion-ballista/labels/good%20first%20issue)
 list to help you get started. You can find datafusion's major designs in docs/source/specification.
 
 We use GitHub issues for maintaining a queue of development work and as the

--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -75,7 +75,7 @@ We will send a summary of all sync ups to the dev@datafusion.apache.org mailing 
 Our source code is hosted on
 [GitHub](https://github.com/apache/arrow-datafusion). More information on contributing is in
 the [Contribution Guide](https://github.com/apache/arrow-datafusion/blob/master/CONTRIBUTING.md)
-, and we have curated a [good-first-issue](https://github.com/apache/datafusion-ballista/labels/good%20first%20issue)
+, and we have curated a [good-first-issue](https://github.com/apache/datafusion-ballista/contribute)
 list to help you get started. You can find datafusion's major designs in docs/source/specification.
 
 We use GitHub issues for maintaining a queue of development work and as the

--- a/docs/source/community/communication.md
+++ b/docs/source/community/communication.md
@@ -75,8 +75,7 @@ We will send a summary of all sync ups to the dev@datafusion.apache.org mailing 
 Our source code is hosted on
 [GitHub](https://github.com/apache/arrow-datafusion). More information on contributing is in
 the [Contribution Guide](https://github.com/apache/arrow-datafusion/blob/master/CONTRIBUTING.md)
-, and we have curated a [good-first-issue]
-(https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+, and we have curated a [good-first-issue](https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 list to help you get started. You can find datafusion's major designs in docs/source/specification.
 
 We use GitHub issues for maintaining a queue of development work and as the


### PR DESCRIPTION
## Which issue does this PR close?

Minor enhancement in the docs, fixing the link to the `good_first_issue` in the docs
Closes #. No issue was created, just a minor improvement
Feel free to reject this PR if needed

 ## Rationale for this change
To enhance to onboarding process of newcomers to the project

## What changes are included in this PR?
Minor change in the docs

## Are there any user-facing changes?
No
