### PR TITLE
Fix Ballista rust.yml github workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -349,12 +349,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: rust-artifacts
-          path: /home/runner/work/arrow-ballista/arrow-ballista/target/release
+          path: target/release
       - name: Restore react artifacts
         uses: actions/download-artifact@v2
         with:
           name: react-artifacts
-          path: /home/runner/work/arrow-ballista/arrow-ballista/ballista/scheduler/ui/build
+          path: ballista/scheduler/ui/build
       - name: Build and push Docker image
         run: |
           echo "github user is $DOCKER_USER"

--- a/ballista-cli/src/exec.rs
+++ b/ballista-cli/src/exec.rs
@@ -53,7 +53,11 @@ pub async fn exec_from_lines(
                         Ok(_) => {}
                         Err(err) => println!("{err:?}"),
                     }
-                    query = "".to_owned();
+
+                    #[allow(clippy::assigning_clones)]
+                    {
+                        query = "".to_owned();
+                    }
                 } else {
                     query.push('\n');
                 }

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -32,12 +32,6 @@ struct SchedulerStateResponse {
     started: u128,
     version: &'static str,
 }
-
-#[derive(Debug, serde::Serialize)]
-struct ExecutorsResponse {
-    executors: Vec<ExecutorMetaResponse>,
-}
-
 #[derive(Debug, serde::Serialize)]
 pub struct ExecutorMetaResponse {
     pub id: String,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [toolchain]
 channel = "stable"


### PR DESCRIPTION
Fix the failing docker builder in the github workflow.

Make clippy happy:
- Remove unused ExecutorsResponse.
- Allow an 'assigning_clone'.
