### PR TITLE
Make Ballista compatible with Datafusion 37.0.0 (from 36.0.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ exclude = [ "python" ]
 resolver = "2"
 
 [workspace.dependencies]
-arrow = { version = "50.0.0", features=["ipc_compression"] }
-arrow-flight = { version = "50.0.0", features = ["flight-sql-experimental"] }
-arrow-schema = { version = "50.0.0", default-features = false }
+arrow = { version = "51.0.0", features=["ipc_compression"] }
+arrow-flight = { version = "51.0.0", features = ["flight-sql-experimental"] }
+arrow-schema = { version = "51.0.0", default-features = false }
 configure_me = { version = "0.4.0" }
 configure_me_codegen = { version = "0.4.4" }
-datafusion = "36.0.0"
-datafusion-cli = "36.0.0"
-datafusion-proto = "36.0.0"
+datafusion = "37.0.0"
+datafusion-cli = "37.0.0"
+datafusion-proto = "37.0.0"
 object_store = "0.9.0"
-sqlparser = "0.43.0"
-tonic = { version = "0.10" }
-tonic-build = { version = "0.10", default-features = false, features = [
+sqlparser = "0.44.0"
+tonic = { version = "0.11" }
+tonic-build = { version = "0.11", default-features = false, features = [
     "transport",
     "prost"
 ] }

--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -477,6 +477,7 @@ impl BallistaContext {
 #[cfg(test)]
 #[cfg(feature = "standalone")]
 mod standalone_tests {
+    use datafusion::config::TableParquetOptions;
     use ballista_core::error::Result;
     use datafusion::dataframe::DataFrameWriteOptions;
     use datafusion::datasource::listing::ListingTableUrl;
@@ -507,7 +508,7 @@ mod standalone_tests {
         df.write_parquet(
             &file_path,
             DataFrameWriteOptions::default(),
-            Some(WriterProperties::default()),
+            Some(TableParquetOptions::default()),
         )
         .await?;
         Ok(())
@@ -662,7 +663,6 @@ mod standalone_tests {
                         collect_stat: x.collect_stat,
                         target_partitions: x.target_partitions,
                         file_sort_order: vec![],
-                        file_type_write_options: None,
                     };
 
                     let table_paths = listing_table

--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -481,7 +481,6 @@ mod standalone_tests {
     use datafusion::config::TableParquetOptions;
     use datafusion::dataframe::DataFrameWriteOptions;
     use datafusion::datasource::listing::ListingTableUrl;
-    
     use tempfile::TempDir;
 
     #[tokio::test]

--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -481,7 +481,7 @@ mod standalone_tests {
     use datafusion::config::TableParquetOptions;
     use datafusion::dataframe::DataFrameWriteOptions;
     use datafusion::datasource::listing::ListingTableUrl;
-    use datafusion::parquet::file::properties::WriterProperties;
+    
     use tempfile::TempDir;
 
     #[tokio::test]

--- a/ballista/client/src/context.rs
+++ b/ballista/client/src/context.rs
@@ -477,8 +477,8 @@ impl BallistaContext {
 #[cfg(test)]
 #[cfg(feature = "standalone")]
 mod standalone_tests {
-    use datafusion::config::TableParquetOptions;
     use ballista_core::error::Result;
+    use datafusion::config::TableParquetOptions;
     use datafusion::dataframe::DataFrameWriteOptions;
     use datafusion::datasource::listing::ListingTableUrl;
     use datafusion::parquet::file::properties::WriterProperties;

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -29,10 +29,10 @@ use crate::error::{BallistaError, Result};
 use crate::serde::scheduler::{Action, PartitionId};
 
 use arrow_flight;
+use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::Ticket;
 use arrow_flight::{flight_service_client::FlightServiceClient, FlightData};
-use arrow_flight::decode::FlightRecordBatchStream;
 use datafusion::arrow::array::ArrayRef;
 use datafusion::arrow::{
     datatypes::{Schema, SchemaRef},

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -29,7 +29,6 @@ use crate::error::{BallistaError, Result};
 use crate::serde::scheduler::{Action, PartitionId};
 
 use arrow_flight;
-use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::utils::flight_data_to_arrow_batch;
 use arrow_flight::Ticket;
 use arrow_flight::{flight_service_client::FlightServiceClient, FlightData};

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -156,8 +156,6 @@ impl BallistaClient {
             };
 
             let mut stream = res.into_inner();
-            //let st = FlightRecordBatchStream::new_from_flight_data(
-            //                stream.map_err(|e| e.into()));
 
             match stream.message().await {
                 Ok(res) => {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -32,7 +32,6 @@ use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning,
     PlanProperties, SendableRecordBatchStream, Statistics,

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -30,8 +30,13 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::ExecutionPlanProperties;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning,
+    PlanProperties, SendableRecordBatchStream, Statistics,
+};
 use datafusion_proto::logical_plan::{
     AsLogicalPlan, DefaultLogicalExtensionCodec, LogicalExtensionCodec,
 };
@@ -42,8 +47,6 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
-use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_plan::ExecutionPlanProperties;
 
 /// This operator sends a logical plan to a Ballista scheduler for execution and
 /// polls the scheduler until the query is complete and then fetches the resulting
@@ -179,7 +182,9 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             extension_codec: self.extension_codec.clone(),
             plan_repr: self.plan_repr,
             session_id: self.session_id.clone(),
-            properties: Self::compute_properties(self.plan.schema().as_ref().clone().into()),
+            properties: Self::compute_properties(
+                self.plan.schema().as_ref().clone().into(),
+            ),
         }))
     }
 

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -34,26 +34,21 @@ use crate::serde::scheduler::{PartitionLocation, PartitionStats};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::runtime::SpawnedTask;
 
 use datafusion::error::Result;
-use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
-use datafusion::physical_plan::{
-    ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
-    RecordBatchStream, SendableRecordBatchStream, Statistics,
-};
+use datafusion::physical_plan::{ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics};
 use futures::{Stream, StreamExt, TryStreamExt};
 
 use crate::error::BallistaError;
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::common::AbortOnDropMany;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use itertools::Itertools;
 use log::{error, info};
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use tokio::sync::{mpsc, Semaphore};
-use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 
 /// ShuffleReaderExec reads partitions that have already been materialized by a ShuffleWriterExec
@@ -67,6 +62,7 @@ pub struct ShuffleReaderExec {
     pub partition: Vec<Vec<PartitionLocation>>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
+    properties: PlanProperties,
 }
 
 impl ShuffleReaderExec {
@@ -76,11 +72,19 @@ impl ShuffleReaderExec {
         partition: Vec<Vec<PartitionLocation>>,
         schema: SchemaRef,
     ) -> Result<Self> {
+        let properties =  PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
+            // TODO partitioning may be known and could be populated here
+            // see https://github.com/apache/arrow-datafusion/issues/758
+            Partitioning::UnknownPartitioning(partition.len()),
+            datafusion::physical_plan::ExecutionMode::Bounded,
+        );
         Ok(Self {
             stage_id,
             schema,
             partition,
             metrics: ExecutionPlanMetricsSet::new(),
+            properties,
         })
     }
 }
@@ -108,16 +112,9 @@ impl ExecutionPlan for ShuffleReaderExec {
         self.schema.clone()
     }
 
-    fn output_partitioning(&self) -> Partitioning {
-        // TODO partitioning may be known and could be populated here
-        // see https://github.com/apache/arrow-datafusion/issues/758
-        Partitioning::UnknownPartitioning(self.partition.len())
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
     }
-
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        None
-    }
-
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
         vec![]
     }
@@ -244,7 +241,7 @@ struct AbortableReceiverStream {
     inner: ReceiverStream<result::Result<SendableRecordBatchStream, BallistaError>>,
 
     #[allow(dead_code)]
-    drop_helper: AbortOnDropMany<()>,
+    drop_helper: Vec<SpawnedTask<()>>,
 }
 
 impl AbortableReceiverStream {
@@ -253,12 +250,12 @@ impl AbortableReceiverStream {
         rx: tokio::sync::mpsc::Receiver<
             result::Result<SendableRecordBatchStream, BallistaError>,
         >,
-        join_handles: Vec<JoinHandle<()>>,
+        spawned_tasks: Vec<SpawnedTask<()>>,
     ) -> AbortableReceiverStream {
         let inner = ReceiverStream::new(rx);
         Self {
             inner,
-            drop_helper: AbortOnDropMany(join_handles),
+            drop_helper: spawned_tasks,
         }
     }
 }
@@ -282,7 +279,7 @@ fn send_fetch_partitions(
 ) -> AbortableReceiverStream {
     let (response_sender, response_receiver) = mpsc::channel(max_request_num);
     let semaphore = Arc::new(Semaphore::new(max_request_num));
-    let mut join_handles = vec![];
+    let mut spawned_tasks: Vec<SpawnedTask<()>> = vec![];
     let (local_locations, remote_locations): (Vec<_>, Vec<_>) = partition_locations
         .into_iter()
         .partition(check_is_local_location);
@@ -295,20 +292,19 @@ fn send_fetch_partitions(
 
     // keep local shuffle files reading in serial order for memory control.
     let response_sender_c = response_sender.clone();
-    let join_handle = tokio::spawn(async move {
+    spawned_tasks.push(SpawnedTask::spawn(async move {
         for p in local_locations {
             let r = PartitionReaderEnum::Local.fetch_partition(&p).await;
             if let Err(e) = response_sender_c.send(r).await {
                 error!("Fail to send response event to the channel due to {}", e);
             }
         }
-    });
-    join_handles.push(join_handle);
+    }));
 
     for p in remote_locations.into_iter() {
         let semaphore = semaphore.clone();
         let response_sender = response_sender.clone();
-        let join_handle = tokio::spawn(async move {
+        spawned_tasks.push(SpawnedTask::spawn(async move {
             // Block if exceeds max request number
             let permit = semaphore.acquire_owned().await.unwrap();
             let r = PartitionReaderEnum::FlightRemote.fetch_partition(&p).await;
@@ -318,11 +314,10 @@ fn send_fetch_partitions(
             }
             // Increase semaphore by dropping existing permits.
             drop(permit);
-        });
-        join_handles.push(join_handle);
+        }));
     }
 
-    AbortableReceiverStream::create(response_receiver, join_handles)
+    AbortableReceiverStream::create(response_receiver, spawned_tasks)
 }
 
 fn check_is_local_location(location: &PartitionLocation) -> bool {

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -308,10 +308,10 @@ fn send_fetch_partitions(
         let semaphore = semaphore.clone();
         let response_sender = response_sender.clone();
         spawned_tasks.push(SpawnedTask::spawn(async move {
-            // Block if exceeds max request number
+            // Block if exceeds max request number.
             let permit = semaphore.acquire_owned().await.unwrap();
             let r = PartitionReaderEnum::FlightRemote.fetch_partition(&p).await;
-            // Block if the channel buffer is ful
+            // Block if the channel buffer is full.
             if let Err(e) = response_sender.send(r).await {
                 error!("Fail to send response event to the channel due to {}", e);
             }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -38,7 +38,10 @@ use datafusion::common::runtime::SpawnedTask;
 
 use datafusion::error::Result;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
-use datafusion::physical_plan::{ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::{
+    ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics,
+};
 use futures::{Stream, StreamExt, TryStreamExt};
 
 use crate::error::BallistaError;
@@ -72,7 +75,7 @@ impl ShuffleReaderExec {
         partition: Vec<Vec<PartitionLocation>>,
         schema: SchemaRef,
     ) -> Result<Self> {
-        let properties =  PlanProperties::new(
+        let properties = PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
             // TODO partitioning may be known and could be populated here
             // see https://github.com/apache/arrow-datafusion/issues/758

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -49,7 +49,10 @@ use datafusion::physical_plan::metrics::{
     self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream, Statistics,
+};
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 
 use datafusion::arrow::error::ArrowError;
@@ -127,12 +130,13 @@ impl ShuffleWriterExec {
         // If [`shuffle_output_partitioning`] is none, then there's no need to do repartitioning.
         // Therefore, the partition is the same as its input plan's.
         let partitioning = shuffle_output_partitioning
-                .clone()
-                .unwrap_or_else(|| plan.properties().output_partitioning().clone());
-        let properties =  PlanProperties::new(
+            .clone()
+            .unwrap_or_else(|| plan.properties().output_partitioning().clone());
+        let properties = PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(plan.schema()),
             partitioning,
-            datafusion::physical_plan::ExecutionMode::Bounded);
+            datafusion::physical_plan::ExecutionMode::Bounded,
+        );
         Ok(Self {
             job_id,
             stage_id,
@@ -156,7 +160,10 @@ impl ShuffleWriterExec {
 
     /// Get the input partition count
     pub fn input_partition_count(&self) -> usize {
-        self.plan.properties().output_partitioning().partition_count()
+        self.plan
+            .properties()
+            .output_partitioning()
+            .partition_count()
     }
 
     /// Get the true output partitioning

--- a/ballista/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/core/src/execution_plans/unresolved_shuffle.rs
@@ -21,11 +21,7 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::expressions::PhysicalSortExpr;
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
-    Statistics,
-};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
 
 /// UnresolvedShuffleExec represents a dependency on the results of a ShuffleWriterExec node which hasn't computed yet.
 ///
@@ -41,6 +37,8 @@ pub struct UnresolvedShuffleExec {
 
     // The partition count this node will have once it is replaced with a ShuffleReaderExec
     pub output_partition_count: usize,
+
+    properties: PlanProperties,
 }
 
 impl UnresolvedShuffleExec {
@@ -50,10 +48,17 @@ impl UnresolvedShuffleExec {
         schema: SchemaRef,
         output_partition_count: usize,
     ) -> Self {
+        let properties =  PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
+            // TODO the output partition is known and should be populated here!
+            // see https://github.com/apache/arrow-datafusion/issues/758
+            Partitioning::UnknownPartitioning(output_partition_count),
+            datafusion::physical_plan::ExecutionMode::Bounded);
         Self {
             stage_id,
             schema,
             output_partition_count,
+            properties,
         }
     }
 }
@@ -81,14 +86,9 @@ impl ExecutionPlan for UnresolvedShuffleExec {
         self.schema.clone()
     }
 
-    fn output_partitioning(&self) -> Partitioning {
-        // TODO the output partition is known and should be populated here!
-        // see https://github.com/apache/arrow-datafusion/issues/758
-        Partitioning::UnknownPartitioning(self.output_partition_count)
-    }
 
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        None
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/ballista/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/core/src/execution_plans/unresolved_shuffle.rs
@@ -21,7 +21,10 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream, Statistics,
+};
 
 /// UnresolvedShuffleExec represents a dependency on the results of a ShuffleWriterExec node which hasn't computed yet.
 ///
@@ -48,12 +51,13 @@ impl UnresolvedShuffleExec {
         schema: SchemaRef,
         output_partition_count: usize,
     ) -> Self {
-        let properties =  PlanProperties::new(
+        let properties = PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
             // TODO the output partition is known and should be populated here!
             // see https://github.com/apache/arrow-datafusion/issues/758
             Partitioning::UnknownPartitioning(output_partition_count),
-            datafusion::physical_plan::ExecutionMode::Bounded);
+            datafusion::physical_plan::ExecutionMode::Bounded,
+        );
         Self {
             stage_id,
             schema,
@@ -85,7 +89,6 @@ impl ExecutionPlan for UnresolvedShuffleExec {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
-
 
     fn properties(&self) -> &PlanProperties {
         &self.properties

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -200,7 +200,8 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             // to get the true output partitioning
             let output_partitioning = match exec.shuffle_output_partitioning() {
                 Some(Partitioning::Hash(exprs, partition_count)) => {
-                    let default_codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
+                    let default_codec =
+                        datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
                     Some(datafusion_proto::protobuf::PhysicalHashRepartition {
                         hash_expr: exprs
                             .iter()

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -181,12 +181,11 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             }
             PhysicalPlanType::UnresolvedShuffle(unresolved_shuffle) => {
                 let schema = Arc::new(convert_required!(unresolved_shuffle.schema)?);
-                Ok(Arc::new(UnresolvedShuffleExec {
-                    stage_id: unresolved_shuffle.stage_id as usize,
+                Ok(Arc::new(UnresolvedShuffleExec::new(
+                    unresolved_shuffle.stage_id as usize,
                     schema,
-                    output_partition_count: unresolved_shuffle.output_partition_count
-                        as usize,
-                }))
+                    unresolved_shuffle.output_partition_count as usize,
+                )))
             }
         }
     }
@@ -201,10 +200,11 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             // to get the true output partitioning
             let output_partitioning = match exec.shuffle_output_partitioning() {
                 Some(Partitioning::Hash(exprs, partition_count)) => {
+                    let default_codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
                     Some(datafusion_proto::protobuf::PhysicalHashRepartition {
                         hash_expr: exprs
                             .iter()
-                            .map(|expr| expr.clone().try_into())
+                            .map(|expr|datafusion_proto::physical_plan::to_proto::serialize_physical_expr(expr.clone(), &default_codec))
                             .collect::<Result<Vec<_>, DataFusionError>>()?,
                         partition_count: *partition_count as u64,
                     })

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use chrono::{TimeZone, Utc};
-use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion::physical_plan::metrics::{
@@ -417,7 +417,8 @@ fn reset_metrics_for_execution_plan(
 ) -> Result<Arc<dyn ExecutionPlan>, BallistaError> {
     plan.transform(&|plan| {
         let children = plan.children().clone();
-        plan.with_new_children(children).map(Transformed::Yes)
+        plan.with_new_children(children).map(Transformed::yes)
     })
-    .map_err(BallistaError::DataFusionError)
+        .data()
+        .map_err(BallistaError::DataFusionError)
 }

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -419,6 +419,6 @@ fn reset_metrics_for_execution_plan(
         let children = plan.children().clone();
         plan.with_new_children(children).map(Transformed::yes)
     })
-        .data()
-        .map_err(BallistaError::DataFusionError)
+    .data()
+    .map_err(BallistaError::DataFusionError)
 }

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -103,7 +103,6 @@ pub fn hash_partitioning_to_proto(
         Some(Partitioning::Hash(exprs, partition_count)) => {
             let default_codec =
                 datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
-            //let k: PhysicalExprNode = exprs.iter().next().unwrap().try_into().unwrap();
             Ok(Some(datafusion_protobuf::PhysicalHashRepartition {
                 hash_expr: exprs
                     .iter()

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -102,7 +102,8 @@ pub fn hash_partitioning_to_proto(
 ) -> Result<Option<datafusion_protobuf::PhysicalHashRepartition>, BallistaError> {
     match output_partitioning {
         Some(Partitioning::Hash(exprs, partition_count)) => {
-            let default_codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
+            let default_codec =
+                datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
             //let k: PhysicalExprNode = exprs.iter().next().unwrap().try_into().unwrap();
             Ok(Some(datafusion_protobuf::PhysicalHashRepartition {
                 hash_expr: exprs

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -29,7 +29,6 @@ use crate::serde::scheduler::{
     PartitionLocation, PartitionStats,
 };
 use datafusion::physical_plan::Partitioning;
-use datafusion_proto::protobuf::PhysicalExprNode;
 use protobuf::{action::ActionType, operator_metric, NamedCount, NamedGauge, NamedTime};
 
 impl TryInto<protobuf::Action> for Action {

--- a/ballista/executor/src/collect.rs
+++ b/ballista/executor/src/collect.rs
@@ -25,11 +25,7 @@ use std::{any::Any, pin::Pin};
 use datafusion::arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::expressions::PhysicalSortExpr;
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
-    Statistics,
-};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
 use datafusion::{error::Result, physical_plan::RecordBatchStream};
 use futures::stream::SelectAll;
 use futures::Stream;
@@ -39,11 +35,20 @@ use futures::Stream;
 #[derive(Debug, Clone)]
 pub struct CollectExec {
     plan: Arc<dyn ExecutionPlan>,
+    properties: PlanProperties,
 }
 
 impl CollectExec {
     pub fn new(plan: Arc<dyn ExecutionPlan>) -> Self {
-        Self { plan }
+        let properties =  PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(plan.schema()),
+            Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::ExecutionMode::Bounded,
+        );
+        Self {
+            plan,
+            properties,
+        }
     }
 }
 
@@ -70,12 +75,8 @@ impl ExecutionPlan for CollectExec {
         self.plan.schema()
     }
 
-    fn output_partitioning(&self) -> Partitioning {
-        Partitioning::UnknownPartitioning(1)
-    }
-
-    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        None
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
@@ -95,7 +96,7 @@ impl ExecutionPlan for CollectExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
-        let num_partitions = self.plan.output_partitioning().partition_count();
+        let num_partitions = self.plan.properties().output_partitioning().partition_count();
 
         let streams = (0..num_partitions)
             .map(|i| self.plan.execute(i, context.clone()))

--- a/ballista/executor/src/collect.rs
+++ b/ballista/executor/src/collect.rs
@@ -25,7 +25,10 @@ use std::{any::Any, pin::Pin};
 use datafusion::arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream, Statistics,
+};
 use datafusion::{error::Result, physical_plan::RecordBatchStream};
 use futures::stream::SelectAll;
 use futures::Stream;
@@ -40,15 +43,12 @@ pub struct CollectExec {
 
 impl CollectExec {
     pub fn new(plan: Arc<dyn ExecutionPlan>) -> Self {
-        let properties =  PlanProperties::new(
+        let properties = PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(plan.schema()),
             Partitioning::UnknownPartitioning(1),
             datafusion::physical_plan::ExecutionMode::Bounded,
         );
-        Self {
-            plan,
-            properties,
-        }
+        Self { plan, properties }
     }
 }
 
@@ -96,7 +96,11 @@ impl ExecutionPlan for CollectExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
-        let num_partitions = self.plan.properties().output_partitioning().partition_count();
+        let num_partitions = self
+            .plan
+            .properties()
+            .output_partitioning()
+            .partition_count();
 
         let streams = (0..num_partitions)
             .map(|i| self.plan.execute(i, context.clone()))

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -212,10 +212,7 @@ mod test {
     use ballista_core::serde::scheduler::PartitionId;
     use datafusion::error::{DataFusionError, Result};
     use datafusion::physical_expr::PhysicalSortExpr;
-    use datafusion::physical_plan::{
-        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
-        SendableRecordBatchStream, Statistics,
-    };
+    use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics};
     use datafusion::prelude::SessionContext;
     use futures::Stream;
     use std::any::Any;
@@ -247,7 +244,21 @@ mod test {
 
     /// An ExecutionPlan which will never terminate
     #[derive(Debug)]
-    pub struct NeverendingOperator;
+    pub struct NeverendingOperator {
+        properties: PlanProperties,
+    }
+
+    impl NeverendingOperator {
+        fn new() -> Self {
+            NeverendingOperator {
+                properties: PlanProperties::new(
+                    datafusion::physical_expr::EquivalenceProperties::new(Arc::new(Schema::empty())),
+                    Partitioning::UnknownPartitioning(1),
+                    datafusion::physical_plan::ExecutionMode::Bounded
+                )
+            }
+        }
+    }
 
     impl DisplayAs for NeverendingOperator {
         fn fmt_as(
@@ -272,12 +283,8 @@ mod test {
             Arc::new(Schema::empty())
         }
 
-        fn output_partitioning(&self) -> Partitioning {
-            Partitioning::UnknownPartitioning(1)
-        }
-
-        fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-            None
+        fn properties(&self) -> &PlanProperties {
+            &self.properties
         }
 
         fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
@@ -316,7 +323,7 @@ mod test {
         let shuffle_write = ShuffleWriterExec::try_new(
             "job-id".to_owned(),
             1,
-            Arc::new(NeverendingOperator),
+            Arc::new(NeverendingOperator::new()),
             work_dir.clone(),
             None,
         )

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -207,7 +207,6 @@ mod test {
     use ballista_core::execution_plans::ShuffleWriterExec;
     use ballista_core::serde::protobuf::ExecutorRegistration;
     use datafusion::execution::context::TaskContext;
-
     use crate::execution_engine::DefaultQueryStageExec;
     use ballista_core::serde::scheduler::PartitionId;
     use datafusion::error::{DataFusionError, Result};

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -200,17 +200,17 @@ impl Executor {
 
 #[cfg(test)]
 mod test {
+    use crate::execution_engine::DefaultQueryStageExec;
     use crate::executor::Executor;
     use crate::metrics::LoggingMetricsCollector;
     use arrow::datatypes::{Schema, SchemaRef};
     use arrow::record_batch::RecordBatch;
     use ballista_core::execution_plans::ShuffleWriterExec;
     use ballista_core::serde::protobuf::ExecutorRegistration;
-    use datafusion::execution::context::TaskContext;
-    use crate::execution_engine::DefaultQueryStageExec;
     use ballista_core::serde::scheduler::PartitionId;
     use datafusion::error::{DataFusionError, Result};
-    
+    use datafusion::execution::context::TaskContext;
+
     use datafusion::physical_plan::{
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
         RecordBatchStream, SendableRecordBatchStream, Statistics,

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -211,7 +211,7 @@ mod test {
     use crate::execution_engine::DefaultQueryStageExec;
     use ballista_core::serde::scheduler::PartitionId;
     use datafusion::error::{DataFusionError, Result};
-    use datafusion::physical_expr::PhysicalSortExpr;
+    
     use datafusion::physical_plan::{
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
         RecordBatchStream, SendableRecordBatchStream, Statistics,

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -212,7 +212,10 @@ mod test {
     use ballista_core::serde::scheduler::PartitionId;
     use datafusion::error::{DataFusionError, Result};
     use datafusion::physical_expr::PhysicalSortExpr;
-    use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics};
+    use datafusion::physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+        RecordBatchStream, SendableRecordBatchStream, Statistics,
+    };
     use datafusion::prelude::SessionContext;
     use futures::Stream;
     use std::any::Any;
@@ -252,10 +255,12 @@ mod test {
         fn new() -> Self {
             NeverendingOperator {
                 properties: PlanProperties::new(
-                    datafusion::physical_expr::EquivalenceProperties::new(Arc::new(Schema::empty())),
+                    datafusion::physical_expr::EquivalenceProperties::new(Arc::new(
+                        Schema::empty(),
+                    )),
                     Partitioning::UnknownPartitioning(1),
-                    datafusion::physical_plan::ExecutionMode::Bounded
-                )
+                    datafusion::physical_plan::ExecutionMode::Bounded,
+                ),
             }
         }
     }

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -33,7 +33,7 @@ use arrow::ipc::writer::IpcWriteOptions;
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty,
     FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse,
-    PutResult, SchemaResult, Ticket, PollInfo,
+    PollInfo, PutResult, SchemaResult, Ticket,
 };
 use datafusion::arrow::{error::ArrowError, record_batch::RecordBatch};
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -210,7 +210,6 @@ impl FlightService for BallistaFlightService {
     ) -> Result<Response<PollInfo>, Status> {
         Err(Status::unimplemented("poll_flight_info"))
     }
-
 }
 
 fn read_partition<T>(

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -33,7 +33,7 @@ use arrow::ipc::writer::IpcWriteOptions;
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty,
     FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse,
-    PutResult, SchemaResult, Ticket,
+    PutResult, SchemaResult, Ticket, PollInfo,
 };
 use datafusion::arrow::{error::ArrowError, record_batch::RecordBatch};
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -203,6 +203,14 @@ impl FlightService for BallistaFlightService {
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
         Err(Status::unimplemented("do_exchange"))
     }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("poll_flight_info"))
+    }
+
 }
 
 fn read_partition<T>(

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use clap::ArgEnum;
 use datafusion::common::tree_node::TreeNode;
-use datafusion::common::tree_node::VisitRecursion;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::physical_plan::{AvroExec, CsvExec, NdJsonExec, ParquetExec};
 use datafusion::error::DataFusionError;
@@ -701,11 +701,11 @@ pub(crate) fn get_scan_files(
             } else if let Some(csv_exec) = plan_any.downcast_ref::<CsvExec>() {
                 csv_exec.base_config().file_groups.clone()
             } else {
-                return Ok(VisitRecursion::Continue);
+                return Ok(TreeNodeRecursion::Continue);
             };
 
         collector.push(file_groups);
-        Ok(VisitRecursion::Skip)
+        Ok(TreeNodeRecursion::Jump)
     })?;
     Ok(collector)
 }

--- a/ballista/scheduler/src/flight_sql.rs
+++ b/ballista/scheduler/src/flight_sql.rs
@@ -103,9 +103,13 @@ impl FlightSqlServiceImpl {
         ]));
         let mut names: Vec<Option<String>> = vec![];
         for catalog_name in ctx.catalog_names() {
-            let catalog = ctx.catalog(&catalog_name).expect("catalog should have been found");
+            let catalog = ctx
+                .catalog(&catalog_name)
+                .expect("catalog should have been found");
             for schema_name in catalog.schema_names() {
-                let schema = catalog.schema(&schema_name).expect("schema should have been found");
+                let schema = catalog
+                    .schema(&schema_name)
+                    .expect("schema should have been found");
                 for table_name in schema.table_names() {
                     names.push(Some(table_name));
                 }

--- a/ballista/scheduler/src/flight_sql.rs
+++ b/ballista/scheduler/src/flight_sql.rs
@@ -69,6 +69,7 @@ use datafusion::common::DFSchemaRef;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::prelude::SessionContext;
 use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
+use prost::bytes::Bytes;
 use prost::Message;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::sleep;
@@ -93,7 +94,6 @@ impl FlightSqlServiceImpl {
         }
     }
 
-    #[allow(deprecated)]
     fn tables(&self, ctx: Arc<SessionContext>) -> Result<RecordBatch, ArrowError> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("catalog_name", DataType::Utf8, true),
@@ -101,9 +101,17 @@ impl FlightSqlServiceImpl {
             Field::new("table_name", DataType::Utf8, false),
             Field::new("table_type", DataType::Utf8, false),
         ]));
-        let tables = ctx.tables()?; // resolved in #501
-        let names: Vec<_> = tables.iter().map(|it| Some(it.as_str())).collect();
-        let types: Vec<_> = names.iter().map(|_| Some("TABLE")).collect();
+        let mut names: Vec<Option<String>> = vec![];
+        for catalog_name in ctx.catalog_names() {
+            let catalog = ctx.catalog(&catalog_name).expect("catalog should have been found");
+            for schema_name in catalog.schema_names() {
+                let schema = catalog.schema(&schema_name).expect("schema should have been found");
+                for table_name in schema.table_names() {
+                    names.push(Some(table_name));
+                }
+            }
+        }
+        let types: Vec<_> = names.iter().map(|_| Some("TABLE".to_string())).collect();
         let cats: Vec<_> = names.iter().map(|_| None).collect();
         let schemas: Vec<_> = names.iter().map(|_| None).collect();
         let rb = RecordBatch::try_new(
@@ -290,15 +298,11 @@ impl FlightSqlServiceImpl {
                 Err(Status::internal("Error getting stats".to_string()))?
             }
             let authority = format!("{}:{}", &host, &port);
-            let loc = Location {
-                uri: format!("grpc+tcp://{authority}"),
-            };
             let buf = fetch.as_any().encode_to_vec();
             let ticket = Ticket { ticket: buf.into() };
-            let fiep = FlightEndpoint {
-                ticket: Some(ticket),
-                location: vec![loc],
-            };
+            let fiep = FlightEndpoint::new()
+                .with_ticket(ticket)
+                .with_location(format!("grpc+tcp://{authority}"));
             fieps.push(fiep);
         }
         Ok(fieps)
@@ -319,15 +323,11 @@ impl FlightSqlServiceImpl {
             settings: vec![],
         };
         let authority = format!("{}:{}", &host, &port); // TODO: use advertise host
-        let loc = Location {
-            uri: format!("grpc+tcp://{authority}"),
-        };
         let buf = fetch.as_any().encode_to_vec();
         let ticket = Ticket { ticket: buf.into() };
-        let fiep = FlightEndpoint {
-            ticket: Some(ticket),
-            location: vec![loc],
-        };
+        let fiep = FlightEndpoint::new()
+            .with_ticket(ticket)
+            .with_location(format!("grpc+tcp://{authority}"));
         let fieps = vec![fiep];
         Ok(fieps)
     }
@@ -406,6 +406,7 @@ impl FlightSqlServiceImpl {
             total_records: num_rows,
             total_bytes: num_bytes,
             ordered: false,
+            app_metadata: Bytes::new(),
         };
         Response::new(info)
     }

--- a/ballista/scheduler/src/flight_sql.rs
+++ b/ballista/scheduler/src/flight_sql.rs
@@ -33,7 +33,7 @@ use arrow_flight::sql::{
 };
 use arrow_flight::{
     Action, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
-    HandshakeResponse, Location, Ticket,
+    HandshakeResponse, Ticket,
 };
 use base64::Engine;
 use futures::Stream;

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -109,8 +109,7 @@ impl DistributedPlanner {
             let unresolved_shuffle = create_unresolved_shuffle(&shuffle_writer);
             stages.push(shuffle_writer);
             Ok((
-                with_new_children_if_necessary(execution_plan, vec![unresolved_shuffle])?
-                    .into(),
+                with_new_children_if_necessary(execution_plan, vec![unresolved_shuffle])?,
                 stages,
             ))
         } else if let Some(_sort_preserving_merge) = execution_plan
@@ -126,8 +125,7 @@ impl DistributedPlanner {
             let unresolved_shuffle = create_unresolved_shuffle(&shuffle_writer);
             stages.push(shuffle_writer);
             Ok((
-                with_new_children_if_necessary(execution_plan, vec![unresolved_shuffle])?
-                    .into(),
+                with_new_children_if_necessary(execution_plan, vec![unresolved_shuffle])?,
                 stages,
             ))
         } else if let Some(repart) =
@@ -158,7 +156,7 @@ impl DistributedPlanner {
             )))
         } else {
             Ok((
-                with_new_children_if_necessary(execution_plan, children)?.into(),
+                with_new_children_if_necessary(execution_plan, children)?,
                 stages,
             ))
         }
@@ -253,7 +251,7 @@ pub fn remove_unresolved_shuffles(
             new_children.push(remove_unresolved_shuffles(child, partition_locations)?);
         }
     }
-    Ok(with_new_children_if_necessary(stage, new_children)?.into())
+    Ok(with_new_children_if_necessary(stage, new_children)?)
 }
 
 /// Rollback the ShuffleReaderExec to UnresolvedShuffleExec.
@@ -281,7 +279,7 @@ pub fn rollback_resolved_shuffles(
             new_children.push(rollback_resolved_shuffles(child)?);
         }
     }
-    Ok(with_new_children_if_necessary(stage, new_children)?.into())
+    Ok(with_new_children_if_necessary(stage, new_children)?)
 }
 
 fn create_shuffle_writer(

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -177,7 +177,10 @@ fn create_unresolved_shuffle(
     Arc::new(UnresolvedShuffleExec::new(
         shuffle_writer.stage_id(),
         shuffle_writer.schema(),
-        shuffle_writer.properties().output_partitioning().partition_count(),
+        shuffle_writer
+            .properties()
+            .output_partitioning()
+            .partition_count(),
     ))
 }
 
@@ -262,8 +265,10 @@ pub fn rollback_resolved_shuffles(
     let mut new_children: Vec<Arc<dyn ExecutionPlan>> = vec![];
     for child in stage.children() {
         if let Some(shuffle_reader) = child.as_any().downcast_ref::<ShuffleReaderExec>() {
-            let output_partition_count =
-                shuffle_reader.properties().output_partitioning().partition_count();
+            let output_partition_count = shuffle_reader
+                .properties()
+                .output_partitioning()
+                .partition_count();
             let stage_id = shuffle_reader.stage_id;
 
             let unresolved_shuffle = Arc::new(UnresolvedShuffleExec::new(
@@ -318,8 +323,11 @@ mod test {
 
     macro_rules! downcast_exec {
         ($exec: expr, $ty: ty) => {
-            $exec.as_any().downcast_ref::<$ty>().expect(
-                &format!("Downcast to {} failed. Got {:?}", stringify!($ty), $exec))
+            $exec.as_any().downcast_ref::<$ty>().expect(&format!(
+                "Downcast to {} failed. Got {:?}",
+                stringify!($ty),
+                $exec
+            ))
         };
     }
 
@@ -525,7 +533,10 @@ order by
 
         // join and partial hash aggregate
         let input = stages[2].children()[0].clone();
-        assert_eq!(2, input.properties().output_partitioning().partition_count());
+        assert_eq!(
+            2,
+            input.properties().output_partitioning().partition_count()
+        );
         assert_eq!(
             2,
             stages[2]
@@ -561,7 +572,8 @@ order by
         assert_eq!(
             2,
             stages[3].children()[0]
-                .properties().output_partitioning()
+                .properties()
+                .output_partitioning()
                 .partition_count()
         );
         assert!(stages[3].shuffle_output_partitioning().is_none());
@@ -570,7 +582,8 @@ order by
         assert_eq!(
             1,
             stages[4].children()[0]
-                .properties().output_partitioning()
+                .properties()
+                .output_partitioning()
                 .partition_count()
         );
         assert!(stages[4].shuffle_output_partitioning().is_none());

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -318,7 +318,8 @@ mod test {
 
     macro_rules! downcast_exec {
         ($exec: expr, $ty: ty) => {
-            $exec.as_any().downcast_ref::<$ty>().unwrap()
+            $exec.as_any().downcast_ref::<$ty>().expect(
+                &format!("Downcast to {} failed. Got {:?}", stringify!($ty), $exec))
         };
     }
 
@@ -344,8 +345,8 @@ mod test {
         let mut planner = DistributedPlanner::new();
         let job_uuid = Uuid::new_v4();
         let stages = planner.plan_query_stages(&job_uuid.to_string(), plan)?;
-        for stage in &stages {
-            println!("{}", displayable(stage.as_ref()).indent(false));
+        for (i, stage) in stages.iter().enumerate() {
+            println!("Stage {i}:\n{}", displayable(stage.as_ref()).indent(false));
         }
 
         /* Expected result:
@@ -450,8 +451,8 @@ order by
         let mut planner = DistributedPlanner::new();
         let job_uuid = Uuid::new_v4();
         let stages = planner.plan_query_stages(&job_uuid.to_string(), plan)?;
-        for stage in &stages {
-            println!("{}", displayable(stage.as_ref()).indent(false));
+        for (i, stage) in stages.iter().enumerate() {
+            println!("Stage {i}:\n{}", displayable(stage.as_ref()).indent(false));
         }
 
         /* Expected result:
@@ -503,7 +504,7 @@ order by
             2,
             stages[0]
                 .shuffle_output_partitioning()
-                .unwrap()
+                .expect("stage 0")
                 .partition_count()
         );
 
@@ -519,7 +520,7 @@ order by
             2,
             stages[1]
                 .shuffle_output_partitioning()
-                .unwrap()
+                .expect("stage 1")
                 .partition_count()
         );
 
@@ -530,7 +531,7 @@ order by
             2,
             stages[2]
                 .shuffle_output_partitioning()
-                .unwrap()
+                .expect("stage 2")
                 .partition_count()
         );
 

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -133,7 +133,7 @@ impl DistributedPlanner {
         } else if let Some(repart) =
             execution_plan.as_any().downcast_ref::<RepartitionExec>()
         {
-            match repart.output_partitioning() {
+            match repart.properties().output_partitioning() {
                 Partitioning::Hash(_, _) => {
                     let shuffle_writer = create_shuffle_writer(
                         job_id,
@@ -177,7 +177,7 @@ fn create_unresolved_shuffle(
     Arc::new(UnresolvedShuffleExec::new(
         shuffle_writer.stage_id(),
         shuffle_writer.schema(),
-        shuffle_writer.output_partitioning().partition_count(),
+        shuffle_writer.properties().output_partitioning().partition_count(),
     ))
 }
 
@@ -263,7 +263,7 @@ pub fn rollback_resolved_shuffles(
     for child in stage.children() {
         if let Some(shuffle_reader) = child.as_any().downcast_ref::<ShuffleReaderExec>() {
             let output_partition_count =
-                shuffle_reader.output_partitioning().partition_count();
+                shuffle_reader.properties().output_partitioning().partition_count();
             let stage_id = shuffle_reader.stage_id;
 
             let unresolved_shuffle = Arc::new(UnresolvedShuffleExec::new(
@@ -495,6 +495,7 @@ order by
         assert_eq!(
             2,
             stages[0].children()[0]
+                .properties()
                 .output_partitioning()
                 .partition_count()
         );
@@ -510,6 +511,7 @@ order by
         assert_eq!(
             1,
             stages[1].children()[0]
+                .properties()
                 .output_partitioning()
                 .partition_count()
         );
@@ -523,7 +525,7 @@ order by
 
         // join and partial hash aggregate
         let input = stages[2].children()[0].clone();
-        assert_eq!(2, input.output_partitioning().partition_count());
+        assert_eq!(2, input.properties().output_partitioning().partition_count());
         assert_eq!(
             2,
             stages[2]
@@ -561,7 +563,7 @@ order by
         assert_eq!(
             2,
             stages[3].children()[0]
-                .output_partitioning()
+                .properties().output_partitioning()
                 .partition_count()
         );
         assert!(stages[3].shuffle_output_partitioning().is_none());
@@ -570,7 +572,7 @@ order by
         assert_eq!(
             1,
             stages[4].children()[0]
-                .output_partitioning()
+                .properties().output_partitioning()
                 .partition_count()
         );
         assert!(stages[4].shuffle_output_partitioning().is_none());

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -151,7 +151,7 @@ impl ExecutionGraph {
     ) -> Result<Self> {
         let mut planner = DistributedPlanner::new();
 
-        let output_partitions = plan.output_partitioning().partition_count();
+        let output_partitions = plan.properties().output_partitioning().partition_count();
 
         let shuffle_stages = planner.plan_query_stages(job_id, plan)?;
 

--- a/ballista/scheduler/src/state/execution_graph/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_graph/execution_stage.rs
@@ -1176,7 +1176,7 @@ fn get_stage_partitions(plan: Arc<dyn ExecutionPlan>) -> usize {
     plan.as_any()
         .downcast_ref::<ShuffleWriterExec>()
         .map(|shuffle_writer| shuffle_writer.input_partition_count())
-        .unwrap_or_else(|| plan.output_partitioning().partition_count())
+        .unwrap_or_else(|| plan.properties().output_partitioning().partition_count())
 }
 
 /// This data structure collects the partition locations for an `ExecutionStage`.

--- a/ballista/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/scheduler/src/state/execution_graph_dot.rs
@@ -281,12 +281,12 @@ aggr=[{}]",
     } else if let Some(exec) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
         format!(
             "CoalescePartitions [{}]",
-            format_partitioning(exec.output_partitioning())
+            format_partitioning(exec.properties().output_partitioning().clone())
         )
     } else if let Some(exec) = plan.as_any().downcast_ref::<RepartitionExec>() {
         format!(
             "RepartitionExec [{}]",
-            format_partitioning(exec.output_partitioning())
+            format_partitioning(exec.properties().output_partitioning().clone())
         )
     } else if let Some(exec) = plan.as_any().downcast_ref::<HashJoinExec>() {
         let join_expr = exec
@@ -323,24 +323,24 @@ filter_expr={}",
     } else if plan.as_any().downcast_ref::<MemoryExec>().is_some() {
         "MemoryExec".to_string()
     } else if let Some(exec) = plan.as_any().downcast_ref::<CsvExec>() {
-        let parts = exec.output_partitioning().partition_count();
+        let parts = exec.properties().output_partitioning().partition_count();
         format!(
             "CSV: {} [{} partitions]",
             get_file_scan(exec.base_config()),
             parts
         )
     } else if let Some(exec) = plan.as_any().downcast_ref::<NdJsonExec>() {
-        let parts = exec.output_partitioning().partition_count();
+        let parts = exec.properties().output_partitioning().partition_count();
         format!("JSON [{parts} partitions]")
     } else if let Some(exec) = plan.as_any().downcast_ref::<AvroExec>() {
-        let parts = exec.output_partitioning().partition_count();
+        let parts = exec.properties().output_partitioning().partition_count();
         format!(
             "Avro: {} [{} partitions]",
             get_file_scan(exec.base_config()),
             parts
         )
     } else if let Some(exec) = plan.as_any().downcast_ref::<ParquetExec>() {
-        let parts = exec.output_partitioning().partition_count();
+        let parts = exec.properties().output_partitioning().partition_count();
         format!(
             "Parquet: {} [{} partitions]",
             get_file_scan(exec.base_config()),

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::common::tree_node::{TreeNode, VisitRecursion};
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::datasource::listing::{ListingTable, ListingTableUrl};
 use datafusion::datasource::source_as_provider;
 use datafusion::error::DataFusionError;
@@ -399,7 +399,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
                     }
                 }
             }
-            Ok(VisitRecursion::Continue)
+            Ok(TreeNodeRecursion::Continue)
         })?;
 
         let plan = session_ctx.state().create_physical_plan(plan).await?;

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -827,7 +827,7 @@ async fn get_table(
             }
             "parquet" => {
                 let path = format!("{path}/{table}");
-                let format = ParquetFormat::default().with_enable_pruning(Some(true));
+                let format = ParquetFormat::default().with_enable_pruning(true);
 
                 (Arc::new(format), path, DEFAULT_PARQUET_EXTENSION)
             }
@@ -844,7 +844,6 @@ async fn get_table(
         collect_stat: true,
         table_partition_cols: vec![],
         file_sort_order: vec![],
-        file_type_write_options: None,
     };
 
     let url = ListingTableUrl::parse(path)?;
@@ -1042,7 +1041,8 @@ async fn get_expected_results(n: usize, path: &str) -> Result<Vec<RecordBatch>> 
                         // there's no support for casting from Utf8 to Decimal, so
                         // we'll cast from Utf8 to Float64 to Decimal for Decimal types
                         let inner_cast = Box::new(Expr::Cast(Cast::new(
-                            Box::new(trim(col(Field::name(field)))),
+                            // TODO
+                            Box::new(trim(vec![col(Field::name(field))])),
                             DataType::Float64,
                         )));
                         Expr::Cast(Cast::new(
@@ -1052,7 +1052,8 @@ async fn get_expected_results(n: usize, path: &str) -> Result<Vec<RecordBatch>> 
                         .alias(Field::name(field))
                     }
                     _ => Expr::Cast(Cast::new(
-                        Box::new(trim(col(Field::name(field)))),
+                        // TODO
+                        Box::new(trim(vec![col(Field::name(field))])),
                         Field::data_type(field).to_owned(),
                     ))
                     .alias(Field::name(field)),

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1583,6 +1583,7 @@ mod ballista_round_trip {
     use datafusion_proto::physical_plan::AsExecutionPlan;
     use std::env;
     use std::ops::Deref;
+    use datafusion::config::TableOptions;
 
     async fn round_trip_logical_plan(n: usize) -> Result<()> {
         let config = SessionConfig::new()
@@ -1608,7 +1609,7 @@ mod ballista_round_trip {
                 .has_header(false)
                 .file_extension(".tbl");
             let cfg = SessionConfig::new();
-            let listing_options = options.to_listing_options(&cfg);
+            let listing_options = options.to_listing_options(&cfg, TableOptions::default());
             let config = ListingTableConfig::new(path.clone())
                 .with_listing_options(listing_options)
                 .with_schema(Arc::new(schema));
@@ -1664,7 +1665,7 @@ mod ballista_round_trip {
                 .has_header(false)
                 .file_extension(".tbl");
             let cfg = SessionConfig::new();
-            let listing_options = options.to_listing_options(&cfg);
+            let listing_options = options.to_listing_options(&cfg, TableOptions::default());
             let config = ListingTableConfig::new(path.clone())
                 .with_listing_options(listing_options)
                 .with_schema(Arc::new(schema));

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1576,6 +1576,7 @@ mod tests {
 mod ballista_round_trip {
     use super::*;
     use ballista_core::serde::BallistaCodec;
+    use datafusion::config::TableOptions;
     use datafusion::datasource::listing::ListingTableUrl;
     use datafusion::execution::options::ReadOptions;
     use datafusion::physical_plan::ExecutionPlan;
@@ -1583,7 +1584,6 @@ mod ballista_round_trip {
     use datafusion_proto::physical_plan::AsExecutionPlan;
     use std::env;
     use std::ops::Deref;
-    use datafusion::config::TableOptions;
 
     async fn round_trip_logical_plan(n: usize) -> Result<()> {
         let config = SessionConfig::new()
@@ -1609,7 +1609,8 @@ mod ballista_round_trip {
                 .has_header(false)
                 .file_extension(".tbl");
             let cfg = SessionConfig::new();
-            let listing_options = options.to_listing_options(&cfg, TableOptions::default());
+            let listing_options =
+                options.to_listing_options(&cfg, TableOptions::default());
             let config = ListingTableConfig::new(path.clone())
                 .with_listing_options(listing_options)
                 .with_schema(Arc::new(schema));
@@ -1665,7 +1666,8 @@ mod ballista_round_trip {
                 .has_header(false)
                 .file_extension(".tbl");
             let cfg = SessionConfig::new();
-            let listing_options = options.to_listing_options(&cfg, TableOptions::default());
+            let listing_options =
+                options.to_listing_options(&cfg, TableOptions::default());
             let config = ListingTableConfig::new(path.clone())
                 .with_listing_options(listing_options)
                 .with_schema(Arc::new(schema));

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1041,7 +1041,6 @@ async fn get_expected_results(n: usize, path: &str) -> Result<Vec<RecordBatch>> 
                         // there's no support for casting from Utf8 to Decimal, so
                         // we'll cast from Utf8 to Float64 to Decimal for Decimal types
                         let inner_cast = Box::new(Expr::Cast(Cast::new(
-                            // TODO
                             Box::new(trim(vec![col(Field::name(field))])),
                             DataType::Float64,
                         )));
@@ -1052,7 +1051,6 @@ async fn get_expected_results(n: usize, path: &str) -> Result<Vec<RecordBatch>> 
                         .alias(Field::name(field))
                     }
                     _ => Expr::Cast(Cast::new(
-                        // TODO
                         Box::new(trim(vec![col(Field::name(field))])),
                         Field::data_type(field).to_owned(),
                     ))


### PR DESCRIPTION
# What changes are included in this PR?
Notable changes needed:
- Compute and provide ExecutionPlan::properties().
- Get rid of AbordOnDropMany and use SpawnedTasks instead.
- Serialize PhysicalExpr with datafusion_proto::physical_plan::to_proto::serialize_physical_expr.
- Update API usage of TreeNode.
- Adapt to removal of deprecated SessionContext::tables()
- Updated planner tests now that HashJoinExec can project.

