### PR TITLE
Remove HDFS support ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See the [architecture guide](docs/source/contributors-guide/architecture.md) for
 
 ## Features
 
-- Supports HDFS as well as cloud object stores. S3 is supported today and GCS and Azure support is planned.
+- Supports cloud object stores. S3 is supported today and GCS and Azure support is planned.
 - DataFrame and SQL APIs available from Python and Rust.
 - Clients can connect to a Ballista cluster using [Flight SQL][flight-sql].
 - JDBC support via Arrow Flight SQL JDBC Driver

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -43,7 +43,5 @@ tokio = "1.0"
 [features]
 azure = ["ballista-core/azure"]
 default = []
-hdfs = ["ballista-core/hdfs"]
-hdfs3 = ["ballista-core/hdfs3"]
 s3 = ["ballista-core/s3"]
 standalone = ["ballista-executor", "ballista-scheduler"]

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -39,9 +39,6 @@ docsrs = []
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = ["datafusion/force_hash_collisions"]
 gcs = ["object_store/gcp"]
-# Used to enable hdfs to be registered in the ObjectStoreRegistry by default
-hdfs = ["datafusion-objectstore-hdfs/hdfs"]
-hdfs3 = ["datafusion-objectstore-hdfs/hdfs3"]
 s3 = ["object_store/aws"]
 
 [dependencies]
@@ -53,7 +50,6 @@ bytes = "1.0"
 chrono = { version = "0.4", default-features = false }
 clap = { workspace = true }
 datafusion = { workspace = true }
-datafusion-objectstore-hdfs = { version = "0.1.4", default-features = false, optional = true }
 datafusion-proto = { workspace = true }
 datafusion-proto-common = { workspace = true }
 futures = "0.3"

--- a/ballista/core/src/object_store_registry/mod.rs
+++ b/ballista/core/src/object_store_registry/mod.rs
@@ -23,8 +23,6 @@ use datafusion::datasource::object_store::{
     DefaultObjectStoreRegistry, ObjectStoreRegistry,
 };
 use datafusion::execution::runtime_env::RuntimeConfig;
-#[cfg(any(feature = "hdfs", feature = "hdfs3"))]
-use datafusion_objectstore_hdfs::object_store::hdfs::HadoopFileSystem;
 #[cfg(feature = "s3")]
 use object_store::aws::AmazonS3Builder;
 #[cfg(feature = "azure")]
@@ -57,13 +55,6 @@ impl BallistaObjectStoreRegistry {
         &self,
         url: &Url,
     ) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
-        #[cfg(any(feature = "hdfs", feature = "hdfs3"))]
-        {
-            if let Some(store) = HadoopFileSystem::new(url.as_str()) {
-                return Ok(Arc::new(store));
-            }
-        }
-
         #[cfg(feature = "s3")]
         {
             if url.as_str().starts_with("s3://") {


### PR DESCRIPTION
... object store creation to be revisited

As part of effort outlined in https://github.com/apache/datafusion-ballista/pull/1066 and https://github.com/apache/datafusion-ballista/issues/1067 this PR removes HDFS support.

Relates to: https://github.com/apache/datafusion-ballista/pull/1066 & https://github.com/apache/datafusion-ballista/issues/1067

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
