### PR TITLE
Promote keda and flight-sql to optional features

### DIFF
--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -34,7 +34,7 @@ name = "ballista-scheduler"
 path = "src/bin/main.rs"
 
 [features]
-default = ["flight-sql"]
+default = []
 flight-sql = []
 prometheus-metrics = ["prometheus", "once_cell"]
 

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -36,6 +36,7 @@ path = "src/bin/main.rs"
 [features]
 default = []
 flight-sql = []
+keda-scaler = []
 prometheus-metrics = ["prometheus", "once_cell"]
 
 

--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -29,6 +29,7 @@ use std::{net::SocketAddr, sync::Arc};
 use crate::api::get_routes;
 use crate::cluster::BallistaCluster;
 use crate::config::SchedulerConfig;
+#[cfg(feature = "flight-sql")]
 use crate::flight_sql::FlightSqlServiceImpl;
 use crate::metrics::default_metrics_collector;
 use crate::scheduler_server::externalscaler::external_scaler_server::ExternalScalerServer;

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -44,12 +44,14 @@ use crate::state::task_manager::TaskLauncher;
 use crate::state::SchedulerState;
 
 // include the generated protobuf source as a submodule
+#[cfg(feature = "keda-scaler")]
 #[allow(clippy::all)]
 pub mod externalscaler {
     include!(concat!(env!("OUT_DIR"), "/externalscaler.rs"));
 }
 
 pub mod event;
+#[cfg(feature = "keda-scaler")]
 mod external_scaler;
 mod grpc;
 pub(crate) mod query_stage_scheduler;


### PR DESCRIPTION
Promote keda and flight-sql to optional features which are disabled by default, and probably removed to contrib folder at some point

relates to #1066 & #1067

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
