### PR TITLE
Ergonomic way to setup/configure `SessionContextExt`

### DIFF
--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -43,6 +43,8 @@ tokio = { workspace = true }
 url = { version = "2.5" }
 
 [dev-dependencies]
+ballista-executor = { path = "../executor", version = "0.12.0" }
+ballista-scheduler = { path = "../scheduler", version = "0.12.0" }
 ctor = { version = "0.2" }
 env_logger = { workspace = true }
 

--- a/ballista/client/src/extension.rs
+++ b/ballista/client/src/extension.rs
@@ -15,15 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub use ballista_core::utils::BallistaSessionConfigExt;
 use ballista_core::{
     config::BallistaConfig,
     serde::protobuf::{
         scheduler_grpc_client::SchedulerGrpcClient, CreateSessionParams, KeyValuePair,
     },
-    utils::{create_df_ctx_with_ballista_query_planner, create_grpc_client_connection},
+    utils::{create_grpc_client_connection, BallistaSessionStateExt},
 };
-use datafusion::{error::DataFusionError, prelude::SessionContext};
-use datafusion_proto::protobuf::LogicalPlanNode;
+use datafusion::{
+    error::DataFusionError, execution::SessionState, prelude::SessionContext,
+};
 use url::Url;
 
 const DEFAULT_SCHEDULER_PORT: u16 = 50050;
@@ -65,18 +67,130 @@ const DEFAULT_SCHEDULER_PORT: u16 = 50050;
 ///
 #[async_trait::async_trait]
 pub trait SessionContextExt {
-    /// Create a context for executing queries against a standalone Ballista scheduler instance
+    /// Creates a context for executing queries against a standalone Ballista scheduler instance
+    ///
     /// It wills start local ballista cluster with scheduler and executor.
     #[cfg(feature = "standalone")]
     async fn standalone() -> datafusion::error::Result<SessionContext>;
 
-    /// Create a context for executing queries against a remote Ballista scheduler instance
+    /// Creates a context for executing queries against a standalone Ballista scheduler instance
+    /// with custom session state.
+    ///
+    /// It wills start local ballista cluster with scheduler and executor.
+    #[cfg(feature = "standalone")]
+    async fn standalone_with_state(
+        state: SessionState,
+    ) -> datafusion::error::Result<SessionContext>;
+
+    /// Creates a context for executing queries against a remote Ballista scheduler instance
     async fn remote(url: &str) -> datafusion::error::Result<SessionContext>;
+
+    /// Creates a context for executing queries against a remote Ballista scheduler instance
+    /// with custom session state
+    async fn remote_with_state(
+        url: &str,
+        state: SessionState,
+    ) -> datafusion::error::Result<SessionContext>;
 }
 
 #[async_trait::async_trait]
 impl SessionContextExt for SessionContext {
+    async fn remote_with_state(
+        url: &str,
+        state: SessionState,
+    ) -> datafusion::error::Result<SessionContext> {
+        let config = state.ballista_config();
+
+        let scheduler_url = Extension::parse_url(url)?;
+        log::info!(
+            "Connecting to Ballista scheduler at {}",
+            scheduler_url.clone()
+        );
+        let remote_session_id =
+            Extension::setup_remote(config, scheduler_url.clone()).await?;
+        log::info!(
+            "Server side SessionContext created with session id: {}",
+            remote_session_id
+        );
+        let session_state =
+            state.upgrade_for_ballista(scheduler_url, remote_session_id)?;
+
+        Ok(SessionContext::new_with_state(session_state))
+    }
+
     async fn remote(url: &str) -> datafusion::error::Result<SessionContext> {
+        let config = BallistaConfig::new()
+            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
+        let scheduler_url = Extension::parse_url(url)?;
+        log::info!(
+            "Connecting to Ballista scheduler at {}",
+            scheduler_url.clone()
+        );
+        let remote_session_id =
+            Extension::setup_remote(config, scheduler_url.clone()).await?;
+        log::info!(
+            "Server side SessionContext created with session id: {}",
+            remote_session_id
+        );
+        let session_state =
+            SessionState::new_ballista_state(scheduler_url, remote_session_id)?;
+
+        Ok(SessionContext::new_with_state(session_state))
+    }
+
+    #[cfg(feature = "standalone")]
+    async fn standalone_with_state(
+        state: SessionState,
+    ) -> datafusion::error::Result<SessionContext> {
+        let config = state.ballista_config();
+
+        let codec_logical = state.config().ballista_logical_extension_codec();
+        let codec_physical = state.config().ballista_physical_extension_codec();
+
+        let ballista_codec =
+            ballista_core::serde::BallistaCodec::new(codec_logical, codec_physical);
+
+        let (remote_session_id, scheduler_url) =
+            Extension::setup_standalone(config, ballista_codec).await?;
+
+        let session_state =
+            state.upgrade_for_ballista(scheduler_url, remote_session_id.clone())?;
+
+        log::info!(
+            "Server side SessionContext created with session id: {}",
+            remote_session_id
+        );
+
+        Ok(SessionContext::new_with_state(session_state))
+    }
+
+    #[cfg(feature = "standalone")]
+    async fn standalone() -> datafusion::error::Result<Self> {
+        log::info!("Running in local mode. Scheduler will be run in-proc");
+        let config = BallistaConfig::new()
+            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
+
+        let ballista_codec = ballista_core::serde::BallistaCodec::default();
+
+        let (remote_session_id, scheduler_url) =
+            Extension::setup_standalone(config, ballista_codec).await?;
+
+        let session_state =
+            SessionState::new_ballista_state(scheduler_url, remote_session_id.clone())?;
+
+        log::info!(
+            "Server side SessionContext created with session id: {}",
+            remote_session_id
+        );
+
+        Ok(SessionContext::new_with_state(session_state))
+    }
+}
+
+struct Extension {}
+
+impl Extension {
+    fn parse_url(url: &str) -> datafusion::error::Result<String> {
         let url =
             Url::parse(url).map_err(|e| DataFusionError::Configuration(e.to_string()))?;
         let host = url.host().ok_or(DataFusionError::Configuration(
@@ -84,17 +198,69 @@ impl SessionContextExt for SessionContext {
         ))?;
         let port = url.port().unwrap_or(DEFAULT_SCHEDULER_PORT);
         let scheduler_url = format!("http://{}:{}", &host, port);
-        log::info!(
-            "Connecting to Ballista scheduler at {}",
-            scheduler_url.clone()
-        );
+
+        Ok(scheduler_url)
+    }
+
+    #[cfg(feature = "standalone")]
+    async fn setup_standalone(
+        config: BallistaConfig,
+        ballista_codec: ballista_core::serde::BallistaCodec<
+            datafusion_proto::protobuf::LogicalPlanNode,
+            datafusion_proto::protobuf::PhysicalPlanNode,
+        >,
+    ) -> datafusion::error::Result<(String, String)> {
+        let addr = ballista_scheduler::standalone::new_standalone_scheduler()
+            .await
+            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
+
+        let scheduler_url = format!("http://localhost:{}", addr.port());
+
+        let mut scheduler = loop {
+            match SchedulerGrpcClient::connect(scheduler_url.clone()).await {
+                Err(_) => {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                    log::info!("Attempting to connect to in-proc scheduler...");
+                }
+                Ok(scheduler) => break scheduler,
+            }
+        };
+
+        let remote_session_id = scheduler
+            .create_session(CreateSessionParams {
+                settings: config
+                    .settings()
+                    .iter()
+                    .map(|(k, v)| KeyValuePair {
+                        key: k.to_owned(),
+                        value: v.to_owned(),
+                    })
+                    .collect::<Vec<_>>(),
+            })
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+            .into_inner()
+            .session_id;
+
+        let concurrent_tasks = config.default_standalone_parallelism();
+        ballista_executor::new_standalone_executor(
+            scheduler,
+            concurrent_tasks,
+            ballista_codec,
+        )
+        .await
+        .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
+
+        Ok((remote_session_id, scheduler_url))
+    }
+
+    async fn setup_remote(
+        config: BallistaConfig,
+        scheduler_url: String,
+    ) -> datafusion::error::Result<String> {
         let connection = create_grpc_client_connection(scheduler_url.clone())
             .await
             .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-
-        let config = BallistaConfig::builder()
-            .build()
-            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
 
         let limit = config.default_grpc_client_max_message_size();
         let mut scheduler = SchedulerGrpcClient::new(connection)
@@ -117,87 +283,6 @@ impl SessionContextExt for SessionContext {
             .into_inner()
             .session_id;
 
-        log::info!(
-            "Server side SessionContext created with session id: {}",
-            remote_session_id
-        );
-
-        let ctx = {
-            create_df_ctx_with_ballista_query_planner::<LogicalPlanNode>(
-                scheduler_url,
-                remote_session_id,
-                &config,
-            )
-        };
-
-        Ok(ctx)
-    }
-
-    #[cfg(feature = "standalone")]
-    async fn standalone() -> datafusion::error::Result<Self> {
-        use ballista_core::serde::BallistaCodec;
-        use datafusion_proto::protobuf::PhysicalPlanNode;
-
-        log::info!("Running in local mode. Scheduler will be run in-proc");
-
-        let addr = ballista_scheduler::standalone::new_standalone_scheduler()
-            .await
-            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
-
-        let scheduler_url = format!("http://localhost:{}", addr.port());
-        let mut scheduler = loop {
-            match SchedulerGrpcClient::connect(scheduler_url.clone()).await {
-                Err(_) => {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-                    log::info!("Attempting to connect to in-proc scheduler...");
-                }
-                Ok(scheduler) => break scheduler,
-            }
-        };
-        let config = BallistaConfig::builder()
-            .build()
-            .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
-        let remote_session_id = scheduler
-            .create_session(CreateSessionParams {
-                settings: config
-                    .settings()
-                    .iter()
-                    .map(|(k, v)| KeyValuePair {
-                        key: k.to_owned(),
-                        value: v.to_owned(),
-                    })
-                    .collect::<Vec<_>>(),
-            })
-            .await
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-            .into_inner()
-            .session_id;
-
-        log::info!(
-            "Server side SessionContext created with session id: {}",
-            remote_session_id
-        );
-
-        let ctx = {
-            create_df_ctx_with_ballista_query_planner::<LogicalPlanNode>(
-                scheduler_url,
-                remote_session_id,
-                &config,
-            )
-        };
-
-        let default_codec: BallistaCodec<LogicalPlanNode, PhysicalPlanNode> =
-            BallistaCodec::default();
-
-        let concurrent_tasks = config.default_standalone_parallelism();
-        ballista_executor::new_standalone_executor(
-            scheduler,
-            concurrent_tasks,
-            default_codec,
-        )
-        .await
-        .map_err(|e| DataFusionError::Configuration(e.to_string()))?;
-
-        Ok(ctx)
+        Ok(remote_session_id)
     }
 }

--- a/ballista/client/tests/setup.rs
+++ b/ballista/client/tests/setup.rs
@@ -1,0 +1,407 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod common;
+
+#[cfg(test)]
+mod remote {
+    use ballista::{
+        extension::{BallistaSessionConfigExt, SessionContextExt},
+        prelude::BALLISTA_JOB_NAME,
+    };
+    use datafusion::{
+        assert_batches_eq,
+        execution::SessionStateBuilder,
+        prelude::{SessionConfig, SessionContext},
+    };
+
+    #[tokio::test]
+    async fn should_execute_sql_show_with_custom_state() -> datafusion::error::Result<()>
+    {
+        let (host, port) = crate::common::setup_test_cluster().await;
+        let url = format!("df://{host}:{port}");
+        let state = SessionStateBuilder::new().with_default_features().build();
+
+        let test_data = crate::common::example_test_data();
+        let ctx: SessionContext = SessionContext::remote_with_state(&url, state).await?;
+
+        ctx.register_parquet(
+            "test",
+            &format!("{test_data}/alltypes_plain.parquet"),
+            Default::default(),
+        )
+        .await?;
+
+        let result = ctx
+            .sql("select string_col, timestamp_col from test where id > 4")
+            .await?
+            .collect()
+            .await?;
+        let expected = [
+            "+------------+---------------------+",
+            "| string_col | timestamp_col       |",
+            "+------------+---------------------+",
+            "| 31         | 2009-03-01T00:01:00 |",
+            "| 30         | 2009-04-01T00:00:00 |",
+            "| 31         | 2009-04-01T00:01:00 |",
+            "+------------+---------------------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_execute_sql_set_configs() -> datafusion::error::Result<()> {
+        let (host, port) = crate::common::setup_test_cluster().await;
+        let url = format!("df://{host}:{port}");
+
+        let session_config = SessionConfig::new_with_ballista()
+            .with_information_schema(true)
+            .set_str(BALLISTA_JOB_NAME, "Super Cool Ballista App");
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config)
+            .build();
+
+        let ctx: SessionContext = SessionContext::remote_with_state(&url, state).await?;
+
+        let result = ctx
+            .sql("select name, value from information_schema.df_settings where name like 'ballista.job.name' order by name limit 1")
+            .await?
+            .collect()
+            .await?;
+
+        let expected = [
+            "+-------------------+-------------------------+",
+            "| name              | value                   |",
+            "+-------------------+-------------------------+",
+            "| ballista.job.name | Super Cool Ballista App |",
+            "+-------------------+-------------------------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "standalone")]
+mod standalone {
+
+    use std::sync::{atomic::AtomicBool, Arc};
+
+    use ballista::{
+        extension::{BallistaSessionConfigExt, SessionContextExt},
+        prelude::BALLISTA_JOB_NAME,
+    };
+    use ballista_core::{
+        config::BALLISTA_PLANNER_OVERRIDE, serde::BallistaPhysicalExtensionCodec,
+    };
+    use datafusion::{
+        assert_batches_eq,
+        common::exec_err,
+        execution::{context::QueryPlanner, SessionState, SessionStateBuilder},
+        logical_expr::LogicalPlan,
+        physical_plan::ExecutionPlan,
+        prelude::{SessionConfig, SessionContext},
+    };
+    use datafusion_proto::{
+        logical_plan::LogicalExtensionCodec, physical_plan::PhysicalExtensionCodec,
+    };
+
+    #[tokio::test]
+    async fn should_execute_sql_set_configs() -> datafusion::error::Result<()> {
+        let session_config = SessionConfig::new_with_ballista()
+            .with_information_schema(true)
+            .set_str(BALLISTA_JOB_NAME, "Super Cool Ballista App");
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config)
+            .build();
+
+        let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
+
+        let result = ctx
+            .sql("select name, value from information_schema.df_settings where name like 'ballista.job.name' order by name limit 1")
+            .await?
+            .collect()
+            .await?;
+
+        let expected = [
+            "+-------------------+-------------------------+",
+            "| name              | value                   |",
+            "+-------------------+-------------------------+",
+            "| ballista.job.name | Super Cool Ballista App |",
+            "+-------------------+-------------------------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+
+        Ok(())
+    }
+
+    // we testing if we can override default logical codec
+    // in this specific test codec will throw exception which will
+    // fail the query.
+    #[tokio::test]
+    async fn should_set_logical_codec() -> datafusion::error::Result<()> {
+        let test_data = crate::common::example_test_data();
+        let codec = Arc::new(BadLogicalCodec::default());
+
+        let session_config = SessionConfig::new_with_ballista()
+            .with_information_schema(true)
+            .with_ballista_logical_extension_codec(codec.clone());
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config)
+            .build();
+
+        let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
+
+        ctx.register_parquet(
+            "test",
+            &format!("{test_data}/alltypes_plain.parquet"),
+            Default::default(),
+        )
+        .await?;
+
+        let write_dir = tempfile::tempdir().expect("temporary directory to be created");
+        let write_dir_path = write_dir
+            .path()
+            .to_str()
+            .expect("path to be converted to str");
+
+        let result = ctx
+            .sql("select * from test")
+            .await?
+            .write_parquet(write_dir_path, Default::default(), Default::default())
+            .await;
+
+        // this codec should query fail
+        assert!(result.is_err());
+        assert!(codec.invoked.load(std::sync::atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    // tests if we can correctly set physical codec
+    #[tokio::test]
+    async fn should_set_physical_codec() -> datafusion::error::Result<()> {
+        let test_data = crate::common::example_test_data();
+        let physical_codec = Arc::new(MockPhysicalCodec::default());
+        let session_config = SessionConfig::new_with_ballista()
+            .with_information_schema(true)
+            .with_ballista_physical_extension_codec(physical_codec.clone());
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config)
+            .build();
+
+        let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
+
+        ctx.register_parquet(
+            "test",
+            &format!("{test_data}/alltypes_plain.parquet"),
+            Default::default(),
+        )
+        .await?;
+
+        let _result = ctx
+            .sql("select string_col, timestamp_col from test where id > 4")
+            .await?
+            .collect()
+            .await;
+
+        assert!(physical_codec
+            .invoked
+            .load(std::sync::atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    // check
+    #[tokio::test]
+    async fn should_override_planner() -> datafusion::error::Result<()> {
+        let session_config = SessionConfig::new_with_ballista()
+            .with_information_schema(true)
+            .set_str(BALLISTA_PLANNER_OVERRIDE, "false");
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config)
+            .with_query_planner(Arc::new(BadPlanner::default()))
+            .build();
+
+        let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
+
+        let result = ctx.sql("SELECT 1").await?.collect().await;
+
+        assert!(result.is_err());
+
+        let session_config = SessionConfig::new_with_ballista()
+            .with_information_schema(true)
+            .set_str(BALLISTA_PLANNER_OVERRIDE, "true");
+
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_config(session_config)
+            .with_query_planner(Arc::new(BadPlanner::default()))
+            .build();
+
+        let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
+
+        let result = ctx.sql("SELECT 1").await?.collect().await;
+
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[derive(Debug, Default)]
+    struct BadLogicalCodec {
+        invoked: AtomicBool,
+    }
+
+    impl LogicalExtensionCodec for BadLogicalCodec {
+        fn try_decode(
+            &self,
+            _buf: &[u8],
+            _inputs: &[datafusion::logical_expr::LogicalPlan],
+            _ctx: &SessionContext,
+        ) -> datafusion::error::Result<datafusion::logical_expr::Extension> {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            exec_err!("this codec does not work")
+        }
+
+        fn try_encode(
+            &self,
+            _node: &datafusion::logical_expr::Extension,
+            _buf: &mut Vec<u8>,
+        ) -> datafusion::error::Result<()> {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            exec_err!("this codec does not work")
+        }
+
+        fn try_decode_table_provider(
+            &self,
+            _buf: &[u8],
+            _table_ref: &datafusion::sql::TableReference,
+            _schema: datafusion::arrow::datatypes::SchemaRef,
+            _ctx: &SessionContext,
+        ) -> datafusion::error::Result<
+            std::sync::Arc<dyn datafusion::catalog::TableProvider>,
+        > {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            exec_err!("this codec does not work")
+        }
+
+        fn try_encode_table_provider(
+            &self,
+            _table_ref: &datafusion::sql::TableReference,
+            _node: std::sync::Arc<dyn datafusion::catalog::TableProvider>,
+            _buf: &mut Vec<u8>,
+        ) -> datafusion::error::Result<()> {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            exec_err!("this codec does not work")
+        }
+
+        fn try_decode_file_format(
+            &self,
+            _buf: &[u8],
+            _ctx: &SessionContext,
+        ) -> datafusion::error::Result<
+            Arc<dyn datafusion::datasource::file_format::FileFormatFactory>,
+        > {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            exec_err!("this codec does not work")
+        }
+
+        fn try_encode_file_format(
+            &self,
+            _buf: &mut Vec<u8>,
+            _node: Arc<dyn datafusion::datasource::file_format::FileFormatFactory>,
+        ) -> datafusion::error::Result<()> {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            //Ok(())
+            exec_err!("this codec does not work")
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockPhysicalCodec {
+        invoked: AtomicBool,
+        codec: Arc<dyn PhysicalExtensionCodec>,
+    }
+
+    impl Default for MockPhysicalCodec {
+        fn default() -> Self {
+            Self {
+                invoked: AtomicBool::new(false),
+                codec: Arc::new(BallistaPhysicalExtensionCodec::default()),
+            }
+        }
+    }
+
+    impl PhysicalExtensionCodec for MockPhysicalCodec {
+        fn try_decode(
+            &self,
+            buf: &[u8],
+            inputs: &[Arc<dyn datafusion::physical_plan::ExecutionPlan>],
+            registry: &dyn datafusion::execution::FunctionRegistry,
+        ) -> datafusion::error::Result<Arc<dyn datafusion::physical_plan::ExecutionPlan>>
+        {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            self.codec.try_decode(buf, inputs, registry)
+        }
+
+        fn try_encode(
+            &self,
+            node: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+            buf: &mut Vec<u8>,
+        ) -> datafusion::error::Result<()> {
+            self.invoked
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            self.codec.try_encode(node, buf)
+        }
+    }
+
+    #[derive(Default)]
+    struct BadPlanner {}
+
+    #[async_trait::async_trait]
+    impl QueryPlanner for BadPlanner {
+        async fn create_physical_plan(
+            &self,
+            _logical_plan: &LogicalPlan,
+            _session_state: &SessionState,
+        ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+            exec_err!("does not work")
+        }
+    }
+}

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -43,6 +43,11 @@ pub const BALLISTA_REPARTITION_WINDOWS: &str = "ballista.repartition.windows";
 pub const BALLISTA_PARQUET_PRUNING: &str = "ballista.parquet.pruning";
 pub const BALLISTA_COLLECT_STATISTICS: &str = "ballista.collect_statistics";
 pub const BALLISTA_STANDALONE_PARALLELISM: &str = "ballista.standalone.parallelism";
+/// If set to false, planner will not be overridden by ballista.
+/// This allows user to replace ballista planner
+// this is a bit of a hack, as we can't detect if there is a
+// custom planner provided
+pub const BALLISTA_PLANNER_OVERRIDE: &str = "ballista.planner.override";
 
 pub const BALLISTA_WITH_INFORMATION_SCHEMA: &str = "ballista.with_information_schema";
 
@@ -216,6 +221,10 @@ impl BallistaConfig {
                              "Configuration for max message size in gRPC clients".to_string(),
                              DataType::UInt64,
                              Some((16 * 1024 * 1024).to_string())),
+            ConfigEntry::new(BALLISTA_PLANNER_OVERRIDE.to_string(),
+                             "Disable overriding provided planner".to_string(),
+                             DataType::Boolean,
+                             Some((true).to_string())),
         ];
         entries
             .iter()
@@ -269,6 +278,10 @@ impl BallistaConfig {
 
     pub fn default_with_information_schema(&self) -> bool {
         self.get_bool_setting(BALLISTA_WITH_INFORMATION_SCHEMA)
+    }
+
+    pub fn planner_override(&self) -> bool {
+        self.get_bool_setting(BALLISTA_PLANNER_OVERRIDE)
     }
 
     fn get_usize_setting(&self, key: &str) -> usize {

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -245,7 +245,7 @@ impl LogicalExtensionCodec for BallistaLogicalExtensionCodec {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BallistaPhysicalExtensionCodec {}
 
 impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1092.

# Rationale for this change

This change provides ergonomic way to configure SessionContextExt, similar to DataFusion context setup from using provided SessionStore.

# What changes are included in this PR?

This change provides two new methods in `SessionContextExt` `async fn standalone_with_state(state: SessionState)` and `async fn remote_with_state(url: &str,state: SessionState)`
Which accepts pre configured `SessionState` as parameter. `SessionState` should be configured in the same way like when `SessionContext` is configured in DataFusion.

```rust
let state = SessionStateBuilder::new().with_default_features().build();
let ctx: SessionContext = SessionContext::remote_with_state(&url, state).await?;
```

This change also exposes a `BallistaSessionConfigExt` which provides method to configure ballista specific settings like, `BallistaConfiguration`, codecs or even `QueryPlanner`.

```rust
use ballista_client::extension::BallistaSessionConfigExt;

let session_config = SessionConfig::new_with_ballista()
    .with_information_schema(true)
    .set_str(BALLISTA_JOB_NAME, "Super Cool Ballista App");

let state = SessionStateBuilder::new()
    .with_default_features()
    .with_config(session_config)
    .build();

let ctx: SessionContext = SessionContext::remote_with_state(&url, state).await?;
```

`LogicalExtensionCodec` and `PhysicalExtensionCodec` can be changed as well:

```rust
use ballista_client::extension::BallistaSessionConfigExt;
let logical_codec = Arc::new(BadLogicalCodec::default());
let physical_codec = Arc::new(MockPhysicalCodec::default());
let session_config = SessionConfig::new_with_ballista()
    .with_information_schema(true)
    .with_ballista_physical_extension_codec(physical_codec.clone())
    .with_ballista_logical_extension_codec(logical_codec.clone())
    ;
let state = SessionStateBuilder::new()
    .with_default_features()
    .with_config(session_config)
    .build();

let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
```

In this case logical and physical codec will be also be propagated to standalone.

Lastly, BallistaQueryPlanner can be replaced: 

```rust
let session_config = SessionConfig::new_with_ballista()
    .with_information_schema(true)
    .set_str(BALLISTA_PLANNER_OVERRIDE, "false");

let state = SessionStateBuilder::new()
    .with_default_features()
    .with_config(session_config)
    .with_query_planner(Arc::new(BadPlanner::default()))
    .build();

let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
```

At the moment there is a hacky way telling ballista not to override provided planner with `.set_str(BALLISTA_PLANNER_OVERRIDE, "false");` as it is not possible to detect if the planner is changed.

# Are there any user-facing changes?

Introduction of two new methods and one extension to new functionality, no braking change

Notes: 

- Object store is not be set automatically anymore, will look into `ballista_core::object_store_registry::with_object_store_registry` deprecation in follow up commits when we expose configuration on scheduler and executor API
- `standalone_with_state` may change slightly adding executor related configuration