### PR TITLE
Executor configuration extended ..

### DIFF
--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -47,9 +47,12 @@ ballista-executor = { path = "../executor", version = "0.12.0" }
 ballista-scheduler = { path = "../scheduler", version = "0.12.0" }
 ctor = { version = "0.2" }
 env_logger = { workspace = true }
+object_store = { workspace = true, features = ["aws"] }
+testcontainers-modules = { version = "0.11", features = ["minio"] }
 
 [features]
 azure = ["ballista-core/azure"]
-default = ["standalone"]
+default = ["standalone", "testcontainers"]
 s3 = ["ballista-core/s3"]
 standalone = ["ballista-executor", "ballista-scheduler"]
+testcontainers = []

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -52,7 +52,7 @@ testcontainers-modules = { version = "0.11", features = ["minio"] }
 
 [features]
 azure = ["ballista-core/azure"]
-default = ["testcontainers"]
+default = []
 s3 = ["ballista-core/s3"]
 standalone = ["ballista-executor", "ballista-scheduler"]
 testcontainers = []

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -52,7 +52,7 @@ testcontainers-modules = { version = "0.11", features = ["minio"] }
 
 [features]
 azure = ["ballista-core/azure"]
-default = ["standalone", "testcontainers"]
+default = ["testcontainers"]
 s3 = ["ballista-core/s3"]
 standalone = ["ballista-executor", "ballista-scheduler"]
 testcontainers = []

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -50,6 +50,6 @@ env_logger = { workspace = true }
 
 [features]
 azure = ["ballista-core/azure"]
-default = []
+default = ["standalone"]
 s3 = ["ballista-core/s3"]
 standalone = ["ballista-executor", "ballista-scheduler"]

--- a/ballista/client/src/extension.rs
+++ b/ballista/client/src/extension.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub use ballista_core::utils::BallistaSessionConfigExt;
+pub use ballista_core::utils::SessionConfigExt;
 use ballista_core::{
     config::BallistaConfig,
     serde::protobuf::{
         scheduler_grpc_client::SchedulerGrpcClient, CreateSessionParams, KeyValuePair,
     },
-    utils::{create_grpc_client_connection, BallistaSessionStateExt},
+    utils::{create_grpc_client_connection, SessionStateExt},
 };
 use datafusion::{
     error::DataFusionError, execution::SessionState, prelude::SessionContext,

--- a/ballista/client/tests/object_store.rs
+++ b/ballista/client/tests/object_store.rs
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! # Object Store Support
+//!
+//! Tests demonstrate how to setup object stores with ballista.
+//!
+//! Test depend on Minio testcontainer acting as S3 object
+//! store.
+//!
+//! Tesctoncainers require docker to run.
+
+mod common;
+
+#[cfg(test)]
+#[cfg(feature = "standalone")]
+#[cfg(feature = "testcontainers")]
+mod standalone {
+
+    use ballista::extension::SessionContextExt;
+    use datafusion::{assert_batches_eq, prelude::SessionContext};
+    use datafusion::{
+        error::DataFusionError,
+        execution::{
+            runtime_env::{RuntimeConfig, RuntimeEnv},
+            SessionStateBuilder,
+        },
+    };
+    use std::sync::Arc;
+    use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+    #[tokio::test]
+    async fn should_execute_sql_write() -> datafusion::error::Result<()> {
+        let container = crate::common::create_minio_container();
+        let node = container.start().await.unwrap();
+
+        node.exec(crate::common::create_bucket_command())
+            .await
+            .unwrap();
+
+        let port = node.get_host_port_ipv4(9000).await.unwrap();
+
+        let object_store = crate::common::create_s3_store(port)
+            .map_err(|e| DataFusionError::External(e.into()))?;
+
+        let test_data = crate::common::example_test_data();
+        let config = RuntimeConfig::new();
+        let runtime_env = RuntimeEnv::new(config)?;
+
+        runtime_env.register_object_store(
+            &format!("s3://{}", crate::common::BUCKET)
+                .as_str()
+                .try_into()
+                .unwrap(),
+            Arc::new(object_store),
+        );
+        let state = SessionStateBuilder::new()
+            .with_runtime_env(runtime_env.into())
+            .build();
+
+        let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
+        ctx.register_parquet(
+            "test",
+            &format!("{test_data}/alltypes_plain.parquet"),
+            Default::default(),
+        )
+        .await?;
+
+        let write_dir_path =
+            &format!("s3://{}/write_test.parquet", crate::common::BUCKET);
+
+        ctx.sql("select * from test")
+            .await?
+            .write_parquet(write_dir_path, Default::default(), Default::default())
+            .await?;
+
+        ctx.register_parquet("written_table", write_dir_path, Default::default())
+            .await?;
+
+        let result = ctx
+            .sql("select id, string_col, timestamp_col from written_table where id > 4")
+            .await?
+            .collect()
+            .await?;
+        let expected = [
+            "+----+------------+---------------------+",
+            "| id | string_col | timestamp_col       |",
+            "+----+------------+---------------------+",
+            "| 5  | 31         | 2009-03-01T00:01:00 |",
+            "| 6  | 30         | 2009-04-01T00:00:00 |",
+            "| 7  | 31         | 2009-04-01T00:01:00 |",
+            "+----+------------+---------------------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "testcontainers")]
+mod remote {
+
+    use ballista::extension::SessionContextExt;
+    use datafusion::{assert_batches_eq, prelude::SessionContext};
+    use datafusion::{
+        error::DataFusionError,
+        execution::{
+            runtime_env::{RuntimeConfig, RuntimeEnv},
+            SessionStateBuilder,
+        },
+    };
+    use std::sync::Arc;
+    use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+    #[tokio::test]
+    async fn should_execute_sql_write() -> datafusion::error::Result<()> {
+        let test_data = crate::common::example_test_data();
+
+        let container = crate::common::create_minio_container();
+        let node = container.start().await.unwrap();
+
+        node.exec(crate::common::create_bucket_command())
+            .await
+            .unwrap();
+
+        let port = node.get_host_port_ipv4(9000).await.unwrap();
+
+        let object_store = crate::common::create_s3_store(port)
+            .map_err(|e| DataFusionError::External(e.into()))?;
+
+        let config = RuntimeConfig::new();
+        let runtime_env = RuntimeEnv::new(config)?;
+
+        runtime_env.register_object_store(
+            &format!("s3://{}", crate::common::BUCKET)
+                .as_str()
+                .try_into()
+                .unwrap(),
+            Arc::new(object_store),
+        );
+        let state = SessionStateBuilder::new()
+            .with_runtime_env(runtime_env.into())
+            .build();
+
+        let (host, port) =
+            crate::common::setup_test_cluster_with_state(state.clone()).await;
+        let url = format!("df://{host}:{port}");
+
+        let ctx: SessionContext = SessionContext::remote_with_state(&url, state).await?;
+        ctx.register_parquet(
+            "test",
+            &format!("{test_data}/alltypes_plain.parquet"),
+            Default::default(),
+        )
+        .await?;
+
+        let write_dir_path =
+            &format!("s3://{}/write_test.parquet", crate::common::BUCKET);
+
+        ctx.sql("select * from test")
+            .await?
+            .write_parquet(write_dir_path, Default::default(), Default::default())
+            .await?;
+
+        ctx.register_parquet("written_table", write_dir_path, Default::default())
+            .await?;
+
+        let result = ctx
+            .sql("select id, string_col, timestamp_col from written_table where id > 4")
+            .await?
+            .collect()
+            .await?;
+        let expected = [
+            "+----+------------+---------------------+",
+            "| id | string_col | timestamp_col       |",
+            "+----+------------+---------------------+",
+            "| 5  | 31         | 2009-03-01T00:01:00 |",
+            "| 6  | 30         | 2009-04-01T00:00:00 |",
+            "| 7  | 31         | 2009-04-01T00:01:00 |",
+            "+----+------------+---------------------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+        Ok(())
+    }
+}

--- a/ballista/client/tests/setup.rs
+++ b/ballista/client/tests/setup.rs
@@ -20,7 +20,7 @@ mod common;
 #[cfg(test)]
 mod remote {
     use ballista::{
-        extension::{BallistaSessionConfigExt, SessionContextExt},
+        extension::{SessionConfigExt, SessionContextExt},
         prelude::BALLISTA_JOB_NAME,
     };
     use datafusion::{
@@ -109,7 +109,7 @@ mod standalone {
     use std::sync::{atomic::AtomicBool, Arc};
 
     use ballista::{
-        extension::{BallistaSessionConfigExt, SessionContextExt},
+        extension::{SessionConfigExt, SessionContextExt},
         prelude::BALLISTA_JOB_NAME,
     };
     use ballista_core::serde::BallistaPhysicalExtensionCodec;

--- a/ballista/client/tests/setup.rs
+++ b/ballista/client/tests/setup.rs
@@ -112,9 +112,7 @@ mod standalone {
         extension::{BallistaSessionConfigExt, SessionContextExt},
         prelude::BALLISTA_JOB_NAME,
     };
-    use ballista_core::{
-        config::BALLISTA_PLANNER_OVERRIDE, serde::BallistaPhysicalExtensionCodec,
-    };
+    use ballista_core::serde::BallistaPhysicalExtensionCodec;
     use datafusion::{
         assert_batches_eq,
         common::exec_err,
@@ -243,12 +241,11 @@ mod standalone {
     async fn should_override_planner() -> datafusion::error::Result<()> {
         let session_config = SessionConfig::new_with_ballista()
             .with_information_schema(true)
-            .set_str(BALLISTA_PLANNER_OVERRIDE, "false");
+            .with_ballista_query_planner(Arc::new(BadPlanner::default()));
 
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(session_config)
-            .with_query_planner(Arc::new(BadPlanner::default()))
             .build();
 
         let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;
@@ -257,14 +254,12 @@ mod standalone {
 
         assert!(result.is_err());
 
-        let session_config = SessionConfig::new_with_ballista()
-            .with_information_schema(true)
-            .set_str(BALLISTA_PLANNER_OVERRIDE, "true");
+        let session_config =
+            SessionConfig::new_with_ballista().with_information_schema(true);
 
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(session_config)
-            .with_query_planner(Arc::new(BadPlanner::default()))
             .build();
 
         let ctx: SessionContext = SessionContext::standalone_with_state(state).await?;

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -43,11 +43,6 @@ pub const BALLISTA_REPARTITION_WINDOWS: &str = "ballista.repartition.windows";
 pub const BALLISTA_PARQUET_PRUNING: &str = "ballista.parquet.pruning";
 pub const BALLISTA_COLLECT_STATISTICS: &str = "ballista.collect_statistics";
 pub const BALLISTA_STANDALONE_PARALLELISM: &str = "ballista.standalone.parallelism";
-/// If set to false, planner will not be overridden by ballista.
-/// This allows user to replace ballista planner
-// this is a bit of a hack, as we can't detect if there is a
-// custom planner provided
-pub const BALLISTA_PLANNER_OVERRIDE: &str = "ballista.planner.override";
 
 pub const BALLISTA_WITH_INFORMATION_SCHEMA: &str = "ballista.with_information_schema";
 
@@ -221,10 +216,6 @@ impl BallistaConfig {
                              "Configuration for max message size in gRPC clients".to_string(),
                              DataType::UInt64,
                              Some((16 * 1024 * 1024).to_string())),
-            ConfigEntry::new(BALLISTA_PLANNER_OVERRIDE.to_string(),
-                             "Disable overriding provided planner".to_string(),
-                             DataType::Boolean,
-                             Some((true).to_string())),
         ];
         entries
             .iter()
@@ -278,10 +269,6 @@ impl BallistaConfig {
 
     pub fn default_with_information_schema(&self) -> bool {
         self.get_bool_setting(BALLISTA_WITH_INFORMATION_SCHEMA)
-    }
-
-    pub fn planner_override(&self) -> bool {
-        self.get_bool_setting(BALLISTA_PLANNER_OVERRIDE)
     }
 
     fn get_usize_setting(&self, key: &str) -> usize {

--- a/ballista/core/src/lib.rs
+++ b/ballista/core/src/lib.rs
@@ -16,6 +16,10 @@
 // under the License.
 
 #![doc = include_str!("../README.md")]
+
+use std::sync::Arc;
+
+use datafusion::{execution::runtime_env::RuntimeEnv, prelude::SessionConfig};
 pub const BALLISTA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn print_version() {
@@ -33,3 +37,23 @@ pub mod utils;
 
 #[macro_use]
 pub mod serde;
+
+///
+/// [RuntimeProducer] is a factory which creates runtime [RuntimeEnv]
+/// from [SessionConfig]. As [SessionConfig] will be propagated
+/// from client to executors, this provides possibility to
+/// create [RuntimeEnv] components and configure them according to
+/// [SessionConfig] or some of its config extension
+///
+/// It is intended to be used with executor configuration
+///
+pub type RuntimeProducer = Arc<
+    dyn Fn(&SessionConfig) -> datafusion::error::Result<Arc<RuntimeEnv>> + Send + Sync,
+>;
+///
+/// [ConfigProducer] is a factory which can create [SessionConfig], with
+/// additional extension or configuration codecs
+///
+/// It is intended to be used with executor configuration
+///
+pub type ConfigProducer = Arc<dyn Fn() -> SessionConfig + Send + Sync>;

--- a/ballista/core/src/object_store_registry/mod.rs
+++ b/ballista/core/src/object_store_registry/mod.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use url::Url;
 
 /// Get a RuntimeConfig with specific ObjectStoreRegistry
+// TODO: #[deprecated] this method
 pub fn with_object_store_registry(config: RuntimeConfig) -> RuntimeConfig {
     let registry = Arc::new(BallistaObjectStoreRegistry::default());
     config.with_object_store_registry(registry)

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -89,7 +89,7 @@ impl Default for BallistaCodec {
     fn default() -> Self {
         Self {
             logical_extension_codec: Arc::new(BallistaLogicalExtensionCodec::default()),
-            physical_extension_codec: Arc::new(BallistaPhysicalExtensionCodec {}),
+            physical_extension_codec: Arc::new(BallistaPhysicalExtensionCodec::default()),
             logical_plan_repr: PhantomData,
             physical_plan_repr: PhantomData,
         }

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -17,12 +17,13 @@
 
 use chrono::{TimeZone, Utc};
 use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion::execution::runtime_env::RuntimeEnv;
+
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion::physical_plan::metrics::{
     Count, Gauge, MetricValue, MetricsSet, Time, Timestamp,
 };
 use datafusion::physical_plan::{ExecutionPlan, Metric};
+use datafusion::prelude::SessionConfig;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use std::collections::HashMap;
@@ -37,6 +38,7 @@ use crate::serde::scheduler::{
 };
 
 use crate::serde::{protobuf, BallistaCodec};
+use crate::RuntimeProducer;
 use protobuf::{operator_metric, NamedCount, NamedGauge, NamedTime};
 
 impl TryInto<Action> for protobuf::Action {
@@ -281,17 +283,17 @@ impl Into<ExecutorData> for protobuf::ExecutorData {
 
 pub fn get_task_definition<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>(
     task: protobuf::TaskDefinition,
-    runtime: Arc<RuntimeEnv>,
+    produce_runtime: RuntimeProducer,
+    session_config: SessionConfig,
     scalar_functions: HashMap<String, Arc<ScalarUDF>>,
     aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
     window_functions: HashMap<String, Arc<WindowUDF>>,
     codec: BallistaCodec<T, U>,
 ) -> Result<TaskDefinition, BallistaError> {
-    let mut props = HashMap::new();
+    let mut session_config = session_config;
     for kv_pair in task.props {
-        props.insert(kv_pair.key, kv_pair.value);
+        session_config = session_config.set_str(&kv_pair.key, &kv_pair.value);
     }
-    let props = Arc::new(props);
 
     let mut task_scalar_functions = HashMap::new();
     let mut task_aggregate_functions = HashMap::new();
@@ -311,7 +313,7 @@ pub fn get_task_definition<T: 'static + AsLogicalPlan, U: 'static + AsExecutionP
         aggregate_functions: task_aggregate_functions,
         window_functions: task_window_functions,
     });
-
+    let runtime = produce_runtime(&session_config)?;
     let encoded_plan = task.plan.as_slice();
     let plan: Arc<dyn ExecutionPlan> = U::try_decode(encoded_plan).and_then(|proto| {
         proto.try_into_physical_plan(
@@ -340,7 +342,7 @@ pub fn get_task_definition<T: 'static + AsLogicalPlan, U: 'static + AsExecutionP
         plan,
         launch_time,
         session_id,
-        props,
+        session_config,
         function_registry,
     })
 }
@@ -350,17 +352,17 @@ pub fn get_task_definition_vec<
     U: 'static + AsExecutionPlan,
 >(
     multi_task: protobuf::MultiTaskDefinition,
-    runtime: Arc<RuntimeEnv>,
+    runtime_producer: RuntimeProducer,
+    session_config: SessionConfig,
     scalar_functions: HashMap<String, Arc<ScalarUDF>>,
     aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
     window_functions: HashMap<String, Arc<WindowUDF>>,
     codec: BallistaCodec<T, U>,
 ) -> Result<Vec<TaskDefinition>, BallistaError> {
-    let mut props = HashMap::new();
+    let mut session_config = session_config;
     for kv_pair in multi_task.props {
-        props.insert(kv_pair.key, kv_pair.value);
+        session_config = session_config.set_str(&kv_pair.key, &kv_pair.value);
     }
-    let props = Arc::new(props);
 
     let mut task_scalar_functions = HashMap::new();
     let mut task_aggregate_functions = HashMap::new();
@@ -380,6 +382,8 @@ pub fn get_task_definition_vec<
         aggregate_functions: task_aggregate_functions,
         window_functions: task_window_functions,
     });
+
+    let runtime = runtime_producer(&session_config)?;
 
     let encoded_plan = multi_task.plan.as_slice();
     let plan: Arc<dyn ExecutionPlan> = U::try_decode(encoded_plan).and_then(|proto| {
@@ -410,7 +414,7 @@ pub fn get_task_definition_vec<
                 plan: reset_metrics_for_execution_plan(plan.clone())?,
                 launch_time,
                 session_id: session_id.clone(),
-                props: props.clone(),
+                session_config: session_config.clone(),
                 function_registry: function_registry.clone(),
             })
         })

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -33,8 +33,9 @@ use std::time::Duration;
 
 use crate::error::BallistaError;
 use crate::serde::scheduler::{
-    Action, ExecutorData, ExecutorMetadata, ExecutorSpecification, PartitionId,
-    PartitionLocation, PartitionStats, SimpleFunctionRegistry, TaskDefinition,
+    Action, BallistaFunctionRegistry, ExecutorData, ExecutorMetadata,
+    ExecutorSpecification, PartitionId, PartitionLocation, PartitionStats,
+    TaskDefinition,
 };
 
 use crate::serde::{protobuf, BallistaCodec};
@@ -308,7 +309,7 @@ pub fn get_task_definition<T: 'static + AsLogicalPlan, U: 'static + AsExecutionP
     for agg_func in window_functions {
         task_window_functions.insert(agg_func.0, agg_func.1);
     }
-    let function_registry = Arc::new(SimpleFunctionRegistry {
+    let function_registry = Arc::new(BallistaFunctionRegistry {
         scalar_functions: task_scalar_functions,
         aggregate_functions: task_aggregate_functions,
         window_functions: task_window_functions,
@@ -377,7 +378,7 @@ pub fn get_task_definition_vec<
     for agg_func in window_functions {
         task_window_functions.insert(agg_func.0, agg_func.1);
     }
-    let function_registry = Arc::new(SimpleFunctionRegistry {
+    let function_registry = Arc::new(BallistaFunctionRegistry {
         scalar_functions: task_scalar_functions,
         aggregate_functions: task_aggregate_functions,
         window_functions: task_window_functions,

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -29,6 +29,7 @@ use datafusion::logical_expr::planner::ExprPlanner;
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::Partitioning;
+use datafusion::prelude::SessionConfig;
 use serde::Serialize;
 
 use crate::error::BallistaError;
@@ -288,7 +289,7 @@ pub struct TaskDefinition {
     pub plan: Arc<dyn ExecutionPlan>,
     pub launch_time: u64,
     pub session_id: String,
-    pub props: Arc<HashMap<String, String>>,
+    pub session_config: SessionConfig,
     pub function_registry: Arc<SimpleFunctionRegistry>,
 }
 

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -334,6 +334,7 @@ impl BallistaSessionStateExt for SessionState {
         session_id: String,
     ) -> datafusion::error::Result<SessionState> {
         let codec_logical = self.config().ballista_logical_extension_codec();
+        let planner_override = self.config().ballista_query_planner();
 
         let new_config = self
             .config()
@@ -348,30 +349,20 @@ impl BallistaSessionStateExt for SessionState {
             .clone()
             .with_option_extension(new_config.clone());
 
-        // at the moment we don't have a way to detect if
-        // user set planner so we provide a configuration to
-        // user to disable planner override
-        let planner_override = self
-            .config()
-            .options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|config| config.planner_override())
-            .unwrap_or(true);
-
         let builder = SessionStateBuilder::new_from_existing(self)
             .with_config(session_config)
             .with_session_id(session_id);
 
-        let builder = if planner_override {
-            let query_planner = BallistaQueryPlanner::<LogicalPlanNode>::with_extension(
-                scheduler_url,
-                new_config,
-                codec_logical,
-            );
-            builder.with_query_planner(Arc::new(query_planner))
-        } else {
-            builder
+        let builder = match planner_override {
+            Some(planner) => builder.with_query_planner(planner),
+            None => {
+                let planner = BallistaQueryPlanner::<LogicalPlanNode>::with_extension(
+                    scheduler_url,
+                    new_config,
+                    codec_logical,
+                );
+                builder.with_query_planner(Arc::new(planner))
+            }
         };
 
         Ok(builder.build())
@@ -402,6 +393,17 @@ pub trait BallistaSessionConfigExt {
     /// returns [PhysicalExtensionCodec] if set
     /// or default ballista codec if not
     fn ballista_physical_extension_codec(&self) -> Arc<dyn PhysicalExtensionCodec>;
+
+    /// Overrides ballista's [QueryPlanner]
+    fn with_ballista_query_planner(
+        self,
+        planner: Arc<dyn QueryPlanner + Send + Sync + 'static>,
+    ) -> SessionConfig;
+
+    /// Returns ballista's [QueryPlanner] if overriden
+    fn ballista_query_planner(
+        &self,
+    ) -> Option<Arc<dyn QueryPlanner + Send + Sync + 'static>>;
 }
 
 impl BallistaSessionConfigExt for SessionConfig {
@@ -433,6 +435,21 @@ impl BallistaSessionConfigExt for SessionConfig {
             .map(|c| c.codec())
             .unwrap_or_else(|| Arc::new(BallistaPhysicalExtensionCodec::default()))
     }
+
+    fn with_ballista_query_planner(
+        self,
+        planner: Arc<dyn QueryPlanner + Send + Sync + 'static>,
+    ) -> SessionConfig {
+        let extension = BallistaQueryPlannerExtension::new(planner);
+        self.with_extension(Arc::new(extension))
+    }
+
+    fn ballista_query_planner(
+        &self,
+    ) -> Option<Arc<dyn QueryPlanner + Send + Sync + 'static>> {
+        self.get_extension::<BallistaQueryPlannerExtension>()
+            .map(|c| c.planner())
+    }
 }
 
 /// Wrapper for [SessionConfig] extension
@@ -462,6 +479,21 @@ impl BallistaConfigExtensionPhysicalCodec {
     }
     fn codec(&self) -> Arc<dyn PhysicalExtensionCodec> {
         self.codec.clone()
+    }
+}
+
+/// Wrapper for [SessionConfig] extension
+/// holding overridden [QueryPlanner]
+struct BallistaQueryPlannerExtension {
+    planner: Arc<dyn QueryPlanner + Send + Sync + 'static>,
+}
+
+impl BallistaQueryPlannerExtension {
+    fn new(planner: Arc<dyn QueryPlanner + Send + Sync + 'static>) -> Self {
+        Self { planner }
+    }
+    fn planner(&self) -> Arc<dyn QueryPlanner + Send + Sync + 'static> {
+        self.planner.clone()
     }
 }
 

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -277,7 +277,7 @@ pub fn create_df_ctx_with_ballista_query_planner<T: 'static + AsLogicalPlan>(
     SessionContext::new_with_state(session_state)
 }
 
-pub trait BallistaSessionStateExt {
+pub trait SessionStateExt {
     fn new_ballista_state(
         scheduler_url: String,
         session_id: String,
@@ -291,7 +291,7 @@ pub trait BallistaSessionStateExt {
     fn ballista_config(&self) -> BallistaConfig;
 }
 
-impl BallistaSessionStateExt for SessionState {
+impl SessionStateExt for SessionState {
     fn ballista_config(&self) -> BallistaConfig {
         self.config()
             .options()
@@ -369,7 +369,7 @@ impl BallistaSessionStateExt for SessionState {
     }
 }
 
-pub trait BallistaSessionConfigExt {
+pub trait SessionConfigExt {
     /// Creates session config which has
     /// ballista configuration initialized
     fn new_with_ballista() -> SessionConfig;
@@ -406,7 +406,7 @@ pub trait BallistaSessionConfigExt {
     ) -> Option<Arc<dyn QueryPlanner + Send + Sync + 'static>>;
 }
 
-impl BallistaSessionConfigExt for SessionConfig {
+impl SessionConfigExt for SessionConfig {
     fn new_with_ballista() -> SessionConfig {
         SessionConfig::new().with_option_extension(BallistaConfig::new().unwrap())
     }

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -41,7 +41,7 @@ anyhow = "1"
 arrow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
-ballista-core = { path = "../core", version = "0.12.0", features = ["s3"] }
+ballista-core = { path = "../core", version = "0.12.0" }
 configure_me = { workspace = true }
 dashmap = { workspace = true }
 datafusion = { workspace = true }

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -88,6 +88,8 @@ async fn main() -> Result<()> {
         cache_io_concurrency: opt.cache_io_concurrency,
         execution_engine: None,
         session_state: None,
+        config_producer: None,
+        runtime_producer: None,
     };
 
     start_executor_process(Arc::new(config)).await

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -90,6 +90,8 @@ async fn main() -> Result<()> {
         function_registry: None,
         config_producer: None,
         runtime_producer: None,
+        logical_codec: None,
+        physical_codec: None,
     };
 
     start_executor_process(Arc::new(config)).await

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -87,6 +87,7 @@ async fn main() -> Result<()> {
         cache_capacity: opt.cache_capacity,
         cache_io_concurrency: opt.cache_io_concurrency,
         execution_engine: None,
+        session_state: None,
     };
 
     start_executor_process(Arc::new(config)).await

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
         cache_capacity: opt.cache_capacity,
         cache_io_concurrency: opt.cache_io_concurrency,
         execution_engine: None,
-        session_state: None,
+        function_registry: None,
         config_producer: None,
         runtime_producer: None,
     };

--- a/ballista/executor/src/execution_loop.rs
+++ b/ballista/executor/src/execution_loop.rs
@@ -171,9 +171,9 @@ async fn run_received_task<T: 'static + AsLogicalPlan, U: 'static + AsExecutionP
         session_config = session_config.set_str(&kv_pair.key, &kv_pair.value);
     }
 
-    let task_scalar_functions = executor.scalar_functions.clone();
-    let task_aggregate_functions = executor.aggregate_functions.clone();
-    let task_window_functions = executor.window_functions.clone();
+    let task_scalar_functions = executor.function_registry.scalar_functions.clone();
+    let task_aggregate_functions = executor.function_registry.aggregate_functions.clone();
+    let task_window_functions = executor.function_registry.window_functions.clone();
 
     let runtime = executor.produce_runtime(&session_config)?;
     let session_id = task.session_id.clone();

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -54,8 +54,7 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::BallistaCodec;
 use ballista_core::utils::{
-    create_grpc_client_connection, create_grpc_server, get_time_before,
-    BallistaSessionConfigExt,
+    create_grpc_client_connection, create_grpc_server, get_time_before, SessionConfigExt,
 };
 use ballista_core::{ConfigProducer, RuntimeProducer, BALLISTA_VERSION};
 

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -55,6 +55,7 @@ use ballista_core::serde::protobuf::{
 use ballista_core::serde::BallistaCodec;
 use ballista_core::utils::{
     create_grpc_client_connection, create_grpc_server, get_time_before,
+    BallistaSessionConfigExt,
 };
 use ballista_core::BALLISTA_VERSION;
 
@@ -200,9 +201,11 @@ pub async fn start_executor_process(opt: Arc<ExecutorProcessConfig>) -> Result<(
                 concurrent_tasks,
                 opt.execution_engine.clone(),
             ));
-            // TODO MM: read codec from configuration when #1096
-            //       is merged.
-            let default_codec = BallistaCodec::default();
+
+            let logical = state.config().ballista_logical_extension_codec();
+            let physical = state.config().ballista_physical_extension_codec();
+            let default_codec = BallistaCodec::new(logical, physical);
+
             (state.config().clone(), executor, default_codec)
         }
         None => {

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -46,9 +46,7 @@ use ballista_core::serde::scheduler::TaskDefinition;
 use ballista_core::serde::BallistaCodec;
 use ballista_core::utils::{create_grpc_client_connection, create_grpc_server};
 use dashmap::DashMap;
-use datafusion::config::ConfigOptions;
 use datafusion::execution::TaskContext;
-use datafusion::prelude::SessionConfig;
 use datafusion_proto::{logical_plan::AsLogicalPlan, physical_plan::AsExecutionPlan};
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::task::JoinHandle;
@@ -342,22 +340,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
             .unwrap();
 
         let task_context = {
-            let task_props = task.props;
-            let mut config = ConfigOptions::new();
-            for (k, v) in task_props.iter() {
-                if let Err(e) = config.set(k, v) {
-                    debug!("Fail to set session config for ({},{}): {:?}", k, v, e);
-                }
-            }
-            let session_config = SessionConfig::from(config);
-
             let function_registry = task.function_registry;
-            let runtime = self.executor.get_runtime();
+            let runtime = self.executor.produce_runtime(&task.session_config).unwrap();
 
             Arc::new(TaskContext::new(
                 Some(task_identity.clone()),
                 task.session_id,
-                session_config,
+                task.session_config,
                 function_registry.scalar_functions.clone(),
                 function_registry.aggregate_functions.clone(),
                 function_registry.window_functions.clone(),
@@ -641,7 +630,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
                     scheduler_id: scheduler_id.clone(),
                     task: get_task_definition(
                         task,
-                        self.executor.get_runtime(),
+                        self.executor.runtime_producer.clone(),
+                        self.executor.produce_config(),
                         self.executor.scalar_functions.clone(),
                         self.executor.aggregate_functions.clone(),
                         self.executor.window_functions.clone(),
@@ -669,7 +659,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
         for multi_task in multi_tasks {
             let multi_task: Vec<TaskDefinition> = get_task_definition_vec(
                 multi_task,
-                self.executor.get_runtime(),
+                self.executor.runtime_producer.clone(),
+                self.executor.produce_config(),
                 self.executor.scalar_functions.clone(),
                 self.executor.aggregate_functions.clone(),
                 self.executor.window_functions.clone(),

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -632,9 +632,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
                         task,
                         self.executor.runtime_producer.clone(),
                         self.executor.produce_config(),
-                        self.executor.scalar_functions.clone(),
-                        self.executor.aggregate_functions.clone(),
-                        self.executor.window_functions.clone(),
+                        self.executor.function_registry.scalar_functions.clone(),
+                        self.executor.function_registry.aggregate_functions.clone(),
+                        self.executor.function_registry.window_functions.clone(),
                         self.codec.clone(),
                     )
                     .map_err(|e| Status::invalid_argument(format!("{e}")))?,
@@ -661,9 +661,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorGrpc
                 multi_task,
                 self.executor.runtime_producer.clone(),
                 self.executor.produce_config(),
-                self.executor.scalar_functions.clone(),
-                self.executor.aggregate_functions.clone(),
-                self.executor.window_functions.clone(),
+                self.executor.function_registry.scalar_functions.clone(),
+                self.executor.function_registry.aggregate_functions.clone(),
+                self.executor.function_registry.window_functions.clone(),
                 self.codec.clone(),
             )
             .map_err(|e| Status::invalid_argument(format!("{e}")))?;

--- a/ballista/executor/src/lib.rs
+++ b/ballista/executor/src/lib.rs
@@ -32,6 +32,7 @@ mod cpu_bound_executor;
 mod standalone;
 
 pub use standalone::new_standalone_executor;
+pub use standalone::new_standalone_executor_from_state;
 
 use log::info;
 

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -100,12 +100,12 @@ pub async fn new_standalone_executor_from_state<
     let config_producer: ConfigProducer = Arc::new(move || config.clone());
     let runtime_producer: RuntimeProducer = Arc::new(move |_| Ok(runtime.clone()));
 
-    let executor = Arc::new(Executor::new_from_state(
+    let executor = Arc::new(Executor::new(
         executor_meta,
         &work_dir,
         runtime_producer,
         config_producer,
-        session_state,
+        Arc::new(session_state.into()),
         Arc::new(LoggingMetricsCollector::default()),
         concurrent_tasks,
         None,
@@ -174,14 +174,12 @@ pub async fn new_standalone_executor<
         Ok(Arc::new(RuntimeEnv::new(config)?))
     });
 
-    let executor = Arc::new(Executor::new_from_runtime(
+    let executor = Arc::new(Executor::new_basic(
         executor_meta,
         &work_dir,
         runtime_producer,
         config_producer,
-        Arc::new(LoggingMetricsCollector::default()),
         concurrent_tasks,
-        None,
     ));
 
     let service = BallistaFlightService::new();

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -19,7 +19,7 @@ use crate::metrics::LoggingMetricsCollector;
 use crate::{execution_loop, executor::Executor, flight_service::BallistaFlightService};
 use arrow_flight::flight_service_server::FlightServiceServer;
 use ballista_core::config::BallistaConfig;
-use ballista_core::utils::BallistaSessionConfigExt;
+use ballista_core::utils::SessionConfigExt;
 use ballista_core::{
     error::Result,
     object_store_registry::with_object_store_registry,

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -18,6 +18,7 @@
 use crate::metrics::LoggingMetricsCollector;
 use crate::{execution_loop, executor::Executor, flight_service::BallistaFlightService};
 use arrow_flight::flight_service_server::FlightServiceServer;
+use ballista_core::config::BallistaConfig;
 use ballista_core::{
     error::Result,
     object_store_registry::with_object_store_registry,
@@ -29,6 +30,8 @@ use ballista_core::{
     BALLISTA_VERSION,
 };
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+use datafusion::execution::SessionState;
+use datafusion::prelude::SessionConfig;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use log::info;
@@ -38,6 +41,80 @@ use tokio::net::TcpListener;
 use tonic::transport::Channel;
 use uuid::Uuid;
 
+/// Creates new standalone executor based on
+/// session_state provided.
+///
+/// This provides flexible way of configuring underlying
+/// components.
+pub async fn new_standalone_executor_from_state<
+    T: 'static + AsLogicalPlan,
+    U: 'static + AsExecutionPlan,
+>(
+    scheduler: SchedulerGrpcClient<Channel>,
+    concurrent_tasks: usize,
+    session_state: &SessionState,
+    codec: BallistaCodec<T, U>,
+) -> Result<()> {
+    // Let the OS assign a random, free port
+    let listener = TcpListener::bind("localhost:0").await?;
+    let addr = listener.local_addr()?;
+    info!(
+        "Ballista v{} Rust Executor listening on {:?}",
+        BALLISTA_VERSION, addr
+    );
+
+    let executor_meta = ExecutorRegistration {
+        id: Uuid::new_v4().to_string(), // assign this executor a unique ID
+        optional_host: Some(OptionalHost::Host("localhost".to_string())),
+        port: addr.port() as u32,
+        // TODO Make it configurable
+        grpc_port: 50020,
+        specification: Some(
+            ExecutorSpecification {
+                task_slots: concurrent_tasks as u32,
+            }
+            .into(),
+        ),
+    };
+    let work_dir = TempDir::new()?
+        .into_path()
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    info!("work_dir: {}", work_dir);
+
+    let executor = Arc::new(Executor::new_from_state(
+        executor_meta,
+        &work_dir,
+        session_state,
+        Arc::new(LoggingMetricsCollector::default()),
+        concurrent_tasks,
+        None,
+    ));
+
+    let service = BallistaFlightService::new();
+    let server = FlightServiceServer::new(service);
+    tokio::spawn(
+        create_grpc_server()
+            .add_service(server)
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(
+                listener,
+            )),
+    );
+
+    let config = session_state
+        .config()
+        .clone()
+        .with_option_extension(BallistaConfig::new().unwrap());
+
+    tokio::spawn(execution_loop::poll_loop(
+        scheduler, executor, codec, config,
+    ));
+    Ok(())
+}
+
+/// Creates standalone executor with most values
+/// set as default.
 pub async fn new_standalone_executor<
     T: 'static + AsLogicalPlan,
     U: 'static + AsExecutionPlan,
@@ -78,7 +155,7 @@ pub async fn new_standalone_executor<
         RuntimeConfig::new().with_temp_file_path(work_dir.clone()),
     );
 
-    let executor = Arc::new(Executor::new(
+    let executor = Arc::new(Executor::new_from_runtime(
         executor_meta,
         &work_dir,
         Arc::new(RuntimeEnv::new(config).unwrap()),
@@ -96,7 +173,10 @@ pub async fn new_standalone_executor<
                 listener,
             )),
     );
-
-    tokio::spawn(execution_loop::poll_loop(scheduler, executor, codec));
+    let config =
+        SessionConfig::new().with_option_extension(BallistaConfig::new().unwrap());
+    tokio::spawn(execution_loop::poll_loop(
+        scheduler, executor, codec, config,
+    ));
     Ok(())
 }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -45,7 +45,7 @@ anyhow = "1"
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.7.7"
-ballista-core = { path = "../core", version = "0.12.0", features = ["s3"] }
+ballista-core = { path = "../core", version = "0.12.0" }
 base64 = { version = "0.22" }
 clap = { workspace = true }
 configure_me = { workspace = true }

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -401,7 +401,7 @@ impl JobState for InMemoryJobState {
         &self,
         config: &BallistaConfig,
     ) -> Result<Arc<SessionContext>> {
-        let session = create_datafusion_context(config, self.session_builder);
+        let session = create_datafusion_context(config, self.session_builder.clone());
         self.sessions.insert(session.session_id(), session.clone());
 
         Ok(session)
@@ -412,7 +412,7 @@ impl JobState for InMemoryJobState {
         session_id: &str,
         config: &BallistaConfig,
     ) -> Result<Arc<SessionContext>> {
-        let session = create_datafusion_context(config, self.session_builder);
+        let session = create_datafusion_context(config, self.session_builder.clone());
         self.sessions
             .insert(session_id.to_string(), session.clone());
 
@@ -486,6 +486,8 @@ impl JobState for InMemoryJobState {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use crate::cluster::memory::InMemoryJobState;
     use crate::cluster::test_util::{test_job_lifecycle, test_job_planning_failure};
     use crate::test_utils::{
@@ -497,17 +499,17 @@ mod test {
     #[tokio::test]
     async fn test_in_memory_job_lifecycle() -> Result<()> {
         test_job_lifecycle(
-            InMemoryJobState::new("", default_session_builder),
+            InMemoryJobState::new("", Arc::new(default_session_builder)),
             test_aggregation_plan(4).await,
         )
         .await?;
         test_job_lifecycle(
-            InMemoryJobState::new("", default_session_builder),
+            InMemoryJobState::new("", Arc::new(default_session_builder)),
             test_two_aggregations_plan(4).await,
         )
         .await?;
         test_job_lifecycle(
-            InMemoryJobState::new("", default_session_builder),
+            InMemoryJobState::new("", Arc::new(default_session_builder)),
             test_join_plan(4).await,
         )
         .await?;
@@ -518,17 +520,17 @@ mod test {
     #[tokio::test]
     async fn test_in_memory_job_planning_failure() -> Result<()> {
         test_job_planning_failure(
-            InMemoryJobState::new("", default_session_builder),
+            InMemoryJobState::new("", Arc::new(default_session_builder)),
             test_aggregation_plan(4).await,
         )
         .await?;
         test_job_planning_failure(
-            InMemoryJobState::new("", default_session_builder),
+            InMemoryJobState::new("", Arc::new(default_session_builder)),
             test_two_aggregations_plan(4).await,
         )
         .await?;
         test_job_planning_failure(
-            InMemoryJobState::new("", default_session_builder),
+            InMemoryJobState::new("", Arc::new(default_session_builder)),
             test_join_plan(4).await,
         )
         .await?;

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -109,7 +109,7 @@ impl BallistaCluster {
         match &config.cluster_storage {
             ClusterStorageConfig::Memory => Ok(BallistaCluster::new_memory(
                 scheduler,
-                default_session_builder,
+                Arc::new(default_session_builder),
             )),
         }
     }

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -424,6 +424,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
         } = query_params
         {
             let mut query_settings = HashMap::new();
+            log::trace!("received query settings: {:?}", settings);
             for kv_pair in settings {
                 query_settings.insert(kv_pair.key, kv_pair.value);
             }
@@ -523,6 +524,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                 .cloned()
                 .unwrap_or_else(|| "None".to_string());
 
+            log::trace!("setting job name: {}", job_name);
             self.submit_job(&job_id, &job_name, session_ctx, &plan)
                 .await
                 .map_err(|e| {

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -56,7 +56,7 @@ mod external_scaler;
 mod grpc;
 pub(crate) mod query_stage_scheduler;
 
-pub(crate) type SessionBuilder = fn(SessionConfig) -> SessionState;
+pub(crate) type SessionBuilder = Arc<dyn Fn(SessionConfig) -> SessionState + Send + Sync>;
 
 #[derive(Clone)]
 pub struct SchedulerServer<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> {

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -21,7 +21,7 @@ use crate::metrics::default_metrics_collector;
 use crate::scheduler_server::SchedulerServer;
 use ballista_core::serde::BallistaCodec;
 use ballista_core::utils::{
-    create_grpc_server, default_session_builder, BallistaSessionConfigExt,
+    create_grpc_server, default_session_builder, SessionConfigExt,
 };
 use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -33,9 +33,15 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 
 pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
-    let metrics_collector = default_metrics_collector()?;
+    new_standalone_scheduler_from_builder(Arc::new(default_session_builder)).await
+}
 
-    let cluster = BallistaCluster::new_memory("localhost:50050", default_session_builder);
+pub async fn new_standalone_scheduler_from_builder(
+    session_builder: crate::scheduler_server::SessionBuilder,
+) -> Result<SocketAddr> {
+    let cluster = BallistaCluster::new_memory("localhost:50050", session_builder);
+
+    let metrics_collector = default_metrics_collector()?;
 
     let mut scheduler_server: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
         SchedulerServer::new(

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -20,11 +20,15 @@ use crate::config::SchedulerConfig;
 use crate::metrics::default_metrics_collector;
 use crate::scheduler_server::SchedulerServer;
 use ballista_core::serde::BallistaCodec;
-use ballista_core::utils::{create_grpc_server, default_session_builder};
+use ballista_core::utils::{
+    create_grpc_server, default_session_builder, BallistaSessionConfigExt,
+};
 use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
 };
+use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion::prelude::SessionConfig;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use log::info;
@@ -33,21 +37,39 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 
 pub async fn new_standalone_scheduler() -> Result<SocketAddr> {
-    new_standalone_scheduler_from_builder(Arc::new(default_session_builder)).await
+    let codec = BallistaCodec::default();
+    new_standalone_scheduler_with_builder(Arc::new(default_session_builder), codec).await
 }
 
-pub async fn new_standalone_scheduler_from_builder(
+pub async fn new_standalone_scheduler_from_state(
+    session_state: &SessionState,
+) -> Result<SocketAddr> {
+    let logical = session_state.config().ballista_logical_extension_codec();
+    let physical = session_state.config().ballista_physical_extension_codec();
+    let codec = BallistaCodec::new(logical, physical);
+
+    let session_state = session_state.clone();
+    let session_builder = Arc::new(move |c: SessionConfig| {
+        SessionStateBuilder::new_from_existing(session_state.clone())
+            .with_config(c)
+            .build()
+    });
+
+    new_standalone_scheduler_with_builder(session_builder, codec).await
+}
+
+async fn new_standalone_scheduler_with_builder(
     session_builder: crate::scheduler_server::SessionBuilder,
+    codec: BallistaCodec,
 ) -> Result<SocketAddr> {
     let cluster = BallistaCluster::new_memory("localhost:50050", session_builder);
-
     let metrics_collector = default_metrics_collector()?;
 
     let mut scheduler_server: SchedulerServer<LogicalPlanNode, PhysicalPlanNode> =
         SchedulerServer::new(
             "localhost:50050".to_owned(),
             cluster,
-            BallistaCodec::default(),
+            codec,
             Arc::new(SchedulerConfig::default()),
             metrics_collector,
         );

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -124,7 +124,7 @@ pub async fn await_condition<Fut: Future<Output = Result<bool>>, F: Fn() -> Fut>
 }
 
 pub fn test_cluster_context() -> BallistaCluster {
-    BallistaCluster::new_memory(TEST_SCHEDULER_NAME, default_session_builder)
+    BallistaCluster::new_memory(TEST_SCHEDULER_NAME, Arc::new(default_session_builder))
 }
 
 pub async fn datafusion_test_context(path: &str) -> Result<SessionContext> {


### PR DESCRIPTION
... this provide much more options to configure executors.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1098.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

expose more configuration options for executor and scheduler, this way users can set up their own instances with custom configuration (object stores, configuration, udfs ...)

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Integration tests have been added which rely on testcontainers infrastructure, thus docker is required for builds. Tests are disabled by default but can be enabled with `testcontainers` option
- `BALLISTA_PLANNER_OVERRIDE` config was removed, there is equivalent method in `SessionConfigExt`
- `BallistaFunctionRegistry` was promoted a bit, cleaning up executor code
- executor code cleanup

to follow up 

- session cofiguration to be propagated from scheduler to executor 
- configuration clean up 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

there are slight changes in original API, but not drastic


<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
