### PR TITLE
support window functions

### DIFF
--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -28,7 +28,6 @@ use ballista_core::{
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
-use datafusion::physical_plan::windows::WindowAggExec;
 use datafusion::physical_plan::{
     with_new_children_if_necessary, ExecutionPlan, Partitioning,
 };

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -148,12 +148,6 @@ impl DistributedPlanner {
                     Ok((children[0].clone(), stages))
                 }
             }
-        } else if let Some(window) =
-            execution_plan.as_any().downcast_ref::<WindowAggExec>()
-        {
-            Err(BallistaError::NotImplemented(format!(
-                "WindowAggExec with window {window:?}"
-            )))
         } else {
             Ok((
                 with_new_children_if_necessary(execution_plan, children)?,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #542 .

 # Rationale for this change

As stated in #542, datafusion adds `SortExec` and `RepartitionExec` based on the window clauses `partition by` and `order by` (See `enforce_distribution.rs` in datafusion and `WindowAggExec::required_input_distribution` .
From what I can see, this restriction on window functions in ballista was put way back when datafusion was in the same repo as ballista and window function support was still in its infancy. Now that datafusion enforces the right hash distribution by placing repartition nodes, I believe ballista currently already supports window functions.

I have tested partitioned, unpartitioned and sorted window expressions with ballista with this PR and compared them with datafusion, it seems to be working as intended. Parititioned window functions get repartitioned by their partition expressions and are parallelised.

Not sure what is the best way to test this given distribution handling is done by datafusion here.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Allow queries with window expressions
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
