### PR TITLE
chore: fix warning mimaloc warning when building

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -35,7 +35,7 @@ datafusion = { workspace = true }
 datafusion-cli = { workspace = true }
 dirs = "5.0.1"
 env_logger = { workspace = true }
-mimalloc = { workspace = true, default-features = false }
+mimalloc = { workspace = true }
 rustyline = "14.0.0"
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -48,7 +48,7 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-mimalloc = { workspace = true, default-features = false, optional = true }
+mimalloc = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -38,7 +38,7 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
-mimalloc = { workspace = true, optional = true, default-features = false }
+mimalloc = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = "1.0.78"


### PR DESCRIPTION
# Which issue does this PR close?

Closes None.

 # Rationale for this change

after last round of refactoring when mimalloc was moved to workspace cargo it started generating warnings.

# What changes are included in this PR?

cleanup mimalloc cargo config which was generating warning 

# Are there any user-facing changes?

No