### PR TITLE
feat: Add option to limit number of executor worker threads

### DIFF
--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -51,13 +51,7 @@ log = { workspace = true }
 mimalloc = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = [
-    "macros",
-    "rt",
-    "rt-multi-thread",
-    "parking_lot",
-    "signal",
-] }
+tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/ballista/executor/executor_config_spec.toml
+++ b/ballista/executor/executor_config_spec.toml
@@ -75,7 +75,6 @@ doc = "Directory for temporary IPC files"
 abbr = "c"
 name = "concurrent_tasks"
 type = "usize"
-default = "0" # defaults to all available cores if left as zero
 doc = "Max concurrent tasks."
 
 [[param]]
@@ -167,6 +166,7 @@ doc = "The number of worker threads for the runtime of caching. Default: 2"
 default = "2"
 
 [[param]]
+abbr = "e"
 name = "executor_cores"
 type = "usize"
 doc = "The number of worker threads. Default: number of available cores"

--- a/ballista/executor/executor_config_spec.toml
+++ b/ballista/executor/executor_config_spec.toml
@@ -165,3 +165,8 @@ name = "cache_io_concurrency"
 type = "u32"
 doc = "The number of worker threads for the runtime of caching. Default: 2"
 default = "2"
+
+[[param]]
+name = "executor_cores"
+type = "usize"
+doc = "The number of worker threads. Default: number of available cores"

--- a/ballista/executor/src/bin/main.rs
+++ b/ballista/executor/src/bin/main.rs
@@ -37,14 +37,10 @@ fn main() -> Result<()> {
         Config::including_optional_config_files(&["/etc/ballista/executor.toml"])
             .unwrap_or_exit();
 
-    let executor_cores = opt
-        .executor_cores
-        .unwrap_or_else(|| std::thread::available_parallelism().unwrap().get());
-
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("ballista_executor")
-        .worker_threads(executor_cores)
+        .worker_threads(opt.executor_cores_or_default())
         .build()
         .unwrap();
 

--- a/ballista/scheduler/src/bin/main.rs
+++ b/ballista/scheduler/src/bin/main.rs
@@ -31,6 +31,7 @@ fn main() -> Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_io()
         .enable_time()
+        .thread_name("ballista_scheduler")
         .thread_stack_size(32 * 1024 * 1024) // 32MB
         .build()
         .unwrap();


### PR DESCRIPTION
`executor_cores` configuration option is similar to `spark.executor.cores`,  it sets number of tokio worker threads limiting executor cpu utilisation.

# Which issue does this PR close?

Closes none .

 # Rationale for this change

provide ability to users to limit number of cores which executor can utilise limiting overall resource utilisation 

# What changes are included in this PR?

- new configuration option 
- tokio executors got their own name 

# Are there any user-facing changes?

new configuration option exposed to user