### PR TITLE
chore: Fix clippy issues after rust update (1.83.0)

### DIFF
--- a/ballista/client/tests/context_unsupported.rs
+++ b/ballista/client/tests/context_unsupported.rs
@@ -21,7 +21,6 @@ mod common;
 ///
 /// It provides indication if/when datafusion
 /// gets support for them
-
 #[cfg(test)]
 mod unsupported {
     use crate::common::{remote_context, standalone_context};

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -52,7 +52,6 @@ pub trait SessionStateExt {
 
 /// [SessionConfig] extension with methods needed
 /// for Ballista configuration
-
 pub trait SessionConfigExt {
     /// Creates session config which has
     /// ballista configuration initialized
@@ -315,7 +314,8 @@ impl SessionConfigHelperExt for SessionConfig {
                 value
             );
             if let Err(e) = s.options_mut().set(key, value) {
-                log::warn!(
+                // there is not much we can do about this error at the moment
+                log::debug!(
                     "could not set configuration key: `{}`, value: `{}`, reason: {}",
                     key,
                     value,
@@ -334,7 +334,8 @@ impl SessionConfigHelperExt for SessionConfig {
                 value
             );
             if let Err(e) = self.options_mut().set(key, value) {
-                log::warn!(
+                // there is not much we can do about this error at the moment
+                log::debug!(
                     "could not set configuration key: `{}`, value: `{}`, reason: {}",
                     key,
                     value,

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -131,7 +131,6 @@ impl BallistaLogicalExtensionCodec {
     /// position is important with encoding process
     /// as position of used codecs is needed
     /// so the same codec can be used for decoding
-
     fn try_any<R>(
         &self,
         mut f: impl FnMut(&dyn LogicalExtensionCodec) -> Result<R>,

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -27,7 +27,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 /// Execution engine extension point
-
 pub trait ExecutionEngine: Sync + Send {
     fn create_query_stage_exec(
         &self,

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -111,7 +111,6 @@ impl Executor {
 
     /// Create a new executor instance with given [RuntimeEnv],
     /// [ScalarUDF], [AggregateUDF] and [WindowUDF]
-
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         metadata: ExecutorRegistration,

--- a/ballista/scheduler/src/display.rs
+++ b/ballista/scheduler/src/display.rs
@@ -87,7 +87,7 @@ impl<'a> DisplayableBallistaExecutionPlan<'a> {
             plan: &'a dyn ExecutionPlan,
             metrics: &'a Vec<MetricsSet>,
         }
-        impl<'a> fmt::Display for Wrapper<'a> {
+        impl fmt::Display for Wrapper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let t = DisplayFormatType::Default;
                 let mut visitor = IndentVisitor {
@@ -121,7 +121,7 @@ struct IndentVisitor<'a, 'b> {
     metric_index: usize,
 }
 
-impl<'a, 'b> ExecutionPlanVisitor for IndentVisitor<'a, 'b> {
+impl ExecutionPlanVisitor for IndentVisitor<'_, '_> {
     type Error = fmt::Error;
     fn pre_visit(
         &mut self,
@@ -150,7 +150,7 @@ impl<'a, 'b> ExecutionPlanVisitor for IndentVisitor<'a, 'b> {
     }
 }
 
-impl<'a> ToStringifiedPlan for DisplayableBallistaExecutionPlan<'a> {
+impl ToStringifiedPlan for DisplayableBallistaExecutionPlan<'_> {
     fn to_stringified(
         &self,
         plan_type: datafusion::logical_expr::PlanType,


### PR DESCRIPTION
Fix clippy issues after rust update (1.83.0),

+ change a logger from warn to debug, as we cant do much with those errors at the moment and they happen even with core datafusion config.

# Which issue does this PR close?

Closes None.

 # Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

