### PR TITLE
add partitioning scheme for unresolved shuffle and shuffle reader exec

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -50,7 +50,7 @@ message ShuffleWriterExecNode {
 message UnresolvedShuffleExecNode {
   uint32 stage_id = 1;
   datafusion_common.Schema schema = 2;
-  uint32 output_partition_count = 4;
+  datafusion.Partitioning partitioning = 5;
 }
 
 message ShuffleReaderExecNode {
@@ -58,6 +58,7 @@ message ShuffleReaderExecNode {
   datafusion_common.Schema schema = 2;
   // The stage to read from
   uint32 stage_id = 3;
+  datafusion.Partitioning partitioning = 4;
 }
 
 message ShuffleReaderPartition {

--- a/ballista/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/core/src/execution_plans/unresolved_shuffle.rs
@@ -46,22 +46,16 @@ pub struct UnresolvedShuffleExec {
 
 impl UnresolvedShuffleExec {
     /// Create a new UnresolvedShuffleExec
-    pub fn new(
-        stage_id: usize,
-        schema: SchemaRef,
-        output_partition_count: usize,
-    ) -> Self {
+    pub fn new(stage_id: usize, schema: SchemaRef, partitioning: Partitioning) -> Self {
         let properties = PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
-            // TODO the output partition is known and should be populated here!
-            // see https://github.com/apache/arrow-datafusion/issues/758
-            Partitioning::UnknownPartitioning(output_partition_count),
+            partitioning,
             datafusion::physical_plan::ExecutionMode::Bounded,
         );
         Self {
             stage_id,
             schema,
-            output_partition_count,
+            output_partition_count: properties.partitioning.partition_count(),
             properties,
         }
     }
@@ -75,7 +69,11 @@ impl DisplayAs for UnresolvedShuffleExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(f, "UnresolvedShuffleExec")
+                write!(
+                    f,
+                    "UnresolvedShuffleExec: {:?}",
+                    self.properties().output_partitioning()
+                )
             }
         }
     }

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -42,8 +42,8 @@ pub struct UnresolvedShuffleExecNode {
     pub stage_id: u32,
     #[prost(message, optional, tag = "2")]
     pub schema: ::core::option::Option<::datafusion_proto_common::Schema>,
-    #[prost(uint32, tag = "4")]
-    pub output_partition_count: u32,
+    #[prost(message, optional, tag = "5")]
+    pub partitioning: ::core::option::Option<::datafusion_proto::protobuf::Partitioning>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleReaderExecNode {
@@ -54,6 +54,8 @@ pub struct ShuffleReaderExecNode {
     /// The stage to read from
     #[prost(uint32, tag = "3")]
     pub stage_id: u32,
+    #[prost(message, optional, tag = "4")]
+    pub partitioning: ::core::option::Option<::datafusion_proto::protobuf::Partitioning>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleReaderPartition {

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -393,6 +393,10 @@ mod test {
             downcast_exec!(unresolved_shuffle, UnresolvedShuffleExec);
         assert_eq!(unresolved_shuffle.stage_id, 1);
         assert_eq!(unresolved_shuffle.output_partition_count, 2);
+        assert_eq!(
+            unresolved_shuffle.properties().partitioning,
+            Partitioning::Hash(vec![Arc::new(Column::new("l_returnflag", 0))], 2)
+        );
 
         // verify stage 2
         let stage2 = stages[2].children()[0].clone();
@@ -402,6 +406,10 @@ mod test {
             downcast_exec!(unresolved_shuffle, UnresolvedShuffleExec);
         assert_eq!(unresolved_shuffle.stage_id, 2);
         assert_eq!(unresolved_shuffle.output_partition_count, 2);
+        assert_eq!(
+            unresolved_shuffle.properties().partitioning,
+            Partitioning::Hash(vec![Arc::new(Column::new("l_returnflag", 0))], 2)
+        );
 
         Ok(())
     }
@@ -556,6 +564,10 @@ order by
         let unresolved_shuffle_reader_1 =
             downcast_exec!(join_input_1, UnresolvedShuffleExec);
         assert_eq!(unresolved_shuffle_reader_1.output_partition_count, 2);
+        assert_eq!(
+            unresolved_shuffle_reader_1.properties().partitioning,
+            Partitioning::Hash(vec![Arc::new(Column::new("l_orderkey", 0))], 2)
+        );
 
         let join_input_2 = join.children()[1].clone();
         // skip CoalesceBatches
@@ -563,6 +575,10 @@ order by
         let unresolved_shuffle_reader_2 =
             downcast_exec!(join_input_2, UnresolvedShuffleExec);
         assert_eq!(unresolved_shuffle_reader_2.output_partition_count, 2);
+        assert_eq!(
+            unresolved_shuffle_reader_2.properties().partitioning,
+            Partitioning::Hash(vec![Arc::new(Column::new("o_orderkey", 0))], 2)
+        );
 
         // final partitioned hash aggregate
         assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-ballista/issues/16.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
unresolved shuffle and shuffle reader exec does not have partitioning info. This becomes a problem when a stage has `InterleaveExec`, which requires all its children to have hash partitioning on the same expressions. Currently even though the partitioning satisfies InterleaveExec's requirements, because children show `UnknownPartitioning` planning such plans into stages fail.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Carry partitioning scheme through shuffles
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
