### PR TITLE
Ballista proto cleanup

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -172,7 +172,7 @@ message TaskInputPartitions {
 
 message KeyValuePair {
   string key = 1;
-  string value = 2;
+  optional string value = 2;
 }
 
 message Action {
@@ -458,10 +458,6 @@ message MultiTaskDefinition {
   repeated KeyValuePair props = 9;
 }
 
-message SessionSettings {
-  repeated KeyValuePair configs = 1;
-}
-
 message JobSessionConfig {
   string session_id = 1;
   repeated KeyValuePair configs = 2;
@@ -526,9 +522,8 @@ message ExecuteQueryParams {
     bytes logical_plan = 1;
     string sql = 2 [deprecated=true]; // I'd suggest to remove this, if SQL needed use `flight-sql`
   }
-  oneof optional_session_id {
-    string session_id = 3;
-  }
+  
+  optional string session_id = 3;
   repeated KeyValuePair settings = 4;
 }
 

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -17,7 +17,6 @@
 
 use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
-use crate::serde::protobuf::execute_query_params::OptionalSessionId;
 use crate::serde::protobuf::{
     execute_query_params::Query, execute_query_result, job_status,
     scheduler_grpc_client::SchedulerGrpcClient, ExecuteQueryParams, GetJobStatusParams,
@@ -218,7 +217,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             .map(
                 |datafusion::config::ConfigEntry { key, value, .. }| KeyValuePair {
                     key: key.to_owned(),
-                    value: value.clone().unwrap_or_else(|| String::from("")),
+                    value: value.clone(),
                 },
             )
             .collect();
@@ -226,9 +225,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
         let query = ExecuteQueryParams {
             query: Some(Query::LogicalPlan(buf)),
             settings,
-            optional_session_id: Some(OptionalSessionId::SessionId(
-                self.session_id.clone(),
-            )),
+            session_id: Some(self.session_id.clone()),
         };
 
         let stream = futures::stream::once(

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -249,8 +249,8 @@ pub struct TaskInputPartitions {
 pub struct KeyValuePair {
     #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub value: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "2")]
+    pub value: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Action {
@@ -708,11 +708,6 @@ pub struct MultiTaskDefinition {
     pub props: ::prost::alloc::vec::Vec<KeyValuePair>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SessionSettings {
-    #[prost(message, repeated, tag = "1")]
-    pub configs: ::prost::alloc::vec::Vec<KeyValuePair>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JobSessionConfig {
     #[prost(string, tag = "1")]
     pub session_id: ::prost::alloc::string::String,
@@ -789,14 +784,12 @@ pub struct UpdateTaskStatusResult {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteQueryParams {
+    #[prost(string, optional, tag = "3")]
+    pub session_id: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag = "4")]
     pub settings: ::prost::alloc::vec::Vec<KeyValuePair>,
     #[prost(oneof = "execute_query_params::Query", tags = "1, 2")]
     pub query: ::core::option::Option<execute_query_params::Query>,
-    #[prost(oneof = "execute_query_params::OptionalSessionId", tags = "3")]
-    pub optional_session_id: ::core::option::Option<
-        execute_query_params::OptionalSessionId,
-    >,
 }
 /// Nested message and enum types in `ExecuteQueryParams`.
 pub mod execute_query_params {
@@ -807,11 +800,6 @@ pub mod execute_query_params {
         /// I'd suggest to remove this, if SQL needed use `flight-sql`
         #[prost(string, tag = "2")]
         Sql(::prost::alloc::string::String),
-    }
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum OptionalSessionId {
-        #[prost(string, tag = "3")]
-        SessionId(::prost::alloc::string::String),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -18,7 +18,7 @@
 use axum::extract::ConnectInfo;
 use ballista_core::config::BALLISTA_JOB_NAME;
 use ballista_core::extension::SessionConfigHelperExt;
-use ballista_core::serde::protobuf::execute_query_params::{OptionalSessionId, Query};
+use ballista_core::serde::protobuf::execute_query_params::Query;
 use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpc;
 use ballista_core::serde::protobuf::{
     execute_query_failure_result, execute_query_result, AvailableTaskSlots,
@@ -337,25 +337,28 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
         let query_params = request.into_inner();
         if let ExecuteQueryParams {
             query: Some(query),
-            optional_session_id,
+            session_id,
             settings,
         } = query_params
         {
             let job_name = settings
                 .iter()
                 .find(|s| s.key == BALLISTA_JOB_NAME)
-                .map(|s| s.value.clone())
-                .unwrap_or_else(|| "None".to_string());
+                .and_then(|s| s.value.clone())
+                .unwrap_or_default();
 
-            let (session_id, session_ctx) = match optional_session_id {
-                Some(OptionalSessionId::SessionId(session_id)) => {
+            let (session_id, session_ctx) = match session_id {
+                Some(session_id) => {
                     match self.state.session_manager.get_session(&session_id).await {
                         Ok(ctx) => {
-                            // [SessionConfig] will be updated from received properties
+                            // Update [SessionConfig] using received properties
 
                             // TODO MM can we do something better here?
                             // move this to update session and use .update_session(&session_params.session_id, &session_config)
-                            // instead of get_session
+                            // instead of get_session.
+                            //
+                            // also we should consider sending properties if/when changed rather than
+                            // all properties every time
 
                             let state = ctx.state_ref();
                             let mut state = state.write();


### PR DESCRIPTION
# Which issue does this PR close?

Closes none.

 # Rationale for this change

Cleanup and simplification of `ballista.proto` and code around it 

# What changes are included in this PR?

There are few changes:

- value of`KeyValuePair` should be optional as it was used with optional configurations values
- few `oneOf`s have been replaced with `optional`
- Unused message has been removed
- 
# Are there any user-facing changes?

No