### PR TITLE
chore: update py-df to 43.1

### DIFF
--- a/examples/tests/object_store.rs
+++ b/examples/tests/object_store.rs
@@ -219,7 +219,6 @@ mod custom_s3_config {
     use ballista_core::RuntimeProducer;
     use ballista_examples::object_store::{CustomObjectStoreRegistry, S3Options};
     use ballista_examples::test_util::examples_test_data;
-    use datafusion::execution::runtime_env::RuntimeEnv;
     use datafusion::execution::SessionState;
     use datafusion::prelude::SessionConfig;
     use datafusion::{assert_batches_eq, prelude::SessionContext};

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -34,12 +34,12 @@ ballista = { path = "../ballista/client", version = "0.12.0" }
 ballista-core = { path = "../ballista/core", version = "0.12.0" }
 ballista-executor = { path = "../ballista/executor", version = "0.12.0", default-features = false }
 ballista-scheduler = { path = "../ballista/scheduler", version = "0.12.0", default-features = false }
-datafusion = { version = "42", features = ["pyarrow", "avro"] }
-datafusion-proto = { version = "42" }
-datafusion-python = { version = "42" }
+datafusion = { version = "43", features = ["pyarrow", "avro"] }
+datafusion-proto = { version = "43" }
+datafusion-python = { version = "43" }
 
 pyo3 = { version = "0.22", features = ["extension-module", "abi3", "abi3-py38"] }
-pyo3-log = "0.11.0"
+pyo3-log = "0.11"
 tokio = { version = "1.42", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 
 [lib]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-datafusion==42.0.0
+datafusion==43.1.0
 pyarrow
 pytest
 maturin==1.5.1


### PR DESCRIPTION
# Which issue does this PR close?

Closes none.

 # Rationale for this change

update py-df to 43.1 after updating ballista to df 43

# What changes are included in this PR?

- py-df deps updates
- fix duplicate import in one of the tests

# Are there any user-facing changes?

No