### PR TITLE
chore: no need to run python test in rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,8 +118,6 @@ jobs:
           export ARROW_TEST_DATA=$(pwd)/testing/data
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
           cargo test --features=testcontainers
-          cd python
-          cargo test
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"


### PR DESCRIPTION
as there is separate set of tests testing python functionality.

# Which issue does this PR close?

Closes none.

 # Rationale for this change

we test python module multiple times, as there are new test which cover python module independently we can disable this test

# What changes are included in this PR?

update to git workflow removing test

# Are there any user-facing changes?

