### PR TITLE
chore: fix executor build issue on release

### DIFF
--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -52,13 +52,7 @@ log = { workspace = true }
 mimalloc = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = [
-    "macros",
-    "rt",
-    "rt-multi-thread",
-    "parking_lot",
-    "signal",
-] }
+tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true }
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

when built from within executor directory build fails as it does not have all required features, if built from root, feature got inherited from scheduler. this patch should fix it 

# What changes are included in this PR?

# Are there any user-facing changes?
