### PR TITLE
fix: do not compile `keda.proto` if feature not used.

### DIFF
--- a/ballista/scheduler/build.rs
+++ b/ballista/scheduler/build.rs
@@ -18,12 +18,18 @@
 fn main() -> Result<(), String> {
     #[cfg(feature = "build-binary")]
     println!("cargo:rerun-if-changed=scheduler_config_spec.toml");
+
     #[cfg(feature = "build-binary")]
     configure_me_codegen::build_script_auto()
         .map_err(|e| format!("configure_me code generation failed: {e}"))?;
 
+    #[cfg(feature = "keda-scaler")]
     println!("cargo:rerun-if-changed=proto/keda.proto");
+
+    #[cfg(feature = "keda-scaler")]
     tonic_build::configure()
         .compile_protos(&["proto/keda.proto"], &["proto"])
-        .map_err(|e| format!("protobuf compilation failed: {e}"))
+        .map_err(|e| format!("protobuf compilation failed: {e}"))?;
+
+    Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes None.

 # Rationale for this change

Scheduler compiles `keda.proto` even if it's disabled, compilation requires `protoc` installed affecting user experience.

# What changes are included in this PR?

with this patch `protoc` will be required only if `keda-scaler` feature is enabled.

# Are there any user-facing changes?

No
