### PR TITLE
chore: publicly expose datafusion in ballista client

### DIFF
--- a/ballista/client/src/lib.rs
+++ b/ballista/client/src/lib.rs
@@ -19,3 +19,4 @@
 
 pub mod extension;
 pub mod prelude;
+pub use datafusion;

--- a/examples/examples/remote-sql.rs
+++ b/examples/examples/remote-sql.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista::prelude::*;
-use ballista_examples::test_util;
-use datafusion::{
+use ballista::datafusion::{
     common::Result,
     execution::SessionStateBuilder,
     prelude::{CsvReadOptions, SessionConfig, SessionContext},
 };
+use ballista::prelude::*;
+use ballista_examples::test_util;
 
 /// This example demonstrates executing a simple query against an Arrow data source (CSV) and
 /// fetching results, using SQL

--- a/examples/examples/standalone-sql.rs
+++ b/examples/examples/standalone-sql.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista::prelude::{SessionConfigExt, SessionContextExt};
-use ballista_examples::test_util;
-use datafusion::{
+use ballista::datafusion::{
     common::Result,
     execution::{options::ParquetReadOptions, SessionStateBuilder},
     prelude::{SessionConfig, SessionContext},
 };
+use ballista::prelude::{SessionConfigExt, SessionContextExt};
+use ballista_examples::test_util;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

we can simply basic usage examples, where we can avoid adding datafusion as dependency. 
something similar has been done with datafusion and arrow. 

# What changes are included in this PR?

# Are there any user-facing changes?
