### PR TITLE
chore: update datafusion to v45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ dependencies = [
  "log",
  "num-bigint",
  "quad-rand",
- "rand",
+ "rand 0.8.5",
  "regex-lite",
  "serde",
  "serde_bytes",
@@ -181,9 +181,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
+checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -202,24 +202,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31dce77d2985522288edae7206bffd5fc4996491841dda01a13a58415867e681"
+checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "half",
  "num",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
+checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -234,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b02656a35cc103f28084bc80a0159668e0a680d919cef127bd7e0aaccb06ec1"
+checksum = "4e899dade2c3b7f5642eb8366cfd898958bcca099cde6dfea543c7e8d3ad88d4"
 dependencies = [
  "bytes",
  "half",
@@ -245,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
+checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -266,28 +265,25 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec222848d70fea5a32af9c3602b08f5d740d5e2d33fbd76bf6fd88759b5b13a7"
+checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
 dependencies = [
  "arrow-array",
- "arrow-buffer",
  "arrow-cast",
- "arrow-data",
  "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
  "lazy_static",
- "lexical-core",
  "regex",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f2861ffa86f107b8ab577d86cff7c7a490243eabe961ba1e1af4f27542bb79"
+checksum = "0a329fb064477c9ec5f0870d2f5130966f91055c7c5bce2b3a084f116bc28c3b"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -297,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab7635558f3f803b492eae56c03cde97ea5f85a1c768f94181cb7db69cd81be"
+checksum = "c7408f2bf3b978eddda272c7699f439760ebc4ac70feca25fefa82c5b8ce808d"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -319,19 +315,17 @@ dependencies = [
  "paste",
  "prost",
  "prost-types",
- "tokio",
  "tonic",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
+checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-schema",
  "flatbuffers",
@@ -341,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eff38eeb8a971ad3a4caf62c5d57f0cff8a48b64a55e3207c4fd696a9234aad"
+checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -361,26 +355,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f202a879d287099139ff0d121e7f55ae5e0efe634b8cf2106ebc27a8715dee"
+checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "arrow-select",
- "half",
- "num",
 ]
 
 [[package]]
 name = "arrow-row"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f936954991c360ba762dff23f5dda16300774fafd722353d9683abd97630ae"
+checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
 dependencies = [
- "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -390,15 +381,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
+checksum = "85934a9d0261e0fa5d4e2a5295107d743b543a6e0484a835d4b8db2da15306f9"
 
 [[package]]
 name = "arrow-select"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
+checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -410,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72993b01cb62507b06f1fb49648d7286c8989ecfabdb7b77a750fcb54410731b"
+checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -427,11 +418,11 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
- "bzip2 0.4.4",
+ "bzip2 0.5.2",
  "flate2",
  "futures-core",
  "memchr",
@@ -868,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "ballista-core",
@@ -888,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-benchmarks"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "ballista",
  "ballista-core",
@@ -897,7 +888,7 @@ dependencies = [
  "env_logger",
  "futures",
  "mimalloc",
- "rand",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "snmalloc-rs",
@@ -907,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-cli"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "ballista",
  "clap 4.5.31",
@@ -922,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-core"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -938,7 +929,7 @@ dependencies = [
  "md-5",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.9.0",
  "rustc_version",
  "serde",
  "tempfile",
@@ -951,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-examples"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "ballista",
  "ballista-core",
@@ -971,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-executor"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -999,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-scheduler"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -1022,7 +1013,7 @@ dependencies = [
  "prometheus",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.9.0",
  "serde",
  "tokio",
  "tokio-stream",
@@ -1078,9 +1069,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake2"
@@ -1093,16 +1084,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "memmap2",
 ]
 
 [[package]]
@@ -1225,21 +1215,20 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b89e7c29231c673a61a46e722602bcd138298f6b9e81e71119693534585f5c"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -1255,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -1269,12 +1258,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1627,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014fc8c384ecacedaabb3bc8359c2a6c6e9d8f7bea65be3434eccacfc37f52d9"
+checksum = "eae420e7a5b0b7f1c39364cc76cbcd0f5fdc416b2514ae3847c2676bbd60702a"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -1639,9 +1622,8 @@ dependencies = [
  "async-compression",
  "async-trait",
  "bytes",
- "bzip2 0.5.1",
+ "bzip2 0.5.2",
  "chrono",
- "dashmap",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1661,13 +1643,13 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "num-traits",
  "object_store",
  "parking_lot",
  "parquet",
- "rand",
+ "rand 0.8.5",
  "regex",
  "sqlparser",
  "tempfile",
@@ -1681,24 +1663,30 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee60d33e210ef96070377ae667ece7caa0e959c8387496773d4a1a72f1a5012e"
+checksum = "6f27987bc22b810939e8dfecc55571e9d50355d6ea8ec1c47af8383a76a6d0e1"
 dependencies = [
- "arrow-schema",
+ "arrow",
  "async-trait",
+ "dashmap",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-plan",
+ "datafusion-sql",
+ "futures",
+ "itertools 0.14.0",
+ "log",
  "parking_lot",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-cli"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413b80c3f0668d2a1ec502d910af7d6f215d789a1f6feae7ef8a952798c8f47a"
+checksum = "36aa3b55844f279df97ae25c5300e1518b4a3aff60f9b95c8acc3a91bf330250"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1726,16 +1714,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b42b7d720fe21ed9cca2ebb635f3f13a12cfab786b41e0fba184fb2e620525b"
+checksum = "e3f6d5b8c9408cc692f7c194b8aa0c0f9b253e065a8d960ad9cdc2a13e697602"
 dependencies = [
  "ahash",
  "apache-avro",
  "arrow",
  "arrow-array",
  "arrow-buffer",
+ "arrow-ipc",
  "arrow-schema",
+ "base64 0.22.1",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
@@ -1752,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fbf14d4079f7ce5306393084fe5057dddfdc2113577e0049310afa12e94281"
+checksum = "0d4603c8e8a4baf77660ab7074cc66fc15cc8a18f2ce9dfadb755fc6ee294e48"
 dependencies = [
  "log",
  "tokio",
@@ -1762,15 +1752,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278dbd64860ed0bb5240fc1f4cb6aeea437153910aea69bcf7d5a8d6d0454f3"
+checksum = "e5bf4bc68623a5cf231eed601ed6eb41f46a37c4d15d11a0bff24cbc8396cd66"
 
 [[package]]
 name = "datafusion-execution"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22cb02af47e756468b3cbfee7a83e3d4f2278d452deb4b033ba933c75169486"
+checksum = "88b491c012cdf8e051053426013429a76f74ee3c2db68496c79c323ca1084d27"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1780,16 +1770,16 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62298eadb1d15b525df1315e61a71519ffc563d41d5c3b2a30fda2d70f77b93c"
+checksum = "e5a181408d4fc5dc22f9252781a8f39f2d0e5d1b33ec9bde242844980a2689c1"
 dependencies = [
  "arrow",
  "chrono",
@@ -1808,20 +1798,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda7f73c5fc349251cd3dcb05773c5bf55d2505a698ef9d38dfc712161ea2f55"
+checksum = "d1129b48e8534d8c03c6543bcdccef0b55c8ac0c1272a15a56c67068b6eb1885"
 dependencies = [
  "arrow",
  "datafusion-common",
- "itertools 0.13.0",
+ "itertools 0.14.0",
+ "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd197f3b2975424d3a4898ea46651be855a46721a56727515dbd5c9e2fb597da"
+checksum = "6125874e4856dfb09b59886784fcb74cde5cfc5930b3a80a1a728ef7a010df6b"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1837,10 +1828,10 @@ dependencies = [
  "datafusion-macros",
  "hashbrown 0.14.5",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "md-5",
- "rand",
+ "rand 0.8.5",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -1849,12 +1840,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabbe48fba18f9981b134124381bee9e46f93518b8ad2f9721ee296cef5affb9"
+checksum = "f3add7b1d3888e05e7c95f2b281af900ca69ebdcb21069ba679b33bde8b3b9d6"
 dependencies = [
  "ahash",
  "arrow",
+ "arrow-buffer",
  "arrow-schema",
  "datafusion-common",
  "datafusion-doc",
@@ -1871,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a3fefed9c8c11268d446d924baca8cabf52fe32f73fdaa20854bac6473590c"
+checksum = "6e18baa4cfc3d2f144f74148ed68a1f92337f5072b6dde204a0dbbdf3324989c"
 dependencies = [
  "ahash",
  "arrow",
@@ -1884,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6360f27464fab857bec698af39b2ae331dc07c8bf008fb4de387a19cdc6815a5"
+checksum = "3ec5ee8cecb0dc370291279673097ddabec03a011f73f30d7f1096457127e03e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1894,21 +1886,23 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "datafusion-common",
+ "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
  "datafusion-functions-aggregate",
+ "datafusion-macros",
  "datafusion-physical-expr-common",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c35c070eb705c12795dab399c3809f4dfbc290678c624d3989490ca9b8449c1"
+checksum = "2c403ddd473bbb0952ba880008428b3c7febf0ed3ce1eec35a205db20efb2a36"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1922,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52229bca26b590b140900752226c829f15fc1a99840e1ca3ce1a9534690b82a8"
+checksum = "1ab18c2fb835614d06a75f24a9e09136d3a8c12a92d97c95a6af316a1787a9c5"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -1939,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367befc303b64a668a10ae6988a064a9289e1999e71a7f8e526b6e14d6bdd9d6"
+checksum = "a77b73bc15e7d1967121fdc7a55d819bfb9d6c03766a6c322247dce9094a53a4"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1949,19 +1943,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5de3c8f386ea991696553afe241a326ecbc3c98a12c562867e4be754d3a060c"
+checksum = "09369b8d962291e808977cf94d495fd8b5b38647232d7ef562c27ac0f495b0af"
 dependencies = [
+ "datafusion-expr",
  "quote",
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b520413906f755910422b016fb73884ae6e9e1b376de4f9584b6c0e031da75"
+checksum = "2403a7e4a84637f3de7d8d4d7a9ccc0cc4be92d89b0161ba3ee5be82f0531c54"
 dependencies = [
  "arrow",
  "chrono",
@@ -1969,7 +1964,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
  "indexmap 2.7.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "recursive",
  "regex",
@@ -1978,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd6ddc378f6ad19af95ccd6790dec8f8e1264bc4c70e99ddc1830c1a1c78ccd"
+checksum = "86ff72ac702b62dbf2650c4e1d715ebd3e4aab14e3885e72e8549e250307347c"
 dependencies = [
  "ahash",
  "arrow",
@@ -1995,48 +1990,54 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "paste",
- "petgraph 0.6.5",
+ "petgraph",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e6c05458eccd74b4c77ed6a1fe63d52434240711de7f6960034794dad1caf5"
+checksum = "60982b7d684e25579ee29754b4333057ed62e2cc925383c5f0bd8cab7962f435"
 dependencies = [
  "ahash",
  "arrow",
+ "arrow-buffer",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
- "itertools 0.13.0",
+ "itertools 0.14.0",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc3a82190f49c37d377f31317e07ab5d7588b837adadba8ac367baad5dc2351"
+checksum = "ac5e85c189d5238a5cf181a624e450c4cd4c66ac77ca551d6f3ff9080bac90bb"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
+ "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.13.0",
+ "futures",
+ "itertools 0.14.0",
  "log",
  "recursive",
+ "url",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6608bc9844b4ddb5ed4e687d173e6c88700b1d0482f43894617d18a1fe75da"
+checksum = "c36bf163956d7e2542657c78b3383fdc78f791317ef358a359feffcdb968106f"
 dependencies = [
  "ahash",
  "arrow",
@@ -2057,7 +2058,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "parking_lot",
  "pin-project-lite",
@@ -2066,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e23b0998195e495bfa7b37cdceb317129a6c40522219f6872d2e0c9ae9f4fcb"
+checksum = "2db5d79f0c974041787b899d24dc91bdab2ff112d1942dd71356a4ce3b407e6c"
 dependencies = [
  "arrow",
  "chrono",
@@ -2082,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc59992a29eed2d2c1dd779deac99083b217774ebcf90ee121840607a4d866f"
+checksum = "de21bde1603aac0ff32cf478e47081be6e3583c6861fe8f57034da911efe7578"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2093,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a884061c79b33d0c8e84a6f4f4be8bdc12c0f53f5af28ddf5d6d95ac0b15fdc"
+checksum = "e13caa4daede211ecec53c78b13c503b592794d125f9a3cc3afe992edf9e7f43"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2133,23 +2134,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2285,12 +2286,6 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -2493,7 +2488,7 @@ dependencies = [
  "into-attr-derive",
  "pest",
  "pest_derive",
- "rand",
+ "rand 0.8.5",
  "tempfile",
 ]
 
@@ -2600,11 +2595,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2771,7 +2766,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -3217,7 +3212,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall 0.5.9",
 ]
@@ -3311,15 +3306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mimalloc"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3371,13 +3357,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -3499,7 +3485,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "ring",
  "rustls-pemfile 2.2.0",
@@ -3576,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8957c0c95a6a1804f3e51a18f69df29be53856a8c5768cc9b6d00fcafcd2917c"
+checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3602,6 +3588,7 @@ dependencies = [
  "object_store",
  "paste",
  "seq-macro",
+ "simdutf8",
  "snap",
  "thrift",
  "tokio",
@@ -3709,21 +3696,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 2.7.1",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "indexmap 2.7.1",
 ]
 
@@ -3753,7 +3730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3815,7 +3792,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3876,7 +3853,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -3889,7 +3866,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "hex",
 ]
 
@@ -3931,7 +3908,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.7.1",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -4019,7 +3996,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls 0.23.23",
@@ -4037,7 +4014,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -4071,8 +4048,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -4082,7 +4070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4092,6 +4090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -4129,18 +4136,18 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -4233,7 +4240,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -4328,7 +4335,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4441,11 +4448,11 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rustyline"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -4456,9 +4463,9 @@ dependencies = [
  "nix",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
  "utf8parse",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4507,7 +4514,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4520,7 +4527,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -4696,6 +4703,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5167,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.23",
  "tokio",
@@ -5312,7 +5325,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -5942,7 +5955,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -6014,7 +6027,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -6022,6 +6044,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
  "datafusion-proto",
  "datafusion-proto-common",
  "futures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "md-5",
  "prost",
@@ -1545,13 +1545,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "a7747ac3a66a06f4ee6718686c8ea976d2d05fb30ada93ebd76b3f9aef97257c"
 dependencies = [
- "quote",
- "syn 2.0.98",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "darling"
@@ -2189,6 +2195,21 @@ name = "dot-structures"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
+
+[[package]]
+name = "dtor"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf39a0bfd1f94d62ffdb2802a7e6244c0f34f6ebacf5d4c26547d08cd1d67a5"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "either"
@@ -4280,21 +4301,21 @@ checksum = "e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ members = ["ballista-cli", "ballista/client", "ballista/core", "ballista/executo
 resolver = "2"
 
 [workspace.dependencies]
-arrow = { version = "53", features = ["ipc_compression"] }
-arrow-flight = { version = "53", features = ["flight-sql-experimental"] }
+arrow = { version = "54", features = ["ipc_compression"] }
+arrow-flight = { version = "54", features = ["flight-sql-experimental"] }
 clap = { version = "4.5", features = ["derive", "cargo"] }
 configure_me = { version = "0.4.0" }
 configure_me_codegen = { version = "0.4.4" }
-datafusion = "44.0.0"
-datafusion-cli = "44.0.0"
-datafusion-proto = "44.0.0"
-datafusion-proto-common = "44.0.0"
+datafusion = "45.0.0"
+datafusion-cli = "45.0.0"
+datafusion-proto = "45.0.0"
+datafusion-proto-common = "45.0.0"
 object_store = "0.11"
 prost = "0.13"
 prost-types = "0.13"
@@ -45,15 +45,15 @@ ctor = { version = "0.2" }
 mimalloc = { version = "0.1" }
 
 tokio = { version = "1" }
-uuid = { version = "1.10", features = ["v4", "v7"] }
-rand = { version = "0.8" }
+uuid = { version = "1.13", features = ["v4", "v7"] }
+rand = { version = "0.9" }
 env_logger = { version = "0.11" }
 futures = { version = "0.3" }
 log = { version = "0.4" }
 parking_lot = { version = "0.12" }
-tempfile = { version = "3" }
+tempfile = { version = "3.16" }
 dashmap = { version = "6.1" }
-async-trait = { version = "0.1.4" }
+async-trait = { version = "0.1" }
 serde = { version = "1.0" }
 tokio-stream = { version = "0.1" }
 url = { version = "2.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tonic-build = { version = "0.12", default-features = false, features = [
 tracing = "0.1"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ctor = { version = "0.2" }
+ctor = { version = "0.4" }
 mimalloc = { version = "0.1" }
 
 tokio = { version = "1" }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-cli"
 description = "Command Line Client for Ballista distributed query engine."
-version = "44.0.0"
+version = "45.0.0"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 edition = "2021"
 keywords = ["ballista", "cli"]
@@ -28,14 +28,14 @@ repository = "https://github.com/apache/arrow-ballista"
 readme = "README.md"
 
 [dependencies]
-ballista = { path = "../ballista/client", version = "44.0.0", features = ["standalone"] }
+ballista = { path = "../ballista/client", version = "45.0.0", features = ["standalone"] }
 clap = { workspace = true, features = ["derive", "cargo"] }
 datafusion = { workspace = true }
 datafusion-cli = { workspace = true }
-dirs = "5.0.1"
+dirs = "6.0"
 env_logger = { workspace = true }
 mimalloc = { workspace = true }
-rustyline = "14.0.0"
+rustyline = "15.0.0"
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }
 
 [features]

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista"
 description = "Ballista Distributed Compute"
 license = "Apache-2.0"
-version = "44.0.0"
+version = "45.0.0"
 homepage = "https://github.com/apache/arrow-ballista"
 repository = "https://github.com/apache/arrow-ballista"
 readme = "README.md"
@@ -28,9 +28,9 @@ edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true }
-ballista-core = { path = "../core", version = "44.0.0" }
-ballista-executor = { path = "../executor", version = "44.0.0", optional = true }
-ballista-scheduler = { path = "../scheduler", version = "44.0.0", optional = true }
+ballista-core = { path = "../core", version = "45.0.0" }
+ballista-executor = { path = "../executor", version = "45.0.0", optional = true }
+ballista-scheduler = { path = "../scheduler", version = "45.0.0", optional = true }
 datafusion = { workspace = true }
 log = { workspace = true }
 
@@ -38,8 +38,8 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-ballista-executor = { path = "../executor", version = "44.0.0" }
-ballista-scheduler = { path = "../scheduler", version = "44.0.0" }
+ballista-executor = { path = "../executor", version = "45.0.0" }
+ballista-scheduler = { path = "../scheduler", version = "45.0.0" }
 ctor = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -43,7 +43,7 @@ ballista-scheduler = { path = "../scheduler", version = "45.0.0" }
 ctor = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }
-rstest = { version = "0.23" }
+rstest = { version = "0.24" }
 tempfile = { workspace = true }
 tonic = { workspace = true }
 

--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -398,7 +398,8 @@ mod supported {
         Ok(())
     }
 
-    /// looks like `ctx.enable_url_table()` changes session context id.
+    // tests if `ctx.enable_url_table()` works correctly
+    // it did not work before datafusion 45.0.0
     #[rstest]
     #[case::standalone(standalone_context())]
     #[case::remote(remote_context())]

--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -397,4 +397,38 @@ mod supported {
 
         Ok(())
     }
+
+    /// looks like `ctx.enable_url_table()` changes session context id.
+    #[rstest]
+    #[case::standalone(standalone_context())]
+    #[case::remote(remote_context())]
+    #[tokio::test]
+    async fn should_execute_sql_show_with_url_table(
+        #[future(awt)]
+        #[case]
+        ctx: SessionContext,
+        test_data: String,
+    ) {
+        let ctx = ctx.enable_url_table();
+
+        let result = ctx
+            .sql(&format!("select string_col, timestamp_col from '{test_data}/alltypes_plain.parquet' where id > 4"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let expected = [
+            "+------------+---------------------+",
+            "| string_col | timestamp_col       |",
+            "+------------+---------------------+",
+            "| 31         | 2009-03-01T00:01:00 |",
+            "| 30         | 2009-04-01T00:00:00 |",
+            "| 31         | 2009-04-01T00:01:00 |",
+            "+------------+---------------------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+    }
 }

--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -409,16 +409,16 @@ mod supported {
         #[case]
         ctx: SessionContext,
         test_data: String,
-    ) {
+    ) -> datafusion::error::Result<()> {
+        // tests check if this configuration option
+        // will work
         let ctx = ctx.enable_url_table();
 
         let result = ctx
             .sql(&format!("select string_col, timestamp_col from '{test_data}/alltypes_plain.parquet' where id > 4"))
-            .await
-            .unwrap()
+            .await?
             .collect()
-            .await
-            .unwrap();
+            .await?;
 
         let expected = [
             "+------------+---------------------+",
@@ -431,5 +431,7 @@ mod supported {
         ];
 
         assert_batches_eq!(expected, &result);
+
+        Ok(())
     }
 }

--- a/ballista/client/tests/context_unsupported.rs
+++ b/ballista/client/tests/context_unsupported.rs
@@ -211,45 +211,4 @@ mod unsupported {
 
         assert_batches_eq!(expected, &result);
     }
-
-    /// looks like `ctx.enable_url_table()` changes session context id.
-    ///
-    /// Error returned:
-    /// ```
-    /// Failed to load SessionContext for session ID b5530099-63d1-43b1-9e11-87ac83bb33e5:
-    /// General error: No session for b5530099-63d1-43b1-9e11-87ac83bb33e5 found
-    /// ```
-    #[rstest]
-    #[case::standalone(standalone_context())]
-    #[case::remote(remote_context())]
-    #[tokio::test]
-    #[should_panic]
-    async fn should_execute_sql_show_with_url_table(
-        #[future(awt)]
-        #[case]
-        ctx: SessionContext,
-        test_data: String,
-    ) {
-        let ctx = ctx.enable_url_table();
-
-        let result = ctx
-            .sql(&format!("select string_col, timestamp_col from '{test_data}/alltypes_plain.parquet' where id > 4"))
-            .await
-            .unwrap()
-            .collect()
-            .await
-            .unwrap();
-
-        let expected = [
-            "+------------+---------------------+",
-            "| string_col | timestamp_col       |",
-            "+------------+---------------------+",
-            "| 31         | 2009-03-01T00:01:00 |",
-            "| 30         | 2009-04-01T00:00:00 |",
-            "| 31         | 2009-04-01T00:01:00 |",
-            "+------------+---------------------+",
-        ];
-
-        assert_batches_eq!(expected, &result);
-    }
 }

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-core"
 description = "Ballista Distributed Compute"
 license = "Apache-2.0"
-version = "44.0.0"
+version = "45.0.0"
 homepage = "https://github.com/apache/arrow-ballista"
 repository = "https://github.com/apache/arrow-ballista"
 readme = "README.md"

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -49,7 +49,7 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 datafusion-proto-common = { workspace = true }
 futures = { workspace = true }
-itertools = "0.13"
+itertools = "0.14"
 log = { workspace = true }
 md-5 = { version = "^0.10.0" }
 prost = { workspace = true }

--- a/ballista/core/proto/datafusion.proto
+++ b/ballista/core/proto/datafusion.proto
@@ -16,1243 +16,1264 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
-
-package datafusion;
-
-option java_multiple_files = true;
-option java_package = "org.apache.arrow.datafusion.protobuf";
-option java_outer_classname = "DatafusionProto";
-
-import "datafusion_common.proto";
-
-// logical plan
-// LogicalPlan is a nested type
-message LogicalPlanNode {
-  oneof LogicalPlanType {
-    ListingTableScanNode listing_scan = 1;
-    ProjectionNode projection = 3;
-    SelectionNode selection = 4;
-    LimitNode limit = 5;
-    AggregateNode aggregate = 6;
-    JoinNode join = 7;
-    SortNode sort = 8;
-    RepartitionNode repartition = 9;
-    EmptyRelationNode empty_relation = 10;
-    CreateExternalTableNode create_external_table = 11;
-    ExplainNode explain = 12;
-    WindowNode window = 13;
-    AnalyzeNode analyze = 14;
-    CrossJoinNode cross_join = 15;
-    ValuesNode values = 16;
-    LogicalExtensionNode extension = 17;
-    CreateCatalogSchemaNode create_catalog_schema = 18;
-    UnionNode union = 19;
-    CreateCatalogNode create_catalog = 20;
-    SubqueryAliasNode subquery_alias = 21;
-    CreateViewNode create_view = 22;
-    DistinctNode distinct = 23;
-    ViewTableScanNode view_scan = 24;
-    CustomTableScanNode custom_scan = 25;
-    PrepareNode prepare = 26;
-    DropViewNode drop_view = 27;
-    DistinctOnNode distinct_on = 28;
-    CopyToNode copy_to = 29;
-    UnnestNode unnest = 30;
-    RecursiveQueryNode recursive_query = 31;
-    CteWorkTableScanNode cte_work_table_scan = 32;
-  }
-}
-
-message LogicalExtensionNode {
-  bytes node = 1;
-  repeated LogicalPlanNode inputs = 2;
-}
-
-message ProjectionColumns {
-  repeated string columns = 1;
-}
-
-message LogicalExprNodeCollection {
-  repeated LogicalExprNode logical_expr_nodes = 1;
-}
-
-message SortExprNodeCollection {
-  repeated SortExprNode sort_expr_nodes = 1;
-}
-
-message ListingTableScanNode {
-  reserved 1; // was string table_name
-  TableReference table_name = 14;
-  repeated string paths = 2;
-  string file_extension = 3;
-  ProjectionColumns projection = 4;
-  datafusion_common.Schema schema = 5;
-  repeated LogicalExprNode filters = 6;
-  repeated string table_partition_cols = 7;
-  bool collect_stat = 8;
-  uint32 target_partitions = 9;
-  oneof FileFormatType {
-    datafusion_common.CsvFormat csv = 10;
-    datafusion_common.ParquetFormat parquet = 11;
-    datafusion_common.AvroFormat avro = 12;
-    datafusion_common.NdJsonFormat json = 15;
-  }
-  repeated SortExprNodeCollection file_sort_order = 13;
-}
-
-message ViewTableScanNode {
-  reserved 1; // was string table_name
-  TableReference table_name = 6;
-  LogicalPlanNode input = 2;
-  datafusion_common.Schema schema = 3;
-  ProjectionColumns projection = 4;
-  string definition = 5;
-}
-
-// Logical Plan to Scan a CustomTableProvider registered at runtime
-message CustomTableScanNode {
-  reserved 1; // was string table_name
-  TableReference table_name = 6;
-  ProjectionColumns projection = 2;
-  datafusion_common.Schema schema = 3;
-  repeated LogicalExprNode filters = 4;
-  bytes custom_table_data = 5;
-}
-
-message ProjectionNode {
-  LogicalPlanNode input = 1;
-  repeated LogicalExprNode expr = 2;
-  oneof optional_alias {
-    string alias = 3;
-  }
-}
-
-message SelectionNode {
-  LogicalPlanNode input = 1;
-  LogicalExprNode expr = 2;
-}
-
-message SortNode {
-  LogicalPlanNode input = 1;
-  repeated SortExprNode expr = 2;
-  // Maximum number of highest/lowest rows to fetch; negative means no limit
-  int64 fetch = 3;
-}
-
-message RepartitionNode {
-  LogicalPlanNode input = 1;
-  oneof partition_method {
-    uint64 round_robin = 2;
-    HashRepartition hash = 3;
-  }
-}
-
-message HashRepartition {
-  repeated LogicalExprNode hash_expr = 1;
-  uint64 partition_count = 2;
-}
-
-message EmptyRelationNode {
-  bool produce_one_row = 1;
-}
-
-message CreateExternalTableNode {
-  reserved 1; // was string name
-  TableReference name = 9;
-  string location = 2;
-  string file_type = 3;
-  datafusion_common.DfSchema schema = 4;
-  repeated string table_partition_cols = 5;
-  bool if_not_exists = 6;
-  bool temporary = 14;
-  string definition = 7;
-  repeated SortExprNodeCollection order_exprs = 10;
-  bool unbounded = 11;
-  map<string, string> options = 8;
-  datafusion_common.Constraints constraints = 12;
-  map<string, LogicalExprNode> column_defaults = 13;
-}
-
-message PrepareNode {
-  string name = 1;
-  repeated datafusion_common.ArrowType data_types = 2;
-  LogicalPlanNode input = 3;
-}
-
-message CreateCatalogSchemaNode {
-  string schema_name = 1;
-  bool if_not_exists = 2;
-  datafusion_common.DfSchema schema = 3;
-}
-
-message CreateCatalogNode {
-  string catalog_name = 1;
-  bool if_not_exists = 2;
-  datafusion_common.DfSchema schema = 3;
-}
-
-message DropViewNode {
-  TableReference name = 1;
-  bool if_exists = 2;
-  datafusion_common.DfSchema schema = 3;
-}
-
-message CreateViewNode {
-  reserved 1; // was string name
-  TableReference name = 5;
-  LogicalPlanNode input = 2;
-  bool or_replace = 3;
-  bool temporary = 6;
-  string definition = 4;
-}
-
-// a node containing data for defining values list. unlike in SQL where it's two dimensional, here
-// the list is flattened, and with the field n_cols it can be parsed and partitioned into rows
-message ValuesNode {
-  uint64 n_cols = 1;
-  repeated LogicalExprNode values_list = 2;
-}
-
-message AnalyzeNode {
-  LogicalPlanNode input = 1;
-  bool verbose = 2;
-}
-
-message ExplainNode {
-  LogicalPlanNode input = 1;
-  bool verbose = 2;
-}
-
-message AggregateNode {
-  LogicalPlanNode input = 1;
-  repeated LogicalExprNode group_expr = 2;
-  repeated LogicalExprNode aggr_expr = 3;
-}
-
-message WindowNode {
-  LogicalPlanNode input = 1;
-  repeated LogicalExprNode window_expr = 2;
-}
-
-message JoinNode {
-  LogicalPlanNode left = 1;
-  LogicalPlanNode right = 2;
-  datafusion_common.JoinType join_type = 3;
-  datafusion_common.JoinConstraint join_constraint = 4;
-  repeated LogicalExprNode left_join_key = 5;
-  repeated LogicalExprNode right_join_key = 6;
-  bool null_equals_null = 7;
-  LogicalExprNode filter = 8;
-}
-
-message DistinctNode {
-  LogicalPlanNode input = 1;
-}
-
-message DistinctOnNode {
-  repeated LogicalExprNode on_expr = 1;
-  repeated LogicalExprNode select_expr = 2;
-  repeated SortExprNode sort_expr = 3;
-  LogicalPlanNode input = 4;
-}
-
-message CopyToNode {
-  LogicalPlanNode input = 1;
-  string output_url = 2;
-  bytes file_type = 3;
-  repeated string partition_by = 7;
-}
-
-message UnnestNode {
-  LogicalPlanNode input = 1;
-  repeated datafusion_common.Column exec_columns = 2;
-  repeated ColumnUnnestListItem list_type_columns = 3;
-  repeated uint64 struct_type_columns = 4;
-  repeated uint64 dependency_indices = 5;
-  datafusion_common.DfSchema schema = 6;
-  UnnestOptions options = 7;
-}
-message ColumnUnnestListItem {
-  uint32 input_index = 1;
-  ColumnUnnestListRecursion recursion = 2;
-}
-
-message ColumnUnnestListRecursions {
-  repeated ColumnUnnestListRecursion recursions = 2;
-}
-
-message ColumnUnnestListRecursion {
-  datafusion_common.Column output_column = 1;
-  uint32 depth = 2;
-}
-
-message UnnestOptions {
-  bool preserve_nulls = 1;
-  repeated RecursionUnnestOption recursions = 2;
-}
-
-message RecursionUnnestOption {
-  datafusion_common.Column output_column = 1;
-  datafusion_common.Column input_column = 2;
-  uint32 depth = 3;
-}
-
-message UnionNode {
-  repeated LogicalPlanNode inputs = 1;
-}
-
-message CrossJoinNode {
-  LogicalPlanNode left = 1;
-  LogicalPlanNode right = 2;
-}
-
-message LimitNode {
-  LogicalPlanNode input = 1;
-  // The number of rows to skip before fetch; non-positive means don't skip any
-  int64 skip = 2;
-  // Maximum number of rows to fetch; negative means no limit
-  int64 fetch = 3;
-}
-
-message SelectionExecNode {
-  LogicalExprNode expr = 1;
-}
-
-message SubqueryAliasNode {
-  reserved 2; // Was string alias
-  LogicalPlanNode input = 1;
-  TableReference alias = 3;
-}
-
-// logical expressions
-message LogicalExprNode {
-  oneof ExprType {
-    // column references
-    datafusion_common.Column column = 1;
-
-    // alias
-    AliasNode alias = 2;
-
-    datafusion_common.ScalarValue literal = 3;
-
-    // binary expressions
-    BinaryExprNode binary_expr = 4;
-
-
-    // null checks
-    IsNull is_null_expr = 6;
-    IsNotNull is_not_null_expr = 7;
-    Not not_expr = 8;
-
-    BetweenNode between = 9;
-    CaseNode case_ = 10;
-    CastNode cast = 11;
-    NegativeNode negative = 13;
-    InListNode in_list = 14;
-    Wildcard wildcard = 15;
-    // was  ScalarFunctionNode scalar_function = 16;
-    TryCastNode try_cast = 17;
-
-    // window expressions
-    WindowExprNode window_expr = 18;
-
-    // AggregateUDF expressions
-    AggregateUDFExprNode aggregate_udf_expr = 19;
-
-    // Scalar UDF expressions
-    ScalarUDFExprNode scalar_udf_expr = 20;
-
-    // GetIndexedField get_indexed_field = 21;
-
-    GroupingSetNode grouping_set = 22;
-
-    CubeNode cube = 23;
-
-    RollupNode rollup = 24;
-
-    IsTrue is_true = 25;
-    IsFalse is_false = 26;
-    IsUnknown is_unknown = 27;
-    IsNotTrue is_not_true = 28;
-    IsNotFalse is_not_false = 29;
-    IsNotUnknown is_not_unknown = 30;
-    LikeNode like = 31;
-    ILikeNode ilike = 32;
-    SimilarToNode similar_to = 33;
-
-    PlaceholderNode placeholder = 34;
-
-    Unnest unnest = 35;
-
-  }
-}
-
-message Wildcard {
-  TableReference qualifier = 1;
-}
-
-message PlaceholderNode {
-  string id = 1;
-  datafusion_common.ArrowType data_type = 2;
-}
-
-message LogicalExprList {
-  repeated LogicalExprNode expr = 1;
-}
-
-message GroupingSetNode {
-  repeated LogicalExprList expr = 1;
-}
-
-message CubeNode {
-  repeated LogicalExprNode expr = 1;
-}
-
-message RollupNode {
-  repeated LogicalExprNode expr = 1;
-}
-
-message NamedStructField {
-  datafusion_common.ScalarValue name = 1;
-}
-
-message ListIndex {
-  LogicalExprNode key = 1;
-}
-
-message ListRange {
-  LogicalExprNode start = 1;
-  LogicalExprNode stop = 2;
-  LogicalExprNode stride = 3;
-}
-
-message IsNull {
-  LogicalExprNode expr = 1;
-}
-
-message IsNotNull {
-  LogicalExprNode expr = 1;
-}
-
-message IsTrue {
-  LogicalExprNode expr = 1;
-}
-
-message IsFalse {
-  LogicalExprNode expr = 1;
-}
-
-message IsUnknown {
-  LogicalExprNode expr = 1;
-}
-
-message IsNotTrue {
-  LogicalExprNode expr = 1;
-}
-
-message IsNotFalse {
-  LogicalExprNode expr = 1;
-}
-
-message IsNotUnknown {
-  LogicalExprNode expr = 1;
-}
-
-message Not {
-  LogicalExprNode expr = 1;
-}
-
-message AliasNode {
-  LogicalExprNode expr = 1;
-  string alias = 2;
-  repeated TableReference relation = 3;
-}
-
-message BinaryExprNode {
-  // Represents the operands from the left inner most expression
-  // to the right outer most expression where each of them are chained
-  // with the operator 'op'.
-  repeated LogicalExprNode operands = 1;
-  string op = 3;
-}
-
-message NegativeNode {
-  LogicalExprNode expr = 1;
-}
-
-message Unnest {
-  repeated LogicalExprNode exprs = 1;
-}
-
-message InListNode {
-  LogicalExprNode expr = 1;
-  repeated LogicalExprNode list = 2;
-  bool negated = 3;
-}
-
-
-message AggregateUDFExprNode {
-  string fun_name = 1;
-  repeated LogicalExprNode args = 2;
-  bool distinct = 5;
-  LogicalExprNode filter = 3;
-  repeated SortExprNode order_by = 4;
-  optional bytes fun_definition = 6;
-}
-
-message ScalarUDFExprNode {
-  string fun_name = 1;
-  repeated LogicalExprNode args = 2;
-  optional bytes fun_definition = 3;
-}
-
-message WindowExprNode {
-  oneof window_function {
-    // BuiltInWindowFunction built_in_function = 2;
-    string udaf = 3;
-    string udwf = 9;
-  }
-  repeated LogicalExprNode exprs = 4;
-  repeated LogicalExprNode partition_by = 5;
-  repeated SortExprNode order_by = 6;
-  // repeated LogicalExprNode filter = 7;
-  WindowFrame window_frame = 8;
-  optional bytes fun_definition = 10;
-}
-
-message BetweenNode {
-  LogicalExprNode expr = 1;
-  bool negated = 2;
-  LogicalExprNode low = 3;
-  LogicalExprNode high = 4;
-}
-
-message LikeNode {
-  bool negated = 1;
-  LogicalExprNode expr = 2;
-  LogicalExprNode pattern = 3;
-  string escape_char = 4;
-}
-
-message ILikeNode {
-  bool negated = 1;
-  LogicalExprNode expr = 2;
-  LogicalExprNode pattern = 3;
-  string escape_char = 4;
-}
-
-message SimilarToNode {
-  bool negated = 1;
-  LogicalExprNode expr = 2;
-  LogicalExprNode pattern = 3;
-  string escape_char = 4;
-}
-
-message CaseNode {
-  LogicalExprNode expr = 1;
-  repeated WhenThen when_then_expr = 2;
-  LogicalExprNode else_expr = 3;
-}
-
-message WhenThen {
-  LogicalExprNode when_expr = 1;
-  LogicalExprNode then_expr = 2;
-}
-
-message CastNode {
-  LogicalExprNode expr = 1;
-  datafusion_common.ArrowType arrow_type = 2;
-}
-
-message TryCastNode {
-  LogicalExprNode expr = 1;
-  datafusion_common.ArrowType arrow_type = 2;
-}
-
-message SortExprNode {
-  LogicalExprNode expr = 1;
-  bool asc = 2;
-  bool nulls_first = 3;
-}
-
-enum WindowFrameUnits {
-  ROWS = 0;
-  RANGE = 1;
-  GROUPS = 2;
-}
-
-message WindowFrame {
-  WindowFrameUnits window_frame_units = 1;
-  WindowFrameBound start_bound = 2;
-  // "optional" keyword is stable in protoc 3.15 but prost is still on 3.14 (see https://github.com/tokio-rs/prost/issues/430 and https://github.com/tokio-rs/prost/pull/455)
-  // this syntax is ugly but is binary compatible with the "optional" keyword (see https://stackoverflow.com/questions/42622015/how-to-define-an-optional-field-in-protobuf-3)
-  oneof end_bound {
-    WindowFrameBound bound = 3;
-  }
-}
-
-enum WindowFrameBoundType {
-  CURRENT_ROW = 0;
-  PRECEDING = 1;
-  FOLLOWING = 2;
-}
-
-message WindowFrameBound {
-  WindowFrameBoundType window_frame_bound_type = 1;
-  datafusion_common.ScalarValue bound_value = 2;
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Arrow Data Types
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-message FixedSizeBinary{
-  int32 length = 1;
-}
-
-enum DateUnit{
-  Day = 0;
-  DateMillisecond = 1;
-}
-
-message AnalyzedLogicalPlanType {
-  string analyzer_name = 1;
-}
-
-message OptimizedLogicalPlanType {
-  string optimizer_name = 1;
-}
-
-message OptimizedPhysicalPlanType {
-  string optimizer_name = 1;
-}
-
-message PlanType {
-  oneof plan_type_enum {
-    datafusion_common.EmptyMessage InitialLogicalPlan = 1;
-    AnalyzedLogicalPlanType AnalyzedLogicalPlan = 7;
-    datafusion_common.EmptyMessage FinalAnalyzedLogicalPlan = 8;
-    OptimizedLogicalPlanType OptimizedLogicalPlan = 2;
-    datafusion_common.EmptyMessage FinalLogicalPlan = 3;
-    datafusion_common.EmptyMessage InitialPhysicalPlan = 4;
-    datafusion_common.EmptyMessage InitialPhysicalPlanWithStats = 9;
-    datafusion_common.EmptyMessage InitialPhysicalPlanWithSchema = 11;
-    OptimizedPhysicalPlanType OptimizedPhysicalPlan = 5;
-    datafusion_common.EmptyMessage FinalPhysicalPlan = 6;
-    datafusion_common.EmptyMessage FinalPhysicalPlanWithStats = 10;
-    datafusion_common.EmptyMessage FinalPhysicalPlanWithSchema = 12;
-    datafusion_common.EmptyMessage PhysicalPlanError = 13;
-  }
-}
-
-message StringifiedPlan {
-  PlanType plan_type = 1;
-  string plan = 2;
-}
-
-message BareTableReference {
-  string table = 1;
-}
-
-message PartialTableReference {
-  string schema = 1;
-  string table = 2;
-}
-
-message FullTableReference {
-  string catalog = 1;
-  string schema = 2;
-  string table = 3;
-}
-
-message TableReference {
-  oneof table_reference_enum {
-    BareTableReference bare = 1;
-    PartialTableReference partial = 2;
-    FullTableReference full = 3;
-  }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////////////
-
-// PhysicalPlanNode is a nested type
-message PhysicalPlanNode {
-  oneof PhysicalPlanType {
-    ParquetScanExecNode parquet_scan = 1;
-    CsvScanExecNode csv_scan = 2;
-    EmptyExecNode empty = 3;
-    ProjectionExecNode projection = 4;
-    GlobalLimitExecNode global_limit = 6;
-    LocalLimitExecNode local_limit = 7;
-    AggregateExecNode aggregate = 8;
-    HashJoinExecNode hash_join = 9;
-    SortExecNode sort = 10;
-    CoalesceBatchesExecNode coalesce_batches = 11;
-    FilterExecNode filter = 12;
-    CoalescePartitionsExecNode merge = 13;
-    RepartitionExecNode repartition = 14;
-    WindowAggExecNode window = 15;
-    CrossJoinExecNode cross_join = 16;
-    AvroScanExecNode avro_scan = 17;
-    PhysicalExtensionNode extension = 18;
-    UnionExecNode union = 19;
-    ExplainExecNode explain = 20;
-    SortPreservingMergeExecNode sort_preserving_merge = 21;
-    NestedLoopJoinExecNode nested_loop_join = 22;
-    AnalyzeExecNode analyze = 23;
-    JsonSinkExecNode json_sink = 24;
-    SymmetricHashJoinExecNode symmetric_hash_join = 25;
-    InterleaveExecNode interleave = 26;
-    PlaceholderRowExecNode placeholder_row = 27;
-    CsvSinkExecNode csv_sink = 28;
-    ParquetSinkExecNode parquet_sink = 29;
-    UnnestExecNode unnest = 30;
-  }
-}
-
-message PartitionColumn {
-  string name = 1;
-  datafusion_common.ArrowType arrow_type = 2;
-}
-
-
-message FileSinkConfig {
-  reserved 6; // writer_mode
-  reserved 8; // was `overwrite` which has been superseded by `insert_op`
-
-  string object_store_url = 1;
-  repeated PartitionedFile file_groups = 2;
-  repeated string table_paths = 3;
-  datafusion_common.Schema output_schema = 4;
-  repeated PartitionColumn table_partition_cols = 5;
-  bool keep_partition_by_columns = 9;
-  InsertOp insert_op = 10;
-}
-
-enum InsertOp {
-  Append = 0;
-  Overwrite = 1;
-  Replace = 2;
-}
-
-message JsonSink {
-  FileSinkConfig config = 1;
-  datafusion_common.JsonWriterOptions writer_options = 2;
-}
-
-message JsonSinkExecNode {
-  PhysicalPlanNode input = 1;
-  JsonSink sink = 2;
-  datafusion_common.Schema sink_schema = 3;
-  PhysicalSortExprNodeCollection sort_order = 4;
-}
-
-message CsvSink {
-  FileSinkConfig config = 1;
-  datafusion_common.CsvWriterOptions writer_options = 2;
-}
-
-message CsvSinkExecNode {
-  PhysicalPlanNode input = 1;
-  CsvSink sink = 2;
-  datafusion_common.Schema sink_schema = 3;
-  PhysicalSortExprNodeCollection sort_order = 4;
-}
-
-message ParquetSink {
-  FileSinkConfig config = 1;
-  datafusion_common.TableParquetOptions parquet_options = 2;
-}
-
-message ParquetSinkExecNode {
-  PhysicalPlanNode input = 1;
-  ParquetSink sink = 2;
-  datafusion_common.Schema sink_schema = 3;
-  PhysicalSortExprNodeCollection sort_order = 4;
-}
-
-message UnnestExecNode {
-  PhysicalPlanNode input = 1;
-  datafusion_common.Schema schema = 2;
-  repeated ListUnnest list_type_columns = 3;
-  repeated uint64 struct_type_columns = 4;
-  UnnestOptions options = 5;
-}
-
-message ListUnnest {
-  uint32 index_in_input_schema = 1;
-  uint32 depth = 2;
-}
-
-message PhysicalExtensionNode {
-  bytes node = 1;
-  repeated PhysicalPlanNode inputs = 2;
-}
-
-// physical expressions
-message PhysicalExprNode {
-  // Was date_time_interval_expr
-  reserved 17;
-
-  oneof ExprType {
-    // column references
-    PhysicalColumn column = 1;
-
-    datafusion_common.ScalarValue literal = 2;
-
-    // binary expressions
-    PhysicalBinaryExprNode binary_expr = 3;
-
-    // aggregate expressions
-    PhysicalAggregateExprNode aggregate_expr = 4;
-
-    // null checks
-    PhysicalIsNull is_null_expr = 5;
-    PhysicalIsNotNull is_not_null_expr = 6;
-    PhysicalNot not_expr = 7;
-
-    PhysicalCaseNode case_ = 8;
-    PhysicalCastNode cast = 9;
-    PhysicalSortExprNode sort = 10;
-    PhysicalNegativeNode negative = 11;
-    PhysicalInListNode in_list = 12;
-    //  was PhysicalScalarFunctionNode scalar_function = 13;
-    PhysicalTryCastNode try_cast = 14;
-    // window expressions
-    PhysicalWindowExprNode window_expr = 15;
-
-    PhysicalScalarUdfNode scalar_udf = 16;
-    // was PhysicalDateTimeIntervalExprNode date_time_interval_expr = 17;
-
-    PhysicalLikeExprNode like_expr = 18;
-
-    PhysicalExtensionExprNode extension = 19;
-
-    UnknownColumn unknown_column = 20;
-  }
-}
-
-message PhysicalScalarUdfNode {
-  string name = 1;
-  repeated PhysicalExprNode args = 2;
-  optional bytes fun_definition = 3;
-  datafusion_common.ArrowType return_type = 4;
-  bool nullable = 5;
-}
-
-message PhysicalAggregateExprNode {
-  oneof AggregateFunction {
-    string user_defined_aggr_function = 4;
-  }
-  repeated PhysicalExprNode expr = 2;
-  repeated PhysicalSortExprNode ordering_req = 5;
-  bool distinct = 3;
-  bool ignore_nulls = 6;
-  optional bytes fun_definition = 7;
-}
-
-message PhysicalWindowExprNode {
-  oneof window_function {
-    // BuiltInWindowFunction built_in_function = 2;
-    string user_defined_aggr_function = 3;
-    string user_defined_window_function = 10;
-  }
-  repeated PhysicalExprNode args = 4;
-  repeated PhysicalExprNode partition_by = 5;
-  repeated PhysicalSortExprNode order_by = 6;
-  WindowFrame window_frame = 7;
-  string name = 8;
-  optional bytes fun_definition = 9;
-}
-
-message PhysicalIsNull {
-  PhysicalExprNode expr = 1;
-}
-
-message PhysicalIsNotNull {
-  PhysicalExprNode expr = 1;
-}
-
-message PhysicalNot {
-  PhysicalExprNode expr = 1;
-}
-
-message PhysicalAliasNode {
-  PhysicalExprNode expr = 1;
-  string alias = 2;
-}
-
-message PhysicalBinaryExprNode {
-  PhysicalExprNode l = 1;
-  PhysicalExprNode r = 2;
-  string op = 3;
-}
-
-message PhysicalDateTimeIntervalExprNode {
-  PhysicalExprNode l = 1;
-  PhysicalExprNode r = 2;
-  string op = 3;
-}
-
-message PhysicalLikeExprNode {
-  bool negated = 1;
-  bool case_insensitive = 2;
-  PhysicalExprNode expr = 3;
-  PhysicalExprNode pattern = 4;
-}
-
-message PhysicalSortExprNode {
-  PhysicalExprNode expr = 1;
-  bool asc = 2;
-  bool nulls_first = 3;
-}
-
-message PhysicalWhenThen {
-  PhysicalExprNode when_expr = 1;
-  PhysicalExprNode then_expr = 2;
-}
-
-message PhysicalInListNode {
-  PhysicalExprNode expr = 1;
-  repeated PhysicalExprNode list = 2;
-  bool negated = 3;
-}
-
-message PhysicalCaseNode {
-  PhysicalExprNode expr = 1;
-  repeated PhysicalWhenThen when_then_expr = 2;
-  PhysicalExprNode else_expr = 3;
-}
-
-message PhysicalTryCastNode {
-  PhysicalExprNode expr = 1;
-  datafusion_common.ArrowType arrow_type = 2;
-}
-
-message PhysicalCastNode {
-  PhysicalExprNode expr = 1;
-  datafusion_common.ArrowType arrow_type = 2;
-}
-
-message PhysicalNegativeNode {
-  PhysicalExprNode expr = 1;
-}
-
-message PhysicalExtensionExprNode {
-  bytes expr = 1;
-  repeated PhysicalExprNode inputs = 2;
-}
-
-message FilterExecNode {
-  PhysicalPlanNode input = 1;
-  PhysicalExprNode expr = 2;
-  uint32 default_filter_selectivity = 3;
-  repeated uint32 projection = 9;
-}
-
-message FileGroup {
-  repeated PartitionedFile files = 1;
-}
-
-message ScanLimit {
-  // wrap into a message to make it optional
-  uint32 limit = 1;
-}
-
-message PhysicalSortExprNodeCollection {
-  repeated PhysicalSortExprNode physical_sort_expr_nodes = 1;
-}
-
-message FileScanExecConf {
-  // Was repeated ConfigOption options = 10;
-  reserved 10;
-
-  repeated FileGroup file_groups = 1;
-  datafusion_common.Schema schema = 2;
-  repeated uint32 projection = 4;
-  ScanLimit limit = 5;
-  datafusion_common.Statistics statistics = 6;
-  repeated string table_partition_cols = 7;
-  string object_store_url = 8;
-  repeated PhysicalSortExprNodeCollection output_ordering = 9;
-}
-
-message ParquetScanExecNode {
-  FileScanExecConf base_conf = 1;
-
-  // Was pruning predicate based on a logical expr.
-  reserved 2;
-
-  PhysicalExprNode predicate = 3;
-}
-
-message CsvScanExecNode {
-  FileScanExecConf base_conf = 1;
-  bool has_header = 2;
-  string delimiter = 3;
-  string quote = 4;
-  oneof optional_escape {
-    string escape = 5;
-  }
-  oneof optional_comment {
-    string comment = 6;
-  }
-  bool newlines_in_values = 7;
-}
-
-message AvroScanExecNode {
-  FileScanExecConf base_conf = 1;
-}
-
-enum PartitionMode {
-  COLLECT_LEFT = 0;
-  PARTITIONED = 1;
-  AUTO = 2;
-}
-
-message HashJoinExecNode {
-  PhysicalPlanNode left = 1;
-  PhysicalPlanNode right = 2;
-  repeated JoinOn on = 3;
-  datafusion_common.JoinType join_type = 4;
-  PartitionMode partition_mode = 6;
-  bool null_equals_null = 7;
-  JoinFilter filter = 8;
-  repeated uint32 projection = 9;
-}
-
-enum StreamPartitionMode {
-  SINGLE_PARTITION = 0;
-  PARTITIONED_EXEC = 1;
-}
-
-message SymmetricHashJoinExecNode {
-  PhysicalPlanNode left = 1;
-  PhysicalPlanNode right = 2;
-  repeated JoinOn on = 3;
-  datafusion_common.JoinType join_type = 4;
-  StreamPartitionMode partition_mode = 6;
-  bool null_equals_null = 7;
-  JoinFilter filter = 8;
-  repeated PhysicalSortExprNode left_sort_exprs = 9;
-  repeated PhysicalSortExprNode right_sort_exprs = 10;
-}
-
-message InterleaveExecNode {
-  repeated PhysicalPlanNode inputs = 1;
-}
-
-message UnionExecNode {
-  repeated PhysicalPlanNode inputs = 1;
-}
-
-message ExplainExecNode {
-  datafusion_common.Schema schema = 1;
-  repeated StringifiedPlan stringified_plans = 2;
-  bool verbose = 3;
-}
-
-message AnalyzeExecNode {
-  bool verbose = 1;
-  bool show_statistics = 2;
-  PhysicalPlanNode input = 3;
-  datafusion_common.Schema schema = 4;
-}
-
-message CrossJoinExecNode {
-  PhysicalPlanNode left = 1;
-  PhysicalPlanNode right = 2;
-}
-
-message PhysicalColumn {
-  string name = 1;
-  uint32 index = 2;
-}
-
-message UnknownColumn {
-  string name = 1;
-}
-
-message JoinOn {
-  PhysicalExprNode left = 1;
-  PhysicalExprNode right = 2;
-}
-
-message EmptyExecNode {
-  datafusion_common.Schema schema = 1;
-}
-
-message PlaceholderRowExecNode {
-  datafusion_common.Schema schema = 1;
-}
-
-message ProjectionExecNode {
-  PhysicalPlanNode input = 1;
-  repeated PhysicalExprNode expr = 2;
-  repeated string expr_name = 3;
-}
-
-enum AggregateMode {
-  PARTIAL = 0;
-  FINAL = 1;
-  FINAL_PARTITIONED = 2;
-  SINGLE = 3;
-  SINGLE_PARTITIONED = 4;
-}
-
-message PartiallySortedInputOrderMode {
-  repeated uint64 columns = 6;
-}
-
-message WindowAggExecNode {
-  PhysicalPlanNode input = 1;
-  repeated PhysicalWindowExprNode window_expr = 2;
-  repeated PhysicalExprNode partition_keys = 5;
-  // Set optional to `None` for `BoundedWindowAggExec`.
-  oneof input_order_mode {
-    datafusion_common.EmptyMessage linear = 7;
-    PartiallySortedInputOrderMode partially_sorted = 8;
-    datafusion_common.EmptyMessage sorted = 9;
-  }
-}
-
-message MaybeFilter {
-  PhysicalExprNode expr = 1;
-}
-
-message MaybePhysicalSortExprs {
-  repeated PhysicalSortExprNode sort_expr = 1;
-}
-
-message AggLimit {
-  // wrap into a message to make it optional
-  uint64 limit = 1;
-}
-
-message AggregateExecNode {
-  repeated PhysicalExprNode group_expr = 1;
-  repeated PhysicalExprNode aggr_expr = 2;
-  AggregateMode mode = 3;
-  PhysicalPlanNode input = 4;
-  repeated string group_expr_name = 5;
-  repeated string aggr_expr_name = 6;
-  // we need the input schema to the partial aggregate to pass to the final aggregate
-  datafusion_common.Schema input_schema = 7;
-  repeated PhysicalExprNode null_expr = 8;
-  repeated bool groups = 9;
-  repeated MaybeFilter filter_expr = 10;
-  AggLimit limit = 11;
-}
-
-message GlobalLimitExecNode {
-  PhysicalPlanNode input = 1;
-  // The number of rows to skip before fetch
-  uint32 skip = 2;
-  // Maximum number of rows to fetch; negative means no limit
-  int64 fetch = 3;
-}
-
-message LocalLimitExecNode {
-  PhysicalPlanNode input = 1;
-  uint32 fetch = 2;
-}
-
-message SortExecNode {
-  PhysicalPlanNode input = 1;
-  repeated PhysicalExprNode expr = 2;
-  // Maximum number of highest/lowest rows to fetch; negative means no limit
-  int64 fetch = 3;
-  bool preserve_partitioning = 4;
-}
-
-message SortPreservingMergeExecNode {
-  PhysicalPlanNode input = 1;
-  repeated PhysicalExprNode expr = 2;
-  // Maximum number of highest/lowest rows to fetch; negative means no limit
-  int64 fetch = 3;
-}
-
-message NestedLoopJoinExecNode {
-  PhysicalPlanNode left = 1;
-  PhysicalPlanNode right = 2;
-  datafusion_common.JoinType join_type = 3;
-  JoinFilter filter = 4;
-}
-
-message CoalesceBatchesExecNode {
-  PhysicalPlanNode input = 1;
-  uint32 target_batch_size = 2;
-  optional uint32 fetch = 3;
-}
-
-message CoalescePartitionsExecNode {
-  PhysicalPlanNode input = 1;
-}
-
-message PhysicalHashRepartition {
-  repeated PhysicalExprNode hash_expr = 1;
-  uint64 partition_count = 2;
-}
-
-message RepartitionExecNode{
-  PhysicalPlanNode input = 1;
-  // oneof partition_method {
-  //   uint64 round_robin = 2;
-  //   PhysicalHashRepartition hash = 3;
-  //   uint64 unknown = 4;
-  // }
-  Partitioning partitioning = 5;
-}
-
-message Partitioning {
-  oneof partition_method {
-    uint64 round_robin = 1;
-    PhysicalHashRepartition hash = 2;
-    uint64 unknown = 3;
-  }
-}
-
-message JoinFilter{
-  PhysicalExprNode expression = 1;
-  repeated ColumnIndex column_indices = 2;
-  datafusion_common.Schema schema = 3;
-}
-
-message ColumnIndex{
-  uint32 index = 1;
-  datafusion_common.JoinSide side = 2;
-}
-
-message PartitionedFile {
-  string path = 1;
-  uint64 size = 2;
-  uint64 last_modified_ns = 3;
-  repeated datafusion_common.ScalarValue partition_values = 4;
-  FileRange range = 5;
-  datafusion_common.Statistics statistics = 6;
-}
-
-message FileRange {
-  int64 start = 1;
-  int64 end = 2;
-}
-
-message PartitionStats {
-  int64 num_rows = 1;
-  int64 num_batches = 2;
-  int64 num_bytes = 3;
-  repeated datafusion_common.ColumnStats column_stats = 4;
-}
-
-message RecursiveQueryNode {
-  string name = 1;
-  LogicalPlanNode static_term = 2;
-  LogicalPlanNode recursive_term = 3;
-  bool is_distinct = 4;
-}
-
-message CteWorkTableScanNode {
-    string name = 1;
-    datafusion_common.Schema schema = 2;
-}
+ syntax = "proto3";
+
+ package datafusion;
+ 
+ option java_multiple_files = true;
+ option java_package = "org.apache.arrow.datafusion.protobuf";
+ option java_outer_classname = "DatafusionProto";
+ 
+ import "datafusion_common.proto";
+ 
+ // logical plan
+ // LogicalPlan is a nested type
+ message LogicalPlanNode {
+   oneof LogicalPlanType {
+     ListingTableScanNode listing_scan = 1;
+     ProjectionNode projection = 3;
+     SelectionNode selection = 4;
+     LimitNode limit = 5;
+     AggregateNode aggregate = 6;
+     JoinNode join = 7;
+     SortNode sort = 8;
+     RepartitionNode repartition = 9;
+     EmptyRelationNode empty_relation = 10;
+     CreateExternalTableNode create_external_table = 11;
+     ExplainNode explain = 12;
+     WindowNode window = 13;
+     AnalyzeNode analyze = 14;
+     CrossJoinNode cross_join = 15;
+     ValuesNode values = 16;
+     LogicalExtensionNode extension = 17;
+     CreateCatalogSchemaNode create_catalog_schema = 18;
+     UnionNode union = 19;
+     CreateCatalogNode create_catalog = 20;
+     SubqueryAliasNode subquery_alias = 21;
+     CreateViewNode create_view = 22;
+     DistinctNode distinct = 23;
+     ViewTableScanNode view_scan = 24;
+     CustomTableScanNode custom_scan = 25;
+     PrepareNode prepare = 26;
+     DropViewNode drop_view = 27;
+     DistinctOnNode distinct_on = 28;
+     CopyToNode copy_to = 29;
+     UnnestNode unnest = 30;
+     RecursiveQueryNode recursive_query = 31;
+     CteWorkTableScanNode cte_work_table_scan = 32;
+     DmlNode dml = 33;
+   }
+ }
+ 
+ message LogicalExtensionNode {
+   bytes node = 1;
+   repeated LogicalPlanNode inputs = 2;
+ }
+ 
+ message ProjectionColumns {
+   repeated string columns = 1;
+ }
+ 
+ message LogicalExprNodeCollection {
+   repeated LogicalExprNode logical_expr_nodes = 1;
+ }
+ 
+ message SortExprNodeCollection {
+   repeated SortExprNode sort_expr_nodes = 1;
+ }
+ 
+ message ListingTableScanNode {
+   reserved 1; // was string table_name
+   TableReference table_name = 14;
+   repeated string paths = 2;
+   string file_extension = 3;
+   ProjectionColumns projection = 4;
+   datafusion_common.Schema schema = 5;
+   repeated LogicalExprNode filters = 6;
+   repeated string table_partition_cols = 7;
+   bool collect_stat = 8;
+   uint32 target_partitions = 9;
+   oneof FileFormatType {
+     datafusion_common.CsvFormat csv = 10;
+     datafusion_common.ParquetFormat parquet = 11;
+     datafusion_common.AvroFormat avro = 12;
+     datafusion_common.NdJsonFormat json = 15;
+   }
+   repeated SortExprNodeCollection file_sort_order = 13;
+ }
+ 
+ message ViewTableScanNode {
+   reserved 1; // was string table_name
+   TableReference table_name = 6;
+   LogicalPlanNode input = 2;
+   datafusion_common.Schema schema = 3;
+   ProjectionColumns projection = 4;
+   string definition = 5;
+ }
+ 
+ // Logical Plan to Scan a CustomTableProvider registered at runtime
+ message CustomTableScanNode {
+   reserved 1; // was string table_name
+   TableReference table_name = 6;
+   ProjectionColumns projection = 2;
+   datafusion_common.Schema schema = 3;
+   repeated LogicalExprNode filters = 4;
+   bytes custom_table_data = 5;
+ }
+ 
+ message ProjectionNode {
+   LogicalPlanNode input = 1;
+   repeated LogicalExprNode expr = 2;
+   oneof optional_alias {
+     string alias = 3;
+   }
+ }
+ 
+ message SelectionNode {
+   LogicalPlanNode input = 1;
+   LogicalExprNode expr = 2;
+ }
+ 
+ message SortNode {
+   LogicalPlanNode input = 1;
+   repeated SortExprNode expr = 2;
+   // Maximum number of highest/lowest rows to fetch; negative means no limit
+   int64 fetch = 3;
+ }
+ 
+ message RepartitionNode {
+   LogicalPlanNode input = 1;
+   oneof partition_method {
+     uint64 round_robin = 2;
+     HashRepartition hash = 3;
+   }
+ }
+ 
+ message HashRepartition {
+   repeated LogicalExprNode hash_expr = 1;
+   uint64 partition_count = 2;
+ }
+ 
+ message EmptyRelationNode {
+   bool produce_one_row = 1;
+ }
+ 
+ message CreateExternalTableNode {
+   reserved 1; // was string name
+   TableReference name = 9;
+   string location = 2;
+   string file_type = 3;
+   datafusion_common.DfSchema schema = 4;
+   repeated string table_partition_cols = 5;
+   bool if_not_exists = 6;
+   bool temporary = 14;
+   string definition = 7;
+   repeated SortExprNodeCollection order_exprs = 10;
+   bool unbounded = 11;
+   map<string, string> options = 8;
+   datafusion_common.Constraints constraints = 12;
+   map<string, LogicalExprNode> column_defaults = 13;
+ }
+ 
+ message PrepareNode {
+   string name = 1;
+   repeated datafusion_common.ArrowType data_types = 2;
+   LogicalPlanNode input = 3;
+ }
+ 
+ message CreateCatalogSchemaNode {
+   string schema_name = 1;
+   bool if_not_exists = 2;
+   datafusion_common.DfSchema schema = 3;
+ }
+ 
+ message CreateCatalogNode {
+   string catalog_name = 1;
+   bool if_not_exists = 2;
+   datafusion_common.DfSchema schema = 3;
+ }
+ 
+ message DropViewNode {
+   TableReference name = 1;
+   bool if_exists = 2;
+   datafusion_common.DfSchema schema = 3;
+ }
+ 
+ message CreateViewNode {
+   reserved 1; // was string name
+   TableReference name = 5;
+   LogicalPlanNode input = 2;
+   bool or_replace = 3;
+   bool temporary = 6;
+   string definition = 4;
+ }
+ 
+ // a node containing data for defining values list. unlike in SQL where it's two dimensional, here
+ // the list is flattened, and with the field n_cols it can be parsed and partitioned into rows
+ message ValuesNode {
+   uint64 n_cols = 1;
+   repeated LogicalExprNode values_list = 2;
+ }
+ 
+ message AnalyzeNode {
+   LogicalPlanNode input = 1;
+   bool verbose = 2;
+ }
+ 
+ message ExplainNode {
+   LogicalPlanNode input = 1;
+   bool verbose = 2;
+ }
+ 
+ message AggregateNode {
+   LogicalPlanNode input = 1;
+   repeated LogicalExprNode group_expr = 2;
+   repeated LogicalExprNode aggr_expr = 3;
+ }
+ 
+ message WindowNode {
+   LogicalPlanNode input = 1;
+   repeated LogicalExprNode window_expr = 2;
+ }
+ 
+ message JoinNode {
+   LogicalPlanNode left = 1;
+   LogicalPlanNode right = 2;
+   datafusion_common.JoinType join_type = 3;
+   datafusion_common.JoinConstraint join_constraint = 4;
+   repeated LogicalExprNode left_join_key = 5;
+   repeated LogicalExprNode right_join_key = 6;
+   bool null_equals_null = 7;
+   LogicalExprNode filter = 8;
+ }
+ 
+ message DistinctNode {
+   LogicalPlanNode input = 1;
+ }
+ 
+ message DistinctOnNode {
+   repeated LogicalExprNode on_expr = 1;
+   repeated LogicalExprNode select_expr = 2;
+   repeated SortExprNode sort_expr = 3;
+   LogicalPlanNode input = 4;
+ }
+ 
+ message CopyToNode {
+   LogicalPlanNode input = 1;
+   string output_url = 2;
+   bytes file_type = 3;
+   repeated string partition_by = 7;
+ }
+ 
+ message DmlNode{
+    enum Type {
+     UPDATE = 0;
+     DELETE = 1;
+     CTAS = 2;
+     INSERT_APPEND = 3;
+     INSERT_OVERWRITE = 4;
+     INSERT_REPLACE = 5;
+     
+   }
+   Type dml_type = 1;
+   LogicalPlanNode input = 2;
+   TableReference table_name = 3;
+   datafusion_common.DfSchema schema = 4;
+ }
+ 
+ message UnnestNode {
+   LogicalPlanNode input = 1;
+   repeated datafusion_common.Column exec_columns = 2;
+   repeated ColumnUnnestListItem list_type_columns = 3;
+   repeated uint64 struct_type_columns = 4;
+   repeated uint64 dependency_indices = 5;
+   datafusion_common.DfSchema schema = 6;
+   UnnestOptions options = 7;
+ }
+ message ColumnUnnestListItem {
+   uint32 input_index = 1;
+   ColumnUnnestListRecursion recursion = 2;
+ }
+ 
+ message ColumnUnnestListRecursions {
+   repeated ColumnUnnestListRecursion recursions = 2;
+ }
+ 
+ message ColumnUnnestListRecursion {
+   datafusion_common.Column output_column = 1;
+   uint32 depth = 2;
+ }
+ 
+ message UnnestOptions {
+   bool preserve_nulls = 1;
+   repeated RecursionUnnestOption recursions = 2;
+ }
+ 
+ message RecursionUnnestOption {
+   datafusion_common.Column output_column = 1;
+   datafusion_common.Column input_column = 2;
+   uint32 depth = 3;
+ }
+ 
+ message UnionNode {
+   repeated LogicalPlanNode inputs = 1;
+ }
+ 
+ message CrossJoinNode {
+   LogicalPlanNode left = 1;
+   LogicalPlanNode right = 2;
+ }
+ 
+ message LimitNode {
+   LogicalPlanNode input = 1;
+   // The number of rows to skip before fetch; non-positive means don't skip any
+   int64 skip = 2;
+   // Maximum number of rows to fetch; negative means no limit
+   int64 fetch = 3;
+ }
+ 
+ message SelectionExecNode {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message SubqueryAliasNode {
+   reserved 2; // Was string alias
+   LogicalPlanNode input = 1;
+   TableReference alias = 3;
+ }
+ 
+ // logical expressions
+ message LogicalExprNode {
+   oneof ExprType {
+     // column references
+     datafusion_common.Column column = 1;
+ 
+     // alias
+     AliasNode alias = 2;
+ 
+     datafusion_common.ScalarValue literal = 3;
+ 
+     // binary expressions
+     BinaryExprNode binary_expr = 4;
+ 
+ 
+     // null checks
+     IsNull is_null_expr = 6;
+     IsNotNull is_not_null_expr = 7;
+     Not not_expr = 8;
+ 
+     BetweenNode between = 9;
+     CaseNode case_ = 10;
+     CastNode cast = 11;
+     NegativeNode negative = 13;
+     InListNode in_list = 14;
+     Wildcard wildcard = 15;
+     // was  ScalarFunctionNode scalar_function = 16;
+     TryCastNode try_cast = 17;
+ 
+     // window expressions
+     WindowExprNode window_expr = 18;
+ 
+     // AggregateUDF expressions
+     AggregateUDFExprNode aggregate_udf_expr = 19;
+ 
+     // Scalar UDF expressions
+     ScalarUDFExprNode scalar_udf_expr = 20;
+ 
+     // GetIndexedField get_indexed_field = 21;
+ 
+     GroupingSetNode grouping_set = 22;
+ 
+     CubeNode cube = 23;
+ 
+     RollupNode rollup = 24;
+ 
+     IsTrue is_true = 25;
+     IsFalse is_false = 26;
+     IsUnknown is_unknown = 27;
+     IsNotTrue is_not_true = 28;
+     IsNotFalse is_not_false = 29;
+     IsNotUnknown is_not_unknown = 30;
+     LikeNode like = 31;
+     ILikeNode ilike = 32;
+     SimilarToNode similar_to = 33;
+ 
+     PlaceholderNode placeholder = 34;
+ 
+     Unnest unnest = 35;
+ 
+   }
+ }
+ 
+ message Wildcard {
+   TableReference qualifier = 1;
+ }
+ 
+ message PlaceholderNode {
+   string id = 1;
+   datafusion_common.ArrowType data_type = 2;
+ }
+ 
+ message LogicalExprList {
+   repeated LogicalExprNode expr = 1;
+ }
+ 
+ message GroupingSetNode {
+   repeated LogicalExprList expr = 1;
+ }
+ 
+ message CubeNode {
+   repeated LogicalExprNode expr = 1;
+ }
+ 
+ message RollupNode {
+   repeated LogicalExprNode expr = 1;
+ }
+ 
+ message NamedStructField {
+   datafusion_common.ScalarValue name = 1;
+ }
+ 
+ message ListIndex {
+   LogicalExprNode key = 1;
+ }
+ 
+ message ListRange {
+   LogicalExprNode start = 1;
+   LogicalExprNode stop = 2;
+   LogicalExprNode stride = 3;
+ }
+ 
+ message IsNull {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsNotNull {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsTrue {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsFalse {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsUnknown {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsNotTrue {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsNotFalse {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message IsNotUnknown {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message Not {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message AliasNode {
+   LogicalExprNode expr = 1;
+   string alias = 2;
+   repeated TableReference relation = 3;
+ }
+ 
+ message BinaryExprNode {
+   // Represents the operands from the left inner most expression
+   // to the right outer most expression where each of them are chained
+   // with the operator 'op'.
+   repeated LogicalExprNode operands = 1;
+   string op = 3;
+ }
+ 
+ message NegativeNode {
+   LogicalExprNode expr = 1;
+ }
+ 
+ message Unnest {
+   repeated LogicalExprNode exprs = 1;
+ }
+ 
+ message InListNode {
+   LogicalExprNode expr = 1;
+   repeated LogicalExprNode list = 2;
+   bool negated = 3;
+ }
+ 
+ 
+ message AggregateUDFExprNode {
+   string fun_name = 1;
+   repeated LogicalExprNode args = 2;
+   bool distinct = 5;
+   LogicalExprNode filter = 3;
+   repeated SortExprNode order_by = 4;
+   optional bytes fun_definition = 6;
+ }
+ 
+ message ScalarUDFExprNode {
+   string fun_name = 1;
+   repeated LogicalExprNode args = 2;
+   optional bytes fun_definition = 3;
+ }
+ 
+ message WindowExprNode {
+   oneof window_function {
+     // BuiltInWindowFunction built_in_function = 2;
+     string udaf = 3;
+     string udwf = 9;
+   }
+   repeated LogicalExprNode exprs = 4;
+   repeated LogicalExprNode partition_by = 5;
+   repeated SortExprNode order_by = 6;
+   // repeated LogicalExprNode filter = 7;
+   WindowFrame window_frame = 8;
+   optional bytes fun_definition = 10;
+ }
+ 
+ message BetweenNode {
+   LogicalExprNode expr = 1;
+   bool negated = 2;
+   LogicalExprNode low = 3;
+   LogicalExprNode high = 4;
+ }
+ 
+ message LikeNode {
+   bool negated = 1;
+   LogicalExprNode expr = 2;
+   LogicalExprNode pattern = 3;
+   string escape_char = 4;
+ }
+ 
+ message ILikeNode {
+   bool negated = 1;
+   LogicalExprNode expr = 2;
+   LogicalExprNode pattern = 3;
+   string escape_char = 4;
+ }
+ 
+ message SimilarToNode {
+   bool negated = 1;
+   LogicalExprNode expr = 2;
+   LogicalExprNode pattern = 3;
+   string escape_char = 4;
+ }
+ 
+ message CaseNode {
+   LogicalExprNode expr = 1;
+   repeated WhenThen when_then_expr = 2;
+   LogicalExprNode else_expr = 3;
+ }
+ 
+ message WhenThen {
+   LogicalExprNode when_expr = 1;
+   LogicalExprNode then_expr = 2;
+ }
+ 
+ message CastNode {
+   LogicalExprNode expr = 1;
+   datafusion_common.ArrowType arrow_type = 2;
+ }
+ 
+ message TryCastNode {
+   LogicalExprNode expr = 1;
+   datafusion_common.ArrowType arrow_type = 2;
+ }
+ 
+ message SortExprNode {
+   LogicalExprNode expr = 1;
+   bool asc = 2;
+   bool nulls_first = 3;
+ }
+ 
+ enum WindowFrameUnits {
+   ROWS = 0;
+   RANGE = 1;
+   GROUPS = 2;
+ }
+ 
+ message WindowFrame {
+   WindowFrameUnits window_frame_units = 1;
+   WindowFrameBound start_bound = 2;
+   // "optional" keyword is stable in protoc 3.15 but prost is still on 3.14 (see https://github.com/tokio-rs/prost/issues/430 and https://github.com/tokio-rs/prost/pull/455)
+   // this syntax is ugly but is binary compatible with the "optional" keyword (see https://stackoverflow.com/questions/42622015/how-to-define-an-optional-field-in-protobuf-3)
+   oneof end_bound {
+     WindowFrameBound bound = 3;
+   }
+ }
+ 
+ enum WindowFrameBoundType {
+   CURRENT_ROW = 0;
+   PRECEDING = 1;
+   FOLLOWING = 2;
+ }
+ 
+ message WindowFrameBound {
+   WindowFrameBoundType window_frame_bound_type = 1;
+   datafusion_common.ScalarValue bound_value = 2;
+ }
+ 
+ ///////////////////////////////////////////////////////////////////////////////////////////////////
+ // Arrow Data Types
+ ///////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+ message FixedSizeBinary{
+   int32 length = 1;
+ }
+ 
+ enum DateUnit{
+   Day = 0;
+   DateMillisecond = 1;
+ }
+ 
+ message AnalyzedLogicalPlanType {
+   string analyzer_name = 1;
+ }
+ 
+ message OptimizedLogicalPlanType {
+   string optimizer_name = 1;
+ }
+ 
+ message OptimizedPhysicalPlanType {
+   string optimizer_name = 1;
+ }
+ 
+ message PlanType {
+   oneof plan_type_enum {
+     datafusion_common.EmptyMessage InitialLogicalPlan = 1;
+     AnalyzedLogicalPlanType AnalyzedLogicalPlan = 7;
+     datafusion_common.EmptyMessage FinalAnalyzedLogicalPlan = 8;
+     OptimizedLogicalPlanType OptimizedLogicalPlan = 2;
+     datafusion_common.EmptyMessage FinalLogicalPlan = 3;
+     datafusion_common.EmptyMessage InitialPhysicalPlan = 4;
+     datafusion_common.EmptyMessage InitialPhysicalPlanWithStats = 9;
+     datafusion_common.EmptyMessage InitialPhysicalPlanWithSchema = 11;
+     OptimizedPhysicalPlanType OptimizedPhysicalPlan = 5;
+     datafusion_common.EmptyMessage FinalPhysicalPlan = 6;
+     datafusion_common.EmptyMessage FinalPhysicalPlanWithStats = 10;
+     datafusion_common.EmptyMessage FinalPhysicalPlanWithSchema = 12;
+     datafusion_common.EmptyMessage PhysicalPlanError = 13;
+   }
+ }
+ 
+ message StringifiedPlan {
+   PlanType plan_type = 1;
+   string plan = 2;
+ }
+ 
+ message BareTableReference {
+   string table = 1;
+ }
+ 
+ message PartialTableReference {
+   string schema = 1;
+   string table = 2;
+ }
+ 
+ message FullTableReference {
+   string catalog = 1;
+   string schema = 2;
+   string table = 3;
+ }
+ 
+ message TableReference {
+   oneof table_reference_enum {
+     BareTableReference bare = 1;
+     PartialTableReference partial = 2;
+     FullTableReference full = 3;
+   }
+ }
+ 
+ /////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+ // PhysicalPlanNode is a nested type
+ message PhysicalPlanNode {
+   oneof PhysicalPlanType {
+     ParquetScanExecNode parquet_scan = 1;
+     CsvScanExecNode csv_scan = 2;
+     EmptyExecNode empty = 3;
+     ProjectionExecNode projection = 4;
+     GlobalLimitExecNode global_limit = 6;
+     LocalLimitExecNode local_limit = 7;
+     AggregateExecNode aggregate = 8;
+     HashJoinExecNode hash_join = 9;
+     SortExecNode sort = 10;
+     CoalesceBatchesExecNode coalesce_batches = 11;
+     FilterExecNode filter = 12;
+     CoalescePartitionsExecNode merge = 13;
+     RepartitionExecNode repartition = 14;
+     WindowAggExecNode window = 15;
+     CrossJoinExecNode cross_join = 16;
+     AvroScanExecNode avro_scan = 17;
+     PhysicalExtensionNode extension = 18;
+     UnionExecNode union = 19;
+     ExplainExecNode explain = 20;
+     SortPreservingMergeExecNode sort_preserving_merge = 21;
+     NestedLoopJoinExecNode nested_loop_join = 22;
+     AnalyzeExecNode analyze = 23;
+     JsonSinkExecNode json_sink = 24;
+     SymmetricHashJoinExecNode symmetric_hash_join = 25;
+     InterleaveExecNode interleave = 26;
+     PlaceholderRowExecNode placeholder_row = 27;
+     CsvSinkExecNode csv_sink = 28;
+     ParquetSinkExecNode parquet_sink = 29;
+     UnnestExecNode unnest = 30;
+   }
+ }
+ 
+ message PartitionColumn {
+   string name = 1;
+   datafusion_common.ArrowType arrow_type = 2;
+ }
+ 
+ 
+ message FileSinkConfig {
+   reserved 6; // writer_mode
+   reserved 8; // was `overwrite` which has been superseded by `insert_op`
+ 
+   string object_store_url = 1;
+   repeated PartitionedFile file_groups = 2;
+   repeated string table_paths = 3;
+   datafusion_common.Schema output_schema = 4;
+   repeated PartitionColumn table_partition_cols = 5;
+   bool keep_partition_by_columns = 9;
+   InsertOp insert_op = 10;
+   string file_extension = 11;
+ }
+ 
+ enum InsertOp {
+   Append = 0;
+   Overwrite = 1;
+   Replace = 2;
+ }
+ 
+ message JsonSink {
+   FileSinkConfig config = 1;
+   datafusion_common.JsonWriterOptions writer_options = 2;
+ }
+ 
+ message JsonSinkExecNode {
+   PhysicalPlanNode input = 1;
+   JsonSink sink = 2;
+   datafusion_common.Schema sink_schema = 3;
+   PhysicalSortExprNodeCollection sort_order = 4;
+ }
+ 
+ message CsvSink {
+   FileSinkConfig config = 1;
+   datafusion_common.CsvWriterOptions writer_options = 2;
+ }
+ 
+ message CsvSinkExecNode {
+   PhysicalPlanNode input = 1;
+   CsvSink sink = 2;
+   datafusion_common.Schema sink_schema = 3;
+   PhysicalSortExprNodeCollection sort_order = 4;
+ }
+ 
+ message ParquetSink {
+   FileSinkConfig config = 1;
+   datafusion_common.TableParquetOptions parquet_options = 2;
+ }
+ 
+ message ParquetSinkExecNode {
+   PhysicalPlanNode input = 1;
+   ParquetSink sink = 2;
+   datafusion_common.Schema sink_schema = 3;
+   PhysicalSortExprNodeCollection sort_order = 4;
+ }
+ 
+ message UnnestExecNode {
+   PhysicalPlanNode input = 1;
+   datafusion_common.Schema schema = 2;
+   repeated ListUnnest list_type_columns = 3;
+   repeated uint64 struct_type_columns = 4;
+   UnnestOptions options = 5;
+ }
+ 
+ message ListUnnest {
+   uint32 index_in_input_schema = 1;
+   uint32 depth = 2;
+ }
+ 
+ message PhysicalExtensionNode {
+   bytes node = 1;
+   repeated PhysicalPlanNode inputs = 2;
+ }
+ 
+ // physical expressions
+ message PhysicalExprNode {
+   // Was date_time_interval_expr
+   reserved 17;
+ 
+   oneof ExprType {
+     // column references
+     PhysicalColumn column = 1;
+ 
+     datafusion_common.ScalarValue literal = 2;
+ 
+     // binary expressions
+     PhysicalBinaryExprNode binary_expr = 3;
+ 
+     // aggregate expressions
+     PhysicalAggregateExprNode aggregate_expr = 4;
+ 
+     // null checks
+     PhysicalIsNull is_null_expr = 5;
+     PhysicalIsNotNull is_not_null_expr = 6;
+     PhysicalNot not_expr = 7;
+ 
+     PhysicalCaseNode case_ = 8;
+     PhysicalCastNode cast = 9;
+     PhysicalSortExprNode sort = 10;
+     PhysicalNegativeNode negative = 11;
+     PhysicalInListNode in_list = 12;
+     //  was PhysicalScalarFunctionNode scalar_function = 13;
+     PhysicalTryCastNode try_cast = 14;
+     // window expressions
+     PhysicalWindowExprNode window_expr = 15;
+ 
+     PhysicalScalarUdfNode scalar_udf = 16;
+     // was PhysicalDateTimeIntervalExprNode date_time_interval_expr = 17;
+ 
+     PhysicalLikeExprNode like_expr = 18;
+ 
+     PhysicalExtensionExprNode extension = 19;
+ 
+     UnknownColumn unknown_column = 20;
+   }
+ }
+ 
+ message PhysicalScalarUdfNode {
+   string name = 1;
+   repeated PhysicalExprNode args = 2;
+   optional bytes fun_definition = 3;
+   datafusion_common.ArrowType return_type = 4;
+   bool nullable = 5;
+ }
+ 
+ message PhysicalAggregateExprNode {
+   oneof AggregateFunction {
+     string user_defined_aggr_function = 4;
+   }
+   repeated PhysicalExprNode expr = 2;
+   repeated PhysicalSortExprNode ordering_req = 5;
+   bool distinct = 3;
+   bool ignore_nulls = 6;
+   optional bytes fun_definition = 7;
+ }
+ 
+ message PhysicalWindowExprNode {
+   oneof window_function {
+     // BuiltInWindowFunction built_in_function = 2;
+     string user_defined_aggr_function = 3;
+     string user_defined_window_function = 10;
+   }
+   repeated PhysicalExprNode args = 4;
+   repeated PhysicalExprNode partition_by = 5;
+   repeated PhysicalSortExprNode order_by = 6;
+   WindowFrame window_frame = 7;
+   string name = 8;
+   optional bytes fun_definition = 9;
+ }
+ 
+ message PhysicalIsNull {
+   PhysicalExprNode expr = 1;
+ }
+ 
+ message PhysicalIsNotNull {
+   PhysicalExprNode expr = 1;
+ }
+ 
+ message PhysicalNot {
+   PhysicalExprNode expr = 1;
+ }
+ 
+ message PhysicalAliasNode {
+   PhysicalExprNode expr = 1;
+   string alias = 2;
+ }
+ 
+ message PhysicalBinaryExprNode {
+   PhysicalExprNode l = 1;
+   PhysicalExprNode r = 2;
+   string op = 3;
+ }
+ 
+ message PhysicalDateTimeIntervalExprNode {
+   PhysicalExprNode l = 1;
+   PhysicalExprNode r = 2;
+   string op = 3;
+ }
+ 
+ message PhysicalLikeExprNode {
+   bool negated = 1;
+   bool case_insensitive = 2;
+   PhysicalExprNode expr = 3;
+   PhysicalExprNode pattern = 4;
+ }
+ 
+ message PhysicalSortExprNode {
+   PhysicalExprNode expr = 1;
+   bool asc = 2;
+   bool nulls_first = 3;
+ }
+ 
+ message PhysicalWhenThen {
+   PhysicalExprNode when_expr = 1;
+   PhysicalExprNode then_expr = 2;
+ }
+ 
+ message PhysicalInListNode {
+   PhysicalExprNode expr = 1;
+   repeated PhysicalExprNode list = 2;
+   bool negated = 3;
+ }
+ 
+ message PhysicalCaseNode {
+   PhysicalExprNode expr = 1;
+   repeated PhysicalWhenThen when_then_expr = 2;
+   PhysicalExprNode else_expr = 3;
+ }
+ 
+ message PhysicalTryCastNode {
+   PhysicalExprNode expr = 1;
+   datafusion_common.ArrowType arrow_type = 2;
+ }
+ 
+ message PhysicalCastNode {
+   PhysicalExprNode expr = 1;
+   datafusion_common.ArrowType arrow_type = 2;
+ }
+ 
+ message PhysicalNegativeNode {
+   PhysicalExprNode expr = 1;
+ }
+ 
+ message PhysicalExtensionExprNode {
+   bytes expr = 1;
+   repeated PhysicalExprNode inputs = 2;
+ }
+ 
+ message FilterExecNode {
+   PhysicalPlanNode input = 1;
+   PhysicalExprNode expr = 2;
+   uint32 default_filter_selectivity = 3;
+   repeated uint32 projection = 9;
+ }
+ 
+ message FileGroup {
+   repeated PartitionedFile files = 1;
+ }
+ 
+ message ScanLimit {
+   // wrap into a message to make it optional
+   uint32 limit = 1;
+ }
+ 
+ message PhysicalSortExprNodeCollection {
+   repeated PhysicalSortExprNode physical_sort_expr_nodes = 1;
+ }
+ 
+ message FileScanExecConf {
+   repeated FileGroup file_groups = 1;
+   datafusion_common.Schema schema = 2;
+   repeated uint32 projection = 4;
+   ScanLimit limit = 5;
+   datafusion_common.Statistics statistics = 6;
+   repeated string table_partition_cols = 7;
+   string object_store_url = 8;
+   repeated PhysicalSortExprNodeCollection output_ordering = 9;
+ 
+   // Was repeated ConfigOption options = 10;
+   reserved 10;
+ 
+   datafusion_common.Constraints constraints = 11;
+ }
+ 
+ message ParquetScanExecNode {
+   FileScanExecConf base_conf = 1;
+ 
+   // Was pruning predicate based on a logical expr.
+   reserved 2;
+ 
+   PhysicalExprNode predicate = 3;
+ }
+ 
+ message CsvScanExecNode {
+   FileScanExecConf base_conf = 1;
+   bool has_header = 2;
+   string delimiter = 3;
+   string quote = 4;
+   oneof optional_escape {
+     string escape = 5;
+   }
+   oneof optional_comment {
+     string comment = 6;
+   }
+   bool newlines_in_values = 7;
+ }
+ 
+ message AvroScanExecNode {
+   FileScanExecConf base_conf = 1;
+ }
+ 
+ enum PartitionMode {
+   COLLECT_LEFT = 0;
+   PARTITIONED = 1;
+   AUTO = 2;
+ }
+ 
+ message HashJoinExecNode {
+   PhysicalPlanNode left = 1;
+   PhysicalPlanNode right = 2;
+   repeated JoinOn on = 3;
+   datafusion_common.JoinType join_type = 4;
+   PartitionMode partition_mode = 6;
+   bool null_equals_null = 7;
+   JoinFilter filter = 8;
+   repeated uint32 projection = 9;
+ }
+ 
+ enum StreamPartitionMode {
+   SINGLE_PARTITION = 0;
+   PARTITIONED_EXEC = 1;
+ }
+ 
+ message SymmetricHashJoinExecNode {
+   PhysicalPlanNode left = 1;
+   PhysicalPlanNode right = 2;
+   repeated JoinOn on = 3;
+   datafusion_common.JoinType join_type = 4;
+   StreamPartitionMode partition_mode = 6;
+   bool null_equals_null = 7;
+   JoinFilter filter = 8;
+   repeated PhysicalSortExprNode left_sort_exprs = 9;
+   repeated PhysicalSortExprNode right_sort_exprs = 10;
+ }
+ 
+ message InterleaveExecNode {
+   repeated PhysicalPlanNode inputs = 1;
+ }
+ 
+ message UnionExecNode {
+   repeated PhysicalPlanNode inputs = 1;
+ }
+ 
+ message ExplainExecNode {
+   datafusion_common.Schema schema = 1;
+   repeated StringifiedPlan stringified_plans = 2;
+   bool verbose = 3;
+ }
+ 
+ message AnalyzeExecNode {
+   bool verbose = 1;
+   bool show_statistics = 2;
+   PhysicalPlanNode input = 3;
+   datafusion_common.Schema schema = 4;
+ }
+ 
+ message CrossJoinExecNode {
+   PhysicalPlanNode left = 1;
+   PhysicalPlanNode right = 2;
+ }
+ 
+ message PhysicalColumn {
+   string name = 1;
+   uint32 index = 2;
+ }
+ 
+ message UnknownColumn {
+   string name = 1;
+ }
+ 
+ message JoinOn {
+   PhysicalExprNode left = 1;
+   PhysicalExprNode right = 2;
+ }
+ 
+ message EmptyExecNode {
+   datafusion_common.Schema schema = 1;
+ }
+ 
+ message PlaceholderRowExecNode {
+   datafusion_common.Schema schema = 1;
+ }
+ 
+ message ProjectionExecNode {
+   PhysicalPlanNode input = 1;
+   repeated PhysicalExprNode expr = 2;
+   repeated string expr_name = 3;
+ }
+ 
+ enum AggregateMode {
+   PARTIAL = 0;
+   FINAL = 1;
+   FINAL_PARTITIONED = 2;
+   SINGLE = 3;
+   SINGLE_PARTITIONED = 4;
+ }
+ 
+ message PartiallySortedInputOrderMode {
+   repeated uint64 columns = 6;
+ }
+ 
+ message WindowAggExecNode {
+   PhysicalPlanNode input = 1;
+   repeated PhysicalWindowExprNode window_expr = 2;
+   repeated PhysicalExprNode partition_keys = 5;
+   // Set optional to `None` for `BoundedWindowAggExec`.
+   oneof input_order_mode {
+     datafusion_common.EmptyMessage linear = 7;
+     PartiallySortedInputOrderMode partially_sorted = 8;
+     datafusion_common.EmptyMessage sorted = 9;
+   }
+ }
+ 
+ message MaybeFilter {
+   PhysicalExprNode expr = 1;
+ }
+ 
+ message MaybePhysicalSortExprs {
+   repeated PhysicalSortExprNode sort_expr = 1;
+ }
+ 
+ message AggLimit {
+   // wrap into a message to make it optional
+   uint64 limit = 1;
+ }
+ 
+ message AggregateExecNode {
+   repeated PhysicalExprNode group_expr = 1;
+   repeated PhysicalExprNode aggr_expr = 2;
+   AggregateMode mode = 3;
+   PhysicalPlanNode input = 4;
+   repeated string group_expr_name = 5;
+   repeated string aggr_expr_name = 6;
+   // we need the input schema to the partial aggregate to pass to the final aggregate
+   datafusion_common.Schema input_schema = 7;
+   repeated PhysicalExprNode null_expr = 8;
+   repeated bool groups = 9;
+   repeated MaybeFilter filter_expr = 10;
+   AggLimit limit = 11;
+ }
+ 
+ message GlobalLimitExecNode {
+   PhysicalPlanNode input = 1;
+   // The number of rows to skip before fetch
+   uint32 skip = 2;
+   // Maximum number of rows to fetch; negative means no limit
+   int64 fetch = 3;
+ }
+ 
+ message LocalLimitExecNode {
+   PhysicalPlanNode input = 1;
+   uint32 fetch = 2;
+ }
+ 
+ message SortExecNode {
+   PhysicalPlanNode input = 1;
+   repeated PhysicalExprNode expr = 2;
+   // Maximum number of highest/lowest rows to fetch; negative means no limit
+   int64 fetch = 3;
+   bool preserve_partitioning = 4;
+ }
+ 
+ message SortPreservingMergeExecNode {
+   PhysicalPlanNode input = 1;
+   repeated PhysicalExprNode expr = 2;
+   // Maximum number of highest/lowest rows to fetch; negative means no limit
+   int64 fetch = 3;
+ }
+ 
+ message NestedLoopJoinExecNode {
+   PhysicalPlanNode left = 1;
+   PhysicalPlanNode right = 2;
+   datafusion_common.JoinType join_type = 3;
+   JoinFilter filter = 4;
+   repeated uint32 projection = 5;
+ }
+ 
+ message CoalesceBatchesExecNode {
+   PhysicalPlanNode input = 1;
+   uint32 target_batch_size = 2;
+   optional uint32 fetch = 3;
+ }
+ 
+ message CoalescePartitionsExecNode {
+   PhysicalPlanNode input = 1;
+ }
+ 
+ message PhysicalHashRepartition {
+   repeated PhysicalExprNode hash_expr = 1;
+   uint64 partition_count = 2;
+ }
+ 
+ message RepartitionExecNode{
+   PhysicalPlanNode input = 1;
+   // oneof partition_method {
+   //   uint64 round_robin = 2;
+   //   PhysicalHashRepartition hash = 3;
+   //   uint64 unknown = 4;
+   // }
+   Partitioning partitioning = 5;
+ }
+ 
+ message Partitioning {
+   oneof partition_method {
+     uint64 round_robin = 1;
+     PhysicalHashRepartition hash = 2;
+     uint64 unknown = 3;
+   }
+ }
+ 
+ message JoinFilter{
+   PhysicalExprNode expression = 1;
+   repeated ColumnIndex column_indices = 2;
+   datafusion_common.Schema schema = 3;
+ }
+ 
+ message ColumnIndex{
+   uint32 index = 1;
+   datafusion_common.JoinSide side = 2;
+ }
+ 
+ message PartitionedFile {
+   string path = 1;
+   uint64 size = 2;
+   uint64 last_modified_ns = 3;
+   repeated datafusion_common.ScalarValue partition_values = 4;
+   FileRange range = 5;
+   datafusion_common.Statistics statistics = 6;
+ }
+ 
+ message FileRange {
+   int64 start = 1;
+   int64 end = 2;
+ }
+ 
+ message PartitionStats {
+   int64 num_rows = 1;
+   int64 num_batches = 2;
+   int64 num_bytes = 3;
+   repeated datafusion_common.ColumnStats column_stats = 4;
+ }
+ 
+ message RecursiveQueryNode {
+   string name = 1;
+   LogicalPlanNode static_term = 2;
+   LogicalPlanNode recursive_term = 3;
+   bool is_distinct = 4;
+ }
+ 
+ message CteWorkTableScanNode {
+     string name = 1;
+     datafusion_common.Schema schema = 2;
+ }

--- a/ballista/core/proto/datafusion_common.proto
+++ b/ballista/core/proto/datafusion_common.proto
@@ -16,559 +16,561 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
-
-package datafusion_common;
-
-message ColumnRelation {
-  string relation = 1;
-}
-
-message Column {
-  string name = 1;
-  ColumnRelation relation = 2;
-}
-
-message DfField{
-  Field field = 1;
-  ColumnRelation qualifier = 2;
-}
-
-message DfSchema {
-  repeated DfField columns = 1;
-  map<string, string> metadata = 2;
-}
-
-message CsvFormat {
-  CsvOptions options = 5;
-}
-
-message ParquetFormat {
-  // Used to be bool enable_pruning = 1;
-  reserved 1;
-  TableParquetOptions options = 2;
-}
-
-message AvroFormat {}
-
-message NdJsonFormat {
-  JsonOptions options = 1;
-}
-
-
-message PrimaryKeyConstraint{
-  repeated uint64 indices = 1;
-}
-
-message UniqueConstraint{
-  repeated uint64 indices = 1;
-}
-
-message Constraint{
-  oneof constraint_mode{
-    PrimaryKeyConstraint primary_key = 1;
-    UniqueConstraint unique = 2;
-  }
-}
-
-message Constraints{
-  repeated Constraint constraints = 1;
-}
-
-enum JoinType {
-  INNER = 0;
-  LEFT = 1;
-  RIGHT = 2;
-  FULL = 3;
-  LEFTSEMI = 4;
-  LEFTANTI = 5;
-  RIGHTSEMI = 6;
-  RIGHTANTI = 7;
-  LEFTMARK = 8;
-}
-
-enum JoinConstraint {
-  ON = 0;
-  USING = 1;
-}
-
-message AvroOptions {}
-message ArrowOptions {}
-
-message Schema {
-  repeated Field columns = 1;
-  map<string, string> metadata = 2;
-}
-
-message Field {
-  // name of the field
-  string name = 1;
-  ArrowType arrow_type = 2;
-  bool nullable = 3;
-  // for complex data types like structs, unions
-  repeated Field children = 4;
-  map<string, string> metadata = 5;
-  int64 dict_id = 6;
-  bool dict_ordered = 7;
-}
-
-message Timestamp{
-  TimeUnit time_unit = 1;
-  string timezone = 2;
-}
-
-enum TimeUnit{
-  Second = 0;
-  Millisecond = 1;
-  Microsecond = 2;
-  Nanosecond = 3;
-}
-
-enum IntervalUnit{
-  YearMonth = 0;
-  DayTime = 1;
-  MonthDayNano = 2;
-}
-
-message Decimal{
-  reserved 1, 2;
-  uint32 precision = 3;
-  int32 scale = 4;
-}
-
-message Decimal256Type{
-  reserved 1, 2;
-  uint32 precision = 3;
-  int32 scale = 4;
-}
-
-message List{
-  Field field_type = 1;
-}
-
-message FixedSizeList{
-  Field field_type = 1;
-  int32 list_size = 2;
-}
-
-message Dictionary{
-  ArrowType key = 1;
-  ArrowType value = 2;
-}
-
-message Struct{
-  repeated Field sub_field_types = 1;
-}
-
-message Map {
-  Field field_type = 1;
-  bool keys_sorted = 2;
-}
-
-enum UnionMode{
-  sparse = 0;
-  dense = 1;
-}
-
-message Union{
-  repeated Field union_types = 1;
-  UnionMode union_mode = 2;
-  repeated int32 type_ids = 3;
-}
-
-// Used for List/FixedSizeList/LargeList/Struct/Map
-message ScalarNestedValue {
-  message Dictionary {
-    bytes ipc_message = 1;
-    bytes arrow_data = 2;
-  }
-
-  bytes ipc_message = 1;
-  bytes arrow_data = 2;
-  Schema schema = 3;
-  repeated Dictionary dictionaries = 4;
-}
-
-message ScalarTime32Value {
-  oneof value {
-    int32 time32_second_value = 1;
-    int32 time32_millisecond_value = 2;
-  };
-}
-
-message ScalarTime64Value {
-  oneof value {
-    int64 time64_microsecond_value = 1;
-    int64 time64_nanosecond_value = 2;
-  };
-}
-
-message ScalarTimestampValue {
-  oneof value {
-    int64 time_microsecond_value = 1;
-    int64 time_nanosecond_value = 2;
-    int64 time_second_value = 3;
-    int64 time_millisecond_value = 4;
-  };
-  string timezone = 5;
-}
-
-message ScalarDictionaryValue {
-  ArrowType index_type = 1;
-  ScalarValue value = 2;
-}
-
-message IntervalDayTimeValue {
-  int32 days = 1;
-  int32 milliseconds = 2;
-}
-
-message IntervalMonthDayNanoValue {
-  int32 months = 1;
-  int32 days = 2;
-  int64 nanos = 3;
-}
-
-message UnionField {
-  int32 field_id = 1;
-  Field field = 2;
-}
-
-message UnionValue {
-  // Note that a null union value must have one or more fields, so we
-  // encode a null UnionValue as one with value_id == 128
-  int32 value_id = 1;
-  ScalarValue value = 2;
-  repeated UnionField fields = 3;
-  UnionMode mode = 4;
-}
-
-message ScalarFixedSizeBinary{
-  bytes values = 1;
-  int32 length = 2;
-}
-
-message ScalarValue{
-  // was PrimitiveScalarType null_value = 19;
-  reserved 19;
-
-  oneof value {
-    // was PrimitiveScalarType null_value = 19;
-    // Null value of any type
-    ArrowType null_value = 33;
-
-    bool   bool_value = 1;
-    string utf8_value = 2;
-    string large_utf8_value = 3;
-    string utf8_view_value = 23;
-    int32  int8_value = 4;
-    int32  int16_value = 5;
-    int32  int32_value = 6;
-    int64  int64_value = 7;
-    uint32 uint8_value = 8;
-    uint32 uint16_value = 9;
-    uint32 uint32_value = 10;
-    uint64 uint64_value = 11;
-    float  float32_value = 12;
-    double float64_value = 13;
-    // Literal Date32 value always has a unit of day
-    int32  date_32_value = 14;
-    ScalarTime32Value time32_value = 15;
-    ScalarNestedValue large_list_value = 16;
-    ScalarNestedValue list_value = 17;
-    ScalarNestedValue fixed_size_list_value = 18;
-    ScalarNestedValue struct_value = 32;
-    ScalarNestedValue map_value = 41;
-
-    Decimal128 decimal128_value = 20;
-    Decimal256 decimal256_value = 39;
-
-    int64 date_64_value = 21;
-    int32 interval_yearmonth_value = 24;
-
-    int64 duration_second_value = 35;
-    int64 duration_millisecond_value = 36;
-    int64 duration_microsecond_value = 37;
-    int64 duration_nanosecond_value = 38;
-
-    ScalarTimestampValue timestamp_value = 26;
-    ScalarDictionaryValue dictionary_value = 27;
-    bytes binary_value = 28;
-    bytes large_binary_value = 29;
-    bytes binary_view_value = 22;
-    ScalarTime64Value time64_value = 30;
-    IntervalDayTimeValue interval_daytime_value = 25;
-    IntervalMonthDayNanoValue interval_month_day_nano = 31;
-    ScalarFixedSizeBinary fixed_size_binary_value = 34;
-    UnionValue union_value = 42;
-  }
-}
-
-message Decimal128{
-  bytes value = 1;
-  int64 p = 2;
-  int64 s = 3;
-}
-
-message Decimal256{
-  bytes value = 1;
-  int64 p = 2;
-  int64 s = 3;
-}
-
-// Serialized data type
-message ArrowType{
-  oneof arrow_type_enum {
-    EmptyMessage NONE = 1;     // arrow::Type::NA
-    EmptyMessage BOOL = 2;     // arrow::Type::BOOL
-    EmptyMessage UINT8 = 3;    // arrow::Type::UINT8
-    EmptyMessage INT8 = 4;     // arrow::Type::INT8
-    EmptyMessage UINT16 = 5;   // represents arrow::Type fields in src/arrow/type.h
-    EmptyMessage INT16 = 6;
-    EmptyMessage UINT32 = 7;
-    EmptyMessage INT32 = 8;
-    EmptyMessage UINT64 = 9;
-    EmptyMessage INT64 = 10 ;
-    EmptyMessage FLOAT16 = 11 ;
-    EmptyMessage FLOAT32 = 12 ;
-    EmptyMessage FLOAT64 = 13 ;
-    EmptyMessage UTF8 = 14 ;
-    EmptyMessage UTF8_VIEW = 35;
-    EmptyMessage LARGE_UTF8 = 32;
-    EmptyMessage BINARY = 15 ;
-    EmptyMessage BINARY_VIEW = 34;
-    int32 FIXED_SIZE_BINARY = 16 ;
-    EmptyMessage LARGE_BINARY = 31;
-    EmptyMessage DATE32 = 17 ;
-    EmptyMessage DATE64 = 18 ;
-    TimeUnit DURATION = 19;
-    Timestamp TIMESTAMP = 20 ;
-    TimeUnit TIME32 = 21 ;
-    TimeUnit TIME64 = 22 ;
-    IntervalUnit INTERVAL = 23 ;
-    Decimal DECIMAL = 24 ;
-    Decimal256Type DECIMAL256 = 36;
-    List LIST = 25;
-    List LARGE_LIST = 26;
-    FixedSizeList FIXED_SIZE_LIST = 27;
-    Struct STRUCT = 28;
-    Union UNION = 29;
-    Dictionary DICTIONARY = 30;
-    Map MAP = 33;
-  }
-}
-
-//Useful for representing an empty enum variant in rust
-// E.G. enum example{One, Two(i32)}
-// maps to
-// message example{
-//    oneof{
-//        EmptyMessage One = 1;
-//        i32 Two = 2;
-//   }
-//}
-message EmptyMessage{}
-
-enum CompressionTypeVariant {
-  GZIP = 0;
-  BZIP2 = 1;
-  XZ = 2;
-  ZSTD = 3;
-  UNCOMPRESSED = 4;
-}
-
-message JsonWriterOptions {
-  CompressionTypeVariant compression = 1;
-}
-
-
-message CsvWriterOptions {
-  // Compression type
-  CompressionTypeVariant compression = 1;
-  // Optional column delimiter. Defaults to `b','`
-  string delimiter = 2;
-  // Whether to write column names as file headers. Defaults to `true`
-  bool has_header = 3;
-  // Optional date format for date arrays
-  string date_format = 4;
-  // Optional datetime format for datetime arrays
-  string datetime_format = 5;
-  // Optional timestamp format for timestamp arrays
-  string timestamp_format = 6;
-  // Optional time format for time arrays
-  string time_format = 7;
-  // Optional value to represent null
-  string null_value = 8;
-  // Optional quote. Defaults to `b'"'`
-  string quote = 9;
-  // Optional escape. Defaults to `'\\'`
-  string escape = 10;
-  // Optional flag whether to double quotes, instead of escaping. Defaults to `true`
-  bool double_quote = 11;
-}
-
-// Options controlling CSV format
-message CsvOptions {
-  bytes has_header = 1; // Indicates if the CSV has a header row
-  bytes delimiter = 2; // Delimiter character as a byte
-  bytes quote = 3; // Quote character as a byte
-  bytes escape = 4; // Optional escape character as a byte
-  CompressionTypeVariant compression = 5; // Compression type
-  optional uint64 schema_infer_max_rec = 6; // Optional max records for schema inference
-  string date_format = 7; // Optional date format
-  string datetime_format = 8; // Optional datetime format
-  string timestamp_format = 9; // Optional timestamp format
-  string timestamp_tz_format = 10; // Optional timestamp with timezone format
-  string time_format = 11; // Optional time format
-  string null_value = 12; // Optional representation of null value
-  string null_regex = 13; // Optional representation of null loading regex
-  bytes comment = 14; // Optional comment character as a byte
-  bytes double_quote = 15; // Indicates if quotes are doubled
-  bytes newlines_in_values = 16; // Indicates if newlines are supported in values
-  bytes terminator = 17; // Optional terminator character as a byte
-}
-
-// Options controlling CSV format
-message JsonOptions {
-  CompressionTypeVariant compression = 1; // Compression type
-  optional uint64 schema_infer_max_rec = 2; // Optional max records for schema inference
-}
-
-message TableParquetOptions {
-  ParquetOptions global = 1;
-  repeated ParquetColumnSpecificOptions column_specific_options = 2;
-  map<string, string> key_value_metadata = 3;
-}
-
-message ParquetColumnSpecificOptions {
-  string column_name = 1;
-  ParquetColumnOptions options = 2;
-}
-
-message ParquetColumnOptions {
-  oneof bloom_filter_enabled_opt {
-    bool bloom_filter_enabled = 1;
-  }
-
-  oneof encoding_opt {
-    string encoding = 2;
-  }
-
-  oneof dictionary_enabled_opt {
-    bool dictionary_enabled = 3;
-  }
-
-  oneof compression_opt {
-    string compression = 4;
-  }
-
-  oneof statistics_enabled_opt {
-    string statistics_enabled = 5;
-  }
-
-  oneof bloom_filter_fpp_opt {
-    double bloom_filter_fpp = 6;
-  }
-
-  oneof bloom_filter_ndv_opt {
-    uint64 bloom_filter_ndv = 7;
-  }
-
-  oneof max_statistics_size_opt {
-    uint32 max_statistics_size = 8;
-  }
-}
-
-message ParquetOptions {
-  // Regular fields
-  bool enable_page_index = 1; // default = true
-  bool pruning = 2; // default = true
-  bool skip_metadata = 3; // default = true
-  bool pushdown_filters = 5; // default = false
-  bool reorder_filters = 6; // default = false
-  uint64 data_pagesize_limit = 7; // default = 1024 * 1024
-  uint64 write_batch_size = 8; // default = 1024
-  string writer_version = 9; // default = "1.0"
-  // bool bloom_filter_enabled = 20; // default = false
-  bool allow_single_file_parallelism = 23; // default = true
-  uint64 maximum_parallel_row_group_writers = 24; // default = 1
-  uint64 maximum_buffered_record_batches_per_stream = 25; // default = 2
-  bool bloom_filter_on_read = 26; // default = true
-  bool bloom_filter_on_write = 27; // default = false
-  bool schema_force_view_types = 28; // default = false
-  bool binary_as_string = 29; // default = false
-
-  oneof metadata_size_hint_opt {
-    uint64 metadata_size_hint = 4;
-  }
-
-  oneof compression_opt {
-    string compression = 10;
-  }
-
-  oneof dictionary_enabled_opt {
-    bool dictionary_enabled = 11;
-  }
-
-  oneof statistics_enabled_opt {
-    string statistics_enabled = 13;
-  }
-
-  oneof max_statistics_size_opt {
-    uint64 max_statistics_size = 14;
-  }
-
-  oneof column_index_truncate_length_opt {
-    uint64 column_index_truncate_length = 17;
-  }
-
-  oneof encoding_opt {
-    string encoding = 19;
-  }
-
-  oneof bloom_filter_fpp_opt {
-    double bloom_filter_fpp = 21;
-  }
-
-  oneof bloom_filter_ndv_opt {
-    uint64 bloom_filter_ndv = 22;
-  }
-
-  uint64 dictionary_page_size_limit = 12;
-
-  uint64 data_page_row_count_limit = 18;
-
-  uint64 max_row_group_size = 15;
-
-  string created_by = 16;
-}
-
-enum JoinSide {
-  LEFT_SIDE = 0;
-  RIGHT_SIDE = 1;
-  NONE = 2;
-}
-
-message Precision{
-  PrecisionInfo precision_info = 1;
-  ScalarValue val = 2;
-}
-
-enum PrecisionInfo {
-  EXACT = 0;
-  INEXACT = 1;
-  ABSENT = 2;
-}
-
-message Statistics {
-  Precision num_rows = 1;
-  Precision total_byte_size = 2;
-  repeated ColumnStats column_stats = 3;
-}
-
-message ColumnStats {
-  Precision min_value = 1;
-  Precision max_value = 2;
-  Precision null_count = 3;
-  Precision distinct_count = 4;
-}
+ syntax = "proto3";
+
+ package datafusion_common;
+ 
+ message ColumnRelation {
+   string relation = 1;
+ }
+ 
+ message Column {
+   string name = 1;
+   ColumnRelation relation = 2;
+ }
+ 
+ message DfField{
+   Field field = 1;
+   ColumnRelation qualifier = 2;
+ }
+ 
+ message DfSchema {
+   repeated DfField columns = 1;
+   map<string, string> metadata = 2;
+ }
+ 
+ message CsvFormat {
+   CsvOptions options = 5;
+ }
+ 
+ message ParquetFormat {
+   // Used to be bool enable_pruning = 1;
+   reserved 1;
+   TableParquetOptions options = 2;
+ }
+ 
+ message AvroFormat {}
+ 
+ message NdJsonFormat {
+   JsonOptions options = 1;
+ }
+ 
+ 
+ message PrimaryKeyConstraint{
+   repeated uint64 indices = 1;
+ }
+ 
+ message UniqueConstraint{
+   repeated uint64 indices = 1;
+ }
+ 
+ message Constraint{
+   oneof constraint_mode{
+     PrimaryKeyConstraint primary_key = 1;
+     UniqueConstraint unique = 2;
+   }
+ }
+ 
+ message Constraints{
+   repeated Constraint constraints = 1;
+ }
+ 
+ enum JoinType {
+   INNER = 0;
+   LEFT = 1;
+   RIGHT = 2;
+   FULL = 3;
+   LEFTSEMI = 4;
+   LEFTANTI = 5;
+   RIGHTSEMI = 6;
+   RIGHTANTI = 7;
+   LEFTMARK = 8;
+ }
+ 
+ enum JoinConstraint {
+   ON = 0;
+   USING = 1;
+ }
+ 
+ message AvroOptions {}
+ message ArrowOptions {}
+ 
+ message Schema {
+   repeated Field columns = 1;
+   map<string, string> metadata = 2;
+ }
+ 
+ message Field {
+   // name of the field
+   string name = 1;
+   ArrowType arrow_type = 2;
+   bool nullable = 3;
+   // for complex data types like structs, unions
+   repeated Field children = 4;
+   map<string, string> metadata = 5;
+   int64 dict_id = 6;
+   bool dict_ordered = 7;
+ }
+ 
+ message Timestamp{
+   TimeUnit time_unit = 1;
+   string timezone = 2;
+ }
+ 
+ enum TimeUnit{
+   Second = 0;
+   Millisecond = 1;
+   Microsecond = 2;
+   Nanosecond = 3;
+ }
+ 
+ enum IntervalUnit{
+   YearMonth = 0;
+   DayTime = 1;
+   MonthDayNano = 2;
+ }
+ 
+ message Decimal{
+   reserved 1, 2;
+   uint32 precision = 3;
+   int32 scale = 4;
+ }
+ 
+ message Decimal256Type{
+   reserved 1, 2;
+   uint32 precision = 3;
+   int32 scale = 4;
+ }
+ 
+ message List{
+   Field field_type = 1;
+ }
+ 
+ message FixedSizeList{
+   Field field_type = 1;
+   int32 list_size = 2;
+ }
+ 
+ message Dictionary{
+   ArrowType key = 1;
+   ArrowType value = 2;
+ }
+ 
+ message Struct{
+   repeated Field sub_field_types = 1;
+ }
+ 
+ message Map {
+   Field field_type = 1;
+   bool keys_sorted = 2;
+ }
+ 
+ enum UnionMode{
+   sparse = 0;
+   dense = 1;
+ }
+ 
+ message Union{
+   repeated Field union_types = 1;
+   UnionMode union_mode = 2;
+   repeated int32 type_ids = 3;
+ }
+ 
+ // Used for List/FixedSizeList/LargeList/Struct/Map
+ message ScalarNestedValue {
+   message Dictionary {
+     bytes ipc_message = 1;
+     bytes arrow_data = 2;
+   }
+ 
+   bytes ipc_message = 1;
+   bytes arrow_data = 2;
+   Schema schema = 3;
+   repeated Dictionary dictionaries = 4;
+ }
+ 
+ message ScalarTime32Value {
+   oneof value {
+     int32 time32_second_value = 1;
+     int32 time32_millisecond_value = 2;
+   };
+ }
+ 
+ message ScalarTime64Value {
+   oneof value {
+     int64 time64_microsecond_value = 1;
+     int64 time64_nanosecond_value = 2;
+   };
+ }
+ 
+ message ScalarTimestampValue {
+   oneof value {
+     int64 time_microsecond_value = 1;
+     int64 time_nanosecond_value = 2;
+     int64 time_second_value = 3;
+     int64 time_millisecond_value = 4;
+   };
+   string timezone = 5;
+ }
+ 
+ message ScalarDictionaryValue {
+   ArrowType index_type = 1;
+   ScalarValue value = 2;
+ }
+ 
+ message IntervalDayTimeValue {
+   int32 days = 1;
+   int32 milliseconds = 2;
+ }
+ 
+ message IntervalMonthDayNanoValue {
+   int32 months = 1;
+   int32 days = 2;
+   int64 nanos = 3;
+ }
+ 
+ message UnionField {
+   int32 field_id = 1;
+   Field field = 2;
+ }
+ 
+ message UnionValue {
+   // Note that a null union value must have one or more fields, so we
+   // encode a null UnionValue as one with value_id == 128
+   int32 value_id = 1;
+   ScalarValue value = 2;
+   repeated UnionField fields = 3;
+   UnionMode mode = 4;
+ }
+ 
+ message ScalarFixedSizeBinary{
+   bytes values = 1;
+   int32 length = 2;
+ }
+ 
+ message ScalarValue{
+   // was PrimitiveScalarType null_value = 19;
+   reserved 19;
+ 
+   oneof value {
+     // was PrimitiveScalarType null_value = 19;
+     // Null value of any type
+     ArrowType null_value = 33;
+ 
+     bool   bool_value = 1;
+     string utf8_value = 2;
+     string large_utf8_value = 3;
+     string utf8_view_value = 23;
+     int32  int8_value = 4;
+     int32  int16_value = 5;
+     int32  int32_value = 6;
+     int64  int64_value = 7;
+     uint32 uint8_value = 8;
+     uint32 uint16_value = 9;
+     uint32 uint32_value = 10;
+     uint64 uint64_value = 11;
+     float  float32_value = 12;
+     double float64_value = 13;
+     // Literal Date32 value always has a unit of day
+     int32  date_32_value = 14;
+     ScalarTime32Value time32_value = 15;
+     ScalarNestedValue large_list_value = 16;
+     ScalarNestedValue list_value = 17;
+     ScalarNestedValue fixed_size_list_value = 18;
+     ScalarNestedValue struct_value = 32;
+     ScalarNestedValue map_value = 41;
+ 
+     Decimal128 decimal128_value = 20;
+     Decimal256 decimal256_value = 39;
+ 
+     int64 date_64_value = 21;
+     int32 interval_yearmonth_value = 24;
+ 
+     int64 duration_second_value = 35;
+     int64 duration_millisecond_value = 36;
+     int64 duration_microsecond_value = 37;
+     int64 duration_nanosecond_value = 38;
+ 
+     ScalarTimestampValue timestamp_value = 26;
+     ScalarDictionaryValue dictionary_value = 27;
+     bytes binary_value = 28;
+     bytes large_binary_value = 29;
+     bytes binary_view_value = 22;
+     ScalarTime64Value time64_value = 30;
+     IntervalDayTimeValue interval_daytime_value = 25;
+     IntervalMonthDayNanoValue interval_month_day_nano = 31;
+     ScalarFixedSizeBinary fixed_size_binary_value = 34;
+     UnionValue union_value = 42;
+   }
+ }
+ 
+ message Decimal128{
+   bytes value = 1;
+   int64 p = 2;
+   int64 s = 3;
+ }
+ 
+ message Decimal256{
+   bytes value = 1;
+   int64 p = 2;
+   int64 s = 3;
+ }
+ 
+ // Serialized data type
+ message ArrowType{
+   oneof arrow_type_enum {
+     EmptyMessage NONE = 1;     // arrow::Type::NA
+     EmptyMessage BOOL = 2;     // arrow::Type::BOOL
+     EmptyMessage UINT8 = 3;    // arrow::Type::UINT8
+     EmptyMessage INT8 = 4;     // arrow::Type::INT8
+     EmptyMessage UINT16 = 5;   // represents arrow::Type fields in src/arrow/type.h
+     EmptyMessage INT16 = 6;
+     EmptyMessage UINT32 = 7;
+     EmptyMessage INT32 = 8;
+     EmptyMessage UINT64 = 9;
+     EmptyMessage INT64 = 10 ;
+     EmptyMessage FLOAT16 = 11 ;
+     EmptyMessage FLOAT32 = 12 ;
+     EmptyMessage FLOAT64 = 13 ;
+     EmptyMessage UTF8 = 14 ;
+     EmptyMessage UTF8_VIEW = 35;
+     EmptyMessage LARGE_UTF8 = 32;
+     EmptyMessage BINARY = 15 ;
+     EmptyMessage BINARY_VIEW = 34;
+     int32 FIXED_SIZE_BINARY = 16 ;
+     EmptyMessage LARGE_BINARY = 31;
+     EmptyMessage DATE32 = 17 ;
+     EmptyMessage DATE64 = 18 ;
+     TimeUnit DURATION = 19;
+     Timestamp TIMESTAMP = 20 ;
+     TimeUnit TIME32 = 21 ;
+     TimeUnit TIME64 = 22 ;
+     IntervalUnit INTERVAL = 23 ;
+     Decimal DECIMAL = 24 ;
+     Decimal256Type DECIMAL256 = 36;
+     List LIST = 25;
+     List LARGE_LIST = 26;
+     FixedSizeList FIXED_SIZE_LIST = 27;
+     Struct STRUCT = 28;
+     Union UNION = 29;
+     Dictionary DICTIONARY = 30;
+     Map MAP = 33;
+   }
+ }
+ 
+ //Useful for representing an empty enum variant in rust
+ // E.G. enum example{One, Two(i32)}
+ // maps to
+ // message example{
+ //    oneof{
+ //        EmptyMessage One = 1;
+ //        i32 Two = 2;
+ //   }
+ //}
+ message EmptyMessage{}
+ 
+ enum CompressionTypeVariant {
+   GZIP = 0;
+   BZIP2 = 1;
+   XZ = 2;
+   ZSTD = 3;
+   UNCOMPRESSED = 4;
+ }
+ 
+ message JsonWriterOptions {
+   CompressionTypeVariant compression = 1;
+ }
+ 
+ 
+ message CsvWriterOptions {
+   // Compression type
+   CompressionTypeVariant compression = 1;
+   // Optional column delimiter. Defaults to `b','`
+   string delimiter = 2;
+   // Whether to write column names as file headers. Defaults to `true`
+   bool has_header = 3;
+   // Optional date format for date arrays
+   string date_format = 4;
+   // Optional datetime format for datetime arrays
+   string datetime_format = 5;
+   // Optional timestamp format for timestamp arrays
+   string timestamp_format = 6;
+   // Optional time format for time arrays
+   string time_format = 7;
+   // Optional value to represent null
+   string null_value = 8;
+   // Optional quote. Defaults to `b'"'`
+   string quote = 9;
+   // Optional escape. Defaults to `'\\'`
+   string escape = 10;
+   // Optional flag whether to double quotes, instead of escaping. Defaults to `true`
+   bool double_quote = 11;
+ }
+ 
+ // Options controlling CSV format
+ message CsvOptions {
+   bytes has_header = 1; // Indicates if the CSV has a header row
+   bytes delimiter = 2; // Delimiter character as a byte
+   bytes quote = 3; // Quote character as a byte
+   bytes escape = 4; // Optional escape character as a byte
+   CompressionTypeVariant compression = 5; // Compression type
+   optional uint64 schema_infer_max_rec = 6; // Optional max records for schema inference
+   string date_format = 7; // Optional date format
+   string datetime_format = 8; // Optional datetime format
+   string timestamp_format = 9; // Optional timestamp format
+   string timestamp_tz_format = 10; // Optional timestamp with timezone format
+   string time_format = 11; // Optional time format
+   string null_value = 12; // Optional representation of null value
+   string null_regex = 13; // Optional representation of null loading regex
+   bytes comment = 14; // Optional comment character as a byte
+   bytes double_quote = 15; // Indicates if quotes are doubled
+   bytes newlines_in_values = 16; // Indicates if newlines are supported in values
+   bytes terminator = 17; // Optional terminator character as a byte
+ }
+ 
+ // Options controlling CSV format
+ message JsonOptions {
+   CompressionTypeVariant compression = 1; // Compression type
+   optional uint64 schema_infer_max_rec = 2; // Optional max records for schema inference
+ }
+ 
+ message TableParquetOptions {
+   ParquetOptions global = 1;
+   repeated ParquetColumnSpecificOptions column_specific_options = 2;
+   map<string, string> key_value_metadata = 3;
+ }
+ 
+ message ParquetColumnSpecificOptions {
+   string column_name = 1;
+   ParquetColumnOptions options = 2;
+ }
+ 
+ message ParquetColumnOptions {
+   oneof bloom_filter_enabled_opt {
+     bool bloom_filter_enabled = 1;
+   }
+ 
+   oneof encoding_opt {
+     string encoding = 2;
+   }
+ 
+   oneof dictionary_enabled_opt {
+     bool dictionary_enabled = 3;
+   }
+ 
+   oneof compression_opt {
+     string compression = 4;
+   }
+ 
+   oneof statistics_enabled_opt {
+     string statistics_enabled = 5;
+   }
+ 
+   oneof bloom_filter_fpp_opt {
+     double bloom_filter_fpp = 6;
+   }
+ 
+   oneof bloom_filter_ndv_opt {
+     uint64 bloom_filter_ndv = 7;
+   }
+ 
+   oneof max_statistics_size_opt {
+     uint32 max_statistics_size = 8;
+   }
+ }
+ 
+ message ParquetOptions {
+   // Regular fields
+   bool enable_page_index = 1; // default = true
+   bool pruning = 2; // default = true
+   bool skip_metadata = 3; // default = true
+   bool pushdown_filters = 5; // default = false
+   bool reorder_filters = 6; // default = false
+   uint64 data_pagesize_limit = 7; // default = 1024 * 1024
+   uint64 write_batch_size = 8; // default = 1024
+   string writer_version = 9; // default = "1.0"
+   // bool bloom_filter_enabled = 20; // default = false
+   bool allow_single_file_parallelism = 23; // default = true
+   uint64 maximum_parallel_row_group_writers = 24; // default = 1
+   uint64 maximum_buffered_record_batches_per_stream = 25; // default = 2
+   bool bloom_filter_on_read = 26; // default = true
+   bool bloom_filter_on_write = 27; // default = false
+   bool schema_force_view_types = 28; // default = false
+   bool binary_as_string = 29; // default = false
+   bool skip_arrow_metadata = 30; // default = false
+ 
+   oneof metadata_size_hint_opt {
+     uint64 metadata_size_hint = 4;
+   }
+ 
+   oneof compression_opt {
+     string compression = 10;
+   }
+ 
+   oneof dictionary_enabled_opt {
+     bool dictionary_enabled = 11;
+   }
+ 
+   oneof statistics_enabled_opt {
+     string statistics_enabled = 13;
+   }
+ 
+   oneof max_statistics_size_opt {
+     uint64 max_statistics_size = 14;
+   }
+ 
+   oneof column_index_truncate_length_opt {
+     uint64 column_index_truncate_length = 17;
+   }
+ 
+   oneof encoding_opt {
+     string encoding = 19;
+   }
+ 
+   oneof bloom_filter_fpp_opt {
+     double bloom_filter_fpp = 21;
+   }
+ 
+   oneof bloom_filter_ndv_opt {
+     uint64 bloom_filter_ndv = 22;
+   }
+ 
+   uint64 dictionary_page_size_limit = 12;
+ 
+   uint64 data_page_row_count_limit = 18;
+ 
+   uint64 max_row_group_size = 15;
+ 
+   string created_by = 16;
+ }
+ 
+ enum JoinSide {
+   LEFT_SIDE = 0;
+   RIGHT_SIDE = 1;
+   NONE = 2;
+ }
+ 
+ message Precision{
+   PrecisionInfo precision_info = 1;
+   ScalarValue val = 2;
+ }
+ 
+ enum PrecisionInfo {
+   EXACT = 0;
+   INEXACT = 1;
+   ABSENT = 2;
+ }
+ 
+ message Statistics {
+   Precision num_rows = 1;
+   Precision total_byte_size = 2;
+   repeated ColumnStats column_stats = 3;
+ }
+ 
+ message ColumnStats {
+   Precision min_value = 1;
+   Precision max_value = 2;
+   Precision sum_value = 5;
+   Precision null_count = 3;
+   Precision distinct_count = 4;
+ }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -51,7 +51,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use itertools::Itertools;
 use log::{error, info};
 use rand::prelude::SliceRandom;
-use rand::thread_rng;
+use rand::rng;
 use tokio::sync::{mpsc, Semaphore};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -174,7 +174,7 @@ impl ExecutionPlan for ShuffleReaderExec {
             .map(|(_, p)| p)
             .collect();
         // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
-        partition_locations.shuffle(&mut thread_rng());
+        partition_locations.shuffle(&mut rng());
 
         let response_receiver =
             send_fetch_partitions(partition_locations, max_request_num, max_message_size);

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-executor"
 description = "Ballista Distributed Compute - Executor"
 license = "Apache-2.0"
-version = "44.0.0"
+version = "45.0.0"
 homepage = "https://github.com/apache/arrow-ballista"
 repository = "https://github.com/apache/arrow-ballista"
 readme = "README.md"
@@ -42,7 +42,7 @@ default = ["build-binary", "mimalloc"]
 arrow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
-ballista-core = { path = "../core", version = "44.0.0" }
+ballista-core = { path = "../core", version = "45.0.0" }
 configure_me = { workspace = true, optional = true }
 dashmap = { workspace = true }
 datafusion = { workspace = true }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-scheduler"
 description = "Ballista Distributed Compute - Scheduler"
 license = "Apache-2.0"
-version = "44.0.0"
+version = "45.0.0"
 homepage = "https://github.com/apache/arrow-ballista"
 repository = "https://github.com/apache/arrow-ballista"
 readme = "README.md"
@@ -46,7 +46,7 @@ rest-api = ["graphviz-rust"]
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.7.7"
-ballista-core = { path = "../core", version = "44.0.0" }
+ballista-core = { path = "../core", version = "45.0.0" }
 base64 = { version = "0.22", optional = true }
 clap = { workspace = true, optional = true }
 configure_me = { workspace = true, optional = true }

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -556,7 +556,7 @@ order by
 
         let join = coalesce_batches.children()[0].clone();
         let join = downcast_exec!(join, HashJoinExec);
-        assert!(join.contain_projection());
+        assert!(join.contains_projection());
 
         let join_input_1 = join.children()[0].clone();
         // skip CoalesceBatches
@@ -687,7 +687,7 @@ order by
         assert_eq!(Some(&Column::new("l_shipmode", 1)), partition_by);
         assert_eq!(InputOrderMode::Sorted, window.input_order_mode);
         let sort = downcast_exec!(window.children()[0], SortExec);
-        match &sort.expr().inner[..] {
+        match &sort.expr().iter().collect::<Vec<_>>()[..] {
             [expr1, expr2] => {
                 assert_eq!(
                     SortOptions {

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -26,6 +26,7 @@ use ballista_core::error::BallistaError;
 use ballista_core::error::Result;
 use ballista_core::extension::SessionConfigHelperExt;
 use datafusion::prelude::SessionConfig;
+use rand::distr::Alphanumeric;
 
 use crate::cluster::JobState;
 use ballista_core::serde::protobuf::{
@@ -39,8 +40,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use log::{debug, error, info, trace, warn};
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::Arc;
@@ -644,7 +644,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
     /// Generate a new random Job ID
     pub fn generate_job_id(&self) -> String {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         std::iter::repeat(())
             .map(|()| rng.sample(Alphanumeric))
             .map(char::from)

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-benchmarks"
 description = "Ballista Benchmarks"
-version = "44.0.0"
+version = "45.0.0"
 edition = "2021"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 homepage = "https://github.com/apache/arrow-ballista"
@@ -32,7 +32,7 @@ default = ["mimalloc"]
 snmalloc = ["snmalloc-rs"]
 
 [dependencies]
-ballista = { path = "../ballista/client", version = "44.0.0" }
+ballista = { path = "../ballista/client", version = "45.0.0" }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }
@@ -51,4 +51,4 @@ tokio = { version = "^1.0", features = [
 ] }
 
 [dev-dependencies]
-ballista-core = { path = "../ballista/core", version = "44.0.0" }
+ballista-core = { path = "../ballista/core", version = "45.0.0" }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -501,7 +501,7 @@ async fn loadtest_ballista(opt: BallistaLoadtestOpt) -> Result<()> {
                 let query_id = query_list_clone
                     .get(
                         (0..query_list_clone.len())
-                            .choose(&mut rand::thread_rng())
+                            .choose(&mut rand::rng())
                             .unwrap(),
                     )
                     .unwrap();

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-examples"
 description = "Ballista usage examples"
-version = "44.0.0"
+version = "45.0.0"
 homepage = "https://github.com/apache/arrow-ballista"
 repository = "https://github.com/apache/arrow-ballista"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
@@ -33,10 +33,10 @@ path = "examples/standalone-sql.rs"
 required-features = ["ballista/standalone"]
 
 [dependencies]
-ballista = { path = "../ballista/client", version = "44.0.0" }
-ballista-core = { path = "../ballista/core", version = "44.0.0" }
-ballista-executor = { path = "../ballista/executor", version = "44.0.0", default-features = false }
-ballista-scheduler = { path = "../ballista/scheduler", version = "44.0.0", default-features = false }
+ballista = { path = "../ballista/client", version = "45.0.0" }
+ballista-core = { path = "../ballista/core", version = "45.0.0" }
+ballista-executor = { path = "../ballista/executor", version = "45.0.0", default-features = false }
+ballista-scheduler = { path = "../ballista/scheduler", version = "45.0.0", default-features = false }
 datafusion = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

keep up to date with datafusion releases

# What changes are included in this PR?

- update datafusion to 45
- update some other dependencies to latest version
- update ballista version to 45
- move test from unsupported to supported after datafusion has latest fix for functionality 

# Are there any user-facing changes?

datafusion version 