### PR TITLE
feat: configure max grpc message size and disable view types in ballista 

### DIFF
--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -61,11 +61,7 @@ const IO_RETRY_WAIT_TIME_MS: u64 = 3000;
 impl BallistaClient {
     /// Create a new BallistaClient to connect to the executor listening on the specified
     /// host and port
-    pub async fn try_new(
-        host: &str,
-        port: u16,
-        grpc_client_max_message_size: usize,
-    ) -> Result<Self> {
+    pub async fn try_new(host: &str, port: u16, max_message_size: usize) -> Result<Self> {
         let addr = format!("http://{host}:{port}");
         debug!("BallistaClient connecting to {}", addr);
         let connection =
@@ -77,8 +73,8 @@ impl BallistaClient {
                 ))
                 })?;
         let flight_client = FlightServiceClient::new(connection)
-            .max_decoding_message_size(grpc_client_max_message_size)
-            .max_encoding_message_size(grpc_client_max_message_size);
+            .max_decoding_message_size(max_message_size)
+            .max_encoding_message_size(max_message_size);
 
         debug!("BallistaClient connected OK: {:?}", flight_client);
 

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -32,6 +32,7 @@ pub const BALLISTA_STANDALONE_PARALLELISM: &str = "ballista.standalone.paralleli
 /// max message size for gRPC clients
 pub const BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE: &str =
     "ballista.grpc_client_max_message_size";
+pub const BALLISTA_SHUFFLE_READER_MAX_REQUESTS: &str = "ballista.shuffle.max_requests";
 
 pub type ParseResult<T> = result::Result<T, String>;
 use std::sync::LazyLock;
@@ -48,6 +49,10 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          "Configuration for max message size in gRPC clients".to_string(),
                          DataType::UInt64,
                          Some((16 * 1024 * 1024).to_string())),
+        ConfigEntry::new(BALLISTA_SHUFFLE_READER_MAX_REQUESTS.to_string(),
+                         "Maximin concurrent requests shuffle reader can serve".to_string(),
+                         DataType::UInt64,
+                         Some((64).to_string())),
     ];
     entries
         .into_iter()
@@ -163,6 +168,10 @@ impl BallistaConfig {
 
     pub fn default_standalone_parallelism(&self) -> usize {
         self.get_usize_setting(BALLISTA_STANDALONE_PARALLELISM)
+    }
+
+    pub fn shuffle_reader_maximum_in_flight_requests(&self) -> usize {
+        self.get_usize_setting(BALLISTA_SHUFFLE_READER_MAX_REQUESTS)
     }
 
     fn get_usize_setting(&self, key: &str) -> usize {

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -32,7 +32,8 @@ pub const BALLISTA_STANDALONE_PARALLELISM: &str = "ballista.standalone.paralleli
 /// max message size for gRPC clients
 pub const BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE: &str =
     "ballista.grpc_client_max_message_size";
-pub const BALLISTA_SHUFFLE_READER_MAX_REQUESTS: &str = "ballista.shuffle.max_requests";
+pub const BALLISTA_SHUFFLE_READER_MAX_REQUESTS: &str =
+    "ballista.shuffle.max_concurrent_read_requests";
 
 pub type ParseResult<T> = result::Result<T, String>;
 use std::sync::LazyLock;
@@ -50,7 +51,7 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          DataType::UInt64,
                          Some((16 * 1024 * 1024).to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_READER_MAX_REQUESTS.to_string(),
-                         "Maximin concurrent requests shuffle reader can serve".to_string(),
+                         "Maximum concurrent requests shuffle reader can process".to_string(),
                          DataType::UInt64,
                          Some((64).to_string())),
     ];
@@ -170,7 +171,7 @@ impl BallistaConfig {
         self.get_usize_setting(BALLISTA_STANDALONE_PARALLELISM)
     }
 
-    pub fn shuffle_reader_maximum_in_flight_requests(&self) -> usize {
+    pub fn shuffle_reader_maximum_concurrent_requests(&self) -> usize {
         self.get_usize_setting(BALLISTA_SHUFFLE_READER_MAX_REQUESTS)
     }
 

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -149,7 +149,8 @@ impl ExecutionPlan for ShuffleReaderExec {
 
         let config = context.session_config();
 
-        let max_request_num = config.ballista_shuffle_reader_maximum_in_flight_requests();
+        let max_request_num =
+            config.ballista_shuffle_reader_maximum_concurrent_requests();
         let max_message_size = config.ballista_grpc_client_max_message_size();
 
         log::debug!(

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -149,9 +149,8 @@ impl ExecutionPlan for ShuffleReaderExec {
 
         let config = context.session_config();
 
-        let max_request_num = config.ballista_grpc_client_max_message_size();
-        let max_message_size =
-            config.ballista_shuffle_reader_maximum_in_flight_requests();
+        let max_request_num = config.ballista_shuffle_reader_maximum_in_flight_requests();
+        let max_message_size = config.ballista_grpc_client_max_message_size();
 
         log::debug!(
             "ShuffleReaderExec::execute({}) max_request_num: {}, max_message_size: {}",

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::client::BallistaClient;
+use crate::extension::SessionConfigExt;
 use crate::serde::scheduler::{PartitionLocation, PartitionStats};
 
 use datafusion::arrow::datatypes::SchemaRef;
@@ -146,8 +147,18 @@ impl ExecutionPlan for ShuffleReaderExec {
         let task_id = context.task_id().unwrap_or_else(|| partition.to_string());
         info!("ShuffleReaderExec::execute({})", task_id);
 
-        // TODO make the maximum size configurable, or make it depends on global memory control
-        let max_request_num = 50usize;
+        let config = context.session_config();
+
+        let max_request_num = config.ballista_grpc_client_max_message_size();
+        let max_message_size =
+            config.ballista_shuffle_reader_maximum_in_flight_requests();
+
+        log::debug!(
+            "ShuffleReaderExec::execute({}) max_request_num: {}, max_message_size: {}",
+            task_id,
+            max_request_num,
+            max_message_size
+        );
         let mut partition_locations = HashMap::new();
         for p in &self.partition[partition] {
             partition_locations
@@ -166,7 +177,7 @@ impl ExecutionPlan for ShuffleReaderExec {
         partition_locations.shuffle(&mut thread_rng());
 
         let response_receiver =
-            send_fetch_partitions(partition_locations, max_request_num);
+            send_fetch_partitions(partition_locations, max_request_num, max_message_size);
 
         let result = RecordBatchStreamAdapter::new(
             Arc::new(self.schema.as_ref().clone()),
@@ -284,6 +295,7 @@ impl Stream for AbortableReceiverStream {
 fn send_fetch_partitions(
     partition_locations: Vec<PartitionLocation>,
     max_request_num: usize,
+    max_message_size: usize,
 ) -> AbortableReceiverStream {
     let (response_sender, response_receiver) = mpsc::channel(max_request_num);
     let semaphore = Arc::new(Semaphore::new(max_request_num));
@@ -302,7 +314,9 @@ fn send_fetch_partitions(
     let response_sender_c = response_sender.clone();
     spawned_tasks.push(SpawnedTask::spawn(async move {
         for p in local_locations {
-            let r = PartitionReaderEnum::Local.fetch_partition(&p).await;
+            let r = PartitionReaderEnum::Local
+                .fetch_partition(&p, max_message_size)
+                .await;
             if let Err(e) = response_sender_c.send(r).await {
                 error!("Fail to send response event to the channel due to {}", e);
             }
@@ -315,7 +329,9 @@ fn send_fetch_partitions(
         spawned_tasks.push(SpawnedTask::spawn(async move {
             // Block if exceeds max request number.
             let permit = semaphore.acquire_owned().await.unwrap();
-            let r = PartitionReaderEnum::FlightRemote.fetch_partition(&p).await;
+            let r = PartitionReaderEnum::FlightRemote
+                .fetch_partition(&p, max_message_size)
+                .await;
             // Block if the channel buffer is full.
             if let Err(e) = response_sender.send(r).await {
                 error!("Fail to send response event to the channel due to {}", e);
@@ -339,6 +355,7 @@ trait PartitionReader: Send + Sync + Clone {
     async fn fetch_partition(
         &self,
         location: &PartitionLocation,
+        max_message_size: usize,
     ) -> result::Result<SendableRecordBatchStream, BallistaError>;
 }
 
@@ -356,9 +373,12 @@ impl PartitionReader for PartitionReaderEnum {
     async fn fetch_partition(
         &self,
         location: &PartitionLocation,
+        max_message_size: usize,
     ) -> result::Result<SendableRecordBatchStream, BallistaError> {
         match self {
-            PartitionReaderEnum::FlightRemote => fetch_partition_remote(location).await,
+            PartitionReaderEnum::FlightRemote => {
+                fetch_partition_remote(location, max_message_size).await
+            }
             PartitionReaderEnum::Local => fetch_partition_local(location).await,
             PartitionReaderEnum::ObjectStoreRemote => {
                 fetch_partition_object_store(location).await
@@ -369,6 +389,7 @@ impl PartitionReader for PartitionReaderEnum {
 
 async fn fetch_partition_remote(
     location: &PartitionLocation,
+    max_message_size: usize,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
@@ -376,19 +397,18 @@ async fn fetch_partition_remote(
     // And we should also avoid to keep alive too many connections for long time.
     let host = metadata.host.as_str();
     let port = metadata.port;
-    let mut ballista_client =
-        BallistaClient::try_new(host, port)
-            .await
-            .map_err(|error| match error {
-                // map grpc connection error to partition fetch error.
-                BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
-                    metadata.id.clone(),
-                    partition_id.stage_id,
-                    partition_id.partition_id,
-                    msg,
-                ),
-                other => other,
-            })?;
+    let mut ballista_client = BallistaClient::try_new(host, port, max_message_size)
+        .await
+        .map_err(|error| match error {
+            // map grpc connection error to partition fetch error.
+            BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
+                metadata.id.clone(),
+                partition_id.stage_id,
+                partition_id.partition_id,
+                msg,
+            ),
+            other => other,
+        })?;
 
     ballista_client
         .fetch_partition(&metadata.id, partition_id, &location.path, host, port)
@@ -644,7 +664,7 @@ mod tests {
         );
 
         let response_receiver =
-            send_fetch_partitions(partition_locations, max_request_num);
+            send_fetch_partitions(partition_locations, max_request_num, 4 * 1024 * 1024);
 
         let stream = RecordBatchStreamAdapter::new(
             Arc::new(schema),

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -169,7 +169,15 @@ impl SessionStateExt for SessionState {
             .clone()
             .with_option_extension(new_config.clone())
             // Ballista disables this option
-            .with_round_robin_repartition(false);
+            .with_round_robin_repartition(false)
+            // There is issue with Utv8View(s) where Arrow IPC will generate
+            // frames which would be too big to send using Arrow Flight.
+            // We disable this option temporary
+            // TODO: enable this option once we get to root of the problem
+            .set_bool(
+                "datafusion.execution.parquet.schema_force_view_types",
+                false,
+            );
 
         let builder = SessionStateBuilder::new_from_existing(self)
             .with_config(session_config)

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -105,10 +105,10 @@ pub trait SessionConfigExt {
     fn with_ballista_job_name(self, job_name: &str) -> Self;
 
     /// get maximum in flight requests for shuffle reader
-    fn ballista_shuffle_reader_maximum_in_flight_requests(&self) -> usize;
+    fn ballista_shuffle_reader_maximum_concurrent_requests(&self) -> usize;
 
     /// Sets maximum in flight requests for shuffle reader
-    fn with_ballista_shuffle_reader_maximum_in_flight_requests(
+    fn with_ballista_shuffle_reader_maximum_concurrent_requests(
         self,
         max_requests: usize,
     ) -> Self;
@@ -293,17 +293,17 @@ impl SessionConfigExt for SessionConfig {
         }
     }
 
-    fn ballista_shuffle_reader_maximum_in_flight_requests(&self) -> usize {
+    fn ballista_shuffle_reader_maximum_concurrent_requests(&self) -> usize {
         self.options()
             .extensions
             .get::<BallistaConfig>()
-            .map(|c| c.shuffle_reader_maximum_in_flight_requests())
+            .map(|c| c.shuffle_reader_maximum_concurrent_requests())
             .unwrap_or_else(|| {
-                BallistaConfig::default().shuffle_reader_maximum_in_flight_requests()
+                BallistaConfig::default().shuffle_reader_maximum_concurrent_requests()
             })
     }
 
-    fn with_ballista_shuffle_reader_maximum_in_flight_requests(
+    fn with_ballista_shuffle_reader_maximum_concurrent_requests(
         self,
         max_requests: usize,
     ) -> Self {

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -234,9 +234,9 @@ where
                 if let SendError(Err(err)) = err {
                     err
                 } else {
-                    FlightError::Tonic(Status::internal(
-                        "Can't send a batch, something went wrong",
-                    ))
+                    FlightError::Tonic(Status::internal(format!(
+                        "Can't send a batch, something went wrong: {err:?}"
+                    )))
                 }
             })?
     }

--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -91,9 +91,15 @@ pub async fn start_server(
         tonic_builder.add_service(ExternalScalerServer::new(scheduler_server.clone()));
 
     #[cfg(feature = "flight-sql")]
-    let tonic_builder = tonic_builder.add_service(FlightServiceServer::new(
-        FlightSqlServiceImpl::new(scheduler_server.clone()),
-    ));
+    let tonic_builder = tonic_builder.add_service(
+        FlightServiceServer::new(FlightSqlServiceImpl::new(scheduler_server.clone()))
+            .max_encoding_message_size(
+                config.grpc_server_max_encoding_message_size as usize,
+            )
+            .max_decoding_message_size(
+                config.grpc_server_max_decoding_message_size as usize,
+            ),
+    );
 
     let tonic = tonic_builder.into_service().into_axum_router();
 


### PR DESCRIPTION
# Which issue does this PR close?

This is a mix of  #1183 and #1184

Closes #1182.

 # Rationale for this change

1. ability to configure maximum message size for arrow flight servers / clients
2. set `datafusion.execution.parquet.schema_force_view_types=false` as it was making issues with tpc-h query 2 

# What changes are included in this PR?

- make grpc message size configurable 
- disable `datafusion.execution.parquet.schema_force_view_types=false`
- add additional configuration option `ballista.shuffle.max_requests` which will limit number of in flight requests for shuffle reader
- refactor duplication in ballista related configuration creation
- refactor duplication in `standalone` mode creation

# Are there any user-facing changes?

No
