### PR TITLE
chore: fix tpch data generator

### DIFF
--- a/benchmarks/tpch-gen.sh
+++ b/benchmarks/tpch-gen.sh
@@ -29,7 +29,7 @@ FILE=./data/supplier.tbl
 if test -f "$FILE"; then
     echo "$FILE exists."
 else
-  docker run -v `pwd`/data:/data -it --rm ghcr.io/databloom-ai/tpch-docker:main -vf -s 1
+  docker run -v `pwd`/data:/data -it --rm ghcr.io/scalytics/tpch-docker:main -vf -s 1
 fi
 
 # Copy expected answers into the ./data/answers directory if it does not already exist
@@ -37,5 +37,5 @@ FILE=./data/answers/q1.out
 if test -f "$FILE"; then
     echo "$FILE exists."
 else
-  docker run -v `pwd`/data:/data -it --entrypoint /bin/bash --rm ghcr.io/databloom-ai/tpch-docker:main -c "cp /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
+  docker run -v `pwd`/data:/data -it --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main -c "cp /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
 fi

--- a/benchmarks/tpch.py
+++ b/benchmarks/tpch.py
@@ -30,8 +30,10 @@ query = args.query
 path = args.path
 table_ext = args.ext
 
-import ballista
-ctx = ballista.BallistaContext("localhost", 50050)
+from ballista import BallistaBuilder
+from datafusion.context import SessionContext
+    
+ctx: SessionContext = BallistaBuilder().remote("df://127.0.0.1:50050")
 
 tables = ["part", "supplier", "partsupp", "customer", "orders", "lineitem", "nation", "region"]
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #None.

 # Rationale for this change

previous docker container used for tcph generation does not work anymore, thus tpch.sh script does not generate any data 

# What changes are included in this PR?

docker container replaced with the one used in datafusion python

# Are there any user-facing changes?

No