### PR TITLE
feat: improve executor logs

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -48,7 +48,7 @@ use crate::error::BallistaError;
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use itertools::Itertools;
-use log::{error, info};
+use log::{debug, error};
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use tokio::sync::{mpsc, Semaphore};
@@ -144,7 +144,7 @@ impl ExecutionPlan for ShuffleReaderExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let task_id = context.task_id().unwrap_or_else(|| partition.to_string());
-        info!("ShuffleReaderExec::execute({})", task_id);
+        debug!("ShuffleReaderExec::execute({})", task_id);
 
         // TODO make the maximum size configurable, or make it depends on global memory control
         let max_request_num = 50usize;
@@ -292,7 +292,7 @@ fn send_fetch_partitions(
         .into_iter()
         .partition(check_is_local_location);
 
-    info!(
+    debug!(
         "local shuffle file counts:{}, remote shuffle file count:{}.",
         local_locations.len(),
         remote_locations.len()

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -25,6 +25,7 @@ use datafusion::arrow::ipc::CompressionType;
 
 use datafusion::arrow::ipc::writer::StreamWriter;
 use std::any::Any;
+use std::fmt::Debug;
 use std::fs;
 use std::fs::File;
 use std::future::Future;
@@ -50,8 +51,8 @@ use datafusion::physical_plan::metrics::{
 };
 
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
-    SendableRecordBatchStream, Statistics,
+    displayable, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PlanProperties, SendableRecordBatchStream, Statistics,
 };
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 
@@ -80,7 +81,21 @@ pub struct ShuffleWriterExec {
     shuffle_output_partitioning: Option<Partitioning>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
+    /// Plan properties
     properties: PlanProperties,
+}
+
+impl std::fmt::Display for ShuffleWriterExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let printable_plan = displayable(self.plan.as_ref())
+            .set_show_statistics(true)
+            .indent(false);
+        write!(
+            f,
+            "ShuffleWriterExec: job={} stage={} work_dir={} partitioning={:?} plan: \n {}",
+            self.job_id, self.stage_id, self.work_dir, self.shuffle_output_partitioning, printable_plan
+        )
+    }
 }
 
 pub struct WriteTracker {

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -286,6 +286,13 @@ impl SessionConfigHelperExt for SessionConfig {
         self.options()
             .entries()
             .iter()
+            // TODO: revisit this log once we this option is removed
+            //
+            // filtering this key as it's creating a lot of warning logs
+            // at the executor side.
+            .filter(|c| {
+                c.key != "datafusion.sql_parser.enable_options_value_normalization"
+            })
             .map(|datafusion::config::ConfigEntry { key, value, .. }| {
                 log::trace!("sending configuration key: `{}`, value`{:?}`", key, value);
                 KeyValuePair {

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -97,7 +97,20 @@ impl DefaultQueryStageExec {
 
 impl Display for DefaultQueryStageExec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DefaultQueryStageExec:\n{}", self.shuffle_writer)
+        let stage_metrics: Vec<String> = self
+            .shuffle_writer
+            .metrics()
+            .unwrap_or_default()
+            .iter()
+            .map(|m| m.to_string())
+            .collect();
+
+        write!(
+            f,
+            "DefaultQueryStageExec: ({})\n{}",
+            stage_metrics.join(", "),
+            self.shuffle_writer
+        )
     }
 }
 

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -23,7 +23,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::ExecutionPlan;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
 /// Execution engine extension point
@@ -42,7 +42,7 @@ pub trait ExecutionEngine: Sync + Send {
 /// partition is re-partitioned and streamed to disk in Arrow IPC format. Future stages of the query
 /// will use the ShuffleReaderExec to read these results.
 #[async_trait]
-pub trait QueryStageExecutor: Sync + Send + Debug {
+pub trait QueryStageExecutor: Sync + Send + Debug + Display {
     async fn execute_query_stage(
         &self,
         input_partition: usize,
@@ -92,6 +92,12 @@ pub struct DefaultQueryStageExec {
 impl DefaultQueryStageExec {
     pub fn new(shuffle_writer: ShuffleWriterExec) -> Self {
         Self { shuffle_writer }
+    }
+}
+
+impl Display for DefaultQueryStageExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DefaultQueryStageExec:\n{}", self.shuffle_writer)
     }
 }
 

--- a/ballista/executor/src/metrics/mod.rs
+++ b/ballista/executor/src/metrics/mod.rs
@@ -49,7 +49,7 @@ impl ExecutorMetricsCollector for LoggingMetricsCollector {
         plan: Arc<dyn QueryStageExecutor>,
     ) {
         info!(
-            "=== [{}/{}/{}] Physical plan with metrics ===\n{:?}\n",
+            "=== [{}/{}/{}] Physical plan with metrics ===\n{}\n",
             job_id, stage_id, partition, plan
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

There are few loggers on executor side which print plan as debug, which does not help a lot to debug execution. Also few loggers are very noisy using info and one which will print on warning level. 

Rationale for this change is to make loggers a bit more usable.

new style:

```
2025-02-20T07:31:57.529932Z  INFO          task_runner ThreadId(24) ballista_executor::metrics: === [KgkYWzF/2/12] Physical plan with metrics ===
DefaultQueryStageExec: (write_time{partition=12}=1.444584ms, repart_time{partition=12}=NOT RECORDED, input_rows{partition=12}=1, output_rows{partition=12}=1)
ShuffleWriterExec: job=KgkYWzF stage=2 work_dir=/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmp6siLuW partitioning=None plan: 
 ProjectionExec: expr=[count(*)@1 as count(*), l_shipmode@0 as l_shipmode], statistics=[Rows=Inexact(112), Bytes=Absent, [(Col[0]:),(Col[1]:)]]
  AggregateExec: mode=FinalPartitioned, gby=[l_shipmode@0 as l_shipmode], aggr=[count(*)], statistics=[Rows=Inexact(112), Bytes=Absent, [(Col[0]:),(Col[1]:)]]
    CoalesceBatchesExec: target_batch_size=8192, statistics=[Rows=Exact(112), Bytes=Exact(78848), [(Col[0]:),(Col[1]:)]]
      ShuffleReaderExec: partitions=16, statistics=[Rows=Exact(112), Bytes=Exact(78848), [(Col[0]:),(Col[1]:)]]
```

old style:

```
2025-02-20T07:38:33.276109Z  INFO          task_runner ThreadId(21) ballista_executor::metrics: === [WSHZ1hC/2/15] Physical plan with metrics ===
DefaultQueryStageExec { shuffle_writer: ShuffleWriterExec { job_id: "WSHZ1hC", stage_id: 2, plan: ProjectionExec { expr: [(Column { name: "count(*)", index: 1 }, "count(*)"), (Column { name: "l_shipmode", index: 0 }, "l_shipmode")], schema: Schema { fields: [Field { name: "count(*)", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }, input: AggregateExec { mode: FinalPartitioned, group_by: PhysicalGroupBy { expr: [(Column { name: "l_shipmode", index: 0 }, "l_shipmode")], null_expr: [], groups: [[false]] }, aggr_expr: [AggregateFunctionExpr { fun: AggregateUDF { inner: Count { name: "count", signature: Signature { type_signature: OneOf([VariadicAny, Nullary]), volatility: Immutable } } }, args: [Literal { value: Int64(1) }], data_type: Int64, name: "count(*)", schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }, ordering_req: LexOrdering { inner: [] }, ignore_nulls: false, ordering_fields: [], is_distinct: false, is_reversed: false, input_types: [Int64], is_nullable: false }], filter_expr: [None], limit: None, input: CoalesceBatchesExec { input: ShuffleReaderExec { stage_id: 1, schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "count(*)[count]", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }, partition: [[PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 0 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/0/data-15.arrow" }], [], [PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 2 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/2/data-15.arrow" }], [], [], [PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 5 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/5/data-15.arrow" }], [PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 6 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/6/data-15.arrow" }], [], [], [], [], [], [PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 12 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/12/data-15.arrow" }], [PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 13 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/13/data-15.arrow" }], [], [PartitionLocation { map_partition_id: 7, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-7.arrow" }, PartitionLocation { map_partition_id: 3, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-3.arrow" }, PartitionLocation { map_partition_id: 12, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-12.arrow" }, PartitionLocation { map_partition_id: 10, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-10.arrow" }, PartitionLocation { map_partition_id: 2, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-2.arrow" }, PartitionLocation { map_partition_id: 5, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-5.arrow" }, PartitionLocation { map_partition_id: 0, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-0.arrow" }, PartitionLocation { map_partition_id: 9, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-9.arrow" }, PartitionLocation { map_partition_id: 11, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-11.arrow" }, PartitionLocation { map_partition_id: 1, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-1.arrow" }, PartitionLocation { map_partition_id: 8, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-8.arrow" }, PartitionLocation { map_partition_id: 6, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-6.arrow" }, PartitionLocation { map_partition_id: 4, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-4.arrow" }, PartitionLocation { map_partition_id: 13, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-13.arrow" }, PartitionLocation { map_partition_id: 14, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-14.arrow" }, PartitionLocation { map_partition_id: 15, partition_id: PartitionId { job_id: "WSHZ1hC", stage_id: 1, partition_id: 15 }, executor_meta: ExecutorMetadata { id: "354639c5-5d58-4403-959e-ed99f252c04d", host: "127.0.0.1", port: 50051, grpc_port: 50052, specification: ExecutorSpecification { task_slots: 14 } }, partition_stats: PartitionStats { num_rows: Some(1), num_batches: Some(1), num_bytes: Some(704) }, path: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ/WSHZ1hC/1/15/data-15.arrow" }]], metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [] } } }, properties: PlanProperties { eq_properties: EquivalenceProperties { eq_group: EquivalenceGroup { classes: [] }, oeq_class: OrderingEquivalenceClass { orderings: [] }, constants: [], schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "count(*)[count]", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} } }, partitioning: Hash([Column { name: "l_shipmode", index: 0 }], 16), emission_type: Incremental, boundedness: Bounded, output_ordering: None } }, target_batch_size: 8192, fetch: None, metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [Metric { value: StartTimestamp(Timestamp { timestamp: Mutex { data: Some(2025-02-20T09:38:33.274645Z) } }), labels: [], partition: Some(15) }, Metric { value: EndTimestamp(Timestamp { timestamp: Mutex { data: Some(2025-02-20T09:38:33.275747Z) } }), labels: [], partition: Some(15) }, Metric { value: ElapsedCompute(Time { nanos: 29543 }), labels: [], partition: Some(15) }, Metric { value: OutputRows(Count { value: 16 }), labels: [], partition: Some(15) }] } } }, cache: PlanProperties { eq_properties: EquivalenceProperties { eq_group: EquivalenceGroup { classes: [] }, oeq_class: OrderingEquivalenceClass { orderings: [] }, constants: [], schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "count(*)[count]", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} } }, partitioning: Hash([Column { name: "l_shipmode", index: 0 }], 16), emission_type: Incremental, boundedness: Bounded, output_ordering: None } }, schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "count(*)", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }, input_schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} }, metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [Metric { value: StartTimestamp(Timestamp { timestamp: Mutex { data: Some(2025-02-20T09:38:33.274647Z) } }), labels: [], partition: Some(15) }, Metric { value: EndTimestamp(Timestamp { timestamp: Mutex { data: Some(2025-02-20T09:38:33.275969Z) } }), labels: [], partition: Some(15) }, Metric { value: ElapsedCompute(Time { nanos: 81375 }), labels: [], partition: Some(15) }, Metric { value: OutputRows(Count { value: 1 }), labels: [], partition: Some(15) }, Metric { value: Gauge { name: "peak_mem_used", gauge: Gauge { value: 17144 } }, labels: [], partition: Some(15) }, Metric { value: SpillCount(Count { value: 0 }), labels: [], partition: Some(15) }, Metric { value: SpilledBytes(Count { value: 0 }), labels: [], partition: Some(15) }, Metric { value: SpilledRows(Count { value: 0 }), labels: [], partition: Some(15) }] } } }, required_input_ordering: None, input_order_mode: Linear, cache: PlanProperties { eq_properties: EquivalenceProperties { eq_group: EquivalenceGroup { classes: [] }, oeq_class: OrderingEquivalenceClass { orderings: [] }, constants: [], schema: Schema { fields: [Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "count(*)", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} } }, partitioning: Hash([Column { name: "l_shipmode", index: 0 }], 16), emission_type: Final, boundedness: Bounded, output_ordering: None } }, metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [Metric { value: StartTimestamp(Timestamp { timestamp: Mutex { data: Some(2025-02-20T09:38:33.274710Z) } }), labels: [], partition: Some(15) }, Metric { value: EndTimestamp(Timestamp { timestamp: Mutex { data: Some(2025-02-20T09:38:33.275818Z) } }), labels: [], partition: Some(15) }, Metric { value: ElapsedCompute(Time { nanos: 2292 }), labels: [], partition: Some(15) }, Metric { value: OutputRows(Count { value: 1 }), labels: [], partition: Some(15) }] } } }, cache: PlanProperties { eq_properties: EquivalenceProperties { eq_group: EquivalenceGroup { classes: [] }, oeq_class: OrderingEquivalenceClass { orderings: [] }, constants: [], schema: Schema { fields: [Field { name: "count(*)", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} } }, partitioning: Hash([Column { name: "l_shipmode", index: 1 }], 16), emission_type: Final, boundedness: Bounded, output_ordering: None } }, work_dir: "/var/folders/h_/cdg2zx090212402xhrwhv62w0000gn/T/.tmppU3VAQ", shuffle_output_partitioning: None, metrics: ExecutionPlanMetricsSet { inner: Mutex { data: MetricsSet { metrics: [Metric { value: Time { name: "write_time", time: Time { nanos: 1208332 } }, labels: [], partition: Some(15) }, Metric { value: Time { name: "repart_time", time: Time { nanos: 0 } }, labels: [], partition: Some(15) }, Metric { value: Count { name: "input_rows", count: Count { value: 1 } }, labels: [], partition: Some(15) }, Metric { value: OutputRows(Count { value: 1 }), labels: [], partition: Some(15) }] } } }, properties: PlanProperties { eq_properties: EquivalenceProperties { eq_group: EquivalenceGroup { classes: [] }, oeq_class: OrderingEquivalenceClass { orderings: [] }, constants: [], schema: Schema { fields: [Field { name: "count(*)", data_type: Int64, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "l_shipmode", data_type: Utf8View, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }], metadata: {} } }, partitioning: Hash([Column { name: "l_shipmode", index: 1 }], 16), emission_type: Incremental, boundedness: Bounded, output_ordering: None } } }

```

# What changes are included in this PR?

- convert from debug to displayable plan 
- change log levels on few loggers
- ignore propagating deprecated configuration as it will trigger warnings

# Are there any user-facing changes?

No