### PR TITLE
Fix unit tests in tpch.rs

### DIFF
--- a/benchmarks/queries/q10.sql
+++ b/benchmarks/queries/q10.sql
@@ -28,4 +28,5 @@ group by
     c_address,
     c_comment
 order by
-    revenue desc;
+    revenue desc
+limit 20;

--- a/benchmarks/queries/q10.sql
+++ b/benchmarks/queries/q10.sql
@@ -28,5 +28,4 @@ group by
     c_address,
     c_comment
 order by
-    revenue desc
-limit 20;
+    revenue desc;

--- a/benchmarks/queries/q18.sql
+++ b/benchmarks/queries/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate
+limit 100;

--- a/benchmarks/queries/q18.sql
+++ b/benchmarks/queries/q18.sql
@@ -29,5 +29,4 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate
-limit 100;
+    o_orderdate;

--- a/benchmarks/queries/q2.sql
+++ b/benchmarks/queries/q2.sql
@@ -40,4 +40,5 @@ order by
     s_acctbal desc,
     n_name,
     s_name,
-    p_partkey;
+    p_partkey
+limit 100;

--- a/benchmarks/queries/q2.sql
+++ b/benchmarks/queries/q2.sql
@@ -40,5 +40,4 @@ order by
     s_acctbal desc,
     n_name,
     s_name,
-    p_partkey
-limit 100;
+    p_partkey;

--- a/benchmarks/queries/q21.sql
+++ b/benchmarks/queries/q21.sql
@@ -36,4 +36,5 @@ group by
     s_name
 order by
     numwait desc,
-    s_name;
+    s_name
+limit 100;

--- a/benchmarks/queries/q21.sql
+++ b/benchmarks/queries/q21.sql
@@ -36,5 +36,4 @@ group by
     s_name
 order by
     numwait desc,
-    s_name
-limit 100;
+    s_name;

--- a/benchmarks/queries/q3.sql
+++ b/benchmarks/queries/q3.sql
@@ -19,4 +19,5 @@ group by
     o_shippriority
 order by
     revenue desc,
-    o_orderdate;
+    o_orderdate
+limit 10;

--- a/benchmarks/queries/q3.sql
+++ b/benchmarks/queries/q3.sql
@@ -19,5 +19,4 @@ group by
     o_shippriority
 order by
     revenue desc,
-    o_orderdate
-limit 10;
+    o_orderdate;

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1137,18 +1137,18 @@ fn get_answer_schema(n: usize) -> Schema {
         7 => Schema::new(vec![
             Field::new("supp_nation", DataType::Utf8, true),
             Field::new("cust_nation", DataType::Utf8, true),
-            Field::new("l_year", DataType::Float64, true),
+            Field::new("l_year", DataType::Int32, true),
             Field::new("revenue", DataType::Decimal128(15, 2), true),
         ]),
 
         8 => Schema::new(vec![
-            Field::new("o_year", DataType::Float64, true),
+            Field::new("o_year", DataType::Int32, true),
             Field::new("mkt_share", DataType::Decimal128(15, 2), true),
         ]),
 
         9 => Schema::new(vec![
             Field::new("nation", DataType::Utf8, true),
-            Field::new("o_year", DataType::Float64, true),
+            Field::new("o_year", DataType::Int32, true),
             Field::new("sum_profit", DataType::Decimal128(15, 2), true),
         ]),
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1368,6 +1368,15 @@ mod tests {
         verify_query(16).await
     }
 
+    // Python code to reproduce the "348406.05" result in DuckDB:
+    // ```python
+    // import duckdb
+    // lineitem = duckdb.read_csv("data/lineitem.tbl", columns={'l_orderkey':'int64', 'l_partkey':'int64', 'l_suppkey':'int64', 'l_linenumber':'int64', 'l_quantity':'int64', 'l_extendedprice':'decimal(15,2)', 'l_discount':'decimal(15,2)', 'l_tax':'decimal(15,2)', 'l_returnflag':'varchar','l_linestatus':'varchar', 'l_shipdate':'date', 'l_commitdate':'date', 'l_receiptdate':'date', 'l_shipinstruct':'varchar', 'l_shipmode':'varchar', 'l_comment':'varchar'})
+    // part = duckdb.read_csv("data/part.tbl", columns={'p_partkey':'int64', 'p_name':'varchar', 'p_mfgr':'varchar', 'p_brand':'varchar', 'p_type':'varchar', 'p_size':'int64', 'p_container':'varchar', 'p_retailprice':'double', 'p_comment':'varchar'})
+    // duckdb.sql("select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and l_quantity < (select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey )")
+    // ```
+    // That is the same as DataFusion's output.
+    #[ignore = "Somehow, the expected result is 348406.02 whereas both DataFusion and DuckDB return 348406.05"]
     #[tokio::test]
     async fn q17() -> Result<()> {
         verify_query(17).await

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -1357,6 +1357,7 @@ mod tests {
         verify_query(14).await
     }
 
+    #[ignore] // TODO: support multiline queries
     #[tokio::test]
     async fn q15() -> Result<()> {
         verify_query(15).await


### PR DESCRIPTION
# Which issue does this PR close?

https://github.com/apache/datafusion-ballista/issues/1194

 # Rationale for this change

Fix unit test in tpch unit tests. Now benchmark test `TPCH_DATA=data/ cargo test` is passing.

# What changes are included in this PR?

There are a list of changes each of which is in a separate commit:

- https://github.com/apache/datafusion-ballista/pull/1195/commits/4cb5a75f8a013490a82c4b84abd2f8e80f23adb6: Use  `get_tbl_tpch_table_schema` to special treat the`.tbl` files that are generated by `tpch-gen.sh` and have an additional trailing column.
- https://github.com/apache/datafusion-ballista/pull/1195/commits/007d148b94f2dff97509e3d876e109e3359793aa: Add missing limits to the tpch queries. Note that this may affect some of the benchmark results.
- https://github.com/apache/datafusion-ballista/pull/1195/commits/76b86079d6dd0a481bdb31d2d64a59e772ed5b04: Ignore `q15()` because it contains multiple statements and is not supported and similarly ignored by `run_q15()`.
- https://github.com/apache/datafusion-ballista/pull/1195/commits/9634d5c9666623a235c0d6332e0a06460d99acbe: Use Int32 for "*year" data types to match the actual query data type.
-  https://github.com/apache/datafusion-ballista/pull/1195/commits/8f6f1a003195857f776969352410cde7447e382a: Normalize query results before compare them with the expected results loaded from CSV file.
- https://github.com/apache/datafusion-ballista/pull/1195/commits/5f16e6aeca4863b14c69ac01a52415be68144cb8: Skip a query results mismatch that seems to be slightly off in the expected results in the tpch data.
- https://github.com/apache/datafusion-ballista/pull/1195/commits/7b80efd1d9055d1ab6fd705aded1231a966d89ca: Format only.

# Are there any user-facing changes?

No