### PR TITLE
chore: update python dependencies

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -30,13 +30,13 @@ publish = false
 
 [dependencies]
 async-trait = "0.1.77"
-ballista = { version = "43.0.0" }
-ballista-core = { version = "43.0.0" }
-ballista-executor = { version = "43.0.0", default-features = false }
-ballista-scheduler = { version = "43.0.0", default-features = false }
-datafusion = { version = "43", features = ["pyarrow", "avro"] }
-datafusion-proto = { version = "43" }
-datafusion-python = { version = "43" }
+ballista = { version = "44.0.0" }
+ballista-core = { version = "44.0.0" }
+ballista-executor = { version = "44.0.0", default-features = false }
+ballista-scheduler = { version = "44.0.0", default-features = false }
+datafusion = { version = "44", features = ["pyarrow", "avro"] }
+datafusion-proto = { version = "44" }
+datafusion-python = { version = "44" }
 
 pyo3 = { version = "0.22", features = ["extension-module", "abi3", "abi3-py38"] }
 pyo3-log = "0.11"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ name = "ballista"
 description = "Python client for Apache Arrow Ballista Distributed SQL Query Engine"
 readme = "README.md"
 license = {file = "LICENSE.txt"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 keywords = ["ballista", "sql", "rust", "distributed"]
 classifier = [
     "Development Status :: 2 - Pre-Alpha",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-datafusion==43.1.0
+datafusion==44.0.0
 pyarrow
 pytest
 maturin==1.5.1


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

keeping py-ballista dependencies up to date 

# What changes are included in this PR?


# Are there any user-facing changes?

removed support for python 3.8