### PR TITLE
feat: publish docker containers for executor and scheduler 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,11 +16,11 @@
 # under the License.
 
 name: Docker
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build_docker:
-    name: Run build Docker script
+    name: Run Build Docker Script
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,4 +28,23 @@ jobs:
       - name: Installs Rust and Cargo
         run: curl -y --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
       - name: Run script
-        run: ./dev/build-ballista-docker.sh
+        run: |
+          ./dev/build-ballista-docker.sh
+          export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
+          if [[ $DOCKER_TAG =~ ^[0-9\.]+-rc[0-9]+$ ]]
+          then
+            echo "publishing docker tag $DOCKER_TAG"
+            docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
+            
+            docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
+            docker tag apache/arrow-ballista-executor:latest "ghcr.io/apache/arrow-ballista-executor:$DOCKER_TAG"
+            docker tag apache/arrow-ballista-scheduler:latest "ghcr.io/apache/arrow-ballista-scheduler:$DOCKER_TAG"
+
+            docker push ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
+            docker push ghcr.io/apache/arrow-ballista-executor:$DOCKER_TAG
+            docker push ghcr.io/apache/arrow-ballista-scheduler:$DOCKER_TAG
+
+          fi
+        env:
+          DOCKER_USER: ${{ github.actor }}
+          DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,19 +32,29 @@ jobs:
           ./dev/build-ballista-docker.sh
 
           docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$BALLISTA_VERSION
-          docker tag apache/arrow-ballista-executor:latest "ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION"
-          docker tag apache/arrow-ballista-scheduler:latest "ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION"
+          docker tag apache/arrow-ballista-executor:latest ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION
+          docker tag apache/arrow-ballista-scheduler:latest ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION
 
-          # release dockers only when tagged 
+          docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:latest
+          docker tag apache/arrow-ballista-executor:latest ghcr.io/apache/arrow-ballista-executor:latest
+          docker tag apache/arrow-ballista-scheduler:latest ghcr.io/apache/arrow-ballista-scheduler:latest
+
+          # release dockers only when there is a tag 
           export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+-rc[0-9]+$ ]]
           then
-            echo "publishing docker tag $DOCKER_TAG"
+            echo "publishing docker tag $BALLISTA_VERSION"
             docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
             
             docker push ghcr.io/apache/arrow-ballista-standalone:$BALLISTA_VERSION
             docker push ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION
             docker push ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION
+
+            echo "publishing docker tag latest"
+
+            docker push ghcr.io/apache/arrow-ballista-standalone:latest
+            docker push ghcr.io/apache/arrow-ballista-executor:latest
+            docker push ghcr.io/apache/arrow-ballista-scheduler:latest
 
           fi
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,11 +29,8 @@ jobs:
         run: curl -y --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
       - name: Run script
         run: |
-          ./dev/build-ballista-docker.sh
 
-          docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$BALLISTA_VERSION
-          docker tag apache/arrow-ballista-executor:latest ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION
-          docker tag apache/arrow-ballista-scheduler:latest ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION
+          ./dev/build-ballista-docker.sh
 
           docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:latest
           docker tag apache/arrow-ballista-executor:latest ghcr.io/apache/arrow-ballista-executor:latest
@@ -43,12 +40,18 @@ jobs:
           export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+-rc[0-9]+$ ]]
           then
-            echo "publishing docker tag $BALLISTA_VERSION"
-            docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
             
-            docker push ghcr.io/apache/arrow-ballista-standalone:$BALLISTA_VERSION
-            docker push ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION
-            docker push ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION
+            docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
+
+            echo "publishing docker tag $DOCKER_TAG"
+
+            docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
+            docker tag apache/arrow-ballista-executor:latest ghcr.io/apache/arrow-ballista-executor:$DOCKER_TAG
+            docker tag apache/arrow-ballista-scheduler:latest ghcr.io/apache/arrow-ballista-scheduler:$DOCKER_TAG
+            
+            docker push ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
+            docker push ghcr.io/apache/arrow-ballista-executor:$DOCKER_TAG
+            docker push ghcr.io/apache/arrow-ballista-scheduler:$DOCKER_TAG
 
             echo "publishing docker tag latest"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,19 +30,21 @@ jobs:
       - name: Run script
         run: |
           ./dev/build-ballista-docker.sh
+
+          docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$BALLISTA_VERSION
+          docker tag apache/arrow-ballista-executor:latest "ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION"
+          docker tag apache/arrow-ballista-scheduler:latest "ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION"
+
+          # release dockers only when tagged 
           export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+-rc[0-9]+$ ]]
           then
             echo "publishing docker tag $DOCKER_TAG"
             docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
             
-            docker tag apache/arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
-            docker tag apache/arrow-ballista-executor:latest "ghcr.io/apache/arrow-ballista-executor:$DOCKER_TAG"
-            docker tag apache/arrow-ballista-scheduler:latest "ghcr.io/apache/arrow-ballista-scheduler:$DOCKER_TAG"
-
-            docker push ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
-            docker push ghcr.io/apache/arrow-ballista-executor:$DOCKER_TAG
-            docker push ghcr.io/apache/arrow-ballista-scheduler:$DOCKER_TAG
+            docker push ghcr.io/apache/arrow-ballista-standalone:$BALLISTA_VERSION
+            docker push ghcr.io/apache/arrow-ballista-executor:$BALLISTA_VERSION
+            docker push ghcr.io/apache/arrow-ballista-scheduler:$BALLISTA_VERSION
 
           fi
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,36 +294,6 @@ jobs:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"
 
-  docker:
-    name: Docker
-    needs: [linux-build-lib]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Restore rust artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-artifacts
-          path: target/release
-      - name: Build and push Docker image
-        run: |
-          echo "github user is $DOCKER_USER"
-          docker build -t arrow-ballista-standalone:latest -f dev/docker/ballista-standalone.Dockerfile .
-          export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
-          if [[ $DOCKER_TAG =~ ^[0-9\.]+-rc[0-9]+$ ]]
-          then
-            echo "publishing docker tag $DOCKER_TAG"
-            docker tag arrow-ballista-standalone:latest ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
-            docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
-            docker push ghcr.io/apache/arrow-ballista-standalone:$DOCKER_TAG
-          fi
-        env:
-          DOCKER_USER: ${{ github.actor }}
-          DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
-
   clippy:
     name: Clippy
     needs: [linux-build-lib]

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -23,8 +23,6 @@ RELEASE_FLAG=${RELEASE_FLAG:=release}
 
 ./dev/build-ballista-executables.sh
 
-# docker compose build
-
 . ./dev/build-set-env.sh
 
 docker build -t "apache/arrow-ballista-standalone:latest" -f dev/docker/ballista-standalone.Dockerfile .

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -30,4 +30,3 @@ docker build -t "apache/arrow-ballista-scheduler:latest" -f dev/docker/ballista-
 docker build -t "apache/arrow-ballista-executor:latest" -f dev/docker/ballista-executor.Dockerfile .
 docker build -t "apache/arrow-ballista-cli:latest" -f dev/docker/ballista-cli.Dockerfile .
 docker build -t "apache/arrow-ballista-benchmarks:latest" -f dev/docker/ballista-benchmarks.Dockerfile .
-

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -23,13 +23,13 @@ RELEASE_FLAG=${RELEASE_FLAG:=release}
 
 ./dev/build-ballista-executables.sh
 
-docker compose build
+# docker compose build
 
 . ./dev/build-set-env.sh
-docker build -t "apache/arrow-ballista-standalone:$BALLISTA_VERSION" -f dev/docker/ballista-standalone.Dockerfile .
 
-docker tag ballista-executor "apache/arrow-ballista-executor:$BALLISTA_VERSION"
-docker tag ballista-scheduler "apache/arrow-ballista-scheduler:$BALLISTA_VERSION"
-docker tag ballista-benchmarks "apache/arrow-ballista-benchmarks:$BALLISTA_VERSION"
+docker build -t "apache/arrow-ballista-standalone:latest" -f dev/docker/ballista-standalone.Dockerfile .
+docker build -t "apache/arrow-ballista-scheduler:latest" -f dev/docker/ballista-scheduler.Dockerfile .
+docker build -t "apache/arrow-ballista-executor:latest" -f dev/docker/ballista-executor.Dockerfile .
+docker build -t "apache/arrow-ballista-cli:latest" -f dev/docker/ballista-cli.Dockerfile .
+docker build -t "apache/arrow-ballista-benchmarks:latest" -f dev/docker/ballista-benchmarks.Dockerfile .
 
-docker build -t "apache/arrow-ballista-cli:$BALLISTA_VERSION" -f dev/docker/ballista-cli.Dockerfile .

--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG RELEASE_FLAG=release
 

--- a/dev/docker/ballista-builder.Dockerfile
+++ b/dev/docker/ballista-builder.Dockerfile
@@ -24,7 +24,7 @@ ENV RUST_BACKTRACE=full
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat curl unzip
+    apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler curl unzip
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get update && \

--- a/dev/docker/ballista-builder.Dockerfile
+++ b/dev/docker/ballista-builder.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.81-bullseye
+FROM rust:1.85-bullseye
 
 ARG EXT_UID
 

--- a/dev/docker/ballista-cli.Dockerfile
+++ b/dev/docker/ballista-cli.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG RELEASE_FLAG=release
 

--- a/dev/docker/ballista-executor.Dockerfile
+++ b/dev/docker/ballista-executor.Dockerfile
@@ -23,8 +23,6 @@ ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 
-RUN apt-get update && apt-get install -y netcat
-
 COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor
 
 # Expose Ballista Executor gRPC port

--- a/dev/docker/ballista-executor.Dockerfile
+++ b/dev/docker/ballista-executor.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG RELEASE_FLAG=release
 

--- a/dev/docker/ballista-scheduler.Dockerfile
+++ b/dev/docker/ballista-scheduler.Dockerfile
@@ -24,8 +24,6 @@ ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y netcat
-
 COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
 
 # Expose Ballista Scheduler gRPC port

--- a/dev/docker/ballista-scheduler.Dockerfile
+++ b/dev/docker/ballista-scheduler.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG RELEASE_FLAG=release
 

--- a/dev/docker/ballista-standalone.Dockerfile
+++ b/dev/docker/ballista-standalone.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/arrow-ballista"
 LABEL org.opencontainers.image.description="Apache Arrow Ballista Distributed SQL Query Engine"

--- a/dev/docker/ballista-standalone.Dockerfile
+++ b/dev/docker/ballista-standalone.Dockerfile
@@ -28,7 +28,7 @@ ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get install -qq -y netcat wget
+RUN apt-get -qq update && apt-get install -qq -y wget
 
 COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
 COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor

--- a/dev/docker/builder-entrypoint.sh
+++ b/dev/docker/builder-entrypoint.sh
@@ -22,4 +22,4 @@ set -x
 
 printenv
 RELEASE_FLAG=${RELEASE_FLAG:=release}
-cargo build --features flight-sql --profile $RELEASE_FLAG "$@"
+cargo build --features rest-api --profile $RELEASE_FLAG "$@"


### PR DESCRIPTION
# Which issue does this PR close?

relates to: #1198 
Closes #1044.

 # Rationale for this change

Publish scheduler and executor docker containers not only standalone 

# What changes are included in this PR?

- updated GitHub actions (Docker) to publish `scheduler` and `executor`
- updated docker build script to use rust `1.85`
- updated container to use ubuntu `24.04`

# Are there any user-facing changes?
