### PR TITLE
minor: make `graphviz-rust` dependency optional

### DIFF
--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -38,9 +38,10 @@ required-features = ["build-binary"]
 build-binary = ["configure_me", "clap", "tracing-subscriber", "tracing-appender", "tracing", "ballista-core/build-binary"]
 default = ["build-binary"]
 flight-sql = ["base64"]
+graphviz-support = ["dep:graphviz-rust"]
 keda-scaler = []
 prometheus-metrics = ["prometheus", "once_cell"]
-rest-api = ["graphviz-rust"]
+rest-api = []
 
 [dependencies]
 arrow-flight = { workspace = true }

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -24,9 +24,12 @@ use ballista_core::BALLISTA_VERSION;
 use datafusion::physical_plan::metrics::{MetricValue, MetricsSet, Time};
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
-use graphviz_rust::cmd::{CommandArg, Format};
-use graphviz_rust::exec;
-use graphviz_rust::printer::PrinterContext;
+#[cfg(feature = "graphviz-support")]
+use graphviz_rust::{
+    cmd::{CommandArg, Format},
+    exec,
+    printer::PrinterContext,
+};
 use http::{header::CONTENT_TYPE, StatusCode};
 use std::sync::Arc;
 use std::time::Duration;
@@ -342,7 +345,7 @@ pub async fn get_query_stage_dot_graph<
         Ok("Not Found".to_string())
     }
 }
-
+#[cfg(feature = "graphviz-support")]
 pub async fn get_job_svg_graph<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,

--- a/ballista/scheduler/src/api/mod.rs
+++ b/ballista/scheduler/src/api/mod.rs
@@ -25,7 +25,7 @@ pub fn get_routes<
 >(
     scheduler_server: Arc<SchedulerServer<T, U>>,
 ) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/api/state", get(handlers::get_scheduler_state::<T, U>))
         .route("/api/executors", get(handlers::get_executors::<T, U>))
         .route("/api/jobs", get(handlers::get_jobs::<T, U>))
@@ -42,10 +42,13 @@ pub fn get_routes<
             "/api/job/:job_id/stage/:stage_id/dot",
             get(handlers::get_query_stage_dot_graph::<T, U>),
         )
-        .route(
-            "/api/job/:job_id/dot_svg",
-            get(handlers::get_job_svg_graph::<T, U>),
-        )
-        .route("/api/metrics", get(handlers::get_scheduler_metrics::<T, U>))
-        .with_state(scheduler_server)
+        .route("/api/metrics", get(handlers::get_scheduler_metrics::<T, U>));
+
+    #[cfg(feature = "graphviz-support")]
+    let router = router.route(
+        "/api/job/:job_id/dot_svg",
+        get(handlers::get_job_svg_graph::<T, U>),
+    );
+
+    router.with_state(scheduler_server)
 }

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -25,10 +25,12 @@ The scheduler also provides a REST API that allows jobs to be monitored.
 
 > This is optional scheduler feature which should be enabled with `rest-api` feature
 
-| API                   | Method | Description                                                 |
-| --------------------- | ------ | ----------------------------------------------------------- |
-| /api/jobs             | GET    | Get a list of jobs that have been submitted to the cluster. |
-| /api/job/{job_id}     | GET    | Get a summary of a submitted job.                           |
-| /api/job/{job_id}/dot | GET    | Produce a query plan in DOT (graphviz) format.              |
-| /api/job/{job_id}     | PATCH  | Cancel a currently running job                              |
-| /api/metrics          | GET    | Return current scheduler metric set                         |
+| API                                  | Method | Description                                                       |
+| ------------------------------------ | ------ | ----------------------------------------------------------------- |
+| /api/jobs                            | GET    | Get a list of jobs that have been submitted to the cluster.       |
+| /api/job/{job_id}                    | GET    | Get a summary of a submitted job.                                 |
+| /api/job/{job_id}/dot                | GET    | Produce a query plan in DOT (graphviz) format.                    |
+| /api/job/:job_id/dot_svg             | GET    | Produce a query plan in SVG format. (`graphviz-support` required) |
+| /api/job/{job_id}                    | PATCH  | Cancel a currently running job                                    |
+| /api/job/:job_id/stage/:stage_id/dot | GET    | Produces stage plan in DOT (graphviz) format                      |
+| /api/metrics                         | GET    | Return current scheduler metric set                               |


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1202.

 # Rationale for this change

# What changes are included in this PR?

- making `graphviz-rust` optional dependency, disabled by default

# Are there any user-facing changes?

- if `graphviz-rust` not enabled rest api: `/api/job/:job_id/dot_svg` will not be exposed 
