### PR TITLE
minor: Decouple `ExecutionGraph` and `DistributedPlanner`

### DIFF
--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -140,6 +140,7 @@ pub struct RunningTaskInfo {
 }
 
 impl ExecutionGraph {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         scheduler_id: &str,
         job_id: &str,
@@ -148,11 +149,9 @@ impl ExecutionGraph {
         plan: Arc<dyn ExecutionPlan>,
         queued_at: u64,
         session_config: Arc<SessionConfig>,
+        planner: &mut dyn DistributedPlanner,
     ) -> Result<Self> {
-        let mut planner = DistributedPlanner::new();
-
         let output_partitions = plan.properties().output_partitioning().partition_count();
-
         let shuffle_stages = planner.plan_query_stages(job_id, plan)?;
 
         let builder = ExecutionStageBuilder::new(session_config.clone());

--- a/ballista/scheduler/src/state/execution_graph_dot.rs
+++ b/ballista/scheduler/src/state/execution_graph_dot.rs
@@ -415,6 +415,7 @@ fn get_file_scan(scan: &FileScanConfig) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::planner::DefaultDistributedPlanner;
     use crate::state::execution_graph::ExecutionGraph;
     use crate::state::execution_graph_dot::ExecutionGraphDot;
     use ballista_core::error::{BallistaError, Result};
@@ -645,6 +646,7 @@ filter_expr="]
             .await?;
         let plan = df.into_optimized_plan()?;
         let plan = ctx.state().create_physical_plan(&plan).await?;
+        let mut planner = DefaultDistributedPlanner::new();
         ExecutionGraph::new(
             "scheduler_id",
             "job_id",
@@ -653,6 +655,7 @@ filter_expr="]
             plan,
             0,
             Arc::new(SessionConfig::new_with_ballista()),
+            &mut planner,
         )
     }
 
@@ -679,6 +682,7 @@ filter_expr="]
             .await?;
         let plan = df.into_optimized_plan()?;
         let plan = ctx.state().create_physical_plan(&plan).await?;
+        let mut planner = DefaultDistributedPlanner::new();
         ExecutionGraph::new(
             "scheduler_id",
             "job_id",
@@ -687,6 +691,7 @@ filter_expr="]
             plan,
             0,
             Arc::new(SessionConfig::new_with_ballista()),
+            &mut planner,
         )
     }
 }

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::planner::DefaultDistributedPlanner;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 
 use crate::state::execution_graph::{
@@ -207,6 +208,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         queued_at: u64,
         session_config: Arc<SessionConfig>,
     ) -> Result<()> {
+        let mut planner = DefaultDistributedPlanner::new();
         let mut graph = ExecutionGraph::new(
             &self.scheduler_id,
             job_id,
@@ -215,6 +217,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             plan,
             queued_at,
             session_config,
+            &mut planner,
         )?;
         info!("Submitting execution graph: {:?}", graph);
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -28,6 +28,7 @@ use async_trait::async_trait;
 
 use crate::config::SchedulerConfig;
 use crate::metrics::SchedulerMetricsCollector;
+use crate::planner::DefaultDistributedPlanner;
 use crate::scheduler_server::{timestamp_millis, SchedulerServer};
 
 use crate::state::executor_manager::ExecutorManager;
@@ -861,7 +862,7 @@ pub async fn test_aggregation_plan_with_job_id(
         "{}",
         DisplayableExecutionPlan::new(plan.as_ref()).indent(false)
     );
-
+    let mut planner = DefaultDistributedPlanner::new();
     ExecutionGraph::new(
         "localhost:50050",
         job_id,
@@ -870,6 +871,7 @@ pub async fn test_aggregation_plan_with_job_id(
         plan,
         0,
         Arc::new(SessionConfig::new_with_ballista()),
+        &mut planner,
     )
     .unwrap()
 }
@@ -906,7 +908,7 @@ pub async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
         "{}",
         DisplayableExecutionPlan::new(plan.as_ref()).indent(false)
     );
-
+    let mut planner = DefaultDistributedPlanner::new();
     ExecutionGraph::new(
         "localhost:50050",
         "job",
@@ -915,6 +917,7 @@ pub async fn test_two_aggregations_plan(partition: usize) -> ExecutionGraph {
         plan,
         0,
         Arc::new(SessionConfig::new_with_ballista()),
+        &mut planner,
     )
     .unwrap()
 }
@@ -943,7 +946,7 @@ pub async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
         .create_physical_plan(&optimized_plan)
         .await
         .unwrap();
-
+    let mut planner = DefaultDistributedPlanner::new();
     ExecutionGraph::new(
         "localhost:50050",
         "job",
@@ -952,6 +955,7 @@ pub async fn test_coalesce_plan(partition: usize) -> ExecutionGraph {
         plan,
         0,
         Arc::new(SessionConfig::new_with_ballista()),
+        &mut planner,
     )
     .unwrap()
 }
@@ -1001,7 +1005,7 @@ pub async fn test_join_plan(partition: usize) -> ExecutionGraph {
         "{}",
         DisplayableExecutionPlan::new(plan.as_ref()).indent(false)
     );
-
+    let mut planner = DefaultDistributedPlanner::new();
     let graph = ExecutionGraph::new(
         "localhost:50050",
         "job",
@@ -1010,6 +1014,7 @@ pub async fn test_join_plan(partition: usize) -> ExecutionGraph {
         plan,
         0,
         Arc::new(SessionConfig::new_with_ballista()),
+        &mut planner,
     )
     .unwrap();
 
@@ -1041,7 +1046,7 @@ pub async fn test_union_all_plan(partition: usize) -> ExecutionGraph {
         "{}",
         DisplayableExecutionPlan::new(plan.as_ref()).indent(false)
     );
-
+    let mut planner = DefaultDistributedPlanner::new();
     let graph = ExecutionGraph::new(
         "localhost:50050",
         "job",
@@ -1050,6 +1055,7 @@ pub async fn test_union_all_plan(partition: usize) -> ExecutionGraph {
         plan,
         0,
         Arc::new(SessionConfig::new_with_ballista()),
+        &mut planner,
     )
     .unwrap();
 
@@ -1081,7 +1087,7 @@ pub async fn test_union_plan(partition: usize) -> ExecutionGraph {
         "{}",
         DisplayableExecutionPlan::new(plan.as_ref()).indent(false)
     );
-
+    let mut planner = DefaultDistributedPlanner::new();
     let graph = ExecutionGraph::new(
         "localhost:50050",
         "job",
@@ -1090,6 +1096,7 @@ pub async fn test_union_plan(partition: usize) -> ExecutionGraph {
         plan,
         0,
         Arc::new(SessionConfig::new_with_ballista()),
+        &mut planner,
     )
     .unwrap();
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

Decouple `ExecutionGraph` and `DistributedPlanner` were coupled together, this change decouples them, making possible to provide a different `DistributedPlanner` to `ExecutionGraph`. 

# What changes are included in this PR?

- create trait `DistributedPlanner`
- add `DefaultDistributedPlanner` as initial implementation of `DistributedPlanner`

# Are there any user-facing changes?

No