### PR TITLE
chore(ci): replace `actions-rs` which are deprecated 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,16 +37,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff
       # Update output format to enable automatic inline annotations.
-#      - name: Run Ruff
-#        run: |
-#          ruff check --output-format=github python/
-#          ruff format --check python/
+  #      - name: Run Ruff
+  #        run: |
+  #          ruff check --output-format=github python/
+  #          ruff format --check python/
 
   generate-license:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
@@ -98,7 +98,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cargo build
-        run: cd python && cargo build 
+        run: cd python && cargo build
 
       - name: Build Python package
         run: cd python && maturin build --release --strip
@@ -135,7 +135,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rm LICENSE.txt
-      
+
       - name: Download LICENSE.txt
         uses: actions/download-artifact@v4
         with:
@@ -198,7 +198,7 @@ jobs:
         run: pip install maturin==1.5.1
       - name: Cargo Build
         run: cd python && cargo build
-      
+
       - name: Build Python package
         run: cd python && maturin build --release --strip
       - name: Archive wheels
@@ -221,7 +221,7 @@ jobs:
           path: .
 
       - run: cat LICENSE.txt
-       
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -234,7 +234,7 @@ jobs:
         run: pip install maturin==1.5.1
       - name: Cargo Build
         run: cd python && cargo build
-      
+
       - name: Build Python package
         run: cd python && maturin build --release --strip
       - name: Archive wheels
@@ -255,9 +255,9 @@ jobs:
         with:
           name: python-wheel-license
           path: .
-          
+
       - run: cat LICENSE.txt
-   
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -272,17 +272,17 @@ jobs:
         run: cd python && cargo build
       - name: Build Python package
         run: cd python && maturin build --release --sdist --out dist --strip
-      
+
       - name: Assert sdist build does not generate wheels
         run: |
-            if [ "$(ls -A target/wheels)" ]; then
-              echo "Error: Sdist build generated wheels"
-              exit 1
-            else
-              echo "Directory is clean"
-            fi
+          if [ "$(ls -A target/wheels)" ]; then
+            echo "Error: Sdist build generated wheels"
+            exit 1
+          else
+            echo "Directory is clean"
+          fi
         shell: bash
-  
+
   merge-build-artifacts:
     runs-on: ubuntu-latest
     needs:
@@ -297,7 +297,7 @@ jobs:
         with:
           name: dist
           pattern: dist-*
-  
+
   # NOTE: PyPI publish needs to be done manually for now after release passed the vote
   # release:
   #   name: Publish in PyPI


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

There spurious CI error, 

- https://github.com/apache/datafusion-ballista/actions/runs/14204334938
-  https://github.com/apache/datafusion-ballista/actions/runs/14196252739

```
actions-rs/toolchain@v1 is not allowed to be used in apache/datafusion-ballista. A...
```

```
r-lib/actions/pr-fetch@master and r-lib/actions/pr-push@master are not allowed to be used in apache/datafusion-ballista. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: 1Password/load-secrets-action@*, A ...
```

# What changes are included in this PR?

replaced deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable` 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
