### PR TITLE
feat: make scheduler session context stateless 

### DIFF
--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -38,7 +38,7 @@ pub trait SessionStateExt {
     /// State will be created with appropriate [SessionConfig] configured
     fn new_ballista_state(
         scheduler_url: String,
-        session_id: String,
+        //session_id: String,
     ) -> datafusion::error::Result<SessionState>;
     /// Upgrades [SessionState] for ballista usage
     ///
@@ -46,7 +46,7 @@ pub trait SessionStateExt {
     fn upgrade_for_ballista(
         self,
         scheduler_url: String,
-        session_id: String,
+        //session_id: String,
     ) -> datafusion::error::Result<SessionState>;
 }
 
@@ -131,7 +131,6 @@ pub trait SessionConfigHelperExt {
 impl SessionStateExt for SessionState {
     fn new_ballista_state(
         scheduler_url: String,
-        session_id: String,
     ) -> datafusion::error::Result<SessionState> {
         let session_config = SessionConfig::new_with_ballista();
         let planner = BallistaQueryPlanner::<LogicalPlanNode>::new(
@@ -145,7 +144,7 @@ impl SessionStateExt for SessionState {
             .with_config(session_config)
             .with_runtime_env(Arc::new(runtime_env))
             .with_query_planner(Arc::new(planner))
-            .with_session_id(session_id)
+            //.with_session_id(session_id)
             .build();
 
         Ok(session_state)
@@ -154,7 +153,6 @@ impl SessionStateExt for SessionState {
     fn upgrade_for_ballista(
         self,
         scheduler_url: String,
-        session_id: String,
     ) -> datafusion::error::Result<SessionState> {
         let codec_logical = self.config().ballista_logical_extension_codec();
         let planner_override = self.config().ballista_query_planner();
@@ -175,7 +173,8 @@ impl SessionStateExt for SessionState {
 
         let builder = SessionStateBuilder::new_from_existing(self)
             .with_config(session_config)
-            .with_session_id(session_id);
+            //.with_session_id(session_id)
+            ;
 
         let builder = match planner_override {
             Some(planner) => builder.with_query_planner(planner),
@@ -452,11 +451,8 @@ mod test {
     // Ballista disables round robin repatriations
     #[tokio::test]
     async fn should_disable_round_robin_repartition() {
-        let state = SessionState::new_ballista_state(
-            "scheduler_url".to_string(),
-            "session_id".to_string(),
-        )
-        .unwrap();
+        let state =
+            SessionState::new_ballista_state("scheduler_url".to_string()).unwrap();
 
         assert!(!state.config().round_robin_repartition());
 
@@ -464,7 +460,7 @@ mod test {
 
         assert!(state.config().round_robin_repartition());
         let state = state
-            .upgrade_for_ballista("scheduler_url".to_string(), "session_id".to_string())
+            .upgrade_for_ballista("scheduler_url".to_string())
             .unwrap();
 
         assert!(!state.config().round_robin_repartition());

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -295,8 +295,6 @@ pub struct InMemoryJobState {
     queued_jobs: DashMap<String, (String, u64)>,
     /// In-memory store of running job statuses. Map from Job ID -> JobStatus
     running_jobs: DashMap<String, JobStatus>,
-    /// Active ballista sessions
-    sessions: DashMap<String, Arc<SessionContext>>,
     /// `SessionBuilder` for building DataFusion `SessionContext` from `BallistaConfig`
     session_builder: SessionBuilder,
     /// Sender of job events
@@ -316,7 +314,7 @@ impl InMemoryJobState {
             completed_jobs: Default::default(),
             queued_jobs: Default::default(),
             running_jobs: Default::default(),
-            sessions: Default::default(),
+            //sessions: Default::default(),
             session_builder,
             job_event_sender: ClusterEventSender::new(100),
             config_producer,
@@ -409,42 +407,27 @@ impl JobState for InMemoryJobState {
         Ok(())
     }
 
-    async fn get_session(&self, session_id: &str) -> Result<Arc<SessionContext>> {
-        self.sessions
-            .get(session_id)
-            .map(|session_ctx| session_ctx.clone())
-            .ok_or_else(|| {
-                BallistaError::General(format!("No session for {session_id} found"))
-            })
-    }
-
     async fn create_session(
         &self,
-        config: &SessionConfig,
-    ) -> Result<Arc<SessionContext>> {
-        let session = create_datafusion_context(config, self.session_builder.clone())?;
-        self.sessions.insert(session.session_id(), session.clone());
-
-        Ok(session)
-    }
-
-    async fn update_session(
-        &self,
         session_id: &str,
         config: &SessionConfig,
     ) -> Result<Arc<SessionContext>> {
-        let session = create_datafusion_context(config, self.session_builder.clone())?;
-        self.sessions
-            .insert(session_id.to_string(), session.clone());
+        self.job_event_sender.send(&JobStateEvent::SessionAccessed {
+            session_id: session_id.to_string(),
+        });
 
-        Ok(session)
+        Ok(create_datafusion_context(
+            config,
+            self.session_builder.clone(),
+        )?)
     }
 
-    async fn remove_session(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<Arc<SessionContext>>> {
-        Ok(self.sessions.remove(session_id).map(|(_key, value)| value))
+    async fn remove_session(&self, session_id: &str) -> Result<()> {
+        self.job_event_sender.send(&JobStateEvent::SessionRemoved {
+            session_id: session_id.to_string(),
+        });
+
+        Ok(())
     }
 
     async fn job_state_events(&self) -> Result<JobStateEventStream> {

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -30,7 +30,6 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::Stream;
 use log::{debug, info, warn};
 
-use ballista_core::config::BallistaConfig;
 use ballista_core::consistent_hash::ConsistentHash;
 use ballista_core::error::Result;
 use ballista_core::serde::protobuf::{
@@ -228,15 +227,9 @@ pub enum JobStateEvent {
         job_id: String,
     },
     /// Event when a new session has been created
-    SessionCreated {
-        session_id: String,
-        config: BallistaConfig,
-    },
-    /// Event when a session configuration has been updated
-    SessionUpdated {
-        session_id: String,
-        config: BallistaConfig,
-    },
+    SessionAccessed { session_id: String },
+    /// Event when a session configuration has been removed
+    SessionRemoved { session_id: String },
 }
 
 /// Stream of `JobStateEvent`. This stream should contain all `JobStateEvent`s received
@@ -292,25 +285,14 @@ pub trait JobState: Send + Sync {
     /// of a job changes in state
     async fn job_state_events(&self) -> Result<JobStateEventStream>;
 
-    /// Get the `SessionContext` associated with `session_id`. Returns an error if the
-    /// session does not exist
-    async fn get_session(&self, session_id: &str) -> Result<Arc<SessionContext>>;
-
     /// Create a new saved session
-    async fn create_session(&self, config: &SessionConfig)
-        -> Result<Arc<SessionContext>>;
-
-    /// Update a new saved session. If the session does not exist, a new one will be created
-    async fn update_session(
+    async fn create_session(
         &self,
         session_id: &str,
         config: &SessionConfig,
     ) -> Result<Arc<SessionContext>>;
 
-    async fn remove_session(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<Arc<SessionContext>>>;
+    async fn remove_session(&self, session_id: &str) -> Result<()>;
 
     // TODO MM not sure this is the best place to put config producer
     fn produce_config(&self) -> SessionConfig;

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -276,10 +276,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
         let session_config =
             session_config.update_from_key_value_pair(&session_params.settings);
 
+        // FIXME: this method is wrong
         let ctx = self
             .state
             .session_manager
-            .create_session(&session_config)
+            .create_session("!!! CHANGE ME !!!", &session_config)
             .await
             .map_err(|e| {
                 Status::internal(format!("Failed to create SessionContext: {e:?}"))
@@ -292,23 +293,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
 
     async fn update_session(
         &self,
-        request: Request<UpdateSessionParams>,
+        _request: Request<UpdateSessionParams>,
     ) -> Result<Response<UpdateSessionResult>, Status> {
-        let session_params = request.into_inner();
-
-        let session_config = self.state.session_manager.produce_config();
-        let session_config =
-            session_config.update_from_key_value_pair(&session_params.settings);
-
-        self.state
-            .session_manager
-            .update_session(&session_params.session_id, &session_config)
-            .await
-            .map_err(|e| {
-                Status::internal(format!("Failed to create SessionContext: {e:?}"))
-            })?;
-
-        Ok(Response::new(UpdateSessionResult { success: true }))
+        Err(Status::unimplemented("not supported"))
     }
 
     async fn remove_session(
@@ -349,39 +336,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
 
             let (session_id, session_ctx) = match session_id {
                 Some(session_id) => {
-                    match self.state.session_manager.get_session(&session_id).await {
-                        Ok(ctx) => {
-                            // Update [SessionConfig] using received properties
-
-                            // TODO MM can we do something better here?
-                            // move this to update session and use .update_session(&session_params.session_id, &session_config)
-                            // instead of get_session.
-                            //
-                            // also we should consider sending properties if/when changed rather than
-                            // all properties every time
-
-                            let state = ctx.state_ref();
-                            let mut state = state.write();
-                            let config = state.config_mut();
-                            config.update_from_key_value_pair_mut(&settings);
-
-                            (session_id, ctx)
-                        }
-                        Err(e) => {
-                            let msg = format!("Failed to load SessionContext for session ID {session_id}: {e}");
-                            error!("{}", msg);
-                            return Ok(Response::new(ExecuteQueryResult {
-                                result: Some(execute_query_result::Result::Failure(
-                                    ExecuteQueryFailureResult {
-                                        failure: Some(execute_query_failure_result::Failure::SessionNotFound(msg)),
-                                    },
-                                )),
-                            }));
-                        }
-                    }
-                }
-                _ => {
-                    // Create default config
                     let session_config = self.state.session_manager.produce_config();
                     let session_config =
                         session_config.update_from_key_value_pair(&settings);
@@ -389,7 +343,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                     let ctx = self
                         .state
                         .session_manager
-                        .create_session(&session_config)
+                        .create_session(&session_id, &session_config)
                         .await
                         .map_err(|e| {
                             Status::internal(format!(
@@ -397,7 +351,17 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                             ))
                         })?;
 
-                    (ctx.session_id(), ctx)
+                    (session_id, ctx)
+                }
+                _ => {
+                    error!("Client should set session_id");
+                    return Ok(Response::new(ExecuteQueryResult {
+                                result: Some(execute_query_result::Result::Failure(
+                                    ExecuteQueryFailureResult {
+                                        failure: Some(execute_query_failure_result::Failure::SessionNotFound("Client should set session_id".to_string())),
+                                    },
+                                )),
+                            }));
                 }
             };
 

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -402,7 +402,7 @@ mod test {
         let ctx = scheduler
             .state
             .session_manager
-            .create_session(&config)
+            .create_session("session_id", &config)
             .await?;
 
         let job_id = "job";

--- a/ballista/scheduler/src/state/session_manager.rs
+++ b/ballista/scheduler/src/state/session_manager.rs
@@ -31,31 +31,16 @@ impl SessionManager {
     pub fn new(state: Arc<dyn JobState>) -> Self {
         Self { state }
     }
-
-    pub async fn remove_session(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<Arc<SessionContext>>> {
+    pub async fn remove_session(&self, session_id: &str) -> Result<()> {
         self.state.remove_session(session_id).await
-    }
-
-    pub async fn update_session(
-        &self,
-        session_id: &str,
-        config: &SessionConfig,
-    ) -> Result<Arc<SessionContext>> {
-        self.state.update_session(session_id, config).await
     }
 
     pub async fn create_session(
         &self,
+        session_id: &str,
         config: &SessionConfig,
     ) -> Result<Arc<SessionContext>> {
-        self.state.create_session(config).await
-    }
-
-    pub async fn get_session(&self, session_id: &str) -> Result<Arc<SessionContext>> {
-        self.state.get_session(session_id).await
+        self.state.create_session(session_id, config).await
     }
 
     pub(crate) fn produce_config(&self) -> SessionConfig {

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -475,7 +475,7 @@ impl SchedulerTest {
         self.scheduler
             .state
             .session_manager
-            .create_session(&self.session_config)
+            .create_session("session_id", &self.session_config)
             .await
     }
 
@@ -490,7 +490,7 @@ impl SchedulerTest {
             .scheduler
             .state
             .session_manager
-            .create_session(&self.session_config)
+            .create_session("session_id", &self.session_config)
             .await?;
 
         self.scheduler
@@ -615,7 +615,7 @@ impl SchedulerTest {
             .scheduler
             .state
             .session_manager
-            .create_session(&self.session_config)
+            .create_session("session_id", &self.session_config)
             .await?;
 
         self.scheduler


### PR DESCRIPTION
... as session context was not cleaned up.

# Which issue does this PR close?

Closes #1220.

 # Rationale for this change

- Scheduler was keeping HashMap of session_id -> SessionContext which was never cleaned up. 
- Scheduler will never emit events about accessed or removed SessionContexts 
- Client SessionContext is authoritative not the scheduler  

# What changes are included in this PR?

- client sets session context, no need for extra `create_context`
- get_context has been replaced with `create_or_update_context`

# Are there any user-facing changes?
