### PR TITLE
chore: reduce log levels for few log statements

### DIFF
--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -25,7 +25,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::{accept, ExecutionPlan, ExecutionPlanVisitor};
 use datafusion::prelude::SessionConfig;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::execution_plans::{ShuffleWriterExec, UnresolvedShuffleExec};
@@ -943,7 +943,7 @@ impl ExecutionGraph {
                 ..
             }
         ) {
-            warn!("Call fetch_runnable_stage on failed Job");
+            debug!("Call fetch_runnable_stage on failed Job");
             return None;
         }
 

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -166,7 +166,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
             .bind_schedulable_tasks(self.task_manager.get_running_job_cache())
             .await?;
         if schedulable_tasks.is_empty() {
-            warn!("No schedulable tasks found to be launched");
+            debug!("No schedulable tasks found to be launched");
             return Ok(());
         }
 


### PR DESCRIPTION

# Which issue does this PR close?

Closes none.

# Rationale for this change

reduce log levels for few log statements, I would argue they do not need to be printed as
warnings.

# What changes are included in this PR?

reduce few logs from warn to debug

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
