### PR TITLE
feat: ballista client collects (few) metrics

### DIFF
--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1293,6 +1293,11 @@ impl ExecutionGraph {
             .map(|l| l.try_into())
             .collect::<Result<Vec<_>>>()?;
 
+        self.end_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
         self.status = JobStatus {
             job_id: self.job_id.clone(),
             job_name: self.job_name.clone(),
@@ -1304,10 +1309,6 @@ impl ExecutionGraph {
                 ended_at: self.end_time,
             })),
         };
-        self.end_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

`DistributedExec` should track statistics, at least number of rows transferred.

As follow up #1252 we can expose job run, schedule wait time, and time needed to transfer data from flight store .

# What changes are included in this PR?

- distributed exec tracks size of data and number of rows transferred to client
- few log levels changed 

# Are there any user-facing changes?

No