### PR TITLE
feat: make execution_graph.stages()  public

### DIFF
--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -218,7 +218,7 @@ impl ExecutionGraph {
         new_tid
     }
 
-    pub(crate) fn stages(&self) -> &HashMap<usize, ExecutionStage> {
+    pub fn stages(&self) -> &HashMap<usize, ExecutionStage> {
         &self.stages
     }
 

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -218,6 +218,7 @@ impl ExecutionGraph {
         new_tid
     }
 
+    /// Exposes executions stages and stage id's
     pub fn stages(&self) -> &HashMap<usize, ExecutionStage> {
         &self.stages
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

this is follow up on #1243 where I missed to make `stages()` public. Making stages public we can react on scheduler emitted events and inspect all stages for given job

# What changes are included in this PR?

- make single method public 

# Are there any user-facing changes?
