### PR TITLE
feat: expose submit and cancel job methods as public in scheduler

### DIFF
--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -376,9 +376,9 @@ mod tests {
         )
         .await?;
 
-        let job_id = "job-1";
+        //let job_id = "job-1";
 
-        test.submit(job_id, "", &plan).await?;
+        let job_id = test.submit("", &plan).await?;
 
         test.tick().await?;
 
@@ -398,7 +398,7 @@ mod tests {
             expected, running_jobs
         );
 
-        test.cancel(job_id).await?;
+        test.cancel(&job_id).await?;
 
         let expected = 0usize;
         let success = await_condition(Duration::from_millis(10), 20, || {

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -376,8 +376,6 @@ mod tests {
         )
         .await?;
 
-        //let job_id = "job-1";
-
         let job_id = test.submit("", &plan).await?;
 
         test.tick().await?;


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

- provide ability to submit and submit and cancel job without going through grpc 


# What changes are included in this PR?

- make methods submit and cancel job public
- submit job will return job id 

# Are there any user-facing changes?

no 