### PR TITLE
fix: clippy issue after rust update to 1.87

### DIFF
--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -426,5 +426,5 @@ fn reset_metrics_for_execution_plan(
         plan.with_new_children(children).map(Transformed::yes)
     })
     .data()
-    .map_err(BallistaError::DataFusionError)
+    .map_err(|e| BallistaError::DataFusionError(Box::new(e)))
 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# increasing the threshold until we get to datafusion 48 which should
+# address this issue. 
+#
+# https://github.com/apache/datafusion/pull/15861
+large-error-threshold = 266


### PR DESCRIPTION

# Which issue does this PR close?

Closes #.

 # Rationale for this change

rust `1.87` clippy has chabged `large-error-threshold` clippy option making noise in ballista and datafusion code.

# What changes are included in this PR?

- ballista controlled code has been fixed to address clippy warning, 
- new `clippy.toml` rule has been added to disable check util we update to datafusion 48, which fixed  datafusion related code.

# Are there any user-facing changes?

No