### PR TITLE
feat: expose cluster state notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
  "ctor",
  "datafusion",
  "env_logger",
+ "futures",
  "log",
  "object_store",
  "testcontainers-modules",

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -177,15 +177,16 @@ pub async fn start_executor_process(
         opt.concurrent_tasks
     };
 
+    // assign this executor an unique ID
+    let executor_id = Uuid::new_v4().to_string();
     info!(
         "Executor starting ... (Datafusion Ballista {})",
         BALLISTA_VERSION
     );
+    info!("Executor id: {}", executor_id);
     info!("Executor working directory: {}", work_dir);
     info!("Executor number of concurrent tasks: {}", concurrent_tasks);
 
-    // assign this executor an unique ID
-    let executor_id = Uuid::new_v4().to_string();
     let executor_meta = ExecutorRegistration {
         id: executor_id.clone(),
         host: opt.external_host.clone(),

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -46,6 +46,8 @@ use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
 
+use super::{ClusterStateEvent, ClusterStateEventStream};
+
 #[derive(Default)]
 pub struct InMemoryClusterState {
     /// Current available task slots for each executor
@@ -54,6 +56,8 @@ pub struct InMemoryClusterState {
     executors: DashMap<String, ExecutorMetadata>,
     /// Last heartbeat received for each executor
     heartbeats: DashMap<String, ExecutorHeartbeat>,
+
+    cluster_event_sender: ClusterEventSender<ClusterStateEvent>,
 }
 
 impl InMemoryClusterState {
@@ -218,22 +222,53 @@ impl ClusterState for InMemoryClusterState {
         guard.insert(
             executor_id.clone(),
             AvailableTaskSlots {
-                executor_id,
+                executor_id: executor_id.clone(),
                 slots: spec.available_task_slots,
             },
         );
+
+        // RegisteredExecutor event is not pushed from here,
+        // in order to align between push and pull policy
+        // event is pushed from `save_executor_metadata`
+        //
+        // self.cluster_event_sender
+        //     .send(&ClusterStateEvent::RegisteredExecutor {
+        //         executor_id: executor_id.to_string(),
+        //     });
 
         Ok(())
     }
 
     async fn save_executor_metadata(&self, metadata: ExecutorMetadata) -> Result<()> {
-        log::debug!("save executor metadata: {}", metadata.id);
+        log::trace!("save executor metadata: {}", metadata.id);
         // TODO: MM it would make sense to add time when ExecutorMetadata is persisted
         //       we can do that adding additional field in ExecutorMetadata representing
         //       insert time. This information may be useful when reporting executor
         //       status and heartbeat is not available (in case of `TaskSchedulingPolicy::PullStaged`)
-        self.executors.insert(metadata.id.clone(), metadata);
-        Ok(())
+        let executor_id = metadata.id.clone();
+        if matches!(self.executors.insert(executor_id.clone(), metadata), None) {
+            self.cluster_event_sender
+                .send(&ClusterStateEvent::RegisteredExecutor {
+                    executor_id: executor_id.to_string(),
+                });
+        }
+
+        //
+        // pull based executor sends `save_executor_metadata`
+        // with all requests, not `ExecutorHeartbeat`, to make it consistent
+        // with push based, registering `ExecutorHeartbeat` every time
+        //
+        let heartbeat = ExecutorHeartbeat {
+            executor_id,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs(),
+            metrics: vec![],
+            status: None,
+        };
+        self.save_executor_heartbeat(heartbeat).await
+        // Ok(())
     }
 
     async fn get_executor_metadata(&self, executor_id: &str) -> Result<ExecutorMetadata> {
@@ -248,7 +283,7 @@ impl ClusterState for InMemoryClusterState {
     }
 
     async fn save_executor_heartbeat(&self, heartbeat: ExecutorHeartbeat) -> Result<()> {
-        log::debug!("saving executor heartbeat: {}", heartbeat.executor_id);
+        log::trace!("saving executor heartbeat: {}", heartbeat.executor_id);
         let executor_id = heartbeat.executor_id.clone();
         if let Some(mut last) = self.heartbeats.get_mut(&executor_id) {
             let _ = std::mem::replace(last.deref_mut(), heartbeat);
@@ -269,6 +304,11 @@ impl ClusterState for InMemoryClusterState {
         self.executors.remove(executor_id);
         self.heartbeats.remove(executor_id);
 
+        self.cluster_event_sender
+            .send(&ClusterStateEvent::RemovedExecutor {
+                executor_id: executor_id.to_string(),
+            });
+
         Ok(())
     }
 
@@ -285,6 +325,10 @@ impl ClusterState for InMemoryClusterState {
 
     async fn registered_executor_metadata(&self) -> Vec<ExecutorMetadata> {
         self.executors.iter().map(|v| v.clone()).collect()
+    }
+
+    async fn cluster_state_events(&self) -> Result<ClusterStateEventStream> {
+        Ok(Box::pin(self.cluster_event_sender.subscribe()))
     }
 }
 
@@ -516,14 +560,15 @@ impl JobState for InMemoryJobState {
 mod test {
     use std::sync::Arc;
 
-    use crate::cluster::memory::InMemoryJobState;
+    use crate::cluster::memory::{InMemoryClusterState, InMemoryJobState};
     use crate::cluster::test_util::{test_job_lifecycle, test_job_planning_failure};
-    use crate::cluster::{JobState, JobStateEvent};
+    use crate::cluster::{ClusterState, ClusterStateEvent, JobState, JobStateEvent};
     use crate::test_utils::{
         test_aggregation_plan, test_join_plan, test_two_aggregations_plan,
     };
     use ballista_core::error::Result;
     use ballista_core::serde::protobuf::JobStatus;
+    use ballista_core::serde::scheduler::{ExecutorMetadata, ExecutorSpecification};
     use ballista_core::utils::{default_config_producer, default_session_builder};
     use futures::StreamExt;
     use tokio::sync::Barrier;
@@ -628,6 +673,54 @@ mod test {
             } => (), // assert!(true, "Last status should be successful job notification"),
             _ => panic!("JobUpdated status expected"),
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_cluster_notification() -> Result<()> {
+        let cluster_state = InMemoryClusterState::default();
+
+        let mut event_stream = cluster_state.cluster_state_events().await?;
+
+        let metadata = ExecutorMetadata {
+            id: "id123".to_string(),
+            host: "".to_string(),
+            port: 50055,
+            grpc_port: 50050,
+            specification: ExecutorSpecification { task_slots: 2 },
+        };
+
+        cluster_state
+            .save_executor_metadata(metadata.clone())
+            .await?;
+        let event = event_stream.next().await;
+
+        assert!(matches!(
+            event,
+            Some(
+                ClusterStateEvent::RegisteredExecutor {
+                executor_id
+            }) if executor_id == "id123".to_string(),
+
+        ));
+
+        // event should not be emitted as executor is already registered
+        cluster_state
+            .save_executor_metadata(metadata.clone())
+            .await?;
+
+        cluster_state.remove_executor("id123").await?;
+        let event = event_stream.next().await;
+
+        assert!(matches!(
+            event,
+            Some(
+                ClusterStateEvent::RemovedExecutor {
+                executor_id
+            }) if executor_id == "id123".to_string(),
+
+        ));
 
         Ok(())
     }

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -246,7 +246,11 @@ impl ClusterState for InMemoryClusterState {
         //       insert time. This information may be useful when reporting executor
         //       status and heartbeat is not available (in case of `TaskSchedulingPolicy::PullStaged`)
         let executor_id = metadata.id.clone();
-        if matches!(self.executors.insert(executor_id.clone(), metadata), None) {
+        if self
+            .executors
+            .insert(executor_id.clone(), metadata)
+            .is_none()
+        {
             self.cluster_event_sender
                 .send(&ClusterStateEvent::RegisteredExecutor {
                     executor_id: executor_id.to_string(),
@@ -701,7 +705,7 @@ mod test {
             Some(
                 ClusterStateEvent::RegisteredExecutor {
                 executor_id
-            }) if executor_id == "id123".to_string(),
+            }) if executor_id == *"id123",
 
         ));
 
@@ -718,7 +722,7 @@ mod test {
             Some(
                 ClusterStateEvent::RemovedExecutor {
                 executor_id
-            }) if executor_id == "id123".to_string(),
+            }) if executor_id == *"id123",
 
         ));
 

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -202,6 +202,10 @@ pub trait ClusterState: Send + Sync + 'static {
 
     /// Get executor heartbeat for the provided executor ID. Return None if the executor does not exist
     fn get_executor_heartbeat(&self, executor_id: &str) -> Option<ExecutorHeartbeat>;
+
+    /// Get a stream of all `ClusterState` events. An event should be published any time that status
+    /// of a cluster changes in state
+    async fn cluster_state_events(&self) -> Result<ClusterStateEventStream>;
 }
 
 /// Events related to the state of jobs. Implementations may or may not support all event types.
@@ -240,6 +244,18 @@ pub enum JobStateEvent {
         config: BallistaConfig,
     },
 }
+
+/// Events related to the state of cluster.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClusterStateEvent {
+    /// Executor registered
+    RegisteredExecutor { executor_id: String },
+    /// Executor removed
+    RemovedExecutor { executor_id: String },
+}
+
+/// Stream of `ClusterStateEvent`.
+pub type ClusterStateEventStream = Pin<Box<dyn Stream<Item = ClusterStateEvent> + Send>>;
 
 /// Stream of `JobStateEvent`. This stream should contain all `JobStateEvent`s received
 /// by any schedulers with a shared `ClusterState`

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -189,7 +189,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             status,
             metadata,
         } = request.into_inner();
-        debug!("Received heart beat request for {:?}", executor_id);
+        trace!("Received heart beat request for {:?}", executor_id);
 
         // If not registered, do registration first before saving heart beat
         if let Err(e) = self

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -33,7 +33,7 @@ use crate::cluster::BallistaCluster;
 use crate::config::SchedulerConfig;
 use crate::metrics::SchedulerMetricsCollector;
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
-use log::{error, warn};
+use log::{debug, error, warn};
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::scheduler_server::query_stage_scheduler::QueryStageScheduler;
@@ -224,6 +224,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         tokio::task::spawn(async move {
             loop {
                 let expired_executors = state.executor_manager.get_expired_executors();
+                debug!("expire_dead_executors: {:?}", expired_executors);
                 for expired in expired_executors {
                     let executor_id = expired.executor_id.clone();
 
@@ -284,6 +285,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         reason: Option<String>,
         wait_secs: u64,
     ) {
+        debug!("remove executor: {}", executor_id);
         let executor_id = executor_id.to_owned();
         tokio::spawn(async move {
             // Wait for `wait_secs` before removing executor

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use log::{debug, error, info, warn};
+use log::{error, info, trace, warn};
 
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::event_loop::{EventAction, EventSender};
@@ -251,7 +251,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 self.state.clean_up_failed_job(job_id);
             }
             QueryStageSchedulerEvent::TaskUpdating(executor_id, tasks_status) => {
-                debug!(
+                trace!(
                     "processing task status updates from {executor_id}: {:?}",
                     tasks_status
                 );

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use ballista_core::error::BallistaError;
 use ballista_core::error::Result;
 use ballista_core::serde::protobuf;
+use log::trace;
 
 use crate::cluster::{BoundTask, ClusterState, ExecutorSlot};
 use crate::config::SchedulerConfig;
@@ -219,9 +220,10 @@ impl ExecutorManager {
     ///
     /// For push-based one, we should use [`register_executor`], instead.
     pub async fn save_executor_metadata(&self, metadata: ExecutorMetadata) -> Result<()> {
-        debug!(
+        trace!(
             "save executor metadata {} with {} task slots (pull-based registration)",
-            metadata.id, metadata.specification.task_slots
+            metadata.id,
+            metadata.specification.task_slots
         );
         self.cluster_state.save_executor_metadata(metadata).await
     }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,6 +39,7 @@ ballista-executor = { path = "../ballista/executor", version = "46.0.0", default
 ballista-scheduler = { path = "../ballista/scheduler", version = "46.0.0", default-features = false }
 datafusion = { workspace = true }
 env_logger = { workspace = true }
+futures = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true, features = ["aws"] }
 tokio = { workspace = true, features = [


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

there are cases when external observers need to react on cluster state changes. 

# What changes are included in this PR?

- expose `ClusterState::cluster_state_events(&self) -> Result<ClusterStateEventStream> `
- change log levels are they might be too noisy


# Are there any user-facing changes?

new interface exposed