### PR TITLE
minor: release docker on release tag (not only rc)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,9 +36,9 @@ jobs:
           docker tag apache/datafusion-ballista-executor:latest ghcr.io/apache/datafusion-ballista-executor:latest
           docker tag apache/datafusion-ballista-scheduler:latest ghcr.io/apache/datafusion-ballista-scheduler:latest
 
-          # release dockers only when there is a tag 
+          # release dockers only when there is a release tag 
           export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
-          if [[ $DOCKER_TAG =~ ^[0-9\.]+-rc[0-9]+$ ]]
+          if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]
           then
             
             docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

# Rationale for this change

looks like docker will only be released on rc candidate (`45.0.0-rc1`) but not on full release `46.0.0`, issue is that regex which checks if it it release tag will look for `rc-number` as tag sufix

# What changes are included in this PR?

fix regex (hopefully correctly :) ) 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
