### PR TITLE
feat: remove `ClusterStorageConfig` as it is redundant

### DIFF
--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -42,7 +42,7 @@ use ballista_core::{consistent_hash, ConfigProducer};
 
 use crate::cluster::memory::{InMemoryClusterState, InMemoryJobState};
 
-use crate::config::{ClusterStorageConfig, SchedulerConfig, TaskDistributionPolicy};
+use crate::config::{SchedulerConfig, TaskDistributionPolicy};
 use crate::scheduler_server::SessionBuilder;
 use crate::state::execution_graph::{create_task_info, ExecutionGraph, TaskDescription};
 use crate::state::task_manager::JobInfoCache;
@@ -122,13 +122,11 @@ impl BallistaCluster {
             .clone()
             .unwrap_or_else(|| Arc::new(default_config_producer));
 
-        match &config.cluster_storage {
-            ClusterStorageConfig::Memory => Ok(BallistaCluster::new_memory(
-                scheduler,
-                session_builder,
-                config_producer,
-            )),
-        }
+        Ok(BallistaCluster::new_memory(
+            scheduler,
+            session_builder,
+            config_producer,
+        ))
     }
 
     pub fn cluster_state(&self) -> Arc<dyn ClusterState> {

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -58,8 +58,6 @@ pub struct SchedulerConfig {
     /// If provided, submitted jobs which do not have tasks scheduled will be resubmitted after `job_resubmit_interval_ms`
     /// milliseconds
     pub job_resubmit_interval_ms: Option<u64>,
-    /// Configuration for ballista cluster storage
-    pub cluster_storage: ClusterStorageConfig,
     /// Time in seconds to allow executor for graceful shutdown. Once an executor signals it has entered Terminating status
     /// the scheduler should only consider the executor dead after this time interval has elapsed
     pub executor_termination_grace_period: u64,
@@ -97,7 +95,6 @@ impl Default for SchedulerConfig {
             finished_job_data_clean_up_interval_seconds: 300,
             finished_job_state_clean_up_interval_seconds: 3600,
             advertise_flight_sql_endpoint: None,
-            cluster_storage: Default::default(),
             job_resubmit_interval_ms: None,
             executor_termination_grace_period: 0,
             scheduler_event_expected_processing_duration: 0,
@@ -176,11 +173,6 @@ impl SchedulerConfig {
         self
     }
 
-    pub fn with_cluster_storage(mut self, config: ClusterStorageConfig) -> Self {
-        self.cluster_storage = config;
-        self
-    }
-
     pub fn with_job_resubmit_interval_ms(mut self, interval_ms: u64) -> Self {
         self.job_resubmit_interval_ms = Some(interval_ms);
         self
@@ -216,12 +208,6 @@ impl SchedulerConfig {
         self.override_session_builder = Some(override_session_builder);
         self
     }
-}
-
-#[derive(Clone, Debug, Default)]
-pub enum ClusterStorageConfig {
-    #[default]
-    Memory,
 }
 
 /// Policy of distributing tasks to available executor slots
@@ -311,7 +297,6 @@ impl TryFrom<Config> for SchedulerConfig {
             finished_job_state_clean_up_interval_seconds: opt
                 .finished_job_state_clean_up_interval_seconds,
             advertise_flight_sql_endpoint: opt.advertise_flight_sql_endpoint,
-            cluster_storage: Default::default(),
             job_resubmit_interval_ms: (opt.job_resubmit_interval_ms > 0)
                 .then_some(opt.job_resubmit_interval_ms),
             executor_termination_grace_period: opt.executor_termination_grace_period,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

`ClusterStorageConfig` configuration had no  sense as it had only one value, and can't be really changed from scheduler config.

# What changes are included in this PR?

removing redundant config option 

# Are there any user-facing changes?

No