### PR TITLE
feat: job id is incremental

### DIFF
--- a/ballista/scheduler/src/display.rs
+++ b/ballista/scheduler/src/display.rs
@@ -53,7 +53,7 @@ pub fn print_stage_metrics(
             DisplayableBallistaExecutionPlan::new(plan, &plan_metrics).indent()
         );
     } else {
-        error!("Fail to combine stage metrics to plan for stage [{}/{}],  plan metrics array size {} does not equal
+        error!("Fail to combine stage metrics to plan for job/stage [{}/{}],  plan metrics array size {} does not equal
                 to the stage metrics array size {}", job_id, stage_id, plan_metrics.len(), stage_metrics.len());
     }
 }

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -27,7 +27,6 @@ use ballista_core::error::BallistaError;
 use ballista_core::error::Result;
 use ballista_core::extension::SessionConfigHelperExt;
 use datafusion::prelude::SessionConfig;
-use rand::distr::Alphanumeric;
 
 use crate::cluster::JobState;
 use ballista_core::serde::protobuf::{
@@ -41,7 +40,6 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use log::{debug, error, info, trace, warn};
-use rand::{rng, Rng};
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::Arc;
@@ -643,16 +641,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         self.active_job_cache
             .remove(job_id)
             .map(|value| value.1.execution_graph)
-    }
-
-    /// Generate a new random Job ID
-    pub fn generate_job_id(&self) -> String {
-        let mut rng = rng();
-        std::iter::repeat(())
-            .map(|()| rng.sample(Alphanumeric))
-            .map(char::from)
-            .take(7)
-            .collect()
     }
 
     /// Clean up a failed job in FailedJobs Keyspace by delayed clean_up_interval seconds


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

previously `job id` is generated randomly, without any ordering guarantees, which make is rather hard to determine ordering of jobs, and returning totally random results on rest api. Spark is generating job id incrementing atomic int. 

# What changes are included in this PR?

- use atomic integer to generate job id, i do not see valid reason not to do it
- move job id generation from task manager to scheduler (if we later want to make it configurable it would be easier to do)

# Are there any user-facing changes?

- no, they might get confused with new job ids 

# Open points

- [ ] `job_id` is used as directory name where job (shuffle) data is persisted, if we use incremental id, we may get into problems with leftover directory names in case of scheduler restart
