### PR TITLE
chore: release datafusion 47.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 **Fixed bugs:**
 
 - fix: clippy issue after rust update to 1.87 [#1262](https://github.com/apache/datafusion-ballista/pull/1262) (milenkovicm)
+- fix: fix tests failing on windows [#1273](https://github.com/apache/datafusion-ballista/pull/1273) (Huy1Ng)
 
 **Merged pull requests:**
 


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

generate a changelog for ballista 47 release

# What changes are included in this PR?

# Are there any user-facing changes?
