### PR TITLE
fix: change code to support rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,15 @@ exclude = ["python"]
 members = ["ballista-cli", "ballista/client", "ballista/core", "ballista/executor", "ballista/scheduler", "benchmarks", "examples"]
 resolver = "2"
 
+[workspace.package]
+# edition to be changed to 2024 when we update 
+# Minimum Supported Rust Version (MSRV) to 1.85.0
+# which is datafusion 49s
+# 
+edition = "2021"
+# we should try to follow datafusion version 
+rust-version = "1.82.0"
+
 [workspace.dependencies]
 arrow = { version = "55", features = ["ipc_compression"] }
 arrow-flight = { version = "55", features = ["flight-sql-experimental"] }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -20,7 +20,8 @@ name = "ballista-cli"
 description = "Command Line Client for Ballista distributed query engine."
 version = "48.0.0"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 keywords = ["ballista", "cli"]
 license = "Apache-2.0"
 homepage = "https://datafusion.apache.org/ballista/"

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -24,7 +24,8 @@ homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -24,7 +24,8 @@ homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 build = "build.rs"
 
 # Exclude proto files so crates.io consumers don't need protoc

--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -149,16 +149,16 @@ impl From<futures::future::Aborted> for BallistaError {
 impl Display for BallistaError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            BallistaError::NotImplemented(ref desc) => {
+            BallistaError::NotImplemented(desc) => {
                 write!(f, "Not implemented: {desc}")
             }
-            BallistaError::General(ref desc) => write!(f, "General error: {desc}"),
-            BallistaError::ArrowError(ref desc) => write!(f, "Arrow error: {desc}"),
-            BallistaError::DataFusionError(ref desc) => {
+            BallistaError::General(desc) => write!(f, "General error: {desc}"),
+            BallistaError::ArrowError(desc) => write!(f, "Arrow error: {desc}"),
+            BallistaError::DataFusionError(desc) => {
                 write!(f, "DataFusion error: {desc}")
             }
-            BallistaError::SqlError(ref desc) => write!(f, "SQL error: {desc}"),
-            BallistaError::IoError(ref desc) => write!(f, "IO error: {desc}"),
+            BallistaError::SqlError(desc) => write!(f, "SQL error: {desc}"),
+            BallistaError::IoError(desc) => write!(f, "IO error: {desc}"),
             BallistaError::TonicError(desc) => write!(f, "Tonic error: {desc}"),
             BallistaError::GrpcError(desc) => write!(f, "Grpc error: {desc}"),
             BallistaError::GrpcConnectionError(desc) => {

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -20,8 +20,8 @@
 //! partition is re-partitioned and streamed to disk in Arrow IPC format. Future stages of the query
 //! will use the ShuffleReaderExec to read these results.
 
-use datafusion::arrow::ipc::writer::IpcWriteOptions;
 use datafusion::arrow::ipc::CompressionType;
+use datafusion::arrow::ipc::writer::IpcWriteOptions;
 
 use datafusion::arrow::ipc::writer::StreamWriter;
 use std::any::Any;
@@ -51,8 +51,8 @@ use datafusion::physical_plan::metrics::{
 };
 
 use datafusion::physical_plan::{
-    displayable, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
-    PlanProperties, SendableRecordBatchStream, Statistics,
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream, Statistics, displayable,
 };
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 
@@ -93,7 +93,11 @@ impl std::fmt::Display for ShuffleWriterExec {
         write!(
             f,
             "ShuffleWriterExec: job={} stage={} work_dir={} partitioning={:?} plan: \n {}",
-            self.job_id, self.stage_id, self.work_dir, self.shuffle_output_partitioning, printable_plan
+            self.job_id,
+            self.stage_id,
+            self.work_dir,
+            self.shuffle_output_partitioning,
+            printable_plan
         )
     }
 }
@@ -188,7 +192,7 @@ impl ShuffleWriterExec {
     }
 
     pub fn execute_shuffle_write(
-        &self,
+        self,
         input_partition: usize,
         context: Arc<TaskContext>,
     ) -> impl Future<Output = Result<Vec<ShuffleWritePartition>>> {
@@ -322,11 +326,7 @@ impl ShuffleWriterExec {
                             w.writer.finish()?;
                             debug!(
                                 "Finished writing shuffle partition {} at {:?}. Batches: {}. Rows: {}. Bytes: {}.",
-                                i,
-                                w.path,
-                                w.num_batches,
-                                w.num_rows,
-                                num_bytes
+                                i, w.path, w.num_batches, w.num_rows, num_bytes
                             );
 
                             part_locs.push(ShuffleWritePartition {
@@ -413,6 +413,7 @@ impl ExecutionPlan for ShuffleWriterExec {
 
         let schema_captured = schema.clone();
         let fut_stream = self
+            .clone()
             .execute_shuffle_write(partition, context)
             .and_then(|part_loc| async move {
                 // build metadata result batch

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -24,7 +24,8 @@ homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.configure_me.bin]
 executor = "executor_config_spec.toml"

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -21,8 +21,8 @@ use ballista_core::serde::protobuf::ShuffleWritePartition;
 use ballista_core::utils;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::metrics::MetricsSet;
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
@@ -122,6 +122,7 @@ impl QueryStageExecutor for DefaultQueryStageExec {
         context: Arc<TaskContext>,
     ) -> Result<Vec<ShuffleWritePartition>> {
         self.shuffle_writer
+            .clone()
             .execute_shuffle_write(input_partition, context)
             .await
     }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -24,7 +24,8 @@ homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.configure_me.bin]
 scheduler = "scheduler_config_spec.toml"

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -29,7 +29,7 @@ use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::{
-    with_new_children_if_necessary, ExecutionPlan, Partitioning,
+    ExecutionPlan, Partitioning, with_new_children_if_necessary,
 };
 
 use log::{debug, info};
@@ -321,7 +321,7 @@ mod test {
     use datafusion::physical_plan::sorts::sort::SortExec;
     use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
     use datafusion::physical_plan::windows::BoundedWindowAggExec;
-    use datafusion::physical_plan::{displayable, ExecutionPlan};
+    use datafusion::physical_plan::{ExecutionPlan, displayable};
     use datafusion::physical_plan::{InputOrderMode, Partitioning};
     use datafusion::prelude::SessionContext;
     use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -681,7 +681,7 @@ order by
         assert_eq!(2, partitioning.partition_count());
         let partition_col = match partitioning {
             Partitioning::Hash(exprs, 2) => match exprs.as_slice() {
-                [ref col] => col.as_any().downcast_ref::<Column>(),
+                [col] => col.as_any().downcast_ref::<Column>(),
                 _ => None,
             },
             _ => None,

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -19,7 +19,8 @@
 name = "ballista-benchmarks"
 description = "Ballista Benchmarks"
 version = "48.0.0"
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,7 +24,8 @@ repository = "https://github.com/apache/datafusion-ballista"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 license = "Apache-2.0"
 keywords = ["arrow", "distributed", "query", "sql"]
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 publish = false
 
 [[example]]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -24,7 +24,8 @@ authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 description = "Apache Arrow Ballista Python Client"
 readme = "README.md"
 license = "Apache-2.0"
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 include = ["/src", "/ballista", "/LICENSE.txt", "pyproject.toml", "Cargo.toml", "Cargo.lock"]
 publish = false
 


### PR DESCRIPTION
# Which issue does this PR close?

This patch changes code to be rust 2024 compliant but does not change rust version to 2024 due to MSRB tracking rust 1.82 like datafusion does. rust version will be updated when we udapte to datafusion 49

relates to #1271 

Closes .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
