### PR TITLE
fix: fail job in case of serde error (pull-mode)

### DIFF
--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -175,6 +175,26 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         Ok(())
     }
 
+    pub(crate) async fn fail_job(
+        &self,
+        job_id: String,
+        fail_message: String,
+    ) -> Result<()> {
+        log::debug!("Received fail job request for job {job_id}");
+
+        self.query_stage_event_loop
+            .get_sender()?
+            .post_event(QueryStageSchedulerEvent::JobRunningFailed {
+                job_id,
+                fail_message,
+                queued_at: timestamp_millis(),
+                failed_at: timestamp_millis(),
+            })
+            .await?;
+
+        Ok(())
+    }
+
     /// Submits a job to executor returning job_id
     pub async fn submit_job(
         &self,

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -56,13 +56,7 @@ pub async fn new_standalone_scheduler_from_state(
     let codec = BallistaCodec::new(logical, physical);
     let session_config = session_state.config().clone();
     let session_state = session_state.clone();
-    let session_builder = Arc::new(move |c: SessionConfig| {
-        Ok(
-            SessionStateBuilder::new_from_existing(session_state.clone())
-                .with_config(c)
-                .build(),
-        )
-    });
+    let session_builder = Arc::new(move |_: SessionConfig| Ok(session_state.clone()));
     let config_producer = Arc::new(move || session_config.clone());
 
     new_standalone_scheduler_with_builder(session_builder, config_producer, codec).await

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -29,7 +29,7 @@ use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
 };
-use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion::execution::SessionState;
 use datafusion::prelude::SessionConfig;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use datafusion_proto::protobuf::PhysicalPlanNode;

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -29,7 +29,7 @@ use ballista_core::{
     error::Result, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
     BALLISTA_VERSION,
 };
-use datafusion::execution::SessionState;
+use datafusion::execution::{SessionState, SessionStateBuilder};
 use datafusion::prelude::SessionConfig;
 use datafusion_proto::protobuf::LogicalPlanNode;
 use datafusion_proto::protobuf::PhysicalPlanNode;
@@ -56,7 +56,13 @@ pub async fn new_standalone_scheduler_from_state(
     let codec = BallistaCodec::new(logical, physical);
     let session_config = session_state.config().clone();
     let session_state = session_state.clone();
-    let session_builder = Arc::new(move |_: SessionConfig| Ok(session_state.clone()));
+    let session_builder = Arc::new(move |c: SessionConfig| {
+        Ok(
+            SessionStateBuilder::new_from_existing(session_state.clone())
+                .with_config(c)
+                .build(),
+        )
+    });
     let config_producer = Arc::new(move || session_config.clone());
 
     new_standalone_scheduler_with_builder(session_builder, config_producer, codec).await


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

In case of physical plan serde error job will keep waiting for job competition as described in #1214
This PR partially fixes #1214 but further work is needed for push mode and to provide a test to permanently cover this issue

# What changes are included in this PR?

- job will fail in case of serde error for pull mode
- a test which covers serde error for unsupported SMJ (SMJ should get serde support in datafusion 50)

# Are there any user-facing changes?

No