### PR TITLE
chore: update datafusion to 49.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
@@ -1674,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "49.0.1"
+version = "49.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4539076347adb068dd1950f64c6437e946dd3449b8284c971bd05f025a2e648"
+checksum = "69dfeda1633bf8ec75b068d9f6c27cdc392ffcf5ff83128d5dbab65b73c1fd02"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-cli"
-version = "49.0.1"
+version = "49.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35496982b962c8ddba70c170be5aaad6b7f160ed730beb00ab2b4ac3812a9a2d"
+checksum = "5966ac4973bf66cf5c189046b1b29de90db9ba059ce7193137dd089e277495de"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2293,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "49.0.1"
+version = "49.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5be95356413f502e8c474335a9e7f345451b7e395a031c10eba51c9929f63c"
+checksum = "1b36a0c84f4500efd90487a004b533bd81de1f2bb3f143f71b7526f33b85d2e2"
 dependencies = [
  "arrow",
  "chrono",
@@ -2309,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-version = "49.0.1"
+version = "49.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74961518bea403a37a8eee85d7963b002184dd18aafa68114df85fea37fe4db"
+checksum = "2ec788be522806740ad6372c0a2f7e45fb37cb37f786d9b77933add49cdd058f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2458,18 +2458,18 @@ checksum = "498cfcded997a93eb31edd639361fa33fd229a8784e953b37d71035fe3890b7b"
 
 [[package]]
 name = "dtor"
-version = "0.0.6"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
 dependencies = [
  "dtor-proc-macro",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ arrow-flight = { version = "55", features = ["flight-sql-experimental"] }
 clap = { version = "4.5", features = ["derive", "cargo"] }
 configure_me = { version = "0.4.0" }
 configure_me_codegen = { version = "0.4.4" }
-datafusion = "49.0.1"
-datafusion-cli = "49.0.1"
-datafusion-proto = "49.0.1"
-datafusion-proto-common = "49.0.1"
+datafusion = "49.0.2"
+datafusion-cli = "49.0.2"
+datafusion-proto = "49.0.2"
+datafusion-proto-common = "49.0.2"
 object_store = "0.12"
 prost = "0.13"
 prost-types = "0.13"
@@ -50,7 +50,7 @@ tonic-build = { version = "0.12", default-features = false, features = [
 tracing = "0.1"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ctor = { version = "0.4" }
+ctor = { version = "0.5" }
 mimalloc = { version = "0.1" }
 
 tokio = { version = "1" }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

# What changes are included in this PR?

- update datafusion to 49.0.2

# Are there any user-facing changes?
