### PR TITLE
minor: make shuffle exec display consistent

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -101,10 +101,14 @@ impl DisplayAs for ShuffleReaderExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(f, "ShuffleReaderExec: partitions={}", self.partition.len())
+                write!(
+                    f,
+                    "ShuffleReaderExec: partitioning={:?}",
+                    self.properties.partitioning,
+                )
             }
             DisplayFormatType::TreeRender => {
-                write!(f, "partitions={}", self.partition.len())
+                write!(f, "partitioning={:?}", self.properties.partitioning)
             }
         }
     }

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -359,12 +359,12 @@ impl DisplayAs for ShuffleWriterExec {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 write!(
                     f,
-                    "ShuffleWriterExec: partitions:{:?}",
+                    "ShuffleWriterExec: partitioning:{:?}",
                     self.shuffle_output_partitioning
                 )
             }
             DisplayFormatType::TreeRender => {
-                write!(f, "partitions={:?}", self.shuffle_output_partitioning)
+                write!(f, "partitioning={:?}", self.shuffle_output_partitioning)
             }
         }
     }

--- a/ballista/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/core/src/execution_plans/unresolved_shuffle.rs
@@ -72,14 +72,14 @@ impl DisplayAs for UnresolvedShuffleExec {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 write!(
                     f,
-                    "UnresolvedShuffleExec: partitions={:?}",
+                    "UnresolvedShuffleExec: partitioning={:?}",
                     self.properties().output_partitioning()
                 )
             }
             DisplayFormatType::TreeRender => {
                 write!(
                     f,
-                    "partitions={:?}",
+                    "partitioning={:?}",
                     self.properties().output_partitioning()
                 )
             }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

Make `DisplayAs` consistent across Shuffle*Exec

# What changes are included in this PR?

# Are there any user-facing changes?
