### PR TITLE
fix: `UnresolvedShuffleExec` should support `with_new_children`

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -37,7 +37,7 @@ use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::runtime::SpawnedTask;
 
-use datafusion::error::Result;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{
     ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
@@ -132,14 +132,15 @@ impl ExecutionPlan for ShuffleReaderExec {
 
     fn with_new_children(
         self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(ShuffleReaderExec::try_new(
-            self.stage_id,
-            self.partition.clone(),
-            self.schema.clone(),
-            self.properties().output_partitioning().clone(),
-        )?))
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Plan(
+                "Ballista ShuffleReaderExec does not support children plans".to_owned(),
+            ))
+        }
     }
 
     fn execute(

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -395,13 +395,13 @@ impl ExecutionPlan for ShuffleWriterExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(ShuffleWriterExec::try_new(
-            self.job_id.clone(),
-            self.stage_id,
-            children[0].clone(),
-            self.work_dir.clone(),
-            self.shuffle_output_partitioning.clone(),
-        )?))
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Plan(
+                "Ballista ShuffleWriterExec does not support children plans".to_owned(),
+            ))
+        }
     }
 
     fn execute(

--- a/ballista/core/src/execution_plans/unresolved_shuffle.rs
+++ b/ballista/core/src/execution_plans/unresolved_shuffle.rs
@@ -110,12 +110,16 @@ impl ExecutionPlan for UnresolvedShuffleExec {
 
     fn with_new_children(
         self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(DataFusionError::Plan(
-            "Ballista UnresolvedShuffleExec does not support with_new_children()"
-                .to_owned(),
-        ))
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Plan(
+                "Ballista UnresolvedShuffleExec does not support children plans"
+                    .to_owned(),
+            ))
+        }
     }
 
     fn execute(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

At the moment `UnresolvedShuffleExec` does not support `with_new_children` which is wrong, `with_new_children` should work if number of children is zero. 

At the moment, ballista just splits the physical plan into stages but as it is demonstrated in #1296 we would need to re-optimise some stages in order to be able to fix #1296 (stage plans may not be correct once they are split)

# What changes are included in this PR?

- implement `UnresolvedShuffleExec::with_new_children`
- add check  if  number of children is 0 when `with_new_children` is called for ShuffleWrite and Read 

# Are there any user-facing changes?

No
