### PR TITLE
fix: Disable CollectLeft join as it is broken in ballista

### DIFF
--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -396,6 +396,20 @@ impl SessionConfigHelperExt for SessionConfig {
             )
             // same like previous comment
             .set_bool("datafusion.sql_parser.map_string_types_to_utf8view", false)
+            //
+            // As mentioned in https://github.com/apache/datafusion-ballista/issues/1055
+            // "Left/full outer join incorrect for CollectLeft / broadcast"
+            //
+            // In order to make correct results (decreasing performance) CollectLeft
+            // has been disabled until fixed
+            .set_u64(
+                "datafusion.optimizer.hash_join_single_partition_threshold",
+                0,
+            )
+            .set_u64(
+                "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+                0,
+            )
     }
 }
 


### PR DESCRIPTION
https://github.com/apache/datafusion-ballista/issues/1055

# Which issue does this PR close?

Closes #.
Relates to #1055

 # Rationale for this change

as described in #1055 `CollectLeft` join is broken in ballista, so in order to keep correctness it will be disabled in original configuration


# What changes are included in this PR?

- setting up configuration values to disable collect left join
- test to verify configuration change

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
