### PR TITLE
fix: `ShuffleReader` should return statistics

### DIFF
--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1141,8 +1141,12 @@ impl ExecutionGraph {
     /// Convert unresolved stage to be resolved
     pub fn resolve_stage(&mut self, stage_id: usize) -> Result<bool> {
         if let Some(ExecutionStage::UnResolved(stage)) = self.stages.remove(&stage_id) {
-            self.stages
-                .insert(stage_id, ExecutionStage::Resolved(stage.to_resolved()?));
+            self.stages.insert(
+                stage_id,
+                ExecutionStage::Resolved(
+                    stage.to_resolved(self.session_config.options())?,
+                ),
+            );
             Ok(true)
         } else {
             warn!(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

with datafusion 48 method which is to be used for Exec statistic information changed. ShuffleReader did not update to reflect change hence no statistic has been propagated to query rules, probably yielding suboptimal plans.

# What changes are included in this PR?

- use `partition_statistics` for to provide `ShuffleReader` statistics 
- provide tests for them
- method `UnresolvedStage::to_resolved` to user provided configuration option rather than hard coded one making optimiser rules used in it configurable
