### PR TITLE
refactor: expand ClusterEventSender visibility to public

### DIFF
--- a/ballista/scheduler/src/cluster/event/mod.rs
+++ b/ballista/scheduler/src/cluster/event/mod.rs
@@ -54,7 +54,7 @@ impl Shared {
     }
 }
 
-pub(crate) struct ClusterEventSender<T: Clone> {
+pub struct ClusterEventSender<T: Clone> {
     sender: broadcast::Sender<T>,
     shared: Arc<Shared>,
 }


### PR DESCRIPTION
# Which issue does this PR close?

This is merely a minor modification, so I haven't linked it to an issue. Please let me know if an issue is required, and I'd be happy to create one and link it accordingly.

 # Rationale for this change

When extending scheduler we noticed that cluster event sender would be useful primitive to public accessed.

# What changes are included in this PR?

expand ClusterEventSender visibility from `public crate` to `public`

# Are there any user-facing changes?

no

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
