### PR TITLE
feat: Improve Remote Shuffle Read Speed and Resource Utilisation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-appender",

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -239,7 +239,7 @@ impl BallistaClient {
 
             let request = tonic::Request::new(arrow_flight::Action {
                 body: buf.clone().into(),
-                r#type: "BLOCKTRANSPORT".to_string(),
+                r#type: "IO_BLOCK_TRANSPORT".to_string(),
             });
             let result = self.flight_client.do_action(request).await;
             let res = match result {

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -36,6 +36,8 @@ pub const BALLISTA_SHUFFLE_READER_MAX_REQUESTS: &str =
     "ballista.shuffle.max_concurrent_read_requests";
 pub const BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ: &str =
     "ballista.shuffle.force_remote_read";
+pub const BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT: &str =
+    "ballista.shuffle.force_remote_prefer_flight";
 
 pub type ParseResult<T> = result::Result<T, String>;
 use std::sync::LazyLock;
@@ -58,6 +60,10 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          Some((64).to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ.to_string(),
                          "Forces the shuffle reader to always read partitions via the Arrow Flight client, even when partitions are local to the node.".to_string(),
+                         DataType::Boolean,
+                         Some((false).to_string())),
+        ConfigEntry::new(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT.to_string(),
+                         "Forces the shuffle reader to use flight reader instead of block reader for remote read.".to_string(),
                          DataType::Boolean,
                          Some((false).to_string())),
 
@@ -190,6 +196,13 @@ impl BallistaConfig {
     /// Use only when necessary, like in tests
     pub fn shuffle_reader_force_remote_read(&self) -> bool {
         self.get_bool_setting(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ)
+    }
+    /// Forces the shuffle reader to prefer flight protocol over block protocol
+    /// to read remote shuffle partition.
+    ///
+    /// Block protocol is usually more performant than flight protocol
+    pub fn shuffle_reader_remote_prefer_flight(&self) -> bool {
+        self.get_bool_setting(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT)
     }
 
     fn get_usize_setting(&self, key: &str) -> usize {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -357,7 +357,7 @@ async fn execute_query(
 
                 info!("Job {job_id} finished executing in {duration:?} ");
                 let streams = partition_location.into_iter().map(move |partition| {
-                    let f = fetch_partition(partition, max_message_size)
+                    let f = fetch_partition(partition, max_message_size, true)
                         .map_err(|e| ArrowError::ExternalError(Box::new(e)));
 
                     futures::stream::once(f).try_flatten()
@@ -372,6 +372,7 @@ async fn execute_query(
 async fn fetch_partition(
     location: PartitionLocation,
     max_message_size: usize,
+    flight_transport: bool,
 ) -> Result<SendableRecordBatchStream> {
     let metadata = location.executor_meta.ok_or_else(|| {
         DataFusionError::Internal("Received empty executor metadata".to_owned())
@@ -391,7 +392,7 @@ async fn fetch_partition(
             &location.path,
             host,
             port,
-            true,
+            flight_transport,
         )
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -391,6 +391,7 @@ async fn fetch_partition(
             &location.path,
             host,
             port,
+            true,
         )
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -501,7 +501,7 @@ async fn fetch_partition_remote(
         })?;
 
     ballista_client
-        .fetch_partition(&metadata.id, partition_id, &location.path, host, port)
+        .fetch_partition(&metadata.id, partition_id, &location.path, host, port, true)
         .await
 }
 

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -161,6 +161,7 @@ impl ExecutionPlan for ShuffleReaderExec {
             config.ballista_shuffle_reader_maximum_concurrent_requests();
         let max_message_size = config.ballista_grpc_client_max_message_size();
         let force_remote_read = config.ballista_shuffle_reader_force_remote_read();
+        let prefer_flight = config.ballista_shuffle_reader_remote_prefer_flight();
 
         if force_remote_read {
             debug!(
@@ -193,6 +194,7 @@ impl ExecutionPlan for ShuffleReaderExec {
             max_request_num,
             max_message_size,
             force_remote_read,
+            prefer_flight,
         );
 
         let result = RecordBatchStreamAdapter::new(
@@ -386,6 +388,7 @@ fn send_fetch_partitions(
     max_request_num: usize,
     max_message_size: usize,
     force_remote_read: bool,
+    flight_transport: bool,
 ) -> AbortableReceiverStream {
     let (response_sender, response_receiver) = mpsc::channel(max_request_num);
     let semaphore = Arc::new(Semaphore::new(max_request_num));
@@ -405,7 +408,7 @@ fn send_fetch_partitions(
     spawned_tasks.push(SpawnedTask::spawn(async move {
         for p in local_locations {
             let r = PartitionReaderEnum::Local
-                .fetch_partition(&p, max_message_size)
+                .fetch_partition(&p, max_message_size, flight_transport)
                 .await;
             if let Err(e) = response_sender_c.send(r).await {
                 error!("Fail to send response event to the channel due to {e}");
@@ -420,7 +423,7 @@ fn send_fetch_partitions(
             // Block if exceeds max request number.
             let permit = semaphore.acquire_owned().await.unwrap();
             let r = PartitionReaderEnum::FlightRemote
-                .fetch_partition(&p, max_message_size)
+                .fetch_partition(&p, max_message_size, flight_transport)
                 .await;
             // Block if the channel buffer is full.
             if let Err(e) = response_sender.send(r).await {
@@ -446,6 +449,7 @@ trait PartitionReader: Send + Sync + Clone {
         &self,
         location: &PartitionLocation,
         max_message_size: usize,
+        flight_transport: bool,
     ) -> result::Result<SendableRecordBatchStream, BallistaError>;
 }
 
@@ -464,10 +468,11 @@ impl PartitionReader for PartitionReaderEnum {
         &self,
         location: &PartitionLocation,
         max_message_size: usize,
+        flight_transport: bool,
     ) -> result::Result<SendableRecordBatchStream, BallistaError> {
         match self {
             PartitionReaderEnum::FlightRemote => {
-                fetch_partition_remote(location, max_message_size).await
+                fetch_partition_remote(location, max_message_size, flight_transport).await
             }
             PartitionReaderEnum::Local => fetch_partition_local(location).await,
             PartitionReaderEnum::ObjectStoreRemote => {
@@ -480,6 +485,7 @@ impl PartitionReader for PartitionReaderEnum {
 async fn fetch_partition_remote(
     location: &PartitionLocation,
     max_message_size: usize,
+    flight_transport: bool,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
@@ -501,7 +507,14 @@ async fn fetch_partition_remote(
         })?;
 
     ballista_client
-        .fetch_partition(&metadata.id, partition_id, &location.path, host, port, true)
+        .fetch_partition(
+            &metadata.id,
+            partition_id,
+            &location.path,
+            host,
+            port,
+            flight_transport,
+        )
         .await
 }
 
@@ -936,6 +949,7 @@ mod tests {
             max_request_num,
             4 * 1024 * 1024,
             false,
+            true,
         );
 
         let stream = RecordBatchStreamAdapter::new(

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -18,7 +18,7 @@
 use crate::config::{
     BallistaConfig, BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE, BALLISTA_JOB_NAME,
     BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
-    BALLISTA_STANDALONE_PARALLELISM,
+    BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, BALLISTA_STANDALONE_PARALLELISM,
 };
 use crate::planner::BallistaQueryPlanner;
 use crate::serde::protobuf::KeyValuePair;
@@ -132,6 +132,13 @@ pub trait SessionConfigExt {
     fn with_ballista_shuffle_reader_maximum_concurrent_requests(
         self,
         max_requests: usize,
+    ) -> Self;
+
+    fn ballista_shuffle_reader_remote_prefer_flight(&self) -> bool;
+
+    fn with_ballista_shuffle_reader_remote_prefer_flight(
+        self,
+        prefer_flight: bool,
     ) -> Self;
 }
 
@@ -355,6 +362,28 @@ impl SessionConfigExt for SessionConfig {
         } else {
             self.with_option_extension(BallistaConfig::default())
                 .set_bool(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, force_remote_read)
+        }
+    }
+
+    fn ballista_shuffle_reader_remote_prefer_flight(&self) -> bool {
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.shuffle_reader_remote_prefer_flight())
+            .unwrap_or_else(|| {
+                BallistaConfig::default().shuffle_reader_remote_prefer_flight()
+            })
+    }
+
+    fn with_ballista_shuffle_reader_remote_prefer_flight(
+        self,
+        prefer_flight: bool,
+    ) -> Self {
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_bool(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, prefer_flight)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_bool(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, prefer_flight)
         }
     }
 }

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -52,6 +52,7 @@ parking_lot = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
+tokio-util = { version = "0.7", features = ["io-util"] }
 tonic = { workspace = true }
 tracing = { workspace = true, optional = true }
 tracing-appender = { workspace = true, optional = true }

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -189,7 +189,7 @@ impl FlightService for BallistaFlightService {
         let action = request.into_inner();
 
         match action.r#type.as_str() {
-            "IO_BLOCK_TRANSFER" => {
+            "IO_BLOCK_TRANSPORT" => {
                 let action =
                     decode_protobuf(&action.body).map_err(|e| from_ballista_err(&e))?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1315

 # Rationale for this change

# What changes are included in this PR?

- changes to arrow flight server to support optimised transport
- changes to ballista client 
- configuration option to disable protocol `ballista.shuffle.force_remote_prefer_flight`

# Are there any user-facing changes?
