### PR TITLE
chore(infra): remove build-macos-x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
   build-windows:
     needs: [generate-license]
-    name: Windows
+    name: Windows x86_64
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -154,7 +154,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist-windows
+          name: dist-windows-x86_64
           path: python/target/wheels/*
 
   build-macos-arm64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,15 +105,14 @@ jobs:
           name: python-wheel-license
           path: LICENSE.txt
 
-  build-python-mac-win:
+  build-windows:
     needs: [generate-license]
-    name: Mac/Win
-    runs-on: ${{ matrix.os }}
+    name: Windows
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
 
@@ -147,25 +146,20 @@ jobs:
           uv run --no-project maturin build --release --strip
 
       - name: List Windows wheels
-        if: matrix.os == 'windows-latest'
         run: dir python\target\wheels\
         # since the runner is dynamic shellcheck (from actionlint) can't infer this is powershell
         # so we specify it explicitly
         shell: powershell
 
-      - name: List Mac wheels
-        if: matrix.os != 'windows-latest'
-        run: find python/target/wheels/
-
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os  }}
+          name: dist-windows
           path: python/target/wheels/*
 
-  build-macos-x86_64:
+  build-macos-arm64:
     needs: [generate-license]
-    name: Mac x86_64
+    name: Mac arm64
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -209,7 +203,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: dist-macos-aarch64
+          name: dist-macos-arm64
           path: python/target/wheels/*
 
   build-manylinux-x86_64:
@@ -339,8 +333,8 @@ jobs:
   merge-build-artifacts:
     runs-on: ubuntu-latest
     needs:
-      - build-python-mac-win
-      - build-macos-x86_64
+      - build-windows
+      - build-macos-arm64
       - build-manylinux-x86_64
       - build-manylinux-aarch64
       - build-sdist


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

~~Follow up to https://github.com/apache/datafusion-ballista/pull/1324, the correct replacement for `macos-13` should be `macos-15-intel` for Intel-based architecture~~
~~according to 
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories~~

Since both `build-python-mac-win` and `build-macos-x86_64` use `macos-latest`, we can consolidate and refactor the steps to run for individual os

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
