### PR TITLE
fix: update REST API route syntax for axum 0.8 compatibility

### DIFF
--- a/ballista/scheduler/src/api/mod.rs
+++ b/ballista/scheduler/src/api/mod.rs
@@ -29,24 +29,24 @@ pub fn get_routes<
         .route("/api/state", get(handlers::get_scheduler_state::<T, U>))
         .route("/api/executors", get(handlers::get_executors::<T, U>))
         .route("/api/jobs", get(handlers::get_jobs::<T, U>))
-        .route("/api/job/:job_id", patch(handlers::cancel_job::<T, U>))
+        .route("/api/job/{job_id}", patch(handlers::cancel_job::<T, U>))
         .route(
-            "/api/job/:job_id/stages",
+            "/api/job/{job_id}/stages",
             get(handlers::get_query_stages::<T, U>),
         )
         .route(
-            "/api/job/:job_id/dot",
+            "/api/job/{job_id}/dot",
             get(handlers::get_job_dot_graph::<T, U>),
         )
         .route(
-            "/api/job/:job_id/stage/:stage_id/dot",
+            "/api/job/{job_id}/stage/{stage_id}/dot",
             get(handlers::get_query_stage_dot_graph::<T, U>),
         )
         .route("/api/metrics", get(handlers::get_scheduler_metrics::<T, U>));
 
     #[cfg(feature = "graphviz-support")]
     let router = router.route(
-        "/api/job/:job_id/dot_svg",
+        "/api/job/{job_id}/dot_svg",
         get(handlers::get_job_svg_graph::<T, U>),
     );
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1329

# Rationale for this change

Axum 0.8 changed route parameter syntax from `:param` to `{param}`. Old syntax causes panic at startup.

# What changes are included in this PR?

Update 5 route definitions in `ballista/scheduler/src/api/mod.rs`

# Are there any user-facing changes?

No - fixes broken functionality.