### PR TITLE
chore: Pinning versions of external actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@
 
 name: Python Release Build
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -49,7 +52,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -131,7 +134,7 @@ jobs:
           path: .
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -188,7 +191,7 @@ jobs:
           path: .
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -231,7 +234,7 @@ jobs:
       - run: cat LICENSE.txt
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -271,12 +274,12 @@ jobs:
       - run: cat LICENSE.txt
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           enable-cache: true
 
@@ -311,12 +314,12 @@ jobs:
       - run: cat LICENSE.txt
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
Changes:
- Pinning versions of ext actions see: [https://infra.apache.org/github-actions-policy.html](https://infra.apache.org/github-actions-policy.html)
- Reduce the scope of the token.