### PR TITLE
feat: Bump docker rust to `rust:1.92-trixie`

### DIFF
--- a/ballista-cli/Dockerfile
+++ b/ballista-cli/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.76-bullseye as builder
+FROM rust:1.92-trixie as builder
 
 COPY ./ballista-cli /usr/src/ballista-cli
 

--- a/dev/docker/ballista-builder.Dockerfile
+++ b/dev/docker/ballista-builder.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust:1.85-bullseye
+FROM rust:1.92-trixie
 
 ARG EXT_UID
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Bumping rust version to `rust:1.92-trixie` in order to pull down a newer `protobuf-compiler` to solve build issues in #1360 . Additionally, all Ubuntu references are on 24.04 which is derived from Trixie.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
