### PR TITLE
[WIP] Add transport channel and server factory abstractions

### DIFF
--- a/ballista/core/src/transport/channel.rs
+++ b/ballista/core/src/transport/channel.rs
@@ -1,0 +1,45 @@
+use std::error::Error;
+use std::sync::Arc;
+
+/// A factory responsible for creating outbound client channels.
+///
+/// This abstraction allows different transport implementations
+/// (e.g. plain HTTP, TLS) without changing core logic.
+pub trait ChannelFactory: Send + Sync {
+    fn create_channel(
+        &self,
+        target: &str,
+    ) -> Result<Arc<dyn std::any::Any + Send + Sync>, Box<dyn Error>>;
+}
+/// Default channel factory using the existing HTTP-based gRPC connection logic.
+pub struct DefaultChannelFactory;
+
+impl ChannelFactory for DefaultChannelFactory {
+    fn create_channel(
+        &self,
+        target: &str,
+    ) -> Result<std::sync::Arc<dyn std::any::Any + Send + Sync>, Box<dyn std::error::Error>> {
+        // NOTE:
+        // For now, this is a placeholder that will be wired
+        // to existing client connection logic in the next step.
+        //
+        // The purpose here is to establish the factory structure
+        // without changing behavior.
+        Err("DefaultChannelFactory not wired yet".into())
+    }
+}
+/// TLS-enabled channel factory (stub).
+///
+/// This implementation is intentionally left unimplemented.
+/// It exists to demonstrate how TLS support can be plugged in
+/// without changing core logic.
+pub struct TlsChannelFactory;
+
+impl ChannelFactory for TlsChannelFactory {
+    fn create_channel(
+        &self,
+        _target: &str,
+    ) -> Result<std::sync::Arc<dyn std::any::Any + Send + Sync>, Box<dyn std::error::Error>> {
+        Err("TlsChannelFactory is not implemented yet".into())
+    }
+}

--- a/ballista/core/src/transport/mod.rs
+++ b/ballista/core/src/transport/mod.rs
@@ -1,0 +1,2 @@
+pub mod channel;
+pub mod server;

--- a/ballista/core/src/transport/server.rs
+++ b/ballista/core/src/transport/server.rs
@@ -1,0 +1,31 @@
+use std::error::Error;
+
+/// A factory responsible for creating inbound servers.
+///
+/// Implementations may create plain HTTP or TLS-enabled servers.
+pub trait ServerFactory: Send + Sync {
+    fn serve(&self, addr: &str) -> Result<(), Box<dyn Error>>;
+}
+/// Default server factory using the existing HTTP server implementation.
+pub struct DefaultServerFactory;
+
+impl ServerFactory for DefaultServerFactory {
+    fn serve(&self, _addr: &str) -> Result<(), Box<dyn std::error::Error>> {
+        // NOTE:
+        // This will later delegate to the existing scheduler/executor
+        // server startup logic.
+        //
+        // For now, this is a structural placeholder.
+        Err("DefaultServerFactory not wired yet".into())
+    }
+}
+/// TLS-enabled server factory (stub).
+///
+/// This is a placeholder for future TLS support (e.g. using rustls).
+pub struct TlsServerFactory;
+
+impl ServerFactory for TlsServerFactory {
+    fn serve(&self, _addr: &str) -> Result<(), Box<dyn std::error::Error>> {
+        Err("TlsServerFactory is not implemented yet".into())
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Related to #1367

## Rationale for this change

Currently, client, scheduler, and executor components create transport connections
directly, which makes it difficult to extend or customize transport behavior
(e.g. adding optional TLS support).

This PR introduces transport-level factory abstractions as a first step toward
supporting optional TLS while keeping plain HTTP as the default.

## What changes are included in this PR?

- Introduces a new `ballista::core::transport` module
- Adds `ChannelFactory` and `ServerFactory` traits
- Provides default factory stubs preserving existing behavior
- Adds TLS factory stubs to demonstrate future extensibility

## Are there any user-facing changes?

No. This PR does not change any runtime behavior and does not introduce TLS yet.

## Are there any breaking changes?

No.
