### PR TITLE
restrict python CI to python directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,13 @@ concurrency:
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - 'python/**'
   push:
     tags: ["*-rc*"]
     branches: ["branch-*"]
+    paths:
+      - 'python/**'
 
 jobs:
   test-release:

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ arrow-src.tar
 arrow-src.tar.gz
 CHANGELOG.md.bak
 Cargo.toml.bak
+data/
 
 # Compiled source
 *.a


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1366.

 # Rationale for this change
We don't update Python release as much. Also, the CI workflow for this is long.

# What changes are included in this PR?
Only trigger Python build if changes are detected inside python/ directory

# Are there any user-facing changes?
N/A