### PR TITLE
feat: add -c config override flag to tpch benchmark

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -417,7 +417,9 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
 
         for kv in &opt.config_overrides {
             if let Some((key, value)) = kv.split_once('=') {
-                config = config.set_str(key.trim(), value.trim());
+                if let Err(e) = config.options_mut().set(key.trim(), value.trim()) {
+                    println!("Warning: could not set config '{}': {}", kv, e);
+                }
             } else {
                 println!(
                     "Warning: ignoring invalid config override '{}'. \


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow arbitrary ballista and datafusion config overrides when running the tpch benchmark via `-c key=value` flags, removing the need to add a dedicated CLI flag for each config option.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
