### PR TITLE
[WIP] feat: Use put_batch_with_indices to track partitions by index for sort-based shuffle

### DIFF
--- a/ballista/core/src/execution_plans/sort_shuffle/buffer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/buffer.rs
@@ -15,157 +15,230 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! In-memory partition buffer for sort-based shuffle.
+//! In-memory partition buffer and scratch space for sort-based shuffle.
 //!
-//! Each output partition has a buffer that accumulates record batches
-//! until the buffer is full or needs to be spilled to disk.
+//! Provides:
+//! - `ScratchSpace`: Reusable per-batch scratch buffer for computing partition
+//!   assignments using a prefix-sum algorithm (modeled on Apache DataFusion Comet).
+//! - `InputBatchStore`: Centralized storage for input record batches.
+//! - `materialize_partition`: Materializes partition data from indices using
+//!   `BatchCoalescer::push_batch_with_indices`.
 
+use std::sync::Arc;
+
+use datafusion::arrow::array::UInt64Builder;
+use datafusion::arrow::compute::BatchCoalescer;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::physical_plan::coalesce::LimitedBatchCoalescer;
+use datafusion::common::Result;
+use datafusion::common::hash_utils::create_hashes;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr_common::utils::evaluate_expressions_to_arrays;
+use datafusion::physical_plan::repartition::REPARTITION_RANDOM_STATE;
 
-/// Buffer for accumulating record batches for a single output partition.
+/// Reusable per-batch scratch buffer for computing partition assignments.
 ///
-/// When the buffer exceeds its maximum size, it signals that it should be
-/// spilled to disk.
-#[derive(Debug)]
-pub struct PartitionBuffer {
-    /// Partition ID this buffer is for
-    partition_id: usize,
-    /// Buffered record batches
-    batches: Vec<RecordBatch>,
-    /// Current memory usage in bytes
-    memory_used: usize,
-    /// Number of rows in the buffer
-    num_rows: usize,
-    /// Schema for this partition's data
-    schema: SchemaRef,
+/// Uses a prefix-sum algorithm to efficiently map rows to partitions:
+/// 1. Evaluate hash expressions and compute partition IDs
+/// 2. Count rows per partition
+/// 3. Compute cumulative offsets (prefix sum)
+/// 4. Place row indices into contiguous slices per partition
+///
+/// After `compute_partition_assignments`, use `partition_indices(id)` to get
+/// the row indices for a specific partition.
+pub struct ScratchSpace {
+    hash_buffer: Vec<u64>,
+    partition_ids: Vec<usize>,
+    partition_row_indices: Vec<u32>,
+    /// Length = num_partitions + 1. After computation,
+    /// partition k's rows are `partition_row_indices[starts[k]..starts[k+1]]`.
+    partition_starts: Vec<usize>,
 }
 
-impl PartitionBuffer {
-    /// Creates a new partition buffer.
-    pub fn new(partition_id: usize, schema: SchemaRef) -> Self {
+impl ScratchSpace {
+    /// Creates a new scratch space for the given number of partitions.
+    pub fn new(num_partitions: usize) -> Self {
         Self {
-            partition_id,
-            batches: Vec::new(),
-            memory_used: 0,
-            num_rows: 0,
-            schema,
+            hash_buffer: Vec::new(),
+            partition_ids: Vec::new(),
+            partition_row_indices: Vec::new(),
+            partition_starts: vec![0; num_partitions + 1],
         }
     }
 
-    /// Returns the partition ID for this buffer.
-    pub fn partition_id(&self) -> usize {
-        self.partition_id
+    /// Compute partition assignments for a batch using hash partitioning.
+    ///
+    /// Uses the same hashing logic as DataFusion's `BatchPartitioner` to ensure
+    /// identical partition assignments.
+    pub fn compute_partition_assignments(
+        &mut self,
+        exprs: &[Arc<dyn PhysicalExpr>],
+        batch: &RecordBatch,
+        num_partitions: usize,
+    ) -> Result<()> {
+        let num_rows = batch.num_rows();
+
+        let arrays = evaluate_expressions_to_arrays(exprs, batch)?;
+
+        self.hash_buffer.resize(num_rows, 0);
+        create_hashes(
+            &arrays,
+            REPARTITION_RANDOM_STATE.random_state(),
+            &mut self.hash_buffer,
+        )?;
+
+        self.partition_ids.resize(num_rows, 0);
+        for (i, hash) in self.hash_buffer.iter().enumerate() {
+            self.partition_ids[i] = (*hash % num_partitions as u64) as usize;
+        }
+
+        self.map_partition_ids_to_starts_and_indices(num_partitions, num_rows);
+        Ok(())
     }
 
-    /// Returns the schema for this buffer's data.
+    /// Prefix-sum algorithm to organize row indices by partition.
+    fn map_partition_ids_to_starts_and_indices(
+        &mut self,
+        num_partitions: usize,
+        num_rows: usize,
+    ) {
+        self.partition_starts.truncate(0);
+        self.partition_starts.resize(num_partitions + 1, 0);
+        self.partition_row_indices.resize(num_rows, 0);
+        for &pid in &self.partition_ids {
+            self.partition_starts[pid] += 1;
+        }
+
+        // Cumulative sum converts counts to end offsets
+        let mut sum = 0;
+        for start in self.partition_starts.iter_mut() {
+            sum += *start;
+            *start = sum;
+        }
+
+        // Reverse iteration converts end offsets to start offsets
+        for row_idx in (0..num_rows).rev() {
+            let pid = self.partition_ids[row_idx];
+            self.partition_starts[pid] -= 1;
+            self.partition_row_indices[self.partition_starts[pid]] = row_idx as u32;
+        }
+    }
+
+    /// Returns the row indices assigned to `partition_id` after calling
+    /// `compute_partition_assignments`.
+    pub fn partition_indices(&self, partition_id: usize) -> &[u32] {
+        let start = self.partition_starts[partition_id];
+        let end = self.partition_starts[partition_id + 1];
+        &self.partition_row_indices[start..end]
+    }
+}
+
+/// Materializes a partition's data from `(batch_idx, row_idx)` pairs into
+/// coalesced `RecordBatch`es using `BatchCoalescer::push_batch_with_indices`.
+///
+/// Uses `scratch_builder` as a reusable builder to avoid allocations.
+pub fn materialize_partition(
+    partition_indices: &[(u32, u32)],
+    input_batches: &InputBatchStore,
+    target_batch_size: usize,
+    scratch_builder: &mut UInt64Builder,
+) -> Result<Vec<RecordBatch>> {
+    if partition_indices.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut coalescer =
+        BatchCoalescer::new(input_batches.schema().clone(), target_batch_size);
+    let mut result = Vec::new();
+
+    let mut start = 0;
+    while start < partition_indices.len() {
+        let current_batch_idx = partition_indices[start].0;
+        let mut end = start + 1;
+        while end < partition_indices.len()
+            && partition_indices[end].0 == current_batch_idx
+        {
+            end += 1;
+        }
+
+        let batch = input_batches.get_batch(current_batch_idx);
+
+        for (_, r) in &partition_indices[start..end] {
+            scratch_builder.append_value(*r as u64);
+        }
+        let idx_array = scratch_builder.finish();
+
+        coalescer.push_batch_with_indices(batch.clone(), &idx_array)?;
+        while let Some(completed) = coalescer.next_completed_batch() {
+            result.push(completed);
+        }
+
+        start = end;
+    }
+
+    coalescer.finish_buffered_batch()?;
+    while let Some(completed) = coalescer.next_completed_batch() {
+        result.push(completed);
+    }
+    Ok(result)
+}
+
+/// Stores all input batches across all partitions
+pub struct InputBatchStore {
+    /// Vector of all incoming record batches
+    batches: Vec<RecordBatch>,
+    /// Schema of all batches
+    schema: SchemaRef,
+    /// Total memory of all record batches
+    total_memory: usize,
+}
+
+impl InputBatchStore {
+    /// Creates new instance of InputBatchStore
+    pub fn new(schema: SchemaRef) -> Self {
+        Self {
+            batches: Vec::new(),
+            schema,
+            total_memory: 0,
+        }
+    }
+
+    /// Appends RecordBatch to the store, returning the batch index.
+    pub fn push_batch(&mut self, batch: RecordBatch) -> usize {
+        let batch_idx = self.batches.len();
+        self.total_memory += batch.get_array_memory_size();
+        self.batches.push(batch);
+        batch_idx
+    }
+
+    /// Return the batch at the given index
+    ///
+    /// # Panics
+    /// Can panic if idx >= batches.len()
+    pub fn get_batch(&self, idx: u32) -> &RecordBatch {
+        &self.batches[idx as usize]
+    }
+
+    /// Returns total memory of all record batches
+    pub fn total_memory(&self) -> usize {
+        self.total_memory
+    }
+
+    /// Drains record batches and memory stats. The same SchemaRef remains.
+    pub fn clear(&mut self) {
+        self.batches.clear();
+        self.total_memory = 0;
+    }
+
+    /// Returns the schema of the stored batches.
     pub fn schema(&self) -> &SchemaRef {
         &self.schema
     }
 
-    /// Returns the current memory usage in bytes.
-    pub fn memory_used(&self) -> usize {
-        self.memory_used
+    /// Returns a reference to all stored batches.
+    pub fn batches(&self) -> &[RecordBatch] {
+        &self.batches
     }
-
-    /// Returns the number of rows in the buffer.
-    pub fn num_rows(&self) -> usize {
-        self.num_rows
-    }
-
-    /// Returns the number of batches in the buffer.
-    pub fn num_batches(&self) -> usize {
-        self.batches.len()
-    }
-
-    /// Returns true if the buffer is empty.
-    pub fn is_empty(&self) -> bool {
-        self.batches.is_empty()
-    }
-
-    /// Appends a record batch to the buffer.
-    ///
-    /// Returns the new total memory usage after appending.
-    pub fn append(&mut self, batch: RecordBatch) -> usize {
-        let batch_size = batch.get_array_memory_size();
-        self.num_rows += batch.num_rows();
-        self.memory_used += batch_size;
-        self.batches.push(batch);
-        self.memory_used
-    }
-
-    /// Drains all batches from the buffer, resetting it to empty.
-    ///
-    /// Returns the drained batches.
-    pub fn drain(&mut self) -> Vec<RecordBatch> {
-        self.memory_used = 0;
-        self.num_rows = 0;
-        std::mem::take(&mut self.batches)
-    }
-
-    /// Takes all batches from the buffer without resetting memory tracking.
-    ///
-    /// This is useful when the caller wants to handle the batches but the
-    /// buffer will be discarded anyway.
-    pub fn take_batches(&mut self) -> Vec<RecordBatch> {
-        std::mem::take(&mut self.batches)
-    }
-
-    /// Drains batches from the buffer, coalescing small batches into
-    /// larger ones up to `target_batch_size` rows each.
-    pub fn drain_coalesced(&mut self, target_batch_size: usize) -> Vec<RecordBatch> {
-        self.memory_used = 0;
-        self.num_rows = 0;
-        let batches = std::mem::take(&mut self.batches);
-        coalesce_batches(batches, &self.schema, target_batch_size)
-    }
-
-    /// Takes all batches, coalescing small batches into larger ones
-    /// up to `target_batch_size` rows each.
-    pub fn take_batches_coalesced(
-        &mut self,
-        target_batch_size: usize,
-    ) -> Vec<RecordBatch> {
-        let batches = std::mem::take(&mut self.batches);
-        coalesce_batches(batches, &self.schema, target_batch_size)
-    }
-}
-
-/// Coalesces small batches into larger ones up to `target_batch_size`
-/// rows each using DataFusion's `LimitedBatchCoalescer`.
-fn coalesce_batches(
-    batches: Vec<RecordBatch>,
-    schema: &SchemaRef,
-    target_batch_size: usize,
-) -> Vec<RecordBatch> {
-    if batches.len() <= 1 {
-        return batches;
-    }
-
-    let mut coalescer =
-        LimitedBatchCoalescer::new(schema.clone(), target_batch_size, None);
-    let mut result = Vec::new();
-
-    for batch in batches {
-        if batch.num_rows() == 0 {
-            continue;
-        }
-        // push_batch can only fail on schema mismatch, which won't
-        // happen here since all batches share the same schema
-        let _ = coalescer.push_batch(batch);
-        while let Some(completed) = coalescer.next_completed_batch() {
-            result.push(completed);
-        }
-    }
-
-    // Flush remaining buffered rows
-    let _ = coalescer.finish();
-    while let Some(completed) = coalescer.next_completed_batch() {
-        result.push(completed);
-    }
-
-    result
 }
 
 #[cfg(test)]
@@ -173,6 +246,7 @@ mod tests {
     use super::*;
     use datafusion::arrow::array::Int32Array;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::expressions::Column;
     use std::sync::Arc;
 
     fn create_test_schema() -> SchemaRef {
@@ -185,47 +259,209 @@ mod tests {
     }
 
     #[test]
-    fn test_new_buffer() {
+    fn test_scratch_space_partition_assignments() {
         let schema = create_test_schema();
-        let buffer = PartitionBuffer::new(0, schema);
+        let batch = create_test_batch(&schema, vec![1, 2, 3, 4, 5, 6]);
+        let exprs: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::new(Column::new("a", 0))];
 
-        assert_eq!(buffer.partition_id(), 0);
-        assert!(buffer.is_empty());
-        assert_eq!(buffer.memory_used(), 0);
-        assert_eq!(buffer.num_rows(), 0);
-        assert_eq!(buffer.num_batches(), 0);
+        let mut scratch = ScratchSpace::new(3);
+        scratch
+            .compute_partition_assignments(&exprs, &batch, 3)
+            .unwrap();
+
+        // Every row should be assigned to exactly one partition
+        let mut total_rows = 0;
+        for pid in 0..3 {
+            total_rows += scratch.partition_indices(pid).len();
+        }
+        assert_eq!(total_rows, 6);
+
+        // Row indices should be within range
+        for pid in 0..3 {
+            for &row_idx in scratch.partition_indices(pid) {
+                assert!(row_idx < 6);
+            }
+        }
     }
 
     #[test]
-    fn test_append() {
+    fn test_scratch_space_reuse() {
         let schema = create_test_schema();
-        let mut buffer = PartitionBuffer::new(0, schema.clone());
+        let exprs: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::new(Column::new("a", 0))];
+        let mut scratch = ScratchSpace::new(2);
 
-        let batch = create_test_batch(&schema, vec![1, 2, 3]);
-        buffer.append(batch);
+        // First batch
+        let batch1 = create_test_batch(&schema, vec![1, 2, 3]);
+        scratch
+            .compute_partition_assignments(&exprs, &batch1, 2)
+            .unwrap();
+        let total1: usize = (0..2).map(|p| scratch.partition_indices(p).len()).sum();
+        assert_eq!(total1, 3);
 
-        assert!(!buffer.is_empty());
-        assert!(buffer.memory_used() > 0);
-        assert_eq!(buffer.num_rows(), 3);
-        assert_eq!(buffer.num_batches(), 1);
+        // Second batch (reuses scratch space)
+        let batch2 = create_test_batch(&schema, vec![10, 20]);
+        scratch
+            .compute_partition_assignments(&exprs, &batch2, 2)
+            .unwrap();
+        let total2: usize = (0..2).map(|p| scratch.partition_indices(p).len()).sum();
+        assert_eq!(total2, 2);
     }
 
     #[test]
-    fn test_drain() {
+    fn test_materialize_partition_empty() {
         let schema = create_test_schema();
-        let mut buffer = PartitionBuffer::new(0, schema.clone());
+        let store = InputBatchStore::new(schema);
+        let mut scratch = UInt64Builder::new();
+        let result = materialize_partition(&[], &store, 8192, &mut scratch).unwrap();
+        assert!(result.is_empty());
+    }
 
-        buffer.append(create_test_batch(&schema, vec![1, 2, 3]));
-        buffer.append(create_test_batch(&schema, vec![4, 5]));
+    #[test]
+    fn test_materialize_partition_single_batch() {
+        let schema = create_test_schema();
+        let mut store = InputBatchStore::new(schema.clone());
+        store.push_batch(create_test_batch(&schema, vec![10, 20, 30, 40, 50]));
 
-        assert_eq!(buffer.num_batches(), 2);
-        assert_eq!(buffer.num_rows(), 5);
+        // Select rows 0, 2, 4 from batch 0
+        let indices = vec![(0u32, 0u32), (0, 2), (0, 4)];
+        let mut scratch = UInt64Builder::new();
+        let result = materialize_partition(&indices, &store, 8192, &mut scratch).unwrap();
 
-        let batches = buffer.drain();
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
 
-        assert_eq!(batches.len(), 2);
-        assert!(buffer.is_empty());
-        assert_eq!(buffer.memory_used(), 0);
-        assert_eq!(buffer.num_rows(), 0);
+        // Verify values
+        let col = result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(col.value(0), 10);
+        assert_eq!(col.value(1), 30);
+        assert_eq!(col.value(2), 50);
+    }
+
+    #[test]
+    fn test_materialize_partition_multiple_batches() {
+        let schema = create_test_schema();
+        let mut store = InputBatchStore::new(schema.clone());
+        store.push_batch(create_test_batch(&schema, vec![10, 20, 30]));
+        store.push_batch(create_test_batch(&schema, vec![40, 50, 60]));
+
+        // Select row 1 from batch 0, rows 0 and 2 from batch 1
+        let indices = vec![(0u32, 1u32), (1, 0), (1, 2)];
+        let mut scratch = UInt64Builder::new();
+        let result = materialize_partition(&indices, &store, 8192, &mut scratch).unwrap();
+
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+    }
+
+    #[test]
+    fn test_materialize_partition_respects_batch_size() {
+        let schema = create_test_schema();
+        let mut store = InputBatchStore::new(schema.clone());
+
+        // Create a large input batch with 20,000 rows
+        let large_batch = create_test_batch(&schema, (0..20000).collect());
+        store.push_batch(large_batch);
+
+        // Select all rows from this partition
+        let indices: Vec<(u32, u32)> = (0..20000).map(|i| (0u32, i as u32)).collect();
+
+        // Use target_batch_size of 8192
+        let mut scratch = UInt64Builder::new();
+        let result = materialize_partition(&indices, &store, 8192, &mut scratch).unwrap();
+
+        // Should produce multiple batches
+        assert!(result.len() >= 2, "Expected multiple output batches");
+
+        // Verify total rows
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 20000);
+
+        // Most batches should be close to target_batch_size (8192)
+        // Last batch may be smaller
+        for (i, batch) in result.iter().enumerate() {
+            if i < result.len() - 1 {
+                // All but last batch should be close to target size
+                assert!(
+                    batch.num_rows() >= 7000 && batch.num_rows() <= 9000,
+                    "Batch {} has {} rows, expected ~8192",
+                    i,
+                    batch.num_rows()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_input_batch_store_memory_tracking() {
+        let schema = create_test_schema();
+        let mut store = InputBatchStore::new(schema.clone());
+
+        assert_eq!(store.total_memory(), 0);
+
+        let batch1 = create_test_batch(&schema, vec![1, 2, 3]);
+        let memory1 = batch1.get_array_memory_size();
+        store.push_batch(batch1);
+        assert_eq!(store.total_memory(), memory1);
+
+        let batch2 = create_test_batch(&schema, vec![4, 5, 6, 7]);
+        let memory2 = batch2.get_array_memory_size();
+        store.push_batch(batch2);
+        assert_eq!(store.total_memory(), memory1 + memory2);
+
+        store.clear();
+        assert_eq!(store.total_memory(), 0);
+        assert_eq!(store.batches().len(), 0);
+    }
+
+    #[test]
+    fn test_materialize_partition_coalesces_small_batches() {
+        let schema = create_test_schema();
+        let mut store = InputBatchStore::new(schema.clone());
+
+        // Create many small input batches (100 batches with 100 rows each)
+        for i in 0..100 {
+            let start = i * 100;
+            let batch = create_test_batch(&schema, (start..start + 100).collect());
+            store.push_batch(batch);
+        }
+
+        // Select all rows from all batches
+        let mut indices = Vec::new();
+        for batch_idx in 0..100u32 {
+            for row_idx in 0..100u32 {
+                indices.push((batch_idx, row_idx));
+            }
+        }
+
+        // Use target_batch_size of 8192
+        let mut scratch = UInt64Builder::new();
+        let result = materialize_partition(&indices, &store, 8192, &mut scratch).unwrap();
+
+        // Should coalesce into far fewer output batches than input batches
+        assert!(
+            result.len() < 10,
+            "Expected coalescing: got {} output batches from 100 input batches",
+            result.len()
+        );
+
+        // Verify total rows
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 10000);
+
+        // Most batches should be well-sized
+        for (i, batch) in result.iter().enumerate() {
+            if i < result.len() - 1 {
+                assert!(
+                    batch.num_rows() >= 7000,
+                    "Batch {} should be well-sized, got {} rows",
+                    i,
+                    batch.num_rows()
+                );
+            }
+        }
     }
 }

--- a/ballista/core/src/execution_plans/sort_shuffle/mod.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/mod.rs
@@ -36,7 +36,7 @@ mod reader;
 mod spill;
 mod writer;
 
-pub use buffer::PartitionBuffer;
+pub use buffer::{InputBatchStore, ScratchSpace};
 pub use config::SortShuffleConfig;
 pub use index::ShuffleIndex;
 pub use reader::{

--- a/benchmarks/src/bin/shuffle_bench.rs
+++ b/benchmarks/src/bin/shuffle_bench.rs
@@ -333,6 +333,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut hash_file_count = 0;
         let mut hash_total_size = 0u64;
 
+        // Warmup iteration (discard result to avoid JIT/allocator initialization overhead)
+        {
+            let temp_dir = TempDir::new()?;
+            let work_dir = temp_dir.path().to_str().unwrap();
+            let _ =
+                benchmark_hash_shuffle(&data, schema.clone(), opt.partitions, work_dir)
+                    .await?;
+            println!("  Warmup iteration completed (not timed)");
+        }
+
         for i in 0..opt.iterations {
             let temp_dir = TempDir::new()?;
             let work_dir = temp_dir.path().to_str().unwrap();
@@ -379,6 +389,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut sort_times: Vec<Duration> = Vec::new();
         let mut sort_file_count = 0;
         let mut sort_total_size = 0u64;
+
+        // Warmup iteration (discard result to avoid JIT/allocator initialization overhead)
+        {
+            let temp_dir = TempDir::new()?;
+            let work_dir = temp_dir.path().to_str().unwrap();
+            let _ = benchmark_sort_shuffle(
+                &data,
+                schema.clone(),
+                opt.partitions,
+                work_dir,
+                buffer_size,
+                memory_limit,
+            )
+            .await?;
+            println!("  Warmup iteration completed (not timed)");
+        }
 
         for i in 0..opt.iterations {
             let temp_dir = TempDir::new()?;


### PR DESCRIPTION
…

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1432 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The default `BatchPartitioner` used in sort-based shuffle creates separate `RecordBatch` instances for each output partition. In situations where the number of output partitions is high, there's a lot of overhead in the metadata with each `RecordBatch`. 

This PR aims to defer materializing the shuffled output batches until spilling/writing results. In the interim, the same input batches are stored, and rows for each partition are tracked via a separate index data structure. 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Remove the `PartitionBuffer` struct
- Introduce `InputBatchStore` and `ScratchSpace` for storing input batches and tracking output partition ownership
- Integrate the above structs to defer materialization until spilling or finalizing results

I found that existing test coverage via the client sort shuffle tests felt sufficient for the changes to the writer.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
