### PR TITLE
[REST]: Cancelling a completed/failed job should return "false"

### DIFF
--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -209,19 +209,31 @@ pub async fn cancel_job<
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-            Ok(Json(CancelJobResponse {
-                cancelled: true,
-                reason: None,
-            }))
+            Ok((
+                StatusCode::OK,
+                Json(CancelJobResponse {
+                    cancelled: true,
+                    reason: None,
+                }),
+            )
+                .into_response())
         }
-        Some(Status::Failed(_)) => Ok(Json(CancelJobResponse {
-            cancelled: false,
-            reason: Some("The job has failed".into()),
-        })),
-        Some(Status::Successful(_)) => Ok(Json(CancelJobResponse {
-            cancelled: false,
-            reason: Some("The job is already completed".into()),
-        })),
+        Some(Status::Failed(_)) => Ok((
+            StatusCode::CONFLICT,
+            Json(CancelJobResponse {
+                cancelled: false,
+                reason: Some("The job has failed".into()),
+            }),
+        )
+            .into_response()),
+        Some(Status::Successful(_)) => Ok((
+            StatusCode::CONFLICT,
+            Json(CancelJobResponse {
+                cancelled: false,
+                reason: Some("The job is already completed".into()),
+            }),
+        )
+            .into_response()),
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1493

# Rationale for this change

Give better feedback from the cancel job REST operation (PATCH /api/job/<job_id>)

# What changes are included in this PR?

For queued and still running jobs the response is still the same as before:
```json
{"cancelled": true}
```

For failed and completed jobs the response is:
```json
{"cancelled": false, "reason": "..."}
```

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
