### PR TITLE
feat: (remote) shuffle reader cleanup

### DIFF
--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -17,17 +17,11 @@
 
 //! Client API for sending requests to executors.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use std::{
-    convert::{TryFrom, TryInto},
-    task::{Context, Poll},
-};
-
 use crate::error::{BallistaError, Result as BResult};
+use crate::extension::BallistaConfigGrpcEndpoint;
+use crate::serde::protobuf;
 use crate::serde::scheduler::{Action, PartitionId};
-
+use crate::utils::create_grpc_client_endpoint;
 use arrow_flight;
 use arrow_flight::Ticket;
 use arrow_flight::utils::flight_data_to_arrow_batch;
@@ -43,21 +37,23 @@ use datafusion::arrow::{
 };
 use datafusion::error::DataFusionError;
 use datafusion::error::Result;
-
-use crate::extension::BallistaConfigGrpcEndpoint;
-use crate::serde::protobuf;
-
-use crate::utils::create_grpc_client_endpoint;
-
 use datafusion::physical_plan::{RecordBatchStream, SendableRecordBatchStream};
 use futures::{Stream, StreamExt};
 use log::{debug, warn};
 use prost::Message;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::{
+    convert::{TryFrom, TryInto},
+    task::{Context, Poll},
+};
 use tonic::{Code, Streaming};
 
 /// Client for interacting with Ballista executors.
 #[derive(Clone)]
 pub struct BallistaClient {
+    host: String,
+    port: u16,
     flight_client: FlightServiceClient<tonic::transport::channel::Channel>,
 }
 
@@ -109,7 +105,11 @@ impl BallistaClient {
 
         debug!("BallistaClient connected OK: {flight_client:?}");
 
-        Ok(Self { flight_client })
+        Ok(Self {
+            flight_client,
+            host: host.to_string(),
+            port,
+        })
     }
 
     /// Retrieves a partition from an executor.
@@ -122,8 +122,6 @@ impl BallistaClient {
         executor_id: &str,
         partition_id: &PartitionId,
         path: &str,
-        host: &str,
-        port: u16,
         flight_transport: bool,
     ) -> BResult<SendableRecordBatchStream> {
         let action = Action::FetchPartition {
@@ -131,8 +129,8 @@ impl BallistaClient {
             stage_id: partition_id.stage_id,
             partition_id: partition_id.partition_id,
             path: path.to_owned(),
-            host: host.to_owned(),
-            port,
+            host: self.host.to_owned(),
+            port: self.port,
         };
 
         let result = if flight_transport {

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -117,10 +117,41 @@ impl BallistaClient {
     /// Depending on the value of the `flight_transport` parameter, this method will utilize either
     /// the Arrow Flight protocol for compatibility, or a more efficient block-based transfer mechanism.
     /// The block-based transfer is optimized for performance and reduces computational overhead on the server.
+    ///
+    /// This method to be used for direct connection to executor holding required shuffle partition
     pub async fn fetch_partition(
         &mut self,
         executor_id: &str,
         partition_id: &PartitionId,
+        path: &str,
+        flight_transport: bool,
+    ) -> BResult<SendableRecordBatchStream> {
+        let host = self.host.clone();
+        let port = self.port;
+        self.fetch_partition_proxied(
+            executor_id,
+            partition_id,
+            &host,
+            port,
+            path,
+            flight_transport,
+        )
+        .await
+    }
+
+    /// Retrieves a partition from an executor.
+    ///
+    /// Depending on the value of the `flight_transport` parameter, this method will utilize either
+    /// the Arrow Flight protocol for compatibility, or a more efficient block-based transfer mechanism.
+    /// The block-based transfer is optimized for performance and reduces computational overhead on the server.
+    ///
+    /// This method to be used if the request may be proxied.
+    pub async fn fetch_partition_proxied(
+        &mut self,
+        executor_id: &str,
+        partition_id: &PartitionId,
+        host: &str,
+        port: u16,
         path: &str,
         flight_transport: bool,
     ) -> BResult<SendableRecordBatchStream> {
@@ -129,8 +160,8 @@ impl BallistaClient {
             stage_id: partition_id.stage_id,
             partition_id: partition_id.partition_id,
             path: path.to_owned(),
-            host: self.host.to_owned(),
-            port: self.port,
+            host: host.to_owned(),
+            port,
         };
 
         let result = if flight_transport {

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -118,7 +118,7 @@ impl BallistaClient {
     /// the Arrow Flight protocol for compatibility, or a more efficient block-based transfer mechanism.
     /// The block-based transfer is optimized for performance and reduces computational overhead on the server.
     ///
-    /// This method to be used for direct connection to executor holding required shuffle partition
+    /// This method is to be used for direct connection to the executor holding the required shuffle partition.
     pub async fn fetch_partition(
         &mut self,
         executor_id: &str,
@@ -126,7 +126,7 @@ impl BallistaClient {
         path: &str,
         flight_transport: bool,
     ) -> BResult<SendableRecordBatchStream> {
-        let host = self.host.clone();
+        let host = self.host.to_owned();
         let port = self.port;
         self.fetch_partition_proxied(
             executor_id,
@@ -145,7 +145,7 @@ impl BallistaClient {
     /// the Arrow Flight protocol for compatibility, or a more efficient block-based transfer mechanism.
     /// The block-based transfer is optimized for performance and reduces computational overhead on the server.
     ///
-    /// This method to be used if the request may be proxied.
+    /// This method should be used if the request may be proxied.
     pub async fn fetch_partition_proxied(
         &mut self,
         executor_id: &str,

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -31,10 +31,8 @@ use datafusion::{
 pub const BALLISTA_JOB_NAME: &str = "ballista.job.name";
 /// Configuration key for standalone processing parallelism.
 pub const BALLISTA_STANDALONE_PARALLELISM: &str = "ballista.standalone.parallelism";
-
 /// Configuration key for disabling default cache extension node.
 pub const BALLISTA_CACHE_NOOP: &str = "ballista.cache.noop";
-
 /// Configuration key for maximum concurrent shuffle read requests.
 pub const BALLISTA_SHUFFLE_READER_MAX_REQUESTS: &str =
     "ballista.shuffle.max_concurrent_read_requests";
@@ -44,7 +42,6 @@ pub const BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ: &str =
 /// Configuration key to prefer Flight protocol for remote shuffle reads.
 pub const BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT: &str =
     "ballista.shuffle.remote_read_prefer_flight";
-
 /// max message size for gRPC clients
 pub const BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE: &str =
     "ballista.grpc_client_max_message_size";
@@ -82,6 +79,8 @@ pub const BALLISTA_SHUFFLE_SORT_BASED_BATCH_SIZE: &str =
     "ballista.shuffle.sort_based.batch_size";
 /// Should client employ pull or push job tracking strategy
 pub const BALLISTA_CLIENT_PULL: &str = "ballista.client.pull";
+/// Should client use tls connection
+pub const BALLISTA_CLIENT_USE_TLS: &str = "ballista.client.use_tls";
 
 /// Result type for configuration parsing operations.
 pub type ParseResult<T> = result::Result<T, String>;
@@ -161,6 +160,10 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          Some((8192).to_string())),
         ConfigEntry::new(BALLISTA_CLIENT_PULL.to_string(),
                          "Should client employ pull or push job tracking. In pull mode client will make a request to server in the loop, until job finishes. Pull mode is kept for legacy clients.".to_string(),
+                         DataType::Boolean,
+                         Some(false.to_string())),
+        ConfigEntry::new(BALLISTA_CLIENT_USE_TLS.to_string(),
+                         "Should connection between client, scheduler, and executors use TLS.".to_string(),
                          DataType::Boolean,
                          Some(false.to_string()))
     ];
@@ -274,11 +277,6 @@ impl BallistaConfig {
         &self.settings
     }
 
-    /// Returns the maximum message size for gRPC clients in bytes.
-    pub fn default_grpc_client_max_message_size(&self) -> usize {
-        self.get_usize_setting(BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE)
-    }
-
     /// Returns the standalone processing parallelism level.
     pub fn default_standalone_parallelism(&self) -> usize {
         self.get_usize_setting(BALLISTA_STANDALONE_PARALLELISM)
@@ -290,23 +288,28 @@ impl BallistaConfig {
     }
 
     /// Returns the gRPC client connection timeout in seconds.
-    pub fn default_grpc_client_connect_timeout_seconds(&self) -> usize {
+    pub fn grpc_client_connect_timeout_seconds(&self) -> usize {
         self.get_usize_setting(BALLISTA_GRPC_CLIENT_CONNECT_TIMEOUT_SECONDS)
     }
 
     /// Returns the gRPC client request timeout in seconds.
-    pub fn default_grpc_client_timeout_seconds(&self) -> usize {
+    pub fn grpc_client_timeout_seconds(&self) -> usize {
         self.get_usize_setting(BALLISTA_GRPC_CLIENT_TIMEOUT_SECONDS)
     }
 
     /// Returns the TCP keep-alive interval for gRPC clients in seconds.
-    pub fn default_grpc_client_tcp_keepalive_seconds(&self) -> usize {
+    pub fn grpc_client_tcp_keepalive_seconds(&self) -> usize {
         self.get_usize_setting(BALLISTA_GRPC_CLIENT_TCP_KEEPALIVE_SECONDS)
     }
 
     /// Returns the HTTP/2 keep-alive interval for gRPC clients in seconds.
-    pub fn default_grpc_client_http2_keepalive_interval_seconds(&self) -> usize {
+    pub fn grpc_client_http2_keepalive_interval_seconds(&self) -> usize {
         self.get_usize_setting(BALLISTA_GRPC_CLIENT_HTTP2_KEEPALIVE_INTERVAL_SECONDS)
+    }
+
+    /// Returns the maximum message size for gRPC clients in bytes.
+    pub fn grpc_client_max_message_size(&self) -> usize {
+        self.get_usize_setting(BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE)
     }
 
     /// Returns whether the default cache node extension is disabled.
@@ -373,6 +376,11 @@ impl BallistaConfig {
         self.get_bool_setting(BALLISTA_CLIENT_PULL)
     }
 
+    /// should client use TLS to communicate with ballista cluster
+    pub fn client_use_tls(&self) -> bool {
+        self.get_bool_setting(BALLISTA_CLIENT_USE_TLS)
+    }
+
     fn get_usize_setting(&self, key: &str) -> usize {
         if let Some(v) = self.settings.get(key) {
             // infallible because we validate all configs in the constructor
@@ -417,6 +425,23 @@ impl BallistaConfig {
             let entries = Self::valid_entries();
             let v = entries.get(key).unwrap().default_value.as_ref().unwrap();
             v.parse::<f64>().unwrap()
+        }
+    }
+    /// sets the configuration value where key starts with ballista
+    /// prefix.
+    pub fn set_with_prefix(
+        &mut self,
+        key: &str,
+        value: &str,
+    ) -> datafusion::error::Result<()> {
+        let entries = Self::valid_entries();
+        //let k = format!("{}.{key}", BallistaConfig::PREFIX);
+
+        if entries.contains_key(key) {
+            self.settings.insert(key.to_string(), value.to_string());
+            Ok(())
+        } else {
+            config_err!("configuration key `{}` does not exist", key)
         }
     }
 }
@@ -539,7 +564,7 @@ mod tests {
     #[test]
     fn default_config() -> Result<()> {
         let config = BallistaConfig::default();
-        assert_eq!(16777216, config.default_grpc_client_max_message_size());
+        assert_eq!(16777216, config.grpc_client_max_message_size());
         Ok(())
     }
 }

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -18,14 +18,12 @@
 
 //! Ballista configuration
 
-use std::result;
-use std::{collections::HashMap, fmt::Display};
-
 use crate::error::{BallistaError, Result};
-
 use datafusion::{
     arrow::datatypes::DataType, common::config_err, config::ConfigExtension,
 };
+use std::result;
+use std::{collections::HashMap, fmt::Display};
 
 /// Configuration key for setting the job name displayed in the web UI.
 pub const BALLISTA_JOB_NAME: &str = "ballista.job.name";
@@ -425,23 +423,6 @@ impl BallistaConfig {
             let entries = Self::valid_entries();
             let v = entries.get(key).unwrap().default_value.as_ref().unwrap();
             v.parse::<f64>().unwrap()
-        }
-    }
-    /// sets the configuration value where key starts with ballista
-    /// prefix.
-    pub fn set_with_prefix(
-        &mut self,
-        key: &str,
-        value: &str,
-    ) -> datafusion::error::Result<()> {
-        let entries = Self::valid_entries();
-        //let k = format!("{}.{key}", BallistaConfig::PREFIX);
-
-        if entries.contains_key(key) {
-            self.settings.insert(key.to_string(), value.to_string());
-            Ok(())
-        } else {
-            config_err!("configuration key `{}` does not exist", key)
         }
     }
 }

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -253,7 +253,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                     self.scheduler_url.clone(),
                     self.session_id.clone(),
                     query,
-                    self.config.default_grpc_client_max_message_size(),
+                    self.config.grpc_client_max_message_size(),
                     GrpcClientConfig::from(&self.config),
                     Arc::new(self.metrics.clone()),
                     partition,
@@ -280,7 +280,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                 execute_query_push(
                     self.scheduler_url.clone(),
                     query,
-                    self.config.default_grpc_client_max_message_size(),
+                    self.config.grpc_client_max_message_size(),
                     GrpcClientConfig::from(&self.config),
                     Arc::new(self.metrics.clone()),
                     partition,
@@ -701,8 +701,6 @@ async fn fetch_partition(
     let partition_id = location.partition_id.ok_or_else(|| {
         DataFusionError::Internal("Received empty partition id".to_owned())
     })?;
-    let host = metadata.host.as_str();
-    let port = metadata.port as u16;
 
     let (client_host, client_port) =
         get_client_host_port(&metadata, &scheduler_url, &flight_proxy)?;
@@ -721,8 +719,6 @@ async fn fetch_partition(
             &metadata.id,
             &partition_id.into(),
             &location.path,
-            host,
-            port,
             flight_transport,
         )
         .await

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -701,6 +701,8 @@ async fn fetch_partition(
     let partition_id = location.partition_id.ok_or_else(|| {
         DataFusionError::Internal("Received empty partition id".to_owned())
     })?;
+    let host = metadata.host.as_str();
+    let port = metadata.port as u16;
 
     let (client_host, client_port) =
         get_client_host_port(&metadata, &scheduler_url, &flight_proxy)?;
@@ -715,9 +717,11 @@ async fn fetch_partition(
     .await
     .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
     ballista_client
-        .fetch_partition(
+        .fetch_partition_proxied(
             &metadata.id,
             &partition_id.into(),
+            host,
+            port,
             &location.path,
             flight_transport,
         )

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -15,10 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
+use crate::client::BallistaClient;
+use crate::config::BallistaConfig;
+use crate::error::BallistaError;
+use crate::execution_plans::sort_shuffle::{
+    get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
+};
+use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
+use crate::serde::scheduler::{PartitionLocation, PartitionStats};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::ipc::reader::StreamReader;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::stats::Precision;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::coalesce::{LimitedBatchCoalescer, PushBatchStatus};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet,
+};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics,
+};
+use futures::{Stream, StreamExt, TryStreamExt, ready};
+use itertools::Itertools;
+use log::{debug, error, trace};
+use rand::prelude::SliceRandom;
+use rand::rng;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -28,36 +54,6 @@ use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-
-use crate::client::BallistaClient;
-use crate::execution_plans::sort_shuffle::{
-    get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
-};
-use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
-use crate::serde::scheduler::{PartitionLocation, PartitionStats};
-
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::runtime::SpawnedTask;
-
-use datafusion::error::{DataFusionError, Result};
-use datafusion::physical_plan::metrics::{
-    BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet,
-};
-use datafusion::physical_plan::{
-    ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
-    PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics,
-};
-use futures::{Stream, StreamExt, TryStreamExt, ready};
-
-use crate::error::BallistaError;
-use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use itertools::Itertools;
-use log::{debug, error, trace};
-use rand::prelude::SliceRandom;
-use rand::rng;
 use tokio::sync::{Semaphore, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -162,17 +158,13 @@ impl ExecutionPlan for ShuffleReaderExec {
         debug!("ShuffleReaderExec::execute({task_id})");
 
         let config = context.session_config();
-
-        let max_request_num =
-            config.ballista_shuffle_reader_maximum_concurrent_requests();
-        let max_message_size = config.ballista_grpc_client_max_message_size();
-        let force_remote_read = config.ballista_shuffle_reader_force_remote_read();
-        let prefer_flight = config.ballista_shuffle_reader_remote_prefer_flight();
         let batch_size = config.batch_size();
-        let customize_endpoint = config.ballista_override_create_grpc_client_endpoint();
-        let use_tls = config.ballista_use_tls();
+        let customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>> =
+            config.ballista_override_create_grpc_client_endpoint();
 
-        if force_remote_read {
+        let config = config.ballista_config();
+
+        if config.shuffle_reader_force_remote_read() {
             debug!(
                 "All shuffle partitions will be read as remote partitions! To disable this behavior set: `{}=false`",
                 crate::config::BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ
@@ -180,7 +172,9 @@ impl ExecutionPlan for ShuffleReaderExec {
         }
 
         log::debug!(
-            "ShuffleReaderExec::execute({task_id}) max_request_num: {max_request_num}, max_message_size: {max_message_size}"
+            "ShuffleReaderExec::execute({task_id}) max_request_num: {}, max_message_size: {}",
+            config.shuffle_reader_maximum_concurrent_requests(),
+            config.grpc_client_max_message_size()
         );
         let mut partition_locations = HashMap::new();
         for p in &self.partition[partition] {
@@ -198,15 +192,8 @@ impl ExecutionPlan for ShuffleReaderExec {
             .collect();
         // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
         partition_locations.shuffle(&mut rng());
-        let response_receiver = send_fetch_partitions(
-            partition_locations,
-            max_request_num,
-            max_message_size,
-            force_remote_read,
-            prefer_flight,
-            customize_endpoint,
-            use_tls,
-        );
+        let response_receiver =
+            send_fetch_partitions(partition_locations, &config, customize_endpoint);
 
         let input_stream = Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
@@ -405,19 +392,19 @@ fn local_remote_read_split(
 
 fn send_fetch_partitions(
     partition_locations: Vec<PartitionLocation>,
-    max_request_num: usize,
-    max_message_size: usize,
-    force_remote_read: bool,
-    flight_transport: bool,
+    config: &BallistaConfig,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
-    use_tls: bool,
 ) -> AbortableReceiverStream {
+    let max_request_num = config.shuffle_reader_maximum_concurrent_requests();
+
     let (response_sender, response_receiver) = mpsc::channel(max_request_num);
     let semaphore = Arc::new(Semaphore::new(max_request_num));
     let mut spawned_tasks: Vec<SpawnedTask<()>> = vec![];
 
-    let (local_locations, remote_locations): (Vec<_>, Vec<_>) =
-        local_remote_read_split(partition_locations, force_remote_read);
+    let (local_locations, remote_locations): (Vec<_>, Vec<_>) = local_remote_read_split(
+        partition_locations,
+        config.shuffle_reader_force_remote_read(),
+    );
 
     debug!(
         "local shuffle file counts:{}, remote shuffle file count:{}.",
@@ -427,46 +414,44 @@ fn send_fetch_partitions(
 
     // keep local shuffle files reading in serial order for memory control.
     let response_sender_c = response_sender.clone();
-    let customize_endpoint_c = customize_endpoint.clone();
-    spawned_tasks.push(SpawnedTask::spawn(async move {
-        for p in local_locations {
-            let r = PartitionReaderEnum::Local
-                .fetch_partition(
-                    &p,
-                    max_message_size,
-                    flight_transport,
-                    customize_endpoint_c.clone(),
-                    use_tls,
-                )
-                .await;
-            if let Err(e) = response_sender_c.send(r).await {
-                error!("Fail to send response event to the channel due to {e}");
+
+    //
+    // fetching local partitions (read from file)
+    //
+
+    spawned_tasks.push(SpawnedTask::spawn_blocking({
+        move || {
+            for p in local_locations {
+                let r = fetch_partition_local(&p);
+                if let Err(e) = response_sender_c.blocking_send(r) {
+                    error!("Fail to send response event to the channel due to {e}");
+                }
             }
         }
     }));
 
+    //
+    // fetching remote partitions (uses grpc flight protocol)
+    //
     for p in remote_locations.into_iter() {
         let semaphore = semaphore.clone();
         let response_sender = response_sender.clone();
-        let customize_endpoint_c = customize_endpoint.clone();
-        spawned_tasks.push(SpawnedTask::spawn(async move {
-            // Block if exceeds max request number.
-            let permit = semaphore.acquire_owned().await.unwrap();
-            let r = PartitionReaderEnum::FlightRemote
-                .fetch_partition(
-                    &p,
-                    max_message_size,
-                    flight_transport,
-                    customize_endpoint_c,
-                    use_tls,
-                )
-                .await;
-            // Block if the channel buffer is full.
-            if let Err(e) = response_sender.send(r).await {
-                error!("Fail to send response event to the channel due to {e}");
+
+        spawned_tasks.push(SpawnedTask::spawn({
+            // TODO: make BallistaConfig cheaper to clone
+            let config = config.clone();
+            let customize_endpoint = customize_endpoint.clone();
+            async move {
+                // Block if exceeds max request number.
+                let permit = semaphore.acquire_owned().await.unwrap();
+                let r = fetch_partition_remote(&p, &config, customize_endpoint).await;
+                // Block if the channel buffer is full.
+                if let Err(e) = response_sender.send(r).await {
+                    error!("Fail to send response event to the channel due to {e}");
+                }
+                // Increase semaphore by dropping existing permits.
+                drop(permit);
             }
-            // Increase semaphore by dropping existing permits.
-            drop(permit);
         }));
     }
 
@@ -477,103 +462,51 @@ fn check_is_local_location(location: &PartitionLocation) -> bool {
     std::path::Path::new(location.path.as_str()).exists()
 }
 
-/// Partition reader Trait, different partition reader can have
-#[async_trait]
-trait PartitionReader: Send + Sync + Clone {
-    // Read partition data from PartitionLocation
-    async fn fetch_partition(
-        &self,
-        location: &PartitionLocation,
-        max_message_size: usize,
-        flight_transport: bool,
-        customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
-        use_tls: bool,
-    ) -> result::Result<SendableRecordBatchStream, BallistaError>;
-}
+async fn new_ballista_client(
+    host: &str,
+    port: u16,
+    config: &BallistaConfig,
+    customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+) -> result::Result<BallistaClient, BallistaError> {
+    let max_message_size = config.grpc_client_max_message_size();
+    let use_tls = config.client_use_tls();
 
-#[derive(Clone)]
-enum PartitionReaderEnum {
-    Local,
-    FlightRemote,
-    #[allow(dead_code)]
-    ObjectStoreRemote,
-}
-
-#[async_trait]
-impl PartitionReader for PartitionReaderEnum {
-    // Notice return `BallistaError::FetchFailed` will let scheduler re-schedule the task.
-    async fn fetch_partition(
-        &self,
-        location: &PartitionLocation,
-        max_message_size: usize,
-        flight_transport: bool,
-        customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
-        use_tls: bool,
-    ) -> result::Result<SendableRecordBatchStream, BallistaError> {
-        match self {
-            PartitionReaderEnum::FlightRemote => {
-                fetch_partition_remote(
-                    location,
-                    max_message_size,
-                    flight_transport,
-                    customize_endpoint,
-                    use_tls,
-                )
-                .await
-            }
-            PartitionReaderEnum::Local => fetch_partition_local(location).await,
-            PartitionReaderEnum::ObjectStoreRemote => {
-                fetch_partition_object_store(location).await
-            }
-        }
-    }
+    BallistaClient::try_new(host, port, max_message_size, use_tls, customize_endpoint)
+        .await
 }
 
 async fn fetch_partition_remote(
     location: &PartitionLocation,
-    max_message_size: usize,
-    flight_transport: bool,
+    config: &BallistaConfig,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
-    use_tls: bool,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
-    // TODO for shuffle client connections, we should avoid creating new connections again and again.
-    // And we should also avoid to keep alive too many connections for long time.
+    let prefer_flight = config.shuffle_reader_remote_prefer_flight();
     let host = metadata.host.as_str();
     let port = metadata.port;
-    let mut ballista_client = BallistaClient::try_new(
-        host,
-        port,
-        max_message_size,
-        use_tls,
-        customize_endpoint,
-    )
-    .await
-    .map_err(|error| match error {
-        // map grpc connection error to partition fetch error.
-        BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
-            metadata.id.clone(),
-            partition_id.stage_id,
-            partition_id.partition_id,
-            msg,
-        ),
-        other => other,
-    })?;
+
+    // TODO for shuffle client connections, we should avoid creating new connections again and again.
+    // And we should also avoid to keep alive too many connections for long time.
+    let mut ballista_client = new_ballista_client(host, port, config, customize_endpoint)
+        .await
+        .map_err(|error| match error {
+            // map grpc connection error to partition fetch error.
+            BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
+                metadata.id.clone(),
+                partition_id.stage_id,
+                partition_id.partition_id,
+                msg,
+            ),
+            other => other,
+        })?;
 
     ballista_client
-        .fetch_partition(
-            &metadata.id,
-            partition_id,
-            &location.path,
-            host,
-            port,
-            flight_transport,
-        )
+        .fetch_partition(&metadata.id, partition_id, &location.path, prefer_flight)
         .await
 }
 
-async fn fetch_partition_local(
+fn fetch_partition_local(
     location: &PartitionLocation,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let path = &location.path;
@@ -635,14 +568,6 @@ fn fetch_partition_local_inner(
     };
 
     Ok(reader)
-}
-
-async fn fetch_partition_object_store(
-    _location: &PartitionLocation,
-) -> result::Result<SendableRecordBatchStream, BallistaError> {
-    Err(BallistaError::NotImplemented(
-        "Should not use ObjectStorePartitionReader".to_string(),
-    ))
 }
 
 struct CoalescedShuffleReaderStream {
@@ -1120,16 +1045,15 @@ mod tests {
             partition_num,
             file_path.to_str().unwrap().to_string(),
         );
+        let mut config = BallistaConfig::default();
 
-        let response_receiver = send_fetch_partitions(
-            partition_locations,
-            max_request_num,
-            4 * 1024 * 1024,
-            false,
-            true,
-            None,
-            false,
-        );
+        config
+            .set_with_prefix(
+                crate::config::BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
+                &max_request_num.to_string(),
+            )
+            .unwrap();
+        let response_receiver = send_fetch_partitions(partition_locations, &config, None);
 
         let stream = RecordBatchStreamAdapter::new(
             Arc::new(schema),

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -16,13 +16,13 @@
 // under the License.
 
 use crate::client::BallistaClient;
-use crate::config::BallistaConfig;
 use crate::error::BallistaError;
 use crate::execution_plans::sort_shuffle::{
     get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
 };
 use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
 use crate::serde::scheduler::{PartitionLocation, PartitionStats};
+use crate::utils::GrpcClientConfig;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::ipc::reader::StreamReader;
@@ -40,6 +40,7 @@ use datafusion::physical_plan::{
     ColumnStatistics, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
     PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics,
 };
+use datafusion::prelude::SessionConfig;
 use futures::{Stream, StreamExt, TryStreamExt, ready};
 use itertools::Itertools;
 use log::{debug, error, trace};
@@ -159,12 +160,8 @@ impl ExecutionPlan for ShuffleReaderExec {
 
         let config = context.session_config();
         let batch_size = config.batch_size();
-        let customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>> =
-            config.ballista_override_create_grpc_client_endpoint();
 
-        let config = config.ballista_config();
-
-        if config.shuffle_reader_force_remote_read() {
+        if config.ballista_shuffle_reader_force_remote_read() {
             debug!(
                 "All shuffle partitions will be read as remote partitions! To disable this behavior set: `{}=false`",
                 crate::config::BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ
@@ -173,8 +170,8 @@ impl ExecutionPlan for ShuffleReaderExec {
 
         log::debug!(
             "ShuffleReaderExec::execute({task_id}) max_request_num: {}, max_message_size: {}",
-            config.shuffle_reader_maximum_concurrent_requests(),
-            config.grpc_client_max_message_size()
+            config.ballista_shuffle_reader_maximum_concurrent_requests(),
+            config.ballista_grpc_client_max_message_size()
         );
         let mut partition_locations = HashMap::new();
         for p in &self.partition[partition] {
@@ -192,8 +189,7 @@ impl ExecutionPlan for ShuffleReaderExec {
             .collect();
         // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
         partition_locations.shuffle(&mut rng());
-        let response_receiver =
-            send_fetch_partitions(partition_locations, &config, customize_endpoint);
+        let response_receiver = send_fetch_partitions(partition_locations, config);
 
         let input_stream = Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
@@ -392,10 +388,9 @@ fn local_remote_read_split(
 
 fn send_fetch_partitions(
     partition_locations: Vec<PartitionLocation>,
-    config: &BallistaConfig,
-    customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+    config: &SessionConfig,
 ) -> AbortableReceiverStream {
-    let max_request_num = config.shuffle_reader_maximum_concurrent_requests();
+    let max_request_num = config.ballista_shuffle_reader_maximum_concurrent_requests();
 
     let (response_sender, response_receiver) = mpsc::channel(max_request_num);
     let semaphore = Arc::new(Semaphore::new(max_request_num));
@@ -403,7 +398,7 @@ fn send_fetch_partitions(
 
     let (local_locations, remote_locations): (Vec<_>, Vec<_>) = local_remote_read_split(
         partition_locations,
-        config.shuffle_reader_force_remote_read(),
+        config.ballista_shuffle_reader_force_remote_read(),
     );
 
     debug!(
@@ -433,18 +428,27 @@ fn send_fetch_partitions(
     //
     // fetching remote partitions (uses grpc flight protocol)
     //
+    let grpc_config: Arc<GrpcClientConfig> = Arc::new((&config.ballista_config()).into());
+    let customize_endpoint = config.ballista_override_create_grpc_client_endpoint();
+    let prefer_flight = config.ballista_shuffle_reader_remote_prefer_flight();
+
     for p in remote_locations.into_iter() {
         let semaphore = semaphore.clone();
         let response_sender = response_sender.clone();
 
         spawned_tasks.push(SpawnedTask::spawn({
-            // TODO: make BallistaConfig cheaper to clone
-            let config = config.clone();
             let customize_endpoint = customize_endpoint.clone();
+            let grpc_config = grpc_config.clone();
             async move {
                 // Block if exceeds max request number.
                 let permit = semaphore.acquire_owned().await.unwrap();
-                let r = fetch_partition_remote(&p, &config, customize_endpoint).await;
+                let r = fetch_partition_remote(
+                    &p,
+                    grpc_config,
+                    prefer_flight,
+                    customize_endpoint,
+                )
+                .await;
                 // Block if the channel buffer is full.
                 if let Err(e) = response_sender.send(r).await {
                     error!("Fail to send response event to the channel due to {e}");
@@ -465,11 +469,11 @@ fn check_is_local_location(location: &PartitionLocation) -> bool {
 async fn new_ballista_client(
     host: &str,
     port: u16,
-    config: &BallistaConfig,
+    config: &GrpcClientConfig,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
 ) -> result::Result<BallistaClient, BallistaError> {
-    let max_message_size = config.grpc_client_max_message_size();
-    let use_tls = config.client_use_tls();
+    let max_message_size = config.max_message_size;
+    let use_tls = config.use_tls;
 
     BallistaClient::try_new(host, port, max_message_size, use_tls, customize_endpoint)
         .await
@@ -477,29 +481,30 @@ async fn new_ballista_client(
 
 async fn fetch_partition_remote(
     location: &PartitionLocation,
-    config: &BallistaConfig,
+    config: Arc<GrpcClientConfig>,
+    prefer_flight: bool,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
-    let prefer_flight = config.shuffle_reader_remote_prefer_flight();
     let host = metadata.host.as_str();
     let port = metadata.port;
 
     // TODO for shuffle client connections, we should avoid creating new connections again and again.
     // And we should also avoid to keep alive too many connections for long time.
-    let mut ballista_client = new_ballista_client(host, port, config, customize_endpoint)
-        .await
-        .map_err(|error| match error {
-            // map grpc connection error to partition fetch error.
-            BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
-                metadata.id.clone(),
-                partition_id.stage_id,
-                partition_id.partition_id,
-                msg,
-            ),
-            other => other,
-        })?;
+    let mut ballista_client =
+        new_ballista_client(host, port, &config, customize_endpoint)
+            .await
+            .map_err(|error| match error {
+                // map grpc connection error to partition fetch error.
+                BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
+                    metadata.id.clone(),
+                    partition_id.stage_id,
+                    partition_id.partition_id,
+                    msg,
+                ),
+                other => other,
+            })?;
 
     ballista_client
         .fetch_partition(&metadata.id, partition_id, &location.path, prefer_flight)
@@ -1045,15 +1050,10 @@ mod tests {
             partition_num,
             file_path.to_str().unwrap().to_string(),
         );
-        let mut config = BallistaConfig::default();
+        let config = SessionConfig::new_with_ballista()
+            .with_ballista_shuffle_reader_maximum_concurrent_requests(max_request_num);
 
-        config
-            .set_with_prefix(
-                crate::config::BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
-                &max_request_num.to_string(),
-            )
-            .unwrap();
-        let response_receiver = send_fetch_partitions(partition_locations, &config, None);
+        let response_receiver = send_fetch_partitions(partition_locations, &config);
 
         let stream = RecordBatchStreamAdapter::new(
             Arc::new(schema),

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -391,6 +391,7 @@ fn send_fetch_partitions(
     config: &SessionConfig,
 ) -> AbortableReceiverStream {
     let max_request_num = config.ballista_shuffle_reader_maximum_concurrent_requests();
+    let sort_shuffle_enabled = config.ballista_sort_shuffle_enabled();
 
     let (response_sender, response_receiver) = mpsc::channel(max_request_num);
     let semaphore = Arc::new(Semaphore::new(max_request_num));
@@ -417,7 +418,7 @@ fn send_fetch_partitions(
     spawned_tasks.push(SpawnedTask::spawn_blocking({
         move || {
             for p in local_locations {
-                let r = fetch_partition_local(&p);
+                let r = fetch_partition_local(&p, sort_shuffle_enabled);
                 if let Err(e) = response_sender_c.blocking_send(r) {
                     error!("Fail to send response event to the channel due to {e}");
                 }
@@ -513,14 +514,21 @@ async fn fetch_partition_remote(
 
 fn fetch_partition_local(
     location: &PartitionLocation,
+    sort_shuffle_enabled: bool,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let path = &location.path;
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
     let data_path = std::path::Path::new(path);
 
+    // TODO: we check if file is there then we open it alter
+    //       replace this check with open, and check for error
+    //
     // Check if this is a sort-based shuffle output (has index file)
-    if is_sort_shuffle_output(data_path) {
+    if sort_shuffle_enabled && is_sort_shuffle_output(data_path) {
+        // note: in some cases sort shuffle is not going to be used
+        //       even its enabled. thus we need to check if there is
+        //       sort shuffle file index
         debug!(
             "Reading sort-based shuffle for partition {} from {:?}",
             partition_id.partition_id, data_path
@@ -560,7 +568,8 @@ fn fetch_partition_local_inner(
     let file = File::open(path).map_err(|e| {
         BallistaError::General(format!("Failed to open partition file at {path}: {e:?}"))
     })?;
-    let file = BufReader::new(file);
+    // TODO: make this configurable
+    let file = BufReader::with_capacity(256 * 1024, file);
     // Safety: setting `skip_validation` requires `unsafe`, user assures data is valid
     let reader = unsafe {
         StreamReader::try_new(file, None)

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::config::{
-    BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE, BALLISTA_JOB_NAME,
+    BALLISTA_CLIENT_USE_TLS, BALLISTA_GRPC_CLIENT_MAX_MESSAGE_SIZE, BALLISTA_JOB_NAME,
     BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
     BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, BALLISTA_STANDALONE_PARALLELISM,
     BallistaConfig,
@@ -392,10 +392,8 @@ impl SessionConfigExt for SessionConfig {
         self.options()
             .extensions
             .get::<BallistaConfig>()
-            .map(|c| c.default_grpc_client_max_message_size())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().default_grpc_client_max_message_size()
-            })
+            .map(|c| c.grpc_client_max_message_size())
+            .unwrap_or_else(|| BallistaConfig::default().grpc_client_max_message_size())
     }
 
     fn with_ballista_job_name(self, job_name: &str) -> Self {
@@ -538,13 +536,20 @@ impl SessionConfigExt for SessionConfig {
     }
 
     fn with_ballista_use_tls(self, use_tls: bool) -> Self {
-        self.with_extension(Arc::new(BallistaUseTls(use_tls)))
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_bool(BALLISTA_CLIENT_USE_TLS, use_tls)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_bool(BALLISTA_CLIENT_USE_TLS, use_tls)
+        }
     }
 
     fn ballista_use_tls(&self) -> bool {
-        self.get_extension::<BallistaUseTls>()
-            .map(|ext| ext.0)
-            .unwrap_or(false)
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.client_use_tls())
+            .unwrap_or_else(|| BallistaConfig::default().client_use_tls())
     }
 }
 
@@ -745,10 +750,6 @@ impl BallistaConfigGrpcEndpoint {
         (self.override_f)(endpoint)
     }
 }
-
-/// Wrapper for cluster-wide TLS configuration
-#[derive(Clone, Copy)]
-pub struct BallistaUseTls(pub bool);
 
 #[derive(Debug)]
 struct BallistaCacheFactory;

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -233,6 +233,9 @@ pub trait SessionConfigExt {
 
     /// Get whether to use TLS for executor connections
     fn ballista_use_tls(&self) -> bool;
+
+    /// Is short shuffle used
+    fn ballista_sort_shuffle_enabled(&self) -> bool;
 }
 
 /// [SessionConfigHelperExt] is set of [SessionConfig] extension methods
@@ -431,6 +434,14 @@ impl SessionConfigExt for SessionConfig {
             .unwrap_or_else(|| {
                 BallistaConfig::default().shuffle_reader_maximum_concurrent_requests()
             })
+    }
+
+    fn ballista_sort_shuffle_enabled(&self) -> bool {
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.shuffle_sort_based_enabled())
+            .unwrap_or_else(|| BallistaConfig::default().shuffle_sort_based_enabled())
     }
 
     fn with_ballista_shuffle_reader_maximum_concurrent_requests(

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -68,13 +68,11 @@ pub struct GrpcClientConfig {
 impl From<&BallistaConfig> for GrpcClientConfig {
     fn from(config: &BallistaConfig) -> Self {
         Self {
-            connect_timeout_seconds: config.default_grpc_client_connect_timeout_seconds()
-                as u64,
-            timeout_seconds: config.default_grpc_client_timeout_seconds() as u64,
-            tcp_keepalive_seconds: config.default_grpc_client_tcp_keepalive_seconds()
-                as u64,
+            connect_timeout_seconds: config.grpc_client_connect_timeout_seconds() as u64,
+            timeout_seconds: config.grpc_client_timeout_seconds() as u64,
+            tcp_keepalive_seconds: config.grpc_client_tcp_keepalive_seconds() as u64,
             http2_keepalive_interval_seconds: config
-                .default_grpc_client_http2_keepalive_interval_seconds()
+                .grpc_client_http2_keepalive_interval_seconds()
                 as u64,
         }
     }
@@ -312,19 +310,19 @@ mod tests {
         // Verify the conversion picks up the right values
         assert_eq!(
             grpc_config.connect_timeout_seconds,
-            ballista_config.default_grpc_client_connect_timeout_seconds() as u64
+            ballista_config.grpc_client_connect_timeout_seconds() as u64
         );
         assert_eq!(
             grpc_config.timeout_seconds,
-            ballista_config.default_grpc_client_timeout_seconds() as u64
+            ballista_config.grpc_client_timeout_seconds() as u64
         );
         assert_eq!(
             grpc_config.tcp_keepalive_seconds,
-            ballista_config.default_grpc_client_tcp_keepalive_seconds() as u64
+            ballista_config.grpc_client_tcp_keepalive_seconds() as u64
         );
         assert_eq!(
             grpc_config.http2_keepalive_interval_seconds,
-            ballista_config.default_grpc_client_http2_keepalive_interval_seconds() as u64
+            ballista_config.grpc_client_http2_keepalive_interval_seconds() as u64
         );
     }
 

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -63,6 +63,10 @@ pub struct GrpcClientConfig {
     pub tcp_keepalive_seconds: u64,
     /// HTTP/2 keep-alive ping interval in seconds
     pub http2_keepalive_interval_seconds: u64,
+    /// Should client use tls
+    pub use_tls: bool,
+    /// Returns the maximum message size for gRPC clients in bytes.
+    pub max_message_size: usize,
 }
 
 impl From<&BallistaConfig> for GrpcClientConfig {
@@ -74,6 +78,8 @@ impl From<&BallistaConfig> for GrpcClientConfig {
             http2_keepalive_interval_seconds: config
                 .grpc_client_http2_keepalive_interval_seconds()
                 as u64,
+            use_tls: config.client_use_tls(),
+            max_message_size: config.grpc_client_max_message_size(),
         }
     }
 }
@@ -85,6 +91,8 @@ impl Default for GrpcClientConfig {
             timeout_seconds: 20,
             tcp_keepalive_seconds: 3600,
             http2_keepalive_interval_seconds: 300,
+            use_tls: false,
+            max_message_size: 16 * 1024 * 1024,
         }
     }
 }
@@ -333,6 +341,8 @@ mod tests {
             timeout_seconds: 30,
             tcp_keepalive_seconds: 1800,
             http2_keepalive_interval_seconds: 150,
+            use_tls: false,
+            max_message_size: 16 * 1024 * 1024,
         };
         let result = create_grpc_client_endpoint("http://localhost:50051", Some(&config));
         assert!(result.is_ok());

--- a/examples/examples/standalone-substrait.rs
+++ b/examples/examples/standalone-substrait.rs
@@ -416,8 +416,6 @@ impl SubstraitSchedulerClient {
                 &metadata.id,
                 &partition_id.into(),
                 &location.path,
-                host,
-                port,
                 flight_transport,
             )
             .await


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

 # Rationale for this change

Simplify shuffle reader in order to implement connection caching

# What changes are included in this PR?

- shuffle reader code refactor
- ballista configuration cleanup 

# Are there any user-facing changes?

No