### PR TITLE
feat: remove full path from partition locations

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -230,9 +230,14 @@ message FetchPartition {
   string job_id = 1;
   uint32 stage_id = 2;
   uint32 partition_id = 3;
-  string path = 4;
   string host = 5;
   uint32 port = 6;
+  optional uint64 file_id = 7;
+  bool is_sort_shuffle = 8 ;
+  
+  // reserved after removing deprecated `path`.
+  reserved 4;
+  reserved "path"; 
 }
 
 message PartitionLocation {
@@ -242,7 +247,12 @@ message PartitionLocation {
   PartitionId partition_id = 2;
   ExecutorMetadata executor_meta = 3;
   PartitionStats partition_stats = 4;
-  string path = 5;
+  optional uint64 file_id = 6;
+  bool is_sort_shuffle = 7;
+
+  // reserved after removing deprecated `path`.
+  reserved 5;
+  reserved "path";
 }
 
 // Unique identifier for a materialized partition of data
@@ -448,10 +458,15 @@ message TaskKilled {
 
 message ShuffleWritePartition {
   uint64 partition_id = 1;
-  string path = 2;
   uint64 num_batches = 3;
   uint64 num_rows = 4;
   uint64 num_bytes = 5;
+  optional uint64 file_id = 6;
+  bool is_sort_shuffle = 7;
+
+  // reserved after removing path
+  reserved 2;
+  reserved "path";
 }
 
 message TaskStatus {

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -233,7 +233,7 @@ message FetchPartition {
   string host = 5;
   uint32 port = 6;
   optional uint64 file_id = 7;
-  bool is_sort_shuffle = 8 ;
+  bool is_sort_shuffle = 8;
   
   // reserved after removing deprecated `path`.
   reserved 4;

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -237,7 +237,7 @@ message FetchPartition {
   
   // reserved after removing deprecated `path`.
   reserved 4;
-  reserved "path"; 
+  reserved "path";
 }
 
 message PartitionLocation {

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -119,11 +119,13 @@ impl BallistaClient {
     /// The block-based transfer is optimized for performance and reduces computational overhead on the server.
     ///
     /// This method is to be used for direct connection to the executor holding the required shuffle partition.
+    #[allow(clippy::too_many_arguments)]
     pub async fn fetch_partition(
         &mut self,
         executor_id: &str,
         partition_id: &PartitionId,
-        path: &str,
+        file_id: Option<u64>,
+        is_sort_shuffle: bool,
         flight_transport: bool,
     ) -> BResult<SendableRecordBatchStream> {
         let host = self.host.to_owned();
@@ -131,9 +133,10 @@ impl BallistaClient {
         self.fetch_partition_proxied(
             executor_id,
             partition_id,
+            file_id,
+            is_sort_shuffle,
             &host,
             port,
-            path,
             flight_transport,
         )
         .await
@@ -146,22 +149,26 @@ impl BallistaClient {
     /// The block-based transfer is optimized for performance and reduces computational overhead on the server.
     ///
     /// This method should be used if the request may be proxied.
+    #[allow(clippy::too_many_arguments)]
     pub async fn fetch_partition_proxied(
         &mut self,
         executor_id: &str,
         partition_id: &PartitionId,
+        file_id: Option<u64>,
+        is_sort_shuffle: bool,
         host: &str,
         port: u16,
-        path: &str,
         flight_transport: bool,
     ) -> BResult<SendableRecordBatchStream> {
         let action = Action::FetchPartition {
             job_id: partition_id.job_id.clone(),
             stage_id: partition_id.stage_id,
             partition_id: partition_id.partition_id,
-            path: path.to_owned(),
+            // path: path.to_owned(),
             host: host.to_owned(),
             port,
+            file_id,
+            is_sort_shuffle,
         };
 
         let result = if flight_transport {

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -164,7 +164,6 @@ impl BallistaClient {
             job_id: partition_id.job_id.clone(),
             stage_id: partition_id.stage_id,
             partition_id: partition_id.partition_id,
-            // path: path.to_owned(),
             host: host.to_owned(),
             port,
             file_id,

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -715,9 +715,10 @@ async fn fetch_partition(
         .fetch_partition_proxied(
             &metadata.id,
             &partition_id.into(),
+            location.file_id,
+            location.is_sort_shuffle,
             host,
             port,
-            &location.path,
             flight_transport,
         )
         .await

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -25,6 +25,9 @@ mod shuffle_writer_trait;
 pub mod sort_shuffle;
 mod unresolved_shuffle;
 
+use std::path::{Path, PathBuf};
+
+use datafusion::common::exec_err;
 pub use distributed_query::DistributedQueryExec;
 pub use shuffle_reader::ShuffleReaderExec;
 pub use shuffle_reader::{stats_for_partition, stats_for_partitions};
@@ -32,3 +35,112 @@ pub use shuffle_writer::ShuffleWriterExec;
 pub use shuffle_writer_trait::ShuffleWriter;
 pub use sort_shuffle::SortShuffleWriterExec;
 pub use unresolved_shuffle::UnresolvedShuffleExec;
+
+/// Creates the file path for a shuffle output partition.
+///
+/// The path structure depends on the shuffle type:
+///
+/// - **Hash shuffle** (`is_sort_shuffle = false`): produces one directory per output
+///   partition; `partition_id` is always part of the path. `file_id` is an optional
+///   sequence number used when a single partition is written in multiple files:
+///   - With `file_id`: `{work_dir}/{job_id}/{stage_id}/{partition_id}/data-{file_id}.arrow`
+///   - Without `file_id`: `{work_dir}/{job_id}/{stage_id}/{partition_id}/data.arrow`
+///
+/// - **Sort shuffle** (`is_sort_shuffle = true`): produces a single output partition,
+///   so `partition_id` is **ignored** and not included in the path. `file_id` acts as a
+///   file sequence counter and is **required**:
+///   - With `file_id`: `{work_dir}/{job_id}/{stage_id}/{file_id}/data.arrow`
+///   - Without `file_id`: returns an error
+///
+/// # Arguments
+///
+/// - `work_dir` — base directory where shuffle files are written
+/// - `job_id` — unique identifier for the job
+/// - `stage_id` — stage within the job that produced this shuffle output
+/// - `partition_id` — output partition index; used by hash shuffle only, ignored for sort shuffle
+/// - `file_id` — file sequence number; optional for hash shuffle, required for sort shuffle
+/// - `is_sort_shuffle` — selects between sort-shuffle and hash-shuffle path layout
+pub fn create_shuffle_path<P: AsRef<Path>>(
+    work_dir: P,
+    job_id: &str,
+    stage_id: usize,
+    partition_id: usize,
+    file_id: Option<u64>,
+    is_sort_shuffle: bool,
+) -> datafusion::error::Result<PathBuf> {
+    let mut path = PathBuf::new();
+
+    path.push(work_dir);
+    path.push(job_id);
+    path.push(stage_id.to_string());
+
+    match (file_id, is_sort_shuffle) {
+        (Some(file_id), false) => {
+            path.push(partition_id.to_string());
+            path.push(format!("data-{}.arrow", file_id));
+        }
+        (Some(file_id), true) => {
+            path.push(file_id.to_string());
+            path.push("data.arrow");
+        }
+        (None, false) => {
+            path.push(partition_id.to_string());
+            path.push("data.arrow");
+        }
+        (None, true) => {
+            exec_err!("cant create path for sort shuffle without file_id provided")?
+        }
+    }
+
+    Ok(path)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_regular_shuffle_with_file_id() {
+        let path = create_shuffle_path("/work", "job1", 2, 3, Some(42), false).unwrap();
+        assert_eq!(path, PathBuf::from("/work/job1/2/3/data-42.arrow"));
+    }
+
+    #[test]
+    fn test_regular_shuffle_without_file_id() {
+        let path = create_shuffle_path("/work", "job1", 2, 3, None, false).unwrap();
+        assert_eq!(path, PathBuf::from("/work/job1/2/3/data.arrow"));
+    }
+
+    #[test]
+    fn test_sort_shuffle_with_file_id() {
+        let path = create_shuffle_path("/work", "job1", 2, 3, Some(42), true).unwrap();
+        assert_eq!(path, PathBuf::from("/work/job1/2/42/data.arrow"));
+    }
+
+    #[test]
+    fn test_sort_shuffle_without_file_id_returns_error() {
+        let result = create_shuffle_path("/work", "job1", 2, 3, None, true);
+        assert!(result.is_err());
+    }
+
+    /// Verifies that even when the root directory `/` is used as `work_dir`, the
+    /// returned path always has a parent (i.e. the file is never at the filesystem root).
+    #[test]
+    fn test_root_work_dir_path_has_parent() {
+        for (file_id, is_sort_shuffle) in
+            [(Some(1), false), (None, false), (Some(1), true)]
+        {
+            let path =
+                create_shuffle_path("/", "job1", 2, 3, file_id, is_sort_shuffle).unwrap();
+            assert!(
+                path.parent().is_some(),
+                "path {path:?} (file_id={file_id:?}, is_sort_shuffle={is_sort_shuffle}) has no parent"
+            );
+            assert_ne!(
+                path.parent().unwrap(),
+                std::path::Path::new("/"),
+                "path {path:?} parent is root — expected deeper nesting"
+            );
+        }
+    }
+}

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -88,7 +88,7 @@ pub fn create_shuffle_path<P: AsRef<Path>>(
             path.push("data.arrow");
         }
         (None, true) => {
-            exec_err!("cant create path for sort shuffle without file_id provided")?
+            exec_err!("can't create path for sort shuffle without file_id provided")?
         }
     }
 

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -51,6 +51,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::BufReader;
+use std::path::Path;
 use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
@@ -70,6 +71,7 @@ pub struct ShuffleReaderExec {
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     properties: Arc<PlanProperties>,
+    work_dir: String,
 }
 
 impl ShuffleReaderExec {
@@ -92,7 +94,20 @@ impl ShuffleReaderExec {
             partition,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
+            work_dir: "".to_string(), // to be updated at the executor side
         })
+    }
+
+    /// changes work dir where shuffle files are located
+    pub fn change_work_dir(&self, work_dir: String) -> Self {
+        Self {
+            stage_id: self.stage_id,
+            schema: self.schema.clone(),
+            partition: self.partition.clone(),
+            metrics: self.metrics.clone(),
+            properties: self.properties.clone(),
+            work_dir,
+        }
     }
 }
 
@@ -189,7 +204,8 @@ impl ExecutionPlan for ShuffleReaderExec {
             .collect();
         // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
         partition_locations.shuffle(&mut rng());
-        let response_receiver = send_fetch_partitions(partition_locations, config);
+        let response_receiver =
+            send_fetch_partitions(&self.work_dir, partition_locations, config);
 
         let input_stream = Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
@@ -374,19 +390,21 @@ impl Stream for AbortableReceiverStream {
 /// while remote partitions are fetched using the Arrow Flight client.
 /// If `force_remote_read` is true, all partitions are treated as remote.
 fn local_remote_read_split(
+    work_dir: &str,
     partition_locations: Vec<PartitionLocation>,
     force_remote_read: bool,
 ) -> (Vec<PartitionLocation>, Vec<PartitionLocation>) {
     if !force_remote_read {
         partition_locations
             .into_iter()
-            .partition(check_is_local_location)
+            .partition(|p| p.path(work_dir).map(|p| p.exists()).unwrap_or(false))
     } else {
         (vec![], partition_locations)
     }
 }
 
 fn send_fetch_partitions(
+    work_dir: &str,
     partition_locations: Vec<PartitionLocation>,
     config: &SessionConfig,
 ) -> AbortableReceiverStream {
@@ -398,6 +416,7 @@ fn send_fetch_partitions(
     let mut spawned_tasks: Vec<SpawnedTask<()>> = vec![];
 
     let (local_locations, remote_locations): (Vec<_>, Vec<_>) = local_remote_read_split(
+        work_dir,
         partition_locations,
         config.ballista_shuffle_reader_force_remote_read(),
     );
@@ -414,11 +433,11 @@ fn send_fetch_partitions(
     //
     // fetching local partitions (read from file)
     //
-
+    let work_dir = work_dir.to_string();
     spawned_tasks.push(SpawnedTask::spawn_blocking({
         move || {
             for p in local_locations {
-                let r = fetch_partition_local(&p, sort_shuffle_enabled);
+                let r = fetch_partition_local(work_dir.clone(), &p, sort_shuffle_enabled);
                 if let Err(e) = response_sender_c.blocking_send(r) {
                     error!("Fail to send response event to the channel due to {e}");
                 }
@@ -463,10 +482,6 @@ fn send_fetch_partitions(
     AbortableReceiverStream::create(response_receiver, spawned_tasks)
 }
 
-fn check_is_local_location(location: &PartitionLocation) -> bool {
-    std::path::Path::new(location.path.as_str()).exists()
-}
-
 async fn new_ballista_client(
     host: &str,
     port: u16,
@@ -488,6 +503,8 @@ async fn fetch_partition_remote(
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
+    let file_id = location.file_id;
+    let is_sort_shuffle = location.is_sort_shuffle;
     let host = metadata.host.as_str();
     let port = metadata.port;
 
@@ -508,15 +525,22 @@ async fn fetch_partition_remote(
             })?;
 
     ballista_client
-        .fetch_partition(&metadata.id, partition_id, &location.path, prefer_flight)
+        .fetch_partition(
+            &metadata.id,
+            partition_id,
+            file_id,
+            is_sort_shuffle,
+            prefer_flight,
+        )
         .await
 }
 
 fn fetch_partition_local(
+    work_dir: String,
     location: &PartitionLocation,
     sort_shuffle_enabled: bool,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
-    let path = &location.path;
+    let path = &location.path(&work_dir)?;
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
     let data_path = std::path::Path::new(path);
@@ -548,7 +572,7 @@ fn fetch_partition_local(
             )
         });
     }
-
+    debug!("fetch local partition file: {data_path:?} ");
     // Standard hash-based shuffle - read the file directly
     let reader = fetch_partition_local_inner(path).map_err(|e| {
         // return BallistaError::FetchFailed may let scheduler retry this task.
@@ -563,10 +587,12 @@ fn fetch_partition_local(
 }
 
 fn fetch_partition_local_inner(
-    path: &str,
+    path: &Path,
 ) -> result::Result<StreamReader<BufReader<File>>, BallistaError> {
     let file = File::open(path).map_err(|e| {
-        BallistaError::General(format!("Failed to open partition file at {path}: {e:?}"))
+        BallistaError::General(format!(
+            "Failed to open partition file at {path:?}: {e:?}"
+        ))
     })?;
     // TODO: make this configurable
     let file = BufReader::with_capacity(256 * 1024, file);
@@ -575,7 +601,7 @@ fn fetch_partition_local_inner(
         StreamReader::try_new(file, None)
             .map_err(|e| {
                 BallistaError::General(format!(
-                    "Failed to create new arrow StreamReader at {path}: {e:?}"
+                    "Failed to create new arrow StreamReader at {path:?}: {e:?}"
                 ))
             })?
             .with_skip_validation(cfg!(feature = "arrow-ipc-optimizations"))
@@ -677,7 +703,7 @@ impl RecordBatchStream for CoalescedShuffleReaderStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::execution_plans::ShuffleWriterExec;
+    use crate::execution_plans::{ShuffleWriterExec, create_shuffle_path};
     use crate::serde::scheduler::{ExecutorMetadata, ExecutorSpecification, PartitionId};
     use crate::utils;
     use datafusion::arrow::array::{Int32Array, StringArray, UInt32Array};
@@ -689,7 +715,6 @@ mod tests {
     use datafusion::datasource::source::DataSourceExec;
     use datafusion::physical_expr::expressions::Column;
     use datafusion::physical_plan::common;
-
     use datafusion::prelude::SessionContext;
     use tempfile::{TempDir, tempdir};
 
@@ -788,7 +813,8 @@ mod tests {
                     num_batches: None,
                     num_bytes: Some(10),
                 },
-                path: "test_path".to_string(),
+                file_id: None,
+                is_sort_shuffle: false,
             })
         }
 
@@ -837,7 +863,8 @@ mod tests {
                     num_batches: None,
                     num_bytes: Some(10),
                 },
-                path: "test_path".to_string(),
+                file_id: None,
+                is_sort_shuffle: false,
             })
         }
 
@@ -887,7 +914,8 @@ mod tests {
                     num_batches: None,
                     num_bytes: Some(10),
                 },
-                path: "test_path".to_string(),
+                file_id: None,
+                is_sort_shuffle: false,
             })
         }
 
@@ -933,7 +961,8 @@ mod tests {
                     specification: ExecutorSpecification { task_slots: 1 },
                 },
                 partition_stats: Default::default(),
-                path: "test_path".to_string(),
+                file_id: None,
+                is_sort_shuffle: false,
             })
         }
 
@@ -995,7 +1024,7 @@ mod tests {
             .unwrap();
 
         // from to input partitions test the first one with two batches
-        let file_path = path.value(0);
+        let file_path = Path::new(path.value(0));
         let reader = fetch_partition_local_inner(file_path).unwrap();
 
         let mut stream: Pin<Box<dyn RecordBatchStream + Send>> =
@@ -1022,21 +1051,34 @@ mod tests {
             RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
                 .unwrap();
         let tmp_dir = tempdir().unwrap();
-        let file_path = tmp_dir.path().join("shuffle_data");
+        let work_dir = tmp_dir.path();
+
+        // job name and stage id are hard-codded
+        let file_path = create_shuffle_path(work_dir, "job", 1, 0, None, false).unwrap();
+
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+
         let file = File::create(&file_path).unwrap();
         let mut writer = StreamWriter::try_new(file, &schema).unwrap();
         writer.write(&batch).unwrap();
         writer.finish().unwrap();
 
-        let partition_locations =
-            get_test_partition_locations(1, file_path.to_str().unwrap().to_string());
+        let partition_locations = get_test_partition_locations(1, None);
 
-        let (local, remote) = local_remote_read_split(partition_locations.clone(), false);
+        let (local, remote) = local_remote_read_split(
+            work_dir.to_string_lossy().as_ref(),
+            partition_locations.clone(),
+            false,
+        );
 
         assert!(!local.is_empty());
         assert!(remote.is_empty());
 
-        let (local, remote) = local_remote_read_split(partition_locations, true);
+        let (local, remote) = local_remote_read_split(
+            work_dir.to_string_lossy().as_ref(),
+            partition_locations,
+            true,
+        );
 
         assert!(local.is_empty());
         assert!(!remote.is_empty());
@@ -1049,20 +1091,31 @@ mod tests {
             RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
                 .unwrap();
         let tmp_dir = tempdir().unwrap();
-        let file_path = tmp_dir.path().join("shuffle_data");
-        let file = File::create(&file_path).unwrap();
-        let mut writer = StreamWriter::try_new(file, &schema).unwrap();
-        writer.write(&batch).unwrap();
-        writer.finish().unwrap();
+        let work_dir = tmp_dir.path();
 
-        let partition_locations = get_test_partition_locations(
-            partition_num,
-            file_path.to_str().unwrap().to_string(),
-        );
+        for p in 0..partition_num {
+            // job name and stage id are hard-codded
+            let file_path =
+                create_shuffle_path(work_dir, "job", 1, p, None, false).unwrap();
+            // this unwrap should not be problem as
+            // this function never return root dir
+            std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+            let file: File = File::create(&file_path).unwrap();
+
+            let mut writer = StreamWriter::try_new(file, &schema).unwrap();
+            writer.write(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let partition_locations = get_test_partition_locations(partition_num, None);
         let config = SessionConfig::new_with_ballista()
             .with_ballista_shuffle_reader_maximum_concurrent_requests(max_request_num);
 
-        let response_receiver = send_fetch_partitions(partition_locations, &config);
+        let response_receiver = send_fetch_partitions(
+            &work_dir.to_string_lossy(),
+            partition_locations,
+            &config,
+        );
 
         let stream = RecordBatchStreamAdapter::new(
             Arc::new(schema),
@@ -1073,7 +1126,10 @@ mod tests {
         assert_eq!(partition_num, result.len());
     }
 
-    fn get_test_partition_locations(n: usize, path: String) -> Vec<PartitionLocation> {
+    fn get_test_partition_locations(
+        n: usize,
+        file_id: Option<u64>,
+    ) -> Vec<PartitionLocation> {
         (0..n)
             .map(|partition_id| PartitionLocation {
                 map_partition_id: 0,
@@ -1090,7 +1146,8 @@ mod tests {
                     specification: ExecutorSpecification { task_slots: 12 },
                 },
                 partition_stats: Default::default(),
-                path: path.clone(),
+                file_id,
+                is_sort_shuffle: false,
             })
             .collect()
     }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -437,7 +437,7 @@ fn send_fetch_partitions(
     spawned_tasks.push(SpawnedTask::spawn_blocking({
         move || {
             for p in local_locations {
-                let r = fetch_partition_local(work_dir.clone(), &p, sort_shuffle_enabled);
+                let r = fetch_partition_local(&work_dir, &p, sort_shuffle_enabled);
                 if let Err(e) = response_sender_c.blocking_send(r) {
                     error!("Fail to send response event to the channel due to {e}");
                 }
@@ -536,11 +536,11 @@ async fn fetch_partition_remote(
 }
 
 fn fetch_partition_local(
-    work_dir: String,
+    work_dir: &str,
     location: &PartitionLocation,
     sort_shuffle_enabled: bool,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
-    let path = &location.path(&work_dir)?;
+    let path = &location.path(work_dir)?;
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
     let data_path = std::path::Path::new(path);

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -1053,7 +1053,7 @@ mod tests {
         let tmp_dir = tempdir().unwrap();
         let work_dir = tmp_dir.path();
 
-        // job name and stage id are hard-codded
+        // job name and stage id are hard-coded
         let file_path = create_shuffle_path(work_dir, "job", 1, 0, None, false).unwrap();
 
         std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -71,7 +71,7 @@ pub struct ShuffleReaderExec {
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     properties: Arc<PlanProperties>,
-    work_dir: String,
+    work_dir: Option<String>,
 }
 
 impl ShuffleReaderExec {
@@ -94,7 +94,7 @@ impl ShuffleReaderExec {
             partition,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
-            work_dir: "".to_string(), // to be updated at the executor side
+            work_dir: None, // to be updated at the executor side
         })
     }
 
@@ -106,7 +106,7 @@ impl ShuffleReaderExec {
             partition: self.partition.clone(),
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
-            work_dir,
+            work_dir: Some(work_dir),
         }
     }
 }
@@ -204,8 +204,16 @@ impl ExecutionPlan for ShuffleReaderExec {
             .collect();
         // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
         partition_locations.shuffle(&mut rng());
+
+        let work_dir = self
+            .work_dir
+            .as_ref()
+            .ok_or(DataFusionError::Configuration(
+                "ShuffleReader work dir should have been set by executor".to_owned(),
+            ))?;
+
         let response_receiver =
-            send_fetch_partitions(&self.work_dir, partition_locations, config);
+            send_fetch_partitions(work_dir, partition_locations, config);
 
         let input_stream = Box::pin(RecordBatchStreamAdapter::new(
             self.schema.clone(),
@@ -965,13 +973,16 @@ mod tests {
                 is_sort_shuffle: false,
             })
         }
+        let work_dir = TempDir::new().unwrap();
 
+        let work_dir = work_dir.path().to_str().unwrap().to_owned();
         let shuffle_reader_exec = ShuffleReaderExec::try_new(
             input_stage_id,
             vec![partitions],
             Arc::new(schema),
             Partitioning::UnknownPartitioning(4),
-        )?;
+        )?
+        .change_work_dir(work_dir);
         let mut stream = shuffle_reader_exec.execute(0, task_ctx)?;
         let batches = utils::collect_stream(&mut stream).await;
 

--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -35,6 +35,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::execution_plans::create_shuffle_path;
 use crate::utils;
 
 use crate::serde::protobuf::ShuffleWritePartition;
@@ -200,10 +201,6 @@ impl ShuffleWriterExec {
         input_partition: usize,
         context: Arc<TaskContext>,
     ) -> impl Future<Output = Result<Vec<ShuffleWritePartition>>> {
-        let mut path = PathBuf::from(&self.work_dir);
-        path.push(&self.job_id);
-        path.push(format!("{}", self.stage_id));
-
         let write_metrics = ShuffleWriteMetrics::new(input_partition, &self.metrics);
         let output_partitioning = self.shuffle_output_partitioning.clone();
         let plan = self.plan.clone();
@@ -215,16 +212,26 @@ impl ShuffleWriterExec {
             match output_partitioning {
                 None => {
                     let timer = write_metrics.write_time.timer();
-                    path.push(format!("{input_partition}"));
-                    std::fs::create_dir_all(&path)?;
-                    path.push("data.arrow");
-                    let path = path.to_str().unwrap();
-                    debug!("Writing results to {path}");
+
+                    let path = create_shuffle_path(
+                        &self.work_dir,
+                        &self.job_id,
+                        self.stage_id,
+                        input_partition,
+                        None,
+                        false,
+                    )?;
+
+                    if let Some(parent) = path.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+
+                    debug!("Writing results to {path:?}");
 
                     // stream results to disk
                     let stats = utils::write_stream_to_disk(
                         &mut stream,
-                        path,
+                        path.as_path(),
                         &write_metrics.write_time,
                     )
                     .await
@@ -247,10 +254,11 @@ impl ShuffleWriterExec {
 
                     Ok(vec![ShuffleWritePartition {
                         partition_id: input_partition as u64,
-                        path: path.to_owned(),
                         num_batches: stats.num_batches.unwrap_or(0),
                         num_rows: stats.num_rows.unwrap_or(0),
                         num_bytes: stats.num_bytes.unwrap_or(0),
+                        file_id: None,
+                        is_sort_shuffle: false,
                     }])
                 }
 
@@ -285,13 +293,19 @@ impl ShuffleWriterExec {
                                         w.writer.write(&output_batch)?;
                                     }
                                     None => {
-                                        let mut path = path.clone();
-                                        path.push(format!("{output_partition}"));
-                                        std::fs::create_dir_all(&path)?;
+                                        let path = create_shuffle_path(
+                                            &self.work_dir,
+                                            &self.job_id,
+                                            self.stage_id,
+                                            output_partition,
+                                            Some(input_partition as u64),
+                                            false,
+                                        )?;
 
-                                        path.push(format!(
-                                            "data-{input_partition}.arrow"
-                                        ));
+                                        if let Some(parent) = path.parent() {
+                                            std::fs::create_dir_all(parent)?;
+                                        }
+
                                         debug!("Writing results to {path:?}");
 
                                         let options = IpcWriteOptions::default()
@@ -337,10 +351,11 @@ impl ShuffleWriterExec {
 
                             part_locs.push(ShuffleWritePartition {
                                 partition_id: i as u64,
-                                path: w.path.to_string_lossy().to_string(),
                                 num_batches: w.num_batches as u64,
                                 num_rows: w.num_rows as u64,
                                 num_bytes,
+                                file_id: Some(input_partition as u64),
+                                is_sort_shuffle: false,
                             });
                         }
                     }
@@ -440,10 +455,13 @@ impl ExecutionPlan for ShuffleWriterExec {
         let schema = result_schema();
 
         let schema_captured = schema.clone();
+        let job_id = self.job_id.to_string();
+        let work_dir = self.work_dir.to_string();
+        let stage_id = self.stage_id;
         let fut_stream = self
             .clone()
             .execute_shuffle_write(partition, context)
-            .and_then(|part_loc| async move {
+            .and_then(move |part_loc| async move {
                 // build metadata result batch
                 let num_writers = part_loc.len();
                 let mut partition_builder = UInt32Builder::with_capacity(num_writers);
@@ -454,7 +472,18 @@ impl ExecutionPlan for ShuffleWriterExec {
                 let mut num_bytes_builder = UInt64Builder::with_capacity(num_writers);
 
                 for loc in &part_loc {
-                    path_builder.append_value(loc.path.clone());
+                    let path = create_shuffle_path(
+                        &work_dir,
+                        &job_id,
+                        stage_id,
+                        loc.partition_id as usize,
+                        loc.file_id,
+                        false,
+                    )?
+                    .to_string_lossy()
+                    .to_string();
+
+                    path_builder.append_value(path);
                     partition_builder.append_value(loc.partition_id as u32);
                     num_rows_builder.append_value(loc.num_rows);
                     num_batches_builder.append_value(loc.num_batches);
@@ -586,6 +615,7 @@ mod tests {
                 || file0.ends_with("\\jobOne\\1\\0\\data-0.arrow")
         );
         let file1 = path.value(1);
+
         assert!(
             file1.ends_with("/jobOne/1/1/data-0.arrow")
                 || file1.ends_with("\\jobOne\\1\\1\\data-0.arrow")

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -34,6 +34,7 @@ use super::buffer::PartitionBuffer;
 use super::config::SortShuffleConfig;
 use super::index::ShuffleIndex;
 use super::spill::SpillManager;
+use crate::execution_plans::create_shuffle_path;
 use crate::serde::protobuf::ShuffleWritePartition;
 
 use datafusion::arrow::array::{
@@ -312,10 +313,12 @@ impl SortShuffleWriterExec {
                 if num_rows > 0 {
                     results.push(ShuffleWritePartition {
                         partition_id: part_id as u64,
-                        path: data_path.to_string_lossy().to_string(),
+                        //path: data_path.to_string_lossy().to_string(),
                         num_batches,
                         num_rows,
                         num_bytes,
+                        file_id: Some(input_partition as u64),
+                        is_sort_shuffle: true,
                     });
                 }
             }
@@ -535,10 +538,13 @@ impl ExecutionPlan for SortShuffleWriterExec {
         let schema = result_schema();
 
         let schema_captured = schema.clone();
+        let job_id = self.job_id.to_string();
+        let work_dir = self.work_dir.to_string();
+        let stage_id = self.stage_id;
         let fut_stream = self
             .clone()
             .execute_shuffle_write(partition, context)
-            .and_then(|part_loc| async move {
+            .and_then(move |part_loc| async move {
                 // Build metadata result batch
                 let num_writers = part_loc.len();
                 let mut partition_builder = UInt32Builder::with_capacity(num_writers);
@@ -549,7 +555,18 @@ impl ExecutionPlan for SortShuffleWriterExec {
                 let mut num_bytes_builder = UInt64Builder::with_capacity(num_writers);
 
                 for loc in &part_loc {
-                    path_builder.append_value(loc.path.clone());
+                    path_builder.append_value(
+                        create_shuffle_path(
+                            &work_dir,
+                            &job_id,
+                            stage_id,
+                            partition,
+                            loc.file_id,
+                            true,
+                        )?
+                        .to_string_lossy(),
+                    );
+
                     partition_builder.append_value(loc.partition_id as u32);
                     num_rows_builder.append_value(loc.num_rows);
                     num_batches_builder.append_value(loc.num_batches);

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -351,12 +351,14 @@ pub struct FetchPartition {
     pub stage_id: u32,
     #[prost(uint32, tag = "3")]
     pub partition_id: u32,
-    #[prost(string, tag = "4")]
-    pub path: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
     pub host: ::prost::alloc::string::String,
     #[prost(uint32, tag = "6")]
     pub port: u32,
+    #[prost(uint64, optional, tag = "7")]
+    pub file_id: ::core::option::Option<u64>,
+    #[prost(bool, tag = "8")]
+    pub is_sort_shuffle: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionLocation {
@@ -370,8 +372,10 @@ pub struct PartitionLocation {
     pub executor_meta: ::core::option::Option<ExecutorMetadata>,
     #[prost(message, optional, tag = "4")]
     pub partition_stats: ::core::option::Option<PartitionStats>,
-    #[prost(string, tag = "5")]
-    pub path: ::prost::alloc::string::String,
+    #[prost(uint64, optional, tag = "6")]
+    pub file_id: ::core::option::Option<u64>,
+    #[prost(bool, tag = "7")]
+    pub is_sort_shuffle: bool,
 }
 /// Unique identifier for a materialized partition of data
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -687,18 +691,20 @@ pub struct ExecutorLost {}
 pub struct ResultLost {}
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TaskKilled {}
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ShuffleWritePartition {
     #[prost(uint64, tag = "1")]
     pub partition_id: u64,
-    #[prost(string, tag = "2")]
-    pub path: ::prost::alloc::string::String,
     #[prost(uint64, tag = "3")]
     pub num_batches: u64,
     #[prost(uint64, tag = "4")]
     pub num_rows: u64,
     #[prost(uint64, tag = "5")]
     pub num_bytes: u64,
+    #[prost(uint64, optional, tag = "6")]
+    pub file_id: ::core::option::Option<u64>,
+    #[prost(bool, tag = "7")]
+    pub is_sort_shuffle: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskStatus {

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -55,9 +55,10 @@ impl TryInto<Action> for protobuf::Action {
                     job_id: fetch.job_id,
                     stage_id: fetch.stage_id as usize,
                     partition_id: fetch.partition_id as usize,
-                    path: fetch.path,
+                    file_id: fetch.file_id,
                     host: fetch.host,
                     port: fetch.port as u16,
+                    is_sort_shuffle: fetch.is_sort_shuffle,
                 })
             }
             _ => Err(BallistaError::General(
@@ -123,7 +124,8 @@ impl TryInto<PartitionLocation> for protobuf::PartitionLocation {
                     )
                 })?
                 .into(),
-            path: self.path,
+            file_id: self.file_id,
+            is_sort_shuffle: self.is_sort_shuffle,
         })
     }
 }

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::BallistaError;
+use crate::execution_plans::create_shuffle_path;
 use crate::registry::BallistaFunctionRegistry;
 use datafusion::arrow::array::{
     ArrayBuilder, StructArray, StructBuilder, UInt64Array, UInt64Builder,
@@ -26,6 +27,7 @@ use datafusion::physical_plan::Partitioning;
 use datafusion::prelude::SessionConfig;
 use serde::Serialize;
 use std::fmt::Debug;
+use std::path::PathBuf;
 use std::{collections::HashMap, fmt, sync::Arc};
 
 /// Conversions from protobuf types to Ballista types.
@@ -44,12 +46,16 @@ pub enum Action {
         stage_id: usize,
         /// The partition identifier within the stage.
         partition_id: usize,
-        /// File path to the partition data.
-        path: String,
+        // /// File path to the partition data.
+        // path: String,
         /// Hostname or IP address of the executor hosting this partition.
         host: String,
         /// Port number for data transfer.
         port: u16,
+        /// shuffle file block id
+        file_id: Option<u64>,
+        /// is shuffle partition sort partition
+        is_sort_shuffle: bool,
     },
 }
 
@@ -86,8 +92,24 @@ pub struct PartitionLocation {
     pub executor_meta: ExecutorMetadata,
     /// Statistics about the partition data.
     pub partition_stats: PartitionStats,
-    /// File path to the partition data.
-    pub path: String,
+    /// shuffle file id
+    pub file_id: Option<u64>,
+    /// is shuffle partition sort partition
+    pub is_sort_shuffle: bool,
+}
+
+impl PartitionLocation {
+    /// creates file actuall file location
+    pub fn path(&self, work_dir: &str) -> datafusion::error::Result<PathBuf> {
+        create_shuffle_path(
+            work_dir,
+            &self.partition_id.job_id,
+            self.partition_id.stage_id,
+            self.partition_id.partition_id,
+            self.file_id,
+            self.is_sort_shuffle,
+        )
+    }
 }
 
 /// Meta-data for an executor, used when fetching shuffle partitions from other executors.

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -99,7 +99,7 @@ pub struct PartitionLocation {
 }
 
 impl PartitionLocation {
-    /// creates file actuall file location
+    /// creates file actual file location
     pub fn path(&self, work_dir: &str) -> datafusion::error::Result<PathBuf> {
         create_shuffle_path(
             work_dir,

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -54,7 +54,7 @@ pub enum Action {
         port: u16,
         /// shuffle file block id
         file_id: Option<u64>,
-        /// is shuffle partition sort partition
+        /// whether this partition uses sort shuffle
         is_sort_shuffle: bool,
     },
 }

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -94,7 +94,7 @@ pub struct PartitionLocation {
     pub partition_stats: PartitionStats,
     /// shuffle file id
     pub file_id: Option<u64>,
-    /// is shuffle partition sort partition
+    /// whether this partition uses sort shuffle
     pub is_sort_shuffle: bool,
 }
 

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -46,8 +46,6 @@ pub enum Action {
         stage_id: usize,
         /// The partition identifier within the stage.
         partition_id: usize,
-        // /// File path to the partition data.
-        // path: String,
         /// Hostname or IP address of the executor hosting this partition.
         host: String,
         /// Port number for data transfer.

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -40,17 +40,19 @@ impl TryInto<protobuf::Action> for Action {
                 job_id,
                 stage_id,
                 partition_id,
-                path,
+                file_id,
                 host,
                 port,
+                is_sort_shuffle,
             } => Ok(protobuf::Action {
                 action_type: Some(ActionType::FetchPartition(protobuf::FetchPartition {
                     job_id,
                     stage_id: stage_id as u32,
                     partition_id: partition_id as u32,
-                    path,
                     host,
                     port: port as u32,
+                    file_id,
+                    is_sort_shuffle,
                 })),
                 settings: vec![],
             }),
@@ -78,7 +80,8 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
             partition_id: Some(self.partition_id.into()),
             executor_meta: Some(self.executor_meta.into()),
             partition_stats: Some(self.partition_stats.into()),
-            path: self.path,
+            file_id: self.file_id,
+            is_sort_shuffle: self.is_sort_shuffle,
         })
     }
 }

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -32,6 +32,7 @@ use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream, metrics};
 use futures::StreamExt;
 use log::error;
 use std::io::BufWriter;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs::File, pin::Pin};
@@ -162,11 +163,11 @@ pub fn default_config_producer() -> SessionConfig {
 /// Stream data to disk in Arrow IPC format
 pub async fn write_stream_to_disk(
     stream: &mut Pin<Box<dyn RecordBatchStream + Send>>,
-    path: &str,
+    path: &Path,
     disk_write_metric: &metrics::Time,
 ) -> Result<PartitionStats> {
     let file = BufWriter::new(File::create(path).map_err(|e| {
-        error!("Failed to create partition file at {path}: {e:?}");
+        error!("Failed to create partition file at {path:?}: {e:?}");
         BallistaError::IoError(e)
     })?);
 

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -22,10 +22,11 @@
 //! for creating query stage executors from physical plans.
 
 use async_trait::async_trait;
-use ballista_core::execution_plans::ShuffleWriterExec;
 use ballista_core::execution_plans::sort_shuffle::SortShuffleWriterExec;
+use ballista_core::execution_plans::{ShuffleReaderExec, ShuffleWriterExec};
 use ballista_core::serde::protobuf::ShuffleWritePartition;
 use ballista_core::utils;
+use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
@@ -89,6 +90,17 @@ impl ExecutionEngine for DefaultExecutionEngine {
         plan: Arc<dyn ExecutionPlan>,
         work_dir: &str,
     ) -> Result<Arc<dyn QueryStageExecutor>> {
+        let plan = plan
+            .transform(|p| {
+                if let Some(reader) = p.as_any().downcast_ref::<ShuffleReaderExec>() {
+                    let reader = Arc::new(reader.change_work_dir(work_dir.to_string()));
+                    Ok(Transformed::yes(reader))
+                } else {
+                    Ok(Transformed::no(p))
+                }
+            })?
+            .data;
+
         // the query plan created by the scheduler always starts with a shuffle writer
         // (either ShuffleWriterExec or SortShuffleWriterExec)
         if let Some(shuffle_writer) = plan.as_any().downcast_ref::<ShuffleWriterExec>() {

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -378,6 +378,7 @@ pub async fn start_executor_process(
 
     // Graceful shutdown notification
     let shutdown_notification = ShutdownNotifier::new();
+    let flight_work_dir = work_dir.clone();
 
     if opt.job_data_clean_up_interval_seconds > 0 {
         let mut interval_time =
@@ -442,11 +443,12 @@ pub async fn start_executor_process(
     };
     let shutdown = shutdown_notification.subscribe_for_shutdown();
     let override_flight = opt.override_arrow_flight_service.clone();
-
+    //let wd = work_dir.clone();
     service_handlers.push(match override_flight {
         None => {
             info!("Starting built-in arrow flight service");
             flight_server_task(
+                flight_work_dir,
                 address,
                 shutdown,
                 opt.grpc_max_encoding_message_size as usize,
@@ -457,7 +459,12 @@ pub async fn start_executor_process(
         }
         Some(flight_provider) => {
             info!("Starting custom, user provided, arrow flight service");
-            (flight_provider)(address, shutdown, opt.grpc_server_config.clone())
+            (flight_provider)(
+                flight_work_dir,
+                address,
+                shutdown,
+                opt.grpc_server_config.clone(),
+            )
         }
     });
 
@@ -557,6 +564,7 @@ pub async fn start_executor_process(
 
 // Arrow flight service
 async fn flight_server_task(
+    work_dir: String,
     address: SocketAddr,
     mut grpc_shutdown: Shutdown,
     max_encoding_message_size: usize,
@@ -570,7 +578,7 @@ async fn flight_server_task(
 
         let server_future = create_grpc_server(&grpc_server_config)
             .add_service(
-                FlightServiceServer::new(BallistaFlightService::new())
+                FlightServiceServer::new(BallistaFlightService::new(work_dir))
                     .max_decoding_message_size(max_decoding_message_size)
                     .max_encoding_message_size(max_encoding_message_size),
             )
@@ -811,7 +819,7 @@ mod tests {
     async fn test_arrow_flight_provider_ergonomics() {
         let config = crate::executor_process::ExecutorProcessConfig {
             override_arrow_flight_service: Some(std::sync::Arc::new(
-                move |address, mut grpc_shutdown, ballista_config| {
+                move |work_dir, address, mut grpc_shutdown, ballista_config| {
                     tokio::spawn(async move {
                         log::info!(
                             "custom arrow flight server listening on: {address:?}"
@@ -822,7 +830,9 @@ mod tests {
                         )
                         .add_service(
                             arrow_flight::flight_service_server::FlightServiceServer::new(
-                                crate::flight_service::BallistaFlightService::new(),
+                                crate::flight_service::BallistaFlightService::new(
+                                    work_dir,
+                                ),
                             ),
                         )
                         .serve_with_shutdown(address, grpc_shutdown.recv());

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -17,10 +17,10 @@
 
 //! Implementation of the Apache Arrow Flight protocol that wraps an executor.
 
+use ballista_core::execution_plans::create_shuffle_path;
 use datafusion::arrow::ipc::reader::StreamReader;
 use std::convert::TryFrom;
 use std::fs::File;
-use std::path::Path;
 use std::pin::Pin;
 use tokio_util::io::ReaderStream;
 
@@ -58,18 +58,14 @@ use tonic::{Request, Response, Status, Streaming};
 /// It supports both decoded streaming via `do_get` and optimized block transfer
 /// via the `IO_BLOCK_TRANSPORT` action.
 #[derive(Clone)]
-pub struct BallistaFlightService {}
+pub struct BallistaFlightService {
+    work_dir: String,
+}
 
 impl BallistaFlightService {
     /// Creates a new BallistaFlightService instance.
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for BallistaFlightService {
-    fn default() -> Self {
-        Self::new()
+    pub fn new(work_dir: String) -> Self {
+        Self { work_dir }
     }
 }
 
@@ -100,21 +96,33 @@ impl FlightService for BallistaFlightService {
 
         match &action {
             BallistaAction::FetchPartition {
-                path, partition_id, ..
+                job_id,
+                stage_id,
+                partition_id,
+                file_id,
+                is_sort_shuffle,
+                ..
             } => {
-                debug!("FetchPartition reading partition {partition_id} from {path}");
-                let data_path = Path::new(path);
+                let path = create_shuffle_path(
+                    &self.work_dir,
+                    job_id,
+                    *stage_id,
+                    *partition_id,
+                    *file_id,
+                    *is_sort_shuffle,
+                )
+                .map_err(|e| {
+                    Status::internal(format!("I/O error, cant create shuffle path: {e}"))
+                })?;
+                debug!("FetchPartition reading partition {partition_id} from {path:?}");
 
                 // Check if this is a sort-based shuffle output
-                if is_sort_shuffle_output(data_path) {
-                    debug!("Detected sort-based shuffle format for {path}");
-                    let index_path = get_index_path(data_path);
-                    let stream = stream_sort_shuffle_partition(
-                        data_path,
-                        &index_path,
-                        *partition_id,
-                    )
-                    .map_err(|e| from_ballista_err(&e))?;
+                if is_sort_shuffle_output(&path) {
+                    debug!("Detected sort-based shuffle format for {path:?}");
+                    let index_path = get_index_path(path.as_path());
+                    let stream =
+                        stream_sort_shuffle_partition(&path, &index_path, *partition_id)
+                            .map_err(|e| from_ballista_err(&e))?;
 
                     let schema = stream.schema();
                     // Map DataFusionError to FlightError
@@ -136,10 +144,10 @@ impl FlightService for BallistaFlightService {
                 }
 
                 // Standard hash-based shuffle - read the entire file
-                let file = File::open(path)
+                let file = File::open(path.clone())
                     .map_err(|e| {
                         BallistaError::General(format!(
-                            "Failed to open partition file at {path}: {e:?}"
+                            "Failed to open partition file at {path:?}: {e:?}"
                         ))
                     })
                     .map_err(|e| from_ballista_err(&e))?;
@@ -251,14 +259,34 @@ impl FlightService for BallistaFlightService {
                     decode_protobuf(&action.body).map_err(|e| from_ballista_err(&e))?;
 
                 match &action {
-                    BallistaAction::FetchPartition { path, .. } => {
-                        debug!("FetchPartition reading {path}");
-                        let data_path = Path::new(path);
+                    BallistaAction::FetchPartition {
+                        job_id,
+                        stage_id,
+                        partition_id,
+                        file_id,
+                        is_sort_shuffle,
+                        ..
+                    } => {
+                        let path = create_shuffle_path(
+                            &self.work_dir,
+                            job_id,
+                            *stage_id,
+                            *partition_id,
+                            *file_id,
+                            *is_sort_shuffle,
+                        )
+                        .map_err(|e| {
+                            Status::internal(format!(
+                                "I/O error, cant create shuffle path: {e}"
+                            ))
+                        })?;
+
+                        debug!("FetchPartition reading {path:?}");
 
                         // Block transport doesn't support sort-based shuffle because it
                         // transfers the entire file, which contains all partitions.
                         // Use flight transport (do_get) for sort-based shuffle.
-                        if is_sort_shuffle_output(data_path) {
+                        if is_sort_shuffle_output(&path) {
                             return Err(Status::unimplemented(
                                 "IO_BLOCK_TRANSPORT does not support sort-based shuffle. \
                                  Set ballista.shuffle.remote_read_prefer_flight=true to use \
@@ -271,7 +299,7 @@ impl FlightService for BallistaFlightService {
                         })?;
 
                         debug!(
-                            "streaming file: {} with size: {}",
+                            "streaming file: {:?} with size: {}",
                             path,
                             file.metadata().await?.len()
                         );

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -144,7 +144,7 @@ impl FlightService for BallistaFlightService {
                 }
 
                 // Standard hash-based shuffle - read the entire file
-                let file = File::open(path.clone())
+                let file = File::open(&path)
                     .map_err(|e| {
                         BallistaError::General(format!(
                             "Failed to open partition file at {path:?}: {e:?}"

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -277,7 +277,7 @@ impl FlightService for BallistaFlightService {
                         )
                         .map_err(|e| {
                             Status::internal(format!(
-                                "I/O error, cant create shuffle path: {e}"
+                                "I/O error, can't create shuffle path: {e}"
                             ))
                         })?;
 

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -112,7 +112,7 @@ impl FlightService for BallistaFlightService {
                     *is_sort_shuffle,
                 )
                 .map_err(|e| {
-                    Status::internal(format!("I/O error, cant create shuffle path: {e}"))
+                    Status::internal(format!("I/O error, can't create shuffle path: {e}"))
                 })?;
                 debug!("FetchPartition reading partition {partition_id} from {path:?}");
 

--- a/ballista/executor/src/lib.rs
+++ b/ballista/executor/src/lib.rs
@@ -65,12 +65,14 @@ use ballista_core::utils::GrpcServerConfig;
 /// [ArrowFlightServerProvider] provides a function which creates a new Arrow Flight server.
 ///
 /// The function should take two arguments:
+/// [String] - executor work directory
 /// [SocketAddr] - the address to bind the server to
 /// [Shutdown] - a shutdown signal to gracefully shutdown the server
 /// [GrpcServerConfig] - the gRPC server configuration for timeout settings
 /// Returns a [tokio::task::JoinHandle] which will be registered as service handler
 ///
 pub type ArrowFlightServerProvider = dyn Fn(
+        String,
         SocketAddr,
         Shutdown,
         GrpcServerConfig,

--- a/ballista/executor/src/lib.rs
+++ b/ballista/executor/src/lib.rs
@@ -64,7 +64,7 @@ use ballista_core::utils::GrpcServerConfig;
 
 /// [ArrowFlightServerProvider] provides a function which creates a new Arrow Flight server.
 ///
-/// The function should take two arguments:
+/// The function should take four arguments:
 /// [String] - executor work directory
 /// [SocketAddr] - the address to bind the server to
 /// [Shutdown] - a shutdown signal to gracefully shutdown the server

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -130,7 +130,7 @@ pub async fn new_standalone_executor_from_builder(
         None,
     ));
 
-    let service = BallistaFlightService::new();
+    let service = BallistaFlightService::new(work_dir);
     let server = FlightServiceServer::new(service)
         .max_decoding_message_size(max_message_size)
         .max_encoding_message_size(max_message_size);

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -41,7 +41,7 @@ use datafusion::physical_plan::{
     ExecutionPlan, Partitioning, with_new_children_if_necessary,
 };
 
-use log::{debug, info};
+use log::info;
 
 type PartialQueryStageResult = (Arc<dyn ExecutionPlan>, Vec<Arc<dyn ShuffleWriter>>);
 
@@ -280,19 +280,7 @@ pub fn remove_unresolved_shuffles(
                     relevant_locations.push(vec![]);
                 }
             }
-            debug!(
-                "Creating shuffle reader: {}",
-                relevant_locations
-                    .iter()
-                    .map(|c| c
-                        .iter()
-                        .filter(|l| !l.path.is_empty())
-                        .map(|l| l.path.clone())
-                        .collect::<Vec<_>>()
-                        .join(", "))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            );
+
             new_children.push(Arc::new(ShuffleReaderExec::try_new(
                 unresolved_shuffle.stage_id,
                 relevant_locations,

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -505,10 +505,11 @@ mod test {
                 for partition_id in 0..num_partitions {
                     partitions.push(ShuffleWritePartition {
                         partition_id: partition_id as u64,
-                        path: "some/path".to_string(),
                         num_batches: 1,
                         num_rows: 1,
                         num_bytes: 1,
+                        file_id: None,
+                        is_sort_shuffle: false,
                     })
                 }
 
@@ -549,7 +550,6 @@ mod test {
         assert_eq!(final_graph.output_locations().len(), 4);
 
         for output_location in final_graph.output_locations() {
-            assert_eq!(output_location.path, "some/path".to_owned());
             assert_eq!(output_location.executor_meta.host, "localhost1".to_owned())
         }
 

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -349,13 +349,14 @@ fn small_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             grpc_port: 0,
             specification: ExecutorSpecification { task_slots: 0 },
         },
-        path: "".to_string(),
         // next few properties are needed
         partition_stats: PartitionStats::new(
             Some(threshold_num_rows as u64 / 128),
             None,
             Some(threshold_byte_size as u64 / 128),
         ),
+        file_id: None,
+        is_sort_shuffle: false,
     };
     vec![vec![location]]
 }
@@ -379,13 +380,15 @@ fn big_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             grpc_port: 0,
             specification: ExecutorSpecification { task_slots: 0 },
         },
-        path: "".to_string(),
+
         // next few properties are needed
         partition_stats: PartitionStats::new(
             Some(threshold_num_rows as u64 * 2),
             None,
             Some(threshold_byte_size as u64 * 2),
         ),
+        file_id: None,
+        is_sort_shuffle: false,
     };
     vec![vec![location]]
 }

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -48,9 +48,10 @@ pub(crate) fn mock_partitions_with_statistics() -> Vec<Vec<PartitionLocation>> {
             grpc_port: 0,
             specification: ExecutorSpecification { task_slots: 0 },
         },
-        path: "".to_string(),
         // next few properties are needed
         partition_stats: PartitionStats::new(Some(42), None, Some(10)),
+        file_id: None,
+        is_sort_shuffle: false,
     };
     vec![vec![location]]
 }
@@ -71,9 +72,10 @@ pub(crate) fn mock_partitions_with_statistics_no_data() -> Vec<Vec<PartitionLoca
             grpc_port: 0,
             specification: ExecutorSpecification { task_slots: 0 },
         },
-        path: "".to_string(),
         // next few properties are needed
         partition_stats: PartitionStats::new(Some(0), None, Some(0)),
+        file_id: None,
+        is_sort_shuffle: false,
     };
     vec![vec![location]]
 }

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1748,7 +1748,8 @@ pub(crate) fn partition_to_location(
                 Some(shuffle.num_batches),
                 Some(shuffle.num_bytes),
             ),
-            path: shuffle.path,
+            file_id: shuffle.file_id,
+            is_sort_shuffle: shuffle.is_sort_shuffle,
         })
         .collect()
 }

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -292,10 +292,11 @@ pub fn default_task_runner() -> impl TaskRunner {
         let partitions: Vec<ShuffleWritePartition> = (0..partitions)
             .map(|i| ShuffleWritePartition {
                 partition_id: i as u64,
-                path: String::default(),
                 num_batches: 1,
                 num_rows: 1,
                 num_bytes: 1,
+                file_id: None,
+                is_sort_shuffle: false,
             })
             .collect();
 
@@ -1192,15 +1193,11 @@ pub fn mock_completed_task(task: TaskDescription, executor_id: &str) -> TaskStat
     for partition_id in 0..num_partitions {
         partitions.push(protobuf::ShuffleWritePartition {
             partition_id: partition_id as u64,
-            path: format!(
-                "/{}/{}/{}",
-                task.partition.job_id,
-                task.partition.stage_id,
-                task.partition.partition_id
-            ),
             num_batches: 1,
             num_rows: 1,
             num_bytes: 1,
+            file_id: None,
+            is_sort_shuffle: false,
         })
     }
 
@@ -1231,15 +1228,11 @@ pub fn mock_failed_task(task: TaskDescription, failed_task: FailedTask) -> TaskS
     for partition_id in 0..num_partitions {
         partitions.push(protobuf::ShuffleWritePartition {
             partition_id: partition_id as u64,
-            path: format!(
-                "/{}/{}/{}",
-                task.partition.job_id,
-                task.partition.stage_id,
-                task.partition.partition_id
-            ),
             num_batches: 1,
             num_rows: 1,
             num_bytes: 1,
+            file_id: None,
+            is_sort_shuffle: false,
         })
     }
 

--- a/examples/examples/mtls-cluster.rs
+++ b/examples/examples/mtls-cluster.rs
@@ -392,9 +392,10 @@ async fn run_executor() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     // Start Flight service with mTLS for serving shuffle data
-    let flight_service = FlightServiceServer::new(BallistaFlightService::new())
-        .max_decoding_message_size(16 * 1024 * 1024)
-        .max_encoding_message_size(16 * 1024 * 1024);
+    let flight_service =
+        FlightServiceServer::new(BallistaFlightService::new(work_dir_str))
+            .max_decoding_message_size(16 * 1024 * 1024)
+            .max_encoding_message_size(16 * 1024 * 1024);
 
     // Spawn Flight server with TLS
     let server_tls = tls.server_tls_config();

--- a/examples/examples/standalone-substrait.rs
+++ b/examples/examples/standalone-substrait.rs
@@ -415,7 +415,8 @@ impl SubstraitSchedulerClient {
             .fetch_partition(
                 &metadata.id,
                 &partition_id.into(),
-                &location.path,
+                location.file_id,
+                location.is_sort_shuffle,
                 flight_transport,
             )
             .await


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

- at the moment full path is used to access shuffle files, having full path in each partition location brings quite overhead.
- absolute path is a bio of security issue, probably low but still

# What changes are included in this PR?

- remove full path from partition locations, generate it using available information 
- shuffle reader will have executor path injected in the same way like shuffle writer

there are going to be follow up changes after this one, adding subdiroctory to store shuffle files and session id between work dir and job

# Are there any user-facing changes?

- no 
