### PR TITLE
feat: Refactor DistributedQueryExec to support job callback mechanisim

### DIFF
--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -15,27 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
-use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
+use crate::execution_plans::job_callback_handler::{
+    FetchResultsHandler, JobCompletionAction, JobCompletionHandler,
+};
+use crate::extension::SessionConfigExt;
+use crate::serde::protobuf::SuccessfulJob;
 use crate::serde::protobuf::get_job_status_result::FlightProxy;
 use crate::serde::protobuf::{
     ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult, KeyValuePair,
     PartitionLocation, execute_query_params::Query, execute_query_result, job_status,
     scheduler_grpc_client::SchedulerGrpcClient,
 };
-use crate::serde::protobuf::{ExecutorMetadata, SuccessfulJob};
 use crate::utils::{GrpcClientConfig, create_grpc_client_endpoint};
-use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::error::ArrowError;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_plan::metrics::{
-    ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
-};
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
@@ -45,14 +43,13 @@ use datafusion::prelude::SessionConfig;
 use datafusion_proto::logical_plan::{
     AsLogicalPlan, DefaultLogicalExtensionCodec, LogicalExtensionCodec,
 };
-use futures::{StreamExt, TryFutureExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt};
 use log::{debug, error, info};
 use std::any::Any;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use url::Url;
 
 /// All metadata available after a distributed job finishes successfully.
 pub struct CompletedJob {
@@ -70,114 +67,6 @@ pub struct CompletedJob {
     pub ended_at: u64,
     /// Wall-clock instant at which the job was submitted to the scheduler.
     pub query_start_time: Instant,
-}
-
-/// Determines what happens on the client side after a distributed job finishes
-#[async_trait]
-pub(crate) trait JobCompletionHandler: Send {
-    async fn handle(
-        self: Box<Self>,
-        completed: CompletedJob,
-    ) -> Result<SendableRecordBatchStream>;
-}
-
-pub(crate) struct FetchResultsHandler {
-    scheduler_url: String,
-    schema: SchemaRef,
-    max_message_size: usize,
-    session_config: SessionConfig,
-    metrics: Arc<ExecutionPlanMetricsSet>,
-    partition: usize,
-}
-
-#[async_trait]
-impl JobCompletionHandler for FetchResultsHandler {
-    async fn handle(
-        self: Box<Self>,
-        completed: CompletedJob,
-    ) -> Result<SendableRecordBatchStream> {
-        let FetchResultsHandler {
-            scheduler_url,
-            schema,
-            max_message_size,
-            session_config,
-            metrics,
-            partition,
-        } = *self;
-
-        let customize_endpoint =
-            session_config.ballista_override_create_grpc_client_endpoint();
-        let use_tls = session_config.ballista_use_tls();
-
-        // Calculate job execution time (server-side execution)
-        let job_execution_ms = completed.ended_at.saturating_sub(completed.started_at);
-        // Calculate scheduling time (server-side queue time)
-        // This includes network latency and actual queue time
-        let scheduling_ms = completed.started_at.saturating_sub(completed.queued_at);
-        // Calculate total query time (end-to-end from client perspective)
-        let total_ms = completed.query_start_time.elapsed().as_millis();
-
-        info!(
-            "Job {} finished executing in {:?}",
-            completed.job_id,
-            Duration::from_millis(job_execution_ms)
-        );
-
-        MetricBuilder::new(&metrics)
-            .gauge("job_execution_time_ms", partition)
-            .set(job_execution_ms as usize);
-        MetricBuilder::new(&metrics)
-            .gauge("job_scheduling_in_ms", partition)
-            .set(scheduling_ms as usize);
-        MetricBuilder::new(&metrics)
-            .gauge("total_query_time_ms", partition)
-            .set(total_ms as usize);
-
-        let metric_row_count = MetricBuilder::new(&metrics).output_rows(partition);
-        let metric_total_bytes =
-            MetricBuilder::new(&metrics).counter("transferred_bytes", partition);
-
-        // Note: data_transfer_time_ms is not set here because partition fetching
-        // happens lazily when the stream is consumed, not during execute_query.
-        // This could be added in a future enhancement by wrapping the stream.
-        let flight_proxy = completed.flight_proxy;
-        let streams = completed.partition_location.into_iter().map(move |loc| {
-            let f = fetch_partition(
-                loc,
-                max_message_size,
-                true,
-                scheduler_url.clone(),
-                flight_proxy.clone(),
-                customize_endpoint.clone(),
-                use_tls,
-            )
-            .map_err(|e| ArrowError::ExternalError(Box::new(e)));
-
-            futures::stream::once(f).try_flatten()
-        });
-
-        let stream = futures::stream::iter(streams)
-            .flatten()
-            .inspect(move |batch| {
-                metric_total_bytes.add(
-                    batch
-                        .as_ref()
-                        .map(|b| b.get_array_memory_size())
-                        .unwrap_or(0),
-                );
-                metric_row_count.add(batch.as_ref().map(|b| b.num_rows()).unwrap_or(0));
-            });
-
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
-    }
-}
-
-/// Specifies which [`JobCompletionHandler`] to use after a distributed job
-/// finishes.
-#[derive(Debug, Clone)]
-pub enum JobCompletionAction {
-    /// Fetch result partitions from executors and stream them back (normal query).
-    FetchResults,
 }
 
 /// This operator sends a logical plan to a Ballista scheduler for execution and
@@ -701,155 +590,5 @@ async fn execute_query_push(
                 });
             }
         };
-    }
-}
-
-fn get_client_host_port(
-    executor_metadata: &ExecutorMetadata,
-    scheduler_url: &str,
-    flight_proxy: &Option<FlightProxy>,
-) -> Result<(String, u16)> {
-    fn split_host_port(address: &str) -> Result<(String, u16)> {
-        let url: Url = address.parse().map_err(|e| {
-            DataFusionError::Execution(format!(
-                "Cannot parse host:port in {address:?}: {e}"
-            ))
-        })?;
-        let host = url
-            .host_str()
-            .ok_or(DataFusionError::Execution(format!(
-                "No host in {address:?}"
-            )))?
-            .to_string();
-        let port: u16 = url.port().ok_or(DataFusionError::Execution(format!(
-            "No port in {address:?}"
-        )))?;
-        Ok((host, port))
-    }
-
-    match flight_proxy {
-        Some(FlightProxy::External(address)) => {
-            debug!("Fetching results from external flight proxy: {}", address);
-            split_host_port(format!("http://{address}").as_str())
-        }
-        Some(FlightProxy::Local(true)) => {
-            debug!("Fetching results from scheduler: {}", scheduler_url);
-            split_host_port(scheduler_url)
-        }
-        Some(FlightProxy::Local(false)) | None => {
-            debug!(
-                "Fetching results from executor: {}:{}",
-                executor_metadata.host, executor_metadata.port
-            );
-            Ok((
-                executor_metadata.host.clone(),
-                executor_metadata.port as u16,
-            ))
-        }
-    }
-}
-
-async fn fetch_partition(
-    location: PartitionLocation,
-    max_message_size: usize,
-    flight_transport: bool,
-    scheduler_url: String,
-    flight_proxy: Option<FlightProxy>,
-    customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
-    use_tls: bool,
-) -> Result<SendableRecordBatchStream> {
-    let metadata = location.executor_meta.ok_or_else(|| {
-        DataFusionError::Internal("Received empty executor metadata".to_owned())
-    })?;
-
-    let partition_id = location.partition_id.ok_or_else(|| {
-        DataFusionError::Internal("Received empty partition id".to_owned())
-    })?;
-    let host = metadata.host.as_str();
-    let port = metadata.port as u16;
-
-    let (client_host, client_port) =
-        get_client_host_port(&metadata, &scheduler_url, &flight_proxy)?;
-
-    let mut ballista_client = BallistaClient::try_new(
-        client_host.as_str(),
-        client_port,
-        max_message_size,
-        use_tls,
-        customize_endpoint,
-    )
-    .await
-    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-    ballista_client
-        .fetch_partition_proxied(
-            &metadata.id,
-            &partition_id.into(),
-            host,
-            port,
-            &location.path,
-            flight_transport,
-        )
-        .await
-        .map_err(|e| DataFusionError::External(Box::new(e)))
-}
-
-#[cfg(test)]
-mod test {
-    use crate::execution_plans::distributed_query::get_client_host_port;
-    use crate::serde::protobuf::ExecutorMetadata;
-    use crate::serde::protobuf::get_job_status_result::FlightProxy;
-
-    #[test]
-    fn test_client_host_port() {
-        let scheduler_host = "scheduler";
-        let scheduler_port: u16 = 5000;
-
-        let scheduler_url = format!("http://{scheduler_host}:{scheduler_port}");
-        let executor = ExecutorMetadata {
-            id: "test".to_string(),
-            host: "executor".to_string(),
-            port: 12345,
-            grpc_port: 1,
-            specification: None,
-        };
-
-        // no flight proxy -> client should fetch results from executor
-        assert_eq!(
-            get_client_host_port(&executor, &scheduler_url, &None).unwrap(),
-            (executor.host.clone(), executor.port as u16)
-        );
-
-        // same, no flight proxy
-        assert_eq!(
-            get_client_host_port(
-                &executor,
-                &scheduler_url,
-                &Some(FlightProxy::Local(false))
-            )
-            .unwrap(),
-            (executor.host.clone(), executor.port as u16)
-        );
-
-        // embedded flight proxy on scheduler
-        assert_eq!(
-            get_client_host_port(
-                &executor,
-                &scheduler_url,
-                &Some(FlightProxy::Local(true))
-            )
-            .unwrap(),
-            (scheduler_host.to_string(), scheduler_port)
-        );
-
-        // external proxy
-        assert_eq!(
-            get_client_host_port(
-                &executor,
-                &scheduler_url,
-                &Some(FlightProxy::External("proxy:1234".to_string()))
-            )
-            .unwrap(),
-            ("proxy".to_string(), 1234_u16)
-        );
     }
 }

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -473,8 +473,6 @@ async fn execute_query_pull(
     query: ExecuteQueryParams,
     max_message_size: usize,
     grpc_config: GrpcClientConfig,
-    metrics: Arc<ExecutionPlanMetricsSet>,
-    partition: usize,
     session_config: SessionConfig,
 ) -> Result<CompletedJob> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
@@ -601,8 +599,6 @@ async fn execute_query_push(
     query: ExecuteQueryParams,
     max_message_size: usize,
     grpc_config: GrpcClientConfig,
-    metrics: Arc<ExecutionPlanMetricsSet>,
-    partition: usize,
     session_config: SessionConfig,
 ) -> Result<CompletedJob> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
@@ -660,7 +656,7 @@ async fn execute_query_push(
         let job_id = status
             .as_ref()
             .map(|s| s.job_id.to_owned())
-            .unwrap_or("unknown_job_id".to_string());// should not happen
+            .unwrap_or("unknown_job_id".to_string()); // should not happen
         let status = status.and_then(|s| s.status);
         let has_status_change = prev_status != status;
         match status {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -345,7 +345,9 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             extension_codec: self.extension_codec.clone(),
             plan_repr: self.plan_repr,
             session_id: self.session_id.clone(),
-            properties: Self::compute_properties(self.schema()),
+            properties: Self::compute_properties(
+                self.plan.schema().as_arrow().clone().into(),
+            ),
             metrics: ExecutionPlanMetricsSet::new(),
             action: self.action.clone(),
         }))
@@ -658,7 +660,7 @@ async fn execute_query_push(
         let job_id = status
             .as_ref()
             .map(|s| s.job_id.to_owned())
-            .unwrap_or("unknown_job_id".to_string());  // should not happen
+            .unwrap_or("unknown_job_id".to_string());// should not happen
         let status = status.and_then(|s| s.status);
         let has_status_change = prev_status != status;
         match status {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -189,7 +189,7 @@ pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     scheduler_url: String,
     /// Ballista configuration
     config: BallistaConfig,
-    /// Logical plan to execute (the inner plan, without any wrapping Analyze node)
+    /// Logical plan to execute
     plan: LogicalPlan,
     /// Codec for LogicalPlan extensions
     extension_codec: Arc<dyn LogicalExtensionCodec>,
@@ -219,8 +219,8 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         plan: LogicalPlan,
         session_id: String,
     ) -> Self {
-        let schema: SchemaRef = plan.schema().as_arrow().clone().into();
-        let properties = Self::compute_properties(schema);
+        let properties =
+            Self::compute_properties(plan.schema().as_arrow().clone().into());
         Self {
             scheduler_url,
             config,
@@ -242,8 +242,8 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         extension_codec: Arc<dyn LogicalExtensionCodec>,
         session_id: String,
     ) -> Self {
-        let schema: SchemaRef = plan.schema().as_arrow().clone().into();
-        let properties = Self::compute_properties(schema);
+        let properties =
+            Self::compute_properties(plan.schema().as_arrow().clone().into());
         Self {
             scheduler_url,
             config,
@@ -258,8 +258,7 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
     }
 
     /// Creates a new distributed query execution plan with a custom completion
-    /// action. Use this to implement EXPLAIN ANALYZE and future callback-style
-    /// patterns.
+    /// action
     pub fn with_action(
         scheduler_url: String,
         config: BallistaConfig,
@@ -268,10 +267,8 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         session_id: String,
         action: JobCompletionAction,
     ) -> Self {
-        let schema: SchemaRef = match &action {
-            JobCompletionAction::FetchResults => plan.schema().as_arrow().clone().into(),
-        };
-        let properties = Self::compute_properties(schema);
+        let properties =
+            Self::compute_properties(plan.schema().as_arrow().clone().into());
         Self {
             scheduler_url,
             config,
@@ -326,11 +323,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     }
 
     fn schema(&self) -> SchemaRef {
-        match &self.action {
-            JobCompletionAction::FetchResults => {
-                self.plan.schema().as_arrow().clone().into()
-            }
-        }
+        self.plan.schema().as_arrow().clone().into()
     }
 
     fn properties(&self) -> &PlanProperties {
@@ -389,13 +382,11 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                 },
             )
             .collect();
-
         let operation_id = uuid::Uuid::now_v7().to_string();
         debug!(
             "Distributed query with session_id: {}, execution operation_id: {}",
             self.session_id, operation_id
         );
-
         let query = ExecuteQueryParams {
             query: Some(Query::LogicalPlan(buf)),
             settings,
@@ -412,17 +403,9 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
         let metrics = Arc::new(self.metrics.clone());
         let schema = self.schema();
         let client_pull = session_config.ballista_config().client_pull();
-
-        // Clone schema for the outer RecordBatchStreamAdapter; the inner clone
-        // is moved into the FetchResultsHandler.
         let schema_for_adapter = schema.clone();
 
-        // ── Core dispatch ─────────────────────────────────────────────────────
-        //
-        // 1. Wait for the remote job to complete (pull or push), yielding a
-        //    CompletedJob receipt.
-        // 2. Construct the appropriate JobCompletionHandler based on `action`.
-        // 3. Hand the receipt to the handler and return its stream.
+        // Wait for the remote job to complete (pull or push), yielding a CompletedJob receipt
         let stream = futures::stream::once(async move {
             let completed = if client_pull {
                 execute_query_pull(
@@ -445,6 +428,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                 .await?
             };
 
+            // Construct the appropriate JobCompletionHandler based on action
             let handler: Box<dyn JobCompletionHandler> = match action {
                 JobCompletionAction::FetchResults => Box::new(FetchResultsHandler {
                     scheduler_url,
@@ -467,6 +451,9 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     }
 
     fn statistics(&self) -> Result<Statistics> {
+        // This execution plan sends the logical plan to the scheduler without
+        // performing the node by node conversion to a full physical plan.
+        // This implies that we cannot infer the statistics at this stage.
         Ok(Statistics::new_unknown(&self.schema()))
     }
 
@@ -474,8 +461,6 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
         Some(self.metrics.clone_inner())
     }
 }
-
-// ── execute_query_pull ────────────────────────────────────────────────────────
 
 /// Client periodically polls the scheduler to check job status.
 /// Returns a [`CompletedJob`] receipt once the job reaches a terminal state.
@@ -486,13 +471,16 @@ async fn execute_query_pull(
     query: ExecuteQueryParams,
     max_message_size: usize,
     grpc_config: GrpcClientConfig,
+    metrics: Arc<ExecutionPlanMetricsSet>,
+    partition: usize,
     session_config: SessionConfig,
 ) -> Result<CompletedJob> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
     let customize_endpoint =
         session_config.ballista_override_create_grpc_client_endpoint();
 
-    let query_start_time = Instant::now();
+    // Capture query submission time for total_query_time_ms
+    let query_start_time = std::time::Instant::now();
 
     info!("Connecting to Ballista scheduler at {scheduler_url}");
     // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
@@ -603,8 +591,6 @@ async fn execute_query_pull(
     }
 }
 
-// ── execute_query_push ────────────────────────────────────────────────────────
-
 /// After job is scheduled, client waits for job updates streamed from server.
 /// Returns a [`CompletedJob`] receipt once the job reaches a terminal state.
 #[allow(clippy::too_many_arguments)]
@@ -613,13 +599,16 @@ async fn execute_query_push(
     query: ExecuteQueryParams,
     max_message_size: usize,
     grpc_config: GrpcClientConfig,
+    metrics: Arc<ExecutionPlanMetricsSet>,
+    partition: usize,
     session_config: SessionConfig,
 ) -> Result<CompletedJob> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
     let customize_endpoint =
         session_config.ballista_override_create_grpc_client_endpoint();
 
-    let query_start_time = Instant::now();
+    // Capture query submission time for total_query_time_ms
+    let query_start_time = std::time::Instant::now();
 
     info!("Connecting to Ballista scheduler at {scheduler_url}");
     // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
@@ -669,7 +658,7 @@ async fn execute_query_push(
         let job_id = status
             .as_ref()
             .map(|s| s.job_id.to_owned())
-            .unwrap_or("unknown_job_id".to_string());
+            .unwrap_or("unknown_job_id".to_string());  // should not happen
         let status = status.and_then(|s| s.status);
         let has_status_change = prev_status != status;
         match status {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -19,21 +19,16 @@ use async_trait::async_trait;
 use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
 use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
-use crate::extension::{
-    BallistaConfigGrpcEndpoint, BallistaGrpcMetadataInterceptor, SessionConfigExt,
-};
 use crate::serde::protobuf::get_job_status_result::FlightProxy;
 use crate::serde::protobuf::{
-    ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult,
-    KeyValuePair, PartitionLocation, execute_query_params::Query, execute_query_result,
-    job_status, scheduler_grpc_client::SchedulerGrpcClient,
+    ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult, KeyValuePair,
+    PartitionLocation, execute_query_params::Query, execute_query_result, job_status,
+    scheduler_grpc_client::SchedulerGrpcClient,
 };
 use crate::serde::protobuf::{ExecutorMetadata, SuccessfulJob};
 use crate::utils::{GrpcClientConfig, create_grpc_client_endpoint};
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::LogicalPlan;
@@ -57,19 +52,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tonic::codegen::InterceptedService;
-use tonic::transport::Channel;
 use url::Url;
-
-// ── Type alias ────────────────────────────────────────────────────────────────
-
-/// Concrete scheduler gRPC client used throughout this module.
-///
-/// Capturing this type alias in handler structs lets us keep trait method
-/// signatures free of generic parameters (i.e. no `<T: GrpcService<...>>`
-/// pollution on [`JobCompletionHandler`]).
-pub(crate) type SchedulerClient =
-    SchedulerGrpcClient<InterceptedService<Channel, BallistaGrpcMetadataInterceptor>>;
 
 // ── CompletedJob ──────────────────────────────────────────────────────────────
 
@@ -77,13 +60,19 @@ pub(crate) type SchedulerClient =
 ///
 /// Every [`JobCompletionHandler`] receives this on completion and can use
 /// whichever fields it needs (e.g. `FetchResultsHandler` uses
-/// `partition_location`; `ExplainAnalyzeHandler` only uses `job_id`).
+/// `partition_location`).
 pub struct CompletedJob {
+    /// Scheduler-assigned job identifier.
     pub job_id: String,
+    /// Locations of all output partitions produced by the job.
     pub partition_location: Vec<PartitionLocation>,
+    /// Optional Flight proxy routing override returned by the scheduler.
     pub flight_proxy: Option<FlightProxy>,
+    /// Epoch-ms timestamp at which the job entered the scheduler queue.
     pub queued_at: u64,
+    /// Epoch-ms timestamp at which the job began executing on executors.
     pub started_at: u64,
+    /// Epoch-ms timestamp at which the job finished executing.
     pub ended_at: u64,
     /// Wall-clock instant at which the job was submitted to the scheduler.
     pub query_start_time: Instant,
@@ -94,10 +83,8 @@ pub struct CompletedJob {
 /// Determines what happens on the *client side* after a distributed job
 /// finishes.  The scheduler is completely unaware of this logic.
 ///
-/// Implement this trait to add new post-job behaviors.  Handlers are
-/// constructed inside [`DistributedQueryExec::execute`] after the
-/// [`SchedulerClient`] already exists, so they can cheaply clone and hold it
-/// without generic type parameters appearing in the trait signature.
+/// Implement this trait to add new post-job behaviors without touching the
+/// scheduler or the poll/push wait loops.
 #[async_trait]
 pub(crate) trait JobCompletionHandler: Send {
     async fn handle(
@@ -196,11 +183,6 @@ impl JobCompletionHandler for FetchResultsHandler {
     }
 }
 
-/// This operator sends a logical plan to a Ballista scheduler for execution and
-/// polls the scheduler until the query is complete and then fetches the resulting
-/// batches directly from the executors that hold the results from the final
-/// query stage.
-
 // ── JobCompletionAction (public config) ───────────────────────────────────────
 
 /// Specifies which [`JobCompletionHandler`] to use after a distributed job
@@ -218,12 +200,11 @@ pub enum JobCompletionAction {
     FetchResults,
 }
 
-
 // ── DistributedQueryExec ──────────────────────────────────────────────────────
 
-/// Sends a logical plan to a Ballista scheduler for execution, waits for
-/// completion, then dispatches to a [`JobCompletionHandler`] that produces the
-/// final result stream.
+/// This operator sends a logical plan to a Ballista scheduler for execution and
+/// polls the scheduler until the query is complete, then dispatches to a
+/// [`JobCompletionHandler`] that produces the final result stream.
 #[derive(Debug, Clone)]
 pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     /// Ballista scheduler URL
@@ -295,10 +276,6 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
     /// Creates a new distributed query execution plan with a custom completion
     /// action. Use this to implement EXPLAIN ANALYZE and future callback-style
     /// patterns.
-    ///
-    /// For [`JobCompletionAction::ExplainAnalyze`], the output schema is the
-    /// standard `(plan_type: Utf8, plan: Utf8)` table, not the inner plan's
-    /// schema.
     pub fn with_action(
         scheduler_url: String,
         config: BallistaConfig,
@@ -309,8 +286,6 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
     ) -> Self {
         let schema: SchemaRef = match &action {
             JobCompletionAction::FetchResults => plan.schema().as_arrow().clone().into(),
-        let properties =
-            Self::compute_properties(plan.schema().as_arrow().clone().into());
         };
         let properties = Self::compute_properties(schema);
         Self {
@@ -399,23 +374,6 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
         }))
     }
 
-    /// Submits the logical plan to the scheduler, waits for completion, and
-    /// dispatches to the appropriate [`JobCompletionHandler`].
-    ///
-    /// Stream type chain in the happy path:
-    ///
-    /// ```text
-    /// once(async {
-    ///     scheduler = build_scheduler_client(...)
-    ///     completed = submit_and_wait(scheduler, ...)   // CompletedJob
-    ///     handler   = FetchResultsHandler | ExplainAnalyzeHandler
-    ///     handler.handle(completed)                     // SendableRecordBatchStream
-    /// })
-    /// // Stream<Item = Result<SendableRecordBatchStream, DataFusionError>>
-    /// .try_flatten()
-    /// // Stream<Item = Result<RecordBatch, DataFusionError>>  (inner stream's error type)
-    /// // Req: DataFusionError: From<DataFusionError> ✓
-    /// ```
     fn execute(
         &self,
         partition: usize,
@@ -423,7 +381,6 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
 
-        // ── Serialize logical plan ────────────────────────────────────────────
         let mut buf: Vec<u8> = vec![];
         let plan_message = T::try_from_logical_plan(
             &self.plan,
@@ -462,7 +419,6 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             operation_id,
         };
 
-        // ── Capture fields for the async block ────────────────────────────────
         let session_config = context.session_config().clone();
         let max_message_size = self.config.grpc_client_max_message_size();
         let grpc_config = GrpcClientConfig::from(&self.config);
@@ -477,20 +433,33 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
         // is moved into the FetchResultsHandler.
         let schema_for_adapter = schema.clone();
 
-        // ── Core loop ─────────────────────────────────────────────────────────
+        // ── Core dispatch ─────────────────────────────────────────────────────
         //
-        // The stream type chain is documented on this method's doc comment.
+        // 1. Wait for the remote job to complete (pull or push), yielding a
+        //    CompletedJob receipt.
+        // 2. Construct the appropriate JobCompletionHandler based on `action`.
+        // 3. Hand the receipt to the handler and return its stream.
         let stream = futures::stream::once(async move {
-            let mut scheduler = build_scheduler_client(
-                scheduler_url.clone(),
-                max_message_size,
-                &grpc_config,
-                &session_config,
-            )
-            .await?;
-
-            let completed =
-                submit_and_wait(&mut scheduler, query, client_pull, &session_id).await?;
+            let completed = if client_pull {
+                execute_query_pull(
+                    scheduler_url.clone(),
+                    session_id,
+                    query,
+                    max_message_size,
+                    grpc_config,
+                    session_config.clone(),
+                )
+                .await?
+            } else {
+                execute_query_push(
+                    scheduler_url.clone(),
+                    query,
+                    max_message_size,
+                    grpc_config,
+                    session_config.clone(),
+                )
+                .await?
+            };
 
             let handler: Box<dyn JobCompletionHandler> = match action {
                 JobCompletionAction::FetchResults => Box::new(FetchResultsHandler {
@@ -501,25 +470,6 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                     metrics,
                     partition,
                 }),
-                    session_config,
-                )
-                .map_err(|e| ArrowError::ExternalError(Box::new(e))),
-            )
-            .try_flatten()
-            .inspect(move |batch| {
-                metric_total_bytes.add(
-                    batch
-                        .as_ref()
-                        .map(|b| b.get_array_memory_size())
-                        .unwrap_or(0),
-                );
-
-                metric_row_count.add(batch.as_ref().map(|b| b.num_rows()).unwrap_or(0));
-            });
-
-            let schema = self.schema();
-            Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
-        }
             };
 
             handler.handle(completed).await
@@ -541,27 +491,30 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     }
 }
 
-// ── build_scheduler_client ────────────────────────────────────────────────────
+// ── execute_query_pull ────────────────────────────────────────────────────────
 
-/// Connects to the Ballista scheduler and returns a ready-to-use gRPC client.
-///
-/// Extracted from the three former functions (`execute_query_pull`,
-/// `execute_query_push`, `execute_explain_analyze`) which all contained
-/// identical connection-establishment code.
-async fn build_scheduler_client(
+/// Client periodically polls the scheduler to check job status.
+/// Returns a [`CompletedJob`] receipt once the job reaches a terminal state.
+#[allow(clippy::too_many_arguments)]
+async fn execute_query_pull(
     scheduler_url: String,
+    session_id: String,
+    query: ExecuteQueryParams,
     max_message_size: usize,
-    grpc_config: &GrpcClientConfig,
-    session_config: &SessionConfig,
-) -> Result<SchedulerClient> {
+    grpc_config: GrpcClientConfig,
+    session_config: SessionConfig,
+) -> Result<CompletedJob> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
     let customize_endpoint =
         session_config.ballista_override_create_grpc_client_endpoint();
 
-    info!("Connecting to Ballista scheduler at {scheduler_url}");
+    let query_start_time = Instant::now();
 
-    let mut endpoint = create_grpc_client_endpoint(scheduler_url, Some(grpc_config))
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    info!("Connecting to Ballista scheduler at {scheduler_url}");
+    // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
+    let mut endpoint =
+        create_grpc_client_endpoint(scheduler_url.clone(), Some(&grpc_config))
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
     if let Some(ref customize) = customize_endpoint {
         endpoint = customize
@@ -574,194 +527,209 @@ async fn build_scheduler_client(
         .await
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
-    Ok(
-        SchedulerGrpcClient::with_interceptor(connection, grpc_interceptor.as_ref().clone())
-            .max_encoding_message_size(max_message_size)
-            .max_decoding_message_size(max_message_size),
+    let mut scheduler = SchedulerGrpcClient::with_interceptor(
+        connection,
+        grpc_interceptor.as_ref().clone(),
     )
-}
+    .max_encoding_message_size(max_message_size)
+    .max_decoding_message_size(max_message_size);
 
-// ── submit_and_wait ───────────────────────────────────────────────────────────
+    let query_result = scheduler
+        .execute_query(query)
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+        .into_inner();
 
-/// Submits a query to the scheduler and blocks until the job reaches a
-/// terminal state, returning [`CompletedJob`] on success.
-///
-/// Supports both *pull* mode (client polls `GetJobStatus` in a loop) and
-/// *push* mode (server streams `GetJobStatusResult` messages).
-///
-/// Extracts the duplicated submit+poll logic that previously appeared
-/// separately in `execute_query_pull`, `execute_query_push`, and
-/// `execute_explain_analyze`.
-async fn submit_and_wait(
-    scheduler: &mut SchedulerClient,
-    query: ExecuteQueryParams,
-    client_pull: bool,
-    session_id: &str,
-) -> Result<CompletedJob> {
-    let query_start_time = Instant::now();
+    let query_result = match query_result.result.unwrap() {
+        execute_query_result::Result::Success(success_result) => success_result,
+        execute_query_result::Result::Failure(failure_result) => {
+            return Err(DataFusionError::Execution(format!(
+                "Fail to execute query due to {failure_result:?}"
+            )));
+        }
+    };
 
-    if client_pull {
-        // ── Pull: submit then poll ────────────────────────────────────────────
-        let query_result = scheduler
-            .execute_query(query)
+    assert_eq!(
+        session_id, query_result.session_id,
+        "Session id inconsistent between Client and Server side in DistributedQueryExec."
+    );
+
+    let job_id = query_result.job_id;
+    let mut prev_status: Option<job_status::Status> = None;
+
+    loop {
+        let GetJobStatusResult {
+            status,
+            flight_proxy,
+        } = scheduler
+            .get_job_status(GetJobStatusParams {
+                job_id: job_id.clone(),
+            })
             .await
             .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
             .into_inner();
-
-        let success = match query_result.result.unwrap() {
-            execute_query_result::Result::Success(s) => s,
-            execute_query_result::Result::Failure(f) => {
-                return Err(DataFusionError::Execution(format!(
-                    "Fail to execute query due to {f:?}"
-                )));
+        let status = status.and_then(|s| s.status);
+        let wait_future = tokio::time::sleep(Duration::from_millis(50));
+        let has_status_change = prev_status != status;
+        match status {
+            None => {
+                if has_status_change {
+                    info!("Job {job_id} is in initialization ...");
+                }
+                wait_future.await;
+                prev_status = status;
+            }
+            Some(job_status::Status::Queued(_)) => {
+                if has_status_change {
+                    info!("Job {job_id} is queued...");
+                }
+                wait_future.await;
+                prev_status = status;
+            }
+            Some(job_status::Status::Running(_)) => {
+                if has_status_change {
+                    info!("Job {job_id} is running...");
+                }
+                wait_future.await;
+                prev_status = status;
+            }
+            Some(job_status::Status::Failed(err)) => {
+                let msg = format!("Job {} failed: {}", job_id, err.error);
+                error!("{msg}");
+                break Err(DataFusionError::Execution(msg));
+            }
+            Some(job_status::Status::Successful(SuccessfulJob {
+                queued_at,
+                started_at,
+                ended_at,
+                partition_location,
+                ..
+            })) => {
+                break Ok(CompletedJob {
+                    job_id,
+                    partition_location,
+                    flight_proxy,
+                    queued_at,
+                    started_at,
+                    ended_at,
+                    query_start_time,
+                });
             }
         };
+    }
+}
 
-        assert_eq!(
-            session_id, success.session_id,
-            "Session id inconsistent between Client and Server side in DistributedQueryExec."
-        );
+// ── execute_query_push ────────────────────────────────────────────────────────
 
-        let job_id = success.job_id;
-        let mut prev_status: Option<job_status::Status> = None;
+/// After job is scheduled, client waits for job updates streamed from server.
+/// Returns a [`CompletedJob`] receipt once the job reaches a terminal state.
+#[allow(clippy::too_many_arguments)]
+async fn execute_query_push(
+    scheduler_url: String,
+    query: ExecuteQueryParams,
+    max_message_size: usize,
+    grpc_config: GrpcClientConfig,
+    session_config: SessionConfig,
+) -> Result<CompletedJob> {
+    let grpc_interceptor = session_config.ballista_grpc_interceptor();
+    let customize_endpoint =
+        session_config.ballista_override_create_grpc_client_endpoint();
 
-        loop {
-            let GetJobStatusResult {
-                status,
-                flight_proxy,
-            } = scheduler
-                .get_job_status(GetJobStatusParams {
-                    job_id: job_id.clone(),
-                })
-                .await
-                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-                .into_inner();
+    let query_start_time = Instant::now();
 
-            let status = status.and_then(|s| s.status);
-            let has_status_change = prev_status != status;
-            let wait_future = tokio::time::sleep(Duration::from_millis(50));
+    info!("Connecting to Ballista scheduler at {scheduler_url}");
+    // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
+    let mut endpoint =
+        create_grpc_client_endpoint(scheduler_url.clone(), Some(&grpc_config))
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
-            match status {
-                None => {
-                    if has_status_change {
-                        info!("Job {job_id} is in initialization...");
-                    }
-                    wait_future.await;
-                    prev_status = status;
-                }
-                Some(job_status::Status::Queued(_)) => {
-                    if has_status_change {
-                        info!("Job {job_id} is queued...");
-                    }
-                    wait_future.await;
-                    prev_status = status;
-                }
-                Some(job_status::Status::Running(_)) => {
-                    if has_status_change {
-                        info!("Job {job_id} is running...");
-                    }
-                    wait_future.await;
-                    prev_status = status;
-                }
-                Some(job_status::Status::Failed(err)) => {
-                    let msg = format!("Job {} failed: {}", job_id, err.error);
-                    error!("{msg}");
-                    return Err(DataFusionError::Execution(msg));
-                }
-                Some(job_status::Status::Successful(SuccessfulJob {
-                    queued_at,
-                    started_at,
-                    ended_at,
-                    partition_location,
-                    ..
-                })) => {
-                    return Ok(CompletedJob {
-                        job_id,
-                        partition_location,
-                        flight_proxy,
-                        queued_at,
-                        started_at,
-                        ended_at,
-                        query_start_time,
-                    });
-                }
-            }
-        }
-    } else {
-        // ── Push: server-streams status updates ───────────────────────────────
-        let mut stream = scheduler
-            .execute_query_push(query)
+    if let Some(ref customize) = customize_endpoint {
+        endpoint = customize
+            .configure_endpoint(endpoint)
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    }
+
+    let connection = endpoint
+        .connect()
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+    let mut scheduler = SchedulerGrpcClient::with_interceptor(
+        connection,
+        grpc_interceptor.as_ref().clone(),
+    )
+    .max_encoding_message_size(max_message_size)
+    .max_decoding_message_size(max_message_size);
+
+    let mut query_status_stream = scheduler
+        .execute_query_push(query)
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+        .into_inner();
+
+    let mut prev_status: Option<job_status::Status> = None;
+
+    loop {
+        let item = query_status_stream
+            .next()
             .await
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-            .into_inner();
+            .ok_or(DataFusionError::Execution(
+                "Stream closed without job completing".to_string(),
+            ))?
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
-        let mut prev_status: Option<job_status::Status> = None;
-
-        loop {
-            let item = stream
-                .next()
-                .await
-                .ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "Stream closed without job completing".to_string(),
-                    )
-                })?
-                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-
-            let GetJobStatusResult {
-                status,
-                flight_proxy,
-            } = item;
-            let job_id = status
-                .as_ref()
-                .map(|s| s.job_id.to_owned())
-                .unwrap_or_else(|| "unknown_job_id".to_string());
-            let status = status.and_then(|s| s.status);
-            let has_status_change = prev_status != status;
-
-            match status {
-                None => {
-                    if has_status_change {
-                        info!("Job {job_id} is in initialization...");
-                    }
-                    prev_status = status;
+        let GetJobStatusResult {
+            status,
+            flight_proxy,
+        } = item;
+        let job_id = status
+            .as_ref()
+            .map(|s| s.job_id.to_owned())
+            .unwrap_or("unknown_job_id".to_string());
+        let status = status.and_then(|s| s.status);
+        let has_status_change = prev_status != status;
+        match status {
+            None => {
+                if has_status_change {
+                    info!("Job {job_id} is in initialization ...");
                 }
-                Some(job_status::Status::Queued(_)) => {
-                    if has_status_change {
-                        info!("Job {job_id} is queued...");
-                    }
-                    prev_status = status;
+                prev_status = status;
+            }
+            Some(job_status::Status::Queued(_)) => {
+                if has_status_change {
+                    info!("Job {job_id} is queued...");
                 }
-                Some(job_status::Status::Running(_)) => {
-                    if has_status_change {
-                        info!("Job {job_id} is running...");
-                    }
-                    prev_status = status;
+                prev_status = status;
+            }
+            Some(job_status::Status::Running(_)) => {
+                if has_status_change {
+                    info!("Job {job_id} is running...");
                 }
-                Some(job_status::Status::Failed(err)) => {
-                    let msg = format!("Job {} failed: {}", job_id, err.error);
-                    error!("{msg}");
-                    return Err(DataFusionError::Execution(msg));
-                }
-                Some(job_status::Status::Successful(SuccessfulJob {
+                prev_status = status;
+            }
+            Some(job_status::Status::Failed(err)) => {
+                let msg = format!("Job {} failed: {}", job_id, err.error);
+                error!("{msg}");
+                break Err(DataFusionError::Execution(msg));
+            }
+            Some(job_status::Status::Successful(SuccessfulJob {
+                queued_at,
+                started_at,
+                ended_at,
+                partition_location,
+                ..
+            })) => {
+                break Ok(CompletedJob {
+                    job_id,
+                    partition_location,
+                    flight_proxy,
                     queued_at,
                     started_at,
                     ended_at,
-                    partition_location,
-                    ..
-                })) => {
-                    return Ok(CompletedJob {
-                        job_id,
-                        partition_location,
-                        flight_proxy,
-                        queued_at,
-                        started_at,
-                        ended_at,
-                        query_start_time,
-                    });
-                }
+                    query_start_time,
+                });
             }
-        }
+        };
     }
 }
 

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -15,18 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use async_trait::async_trait;
 use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
 use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
+use crate::extension::{
+    BallistaConfigGrpcEndpoint, BallistaGrpcMetadataInterceptor, SessionConfigExt,
+};
 use crate::serde::protobuf::get_job_status_result::FlightProxy;
 use crate::serde::protobuf::{
-    ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult, KeyValuePair,
-    PartitionLocation, execute_query_params::Query, execute_query_result, job_status,
-    scheduler_grpc_client::SchedulerGrpcClient,
+    ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult,
+    KeyValuePair, PartitionLocation, execute_query_params::Query, execute_query_result,
+    job_status, scheduler_grpc_client::SchedulerGrpcClient,
 };
 use crate::serde::protobuf::{ExecutorMetadata, SuccessfulJob};
 use crate::utils::{GrpcClientConfig, create_grpc_client_endpoint};
 use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result};
@@ -45,26 +50,187 @@ use datafusion::prelude::SessionConfig;
 use datafusion_proto::logical_plan::{
     AsLogicalPlan, DefaultLogicalExtensionCodec, LogicalExtensionCodec,
 };
-use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
+use futures::{StreamExt, TryFutureExt, TryStreamExt};
 use log::{debug, error, info};
 use std::any::Any;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tonic::codegen::InterceptedService;
+use tonic::transport::Channel;
 use url::Url;
+
+// ── Type alias ────────────────────────────────────────────────────────────────
+
+/// Concrete scheduler gRPC client used throughout this module.
+///
+/// Capturing this type alias in handler structs lets us keep trait method
+/// signatures free of generic parameters (i.e. no `<T: GrpcService<...>>`
+/// pollution on [`JobCompletionHandler`]).
+pub(crate) type SchedulerClient =
+    SchedulerGrpcClient<InterceptedService<Channel, BallistaGrpcMetadataInterceptor>>;
+
+// ── CompletedJob ──────────────────────────────────────────────────────────────
+
+/// All metadata available after a distributed job finishes successfully.
+///
+/// Every [`JobCompletionHandler`] receives this on completion and can use
+/// whichever fields it needs (e.g. `FetchResultsHandler` uses
+/// `partition_location`; `ExplainAnalyzeHandler` only uses `job_id`).
+pub struct CompletedJob {
+    pub job_id: String,
+    pub partition_location: Vec<PartitionLocation>,
+    pub flight_proxy: Option<FlightProxy>,
+    pub queued_at: u64,
+    pub started_at: u64,
+    pub ended_at: u64,
+    /// Wall-clock instant at which the job was submitted to the scheduler.
+    pub query_start_time: Instant,
+}
+
+// ── JobCompletionHandler trait ────────────────────────────────────────────────
+
+/// Determines what happens on the *client side* after a distributed job
+/// finishes.  The scheduler is completely unaware of this logic.
+///
+/// Implement this trait to add new post-job behaviors.  Handlers are
+/// constructed inside [`DistributedQueryExec::execute`] after the
+/// [`SchedulerClient`] already exists, so they can cheaply clone and hold it
+/// without generic type parameters appearing in the trait signature.
+#[async_trait]
+pub(crate) trait JobCompletionHandler: Send {
+    async fn handle(
+        self: Box<Self>,
+        completed: CompletedJob,
+    ) -> Result<SendableRecordBatchStream>;
+}
+
+// ── FetchResultsHandler ───────────────────────────────────────────────────────
+
+/// Fetches result partitions from executors via Arrow Flight and streams them
+/// back to the caller. This is the default handler for normal queries.
+pub(crate) struct FetchResultsHandler {
+    scheduler_url: String,
+    schema: SchemaRef,
+    max_message_size: usize,
+    session_config: SessionConfig,
+    metrics: Arc<ExecutionPlanMetricsSet>,
+    partition: usize,
+}
+
+#[async_trait]
+impl JobCompletionHandler for FetchResultsHandler {
+    async fn handle(
+        self: Box<Self>,
+        completed: CompletedJob,
+    ) -> Result<SendableRecordBatchStream> {
+        let FetchResultsHandler {
+            scheduler_url,
+            schema,
+            max_message_size,
+            session_config,
+            metrics,
+            partition,
+        } = *self;
+
+        let customize_endpoint =
+            session_config.ballista_override_create_grpc_client_endpoint();
+        let use_tls = session_config.ballista_use_tls();
+
+        // ── Timing metrics ────────────────────────────────────────────────────
+        let job_execution_ms = completed.ended_at.saturating_sub(completed.started_at);
+        let scheduling_ms = completed.started_at.saturating_sub(completed.queued_at);
+        let total_ms = completed.query_start_time.elapsed().as_millis();
+
+        info!(
+            "Job {} finished executing in {:?}",
+            completed.job_id,
+            Duration::from_millis(job_execution_ms)
+        );
+
+        MetricBuilder::new(&metrics)
+            .gauge("job_execution_time_ms", partition)
+            .set(job_execution_ms as usize);
+        MetricBuilder::new(&metrics)
+            .gauge("job_scheduling_in_ms", partition)
+            .set(scheduling_ms as usize);
+        MetricBuilder::new(&metrics)
+            .gauge("total_query_time_ms", partition)
+            .set(total_ms as usize);
+
+        let metric_row_count = MetricBuilder::new(&metrics).output_rows(partition);
+        let metric_total_bytes =
+            MetricBuilder::new(&metrics).counter("transferred_bytes", partition);
+
+        // ── Partition streams ─────────────────────────────────────────────────
+        let flight_proxy = completed.flight_proxy;
+        let streams = completed.partition_location.into_iter().map(move |loc| {
+            let f = fetch_partition(
+                loc,
+                max_message_size,
+                true,
+                scheduler_url.clone(),
+                flight_proxy.clone(),
+                customize_endpoint.clone(),
+                use_tls,
+            )
+            .map_err(|e| ArrowError::ExternalError(Box::new(e)));
+
+            futures::stream::once(f).try_flatten()
+        });
+
+        let stream = futures::stream::iter(streams)
+            .flatten()
+            .inspect(move |batch| {
+                metric_total_bytes.add(
+                    batch
+                        .as_ref()
+                        .map(|b| b.get_array_memory_size())
+                        .unwrap_or(0),
+                );
+                metric_row_count.add(batch.as_ref().map(|b| b.num_rows()).unwrap_or(0));
+            });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
 
 /// This operator sends a logical plan to a Ballista scheduler for execution and
 /// polls the scheduler until the query is complete and then fetches the resulting
 /// batches directly from the executors that hold the results from the final
 /// query stage.
+
+// ── JobCompletionAction (public config) ───────────────────────────────────────
+
+/// Specifies which [`JobCompletionHandler`] to use after a distributed job
+/// finishes.
+///
+/// Stored in [`DistributedQueryExec`] so the struct can remain `Clone` and
+/// still produce the output schema before `execute()` is called.  Inside
+/// `execute()` the enum is matched to construct the concrete handler.
+///
+/// This keeps the scheduler unaware of callback logic: it always executes a
+/// plain job; the client decides how to interpret the result.
+#[derive(Debug, Clone)]
+pub enum JobCompletionAction {
+    /// Fetch result partitions from executors and stream them back (normal query).
+    FetchResults,
+}
+
+
+// ── DistributedQueryExec ──────────────────────────────────────────────────────
+
+/// Sends a logical plan to a Ballista scheduler for execution, waits for
+/// completion, then dispatches to a [`JobCompletionHandler`] that produces the
+/// final result stream.
 #[derive(Debug, Clone)]
 pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     /// Ballista scheduler URL
     scheduler_url: String,
     /// Ballista configuration
     config: BallistaConfig,
-    /// Logical plan to execute
+    /// Logical plan to execute (the inner plan, without any wrapping Analyze node)
     plan: LogicalPlan,
     /// Codec for LogicalPlan extensions
     extension_codec: Arc<dyn LogicalExtensionCodec>,
@@ -74,14 +240,10 @@ pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     session_id: String,
     /// Plan properties
     properties: PlanProperties,
-    /// Execution metrics, currently exposes:
-    /// - output_rows: Total number of rows returned
-    /// - transferred_bytes: Total bytes transferred from executors
-    /// - job_execution_time_ms: Time spent executing on the cluster (server-side)
-    /// - job_scheduling_in_ms: Time from query submission to job start (includes queue time)
-    /// - job_execution_time_ms: Time spent executing on the cluster (ended_at - started_at)
-    /// - job_scheduling_in_ms: Time job waited in scheduler queue (started_at - queued_at)
+    /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
+    /// Which handler to invoke after the remote job completes.
+    action: JobCompletionAction,
 }
 
 impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
@@ -92,8 +254,8 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         plan: LogicalPlan,
         session_id: String,
     ) -> Self {
-        let properties =
-            Self::compute_properties(plan.schema().as_arrow().clone().into());
+        let schema: SchemaRef = plan.schema().as_arrow().clone().into();
+        let properties = Self::compute_properties(schema);
         Self {
             scheduler_url,
             config,
@@ -103,6 +265,7 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
             session_id,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+            action: JobCompletionAction::FetchResults,
         }
     }
 
@@ -114,8 +277,8 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         extension_codec: Arc<dyn LogicalExtensionCodec>,
         session_id: String,
     ) -> Self {
-        let properties =
-            Self::compute_properties(plan.schema().as_arrow().clone().into());
+        let schema: SchemaRef = plan.schema().as_arrow().clone().into();
+        let properties = Self::compute_properties(schema);
         Self {
             scheduler_url,
             config,
@@ -125,6 +288,41 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
             session_id,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+            action: JobCompletionAction::FetchResults,
+        }
+    }
+
+    /// Creates a new distributed query execution plan with a custom completion
+    /// action. Use this to implement EXPLAIN ANALYZE and future callback-style
+    /// patterns.
+    ///
+    /// For [`JobCompletionAction::ExplainAnalyze`], the output schema is the
+    /// standard `(plan_type: Utf8, plan: Utf8)` table, not the inner plan's
+    /// schema.
+    pub fn with_action(
+        scheduler_url: String,
+        config: BallistaConfig,
+        plan: LogicalPlan,
+        extension_codec: Arc<dyn LogicalExtensionCodec>,
+        session_id: String,
+        action: JobCompletionAction,
+    ) -> Self {
+        let schema: SchemaRef = match &action {
+            JobCompletionAction::FetchResults => plan.schema().as_arrow().clone().into(),
+        let properties =
+            Self::compute_properties(plan.schema().as_arrow().clone().into());
+        };
+        let properties = Self::compute_properties(schema);
+        Self {
+            scheduler_url,
+            config,
+            plan,
+            extension_codec,
+            plan_repr: PhantomData,
+            session_id,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+            action,
         }
     }
 
@@ -169,7 +367,11 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.plan.schema().as_arrow().clone().into()
+        match &self.action {
+            JobCompletionAction::FetchResults => {
+                self.plan.schema().as_arrow().clone().into()
+            }
+        }
     }
 
     fn properties(&self) -> &PlanProperties {
@@ -191,13 +393,29 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             extension_codec: self.extension_codec.clone(),
             plan_repr: self.plan_repr,
             session_id: self.session_id.clone(),
-            properties: Self::compute_properties(
-                self.plan.schema().as_arrow().clone().into(),
-            ),
+            properties: Self::compute_properties(self.schema()),
             metrics: ExecutionPlanMetricsSet::new(),
+            action: self.action.clone(),
         }))
     }
 
+    /// Submits the logical plan to the scheduler, waits for completion, and
+    /// dispatches to the appropriate [`JobCompletionHandler`].
+    ///
+    /// Stream type chain in the happy path:
+    ///
+    /// ```text
+    /// once(async {
+    ///     scheduler = build_scheduler_client(...)
+    ///     completed = submit_and_wait(scheduler, ...)   // CompletedJob
+    ///     handler   = FetchResultsHandler | ExplainAnalyzeHandler
+    ///     handler.handle(completed)                     // SendableRecordBatchStream
+    /// })
+    /// // Stream<Item = Result<SendableRecordBatchStream, DataFusionError>>
+    /// .try_flatten()
+    /// // Stream<Item = Result<RecordBatch, DataFusionError>>  (inner stream's error type)
+    /// // Req: DataFusionError: From<DataFusionError> ✓
+    /// ```
     fn execute(
         &self,
         partition: usize,
@@ -205,6 +423,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
 
+        // ── Serialize logical plan ────────────────────────────────────────────
         let mut buf: Vec<u8> = vec![];
         let plan_message = T::try_from_logical_plan(
             &self.plan,
@@ -229,11 +448,13 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                 },
             )
             .collect();
+
         let operation_id = uuid::Uuid::now_v7().to_string();
         debug!(
             "Distributed query with session_id: {}, execution operation_id: {}",
             self.session_id, operation_id
         );
+
         let query = ExecuteQueryParams {
             query: Some(Query::LogicalPlan(buf)),
             settings,
@@ -241,49 +462,45 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             operation_id,
         };
 
-        let metric_row_count = MetricBuilder::new(&self.metrics).output_rows(partition);
-        let metric_total_bytes =
-            MetricBuilder::new(&self.metrics).counter("transferred_bytes", partition);
-
+        // ── Capture fields for the async block ────────────────────────────────
         let session_config = context.session_config().clone();
+        let max_message_size = self.config.grpc_client_max_message_size();
+        let grpc_config = GrpcClientConfig::from(&self.config);
+        let scheduler_url = self.scheduler_url.clone();
+        let session_id = self.session_id.clone();
+        let action = self.action.clone();
+        let metrics = Arc::new(self.metrics.clone());
+        let schema = self.schema();
+        let client_pull = session_config.ballista_config().client_pull();
 
-        if session_config.ballista_config().client_pull() {
-            let stream = futures::stream::once(
-                execute_query_pull(
-                    self.scheduler_url.clone(),
-                    self.session_id.clone(),
-                    query,
-                    self.config.grpc_client_max_message_size(),
-                    GrpcClientConfig::from(&self.config),
-                    Arc::new(self.metrics.clone()),
-                    partition,
-                    session_config,
-                )
-                .map_err(|e| ArrowError::ExternalError(Box::new(e))),
+        // Clone schema for the outer RecordBatchStreamAdapter; the inner clone
+        // is moved into the FetchResultsHandler.
+        let schema_for_adapter = schema.clone();
+
+        // ── Core loop ─────────────────────────────────────────────────────────
+        //
+        // The stream type chain is documented on this method's doc comment.
+        let stream = futures::stream::once(async move {
+            let mut scheduler = build_scheduler_client(
+                scheduler_url.clone(),
+                max_message_size,
+                &grpc_config,
+                &session_config,
             )
-            .try_flatten()
-            .inspect(move |batch| {
-                metric_total_bytes.add(
-                    batch
-                        .as_ref()
-                        .map(|b| b.get_array_memory_size())
-                        .unwrap_or(0),
-                );
+            .await?;
 
-                metric_row_count.add(batch.as_ref().map(|b| b.num_rows()).unwrap_or(0));
-            });
+            let completed =
+                submit_and_wait(&mut scheduler, query, client_pull, &session_id).await?;
 
-            let schema = self.schema();
-            Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
-        } else {
-            let stream = futures::stream::once(
-                execute_query_push(
-                    self.scheduler_url.clone(),
-                    query,
-                    self.config.grpc_client_max_message_size(),
-                    GrpcClientConfig::from(&self.config),
-                    Arc::new(self.metrics.clone()),
+            let handler: Box<dyn JobCompletionHandler> = match action {
+                JobCompletionAction::FetchResults => Box::new(FetchResultsHandler {
+                    scheduler_url,
+                    schema,
+                    max_message_size,
+                    session_config,
+                    metrics,
                     partition,
+                }),
                     session_config,
                 )
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),
@@ -303,12 +520,19 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             let schema = self.schema();
             Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
         }
+            };
+
+            handler.handle(completed).await
+        })
+        .try_flatten();
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema_for_adapter,
+            stream,
+        )))
     }
 
     fn statistics(&self) -> Result<Statistics> {
-        // This execution plan sends the logical plan to the scheduler without
-        // performing the node by node conversion to a full physical plan.
-        // This implies that we cannot infer the statistics at this stage.
         Ok(Statistics::new_unknown(&self.schema()))
     }
 
@@ -317,33 +541,27 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
     }
 }
 
-/// Client will periodically invoke scheduler to check
-/// job status. There is preconfigured wait period between
-/// pulls, which increases query latency.
-#[allow(clippy::too_many_arguments)]
-async fn execute_query_pull(
+// ── build_scheduler_client ────────────────────────────────────────────────────
+
+/// Connects to the Ballista scheduler and returns a ready-to-use gRPC client.
+///
+/// Extracted from the three former functions (`execute_query_pull`,
+/// `execute_query_push`, `execute_explain_analyze`) which all contained
+/// identical connection-establishment code.
+async fn build_scheduler_client(
     scheduler_url: String,
-    session_id: String,
-    query: ExecuteQueryParams,
     max_message_size: usize,
-    grpc_config: GrpcClientConfig,
-    metrics: Arc<ExecutionPlanMetricsSet>,
-    partition: usize,
-    session_config: SessionConfig,
-) -> Result<impl Stream<Item = Result<RecordBatch>> + Send> {
+    grpc_config: &GrpcClientConfig,
+    session_config: &SessionConfig,
+) -> Result<SchedulerClient> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
     let customize_endpoint =
         session_config.ballista_override_create_grpc_client_endpoint();
-    let use_tls = session_config.ballista_use_tls();
-
-    // Capture query submission time for total_query_time_ms
-    let query_start_time = std::time::Instant::now();
 
     info!("Connecting to Ballista scheduler at {scheduler_url}");
-    // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
-    let mut endpoint =
-        create_grpc_client_endpoint(scheduler_url.clone(), Some(&grpc_config))
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+    let mut endpoint = create_grpc_client_endpoint(scheduler_url, Some(grpc_config))
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
     if let Some(ref customize) = customize_endpoint {
         endpoint = customize
@@ -356,289 +574,198 @@ async fn execute_query_pull(
         .await
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
-    let mut scheduler = SchedulerGrpcClient::with_interceptor(
-        connection,
-        grpc_interceptor.as_ref().clone(),
+    Ok(
+        SchedulerGrpcClient::with_interceptor(connection, grpc_interceptor.as_ref().clone())
+            .max_encoding_message_size(max_message_size)
+            .max_decoding_message_size(max_message_size),
     )
-    .max_encoding_message_size(max_message_size)
-    .max_decoding_message_size(max_message_size);
+}
 
-    let query_result = scheduler
-        .execute_query(query)
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-        .into_inner();
+// ── submit_and_wait ───────────────────────────────────────────────────────────
 
-    let query_result = match query_result.result.unwrap() {
-        execute_query_result::Result::Success(success_result) => success_result,
-        execute_query_result::Result::Failure(failure_result) => {
-            return Err(DataFusionError::Execution(format!(
-                "Fail to execute query due to {failure_result:?}"
-            )));
-        }
-    };
+/// Submits a query to the scheduler and blocks until the job reaches a
+/// terminal state, returning [`CompletedJob`] on success.
+///
+/// Supports both *pull* mode (client polls `GetJobStatus` in a loop) and
+/// *push* mode (server streams `GetJobStatusResult` messages).
+///
+/// Extracts the duplicated submit+poll logic that previously appeared
+/// separately in `execute_query_pull`, `execute_query_push`, and
+/// `execute_explain_analyze`.
+async fn submit_and_wait(
+    scheduler: &mut SchedulerClient,
+    query: ExecuteQueryParams,
+    client_pull: bool,
+    session_id: &str,
+) -> Result<CompletedJob> {
+    let query_start_time = Instant::now();
 
-    assert_eq!(
-        session_id, query_result.session_id,
-        "Session id inconsistent between Client and Server side in DistributedQueryExec."
-    );
-
-    let job_id = query_result.job_id;
-    let mut prev_status: Option<job_status::Status> = None;
-
-    loop {
-        let GetJobStatusResult {
-            status,
-            flight_proxy,
-        } = scheduler
-            .get_job_status(GetJobStatusParams {
-                job_id: job_id.clone(),
-            })
+    if client_pull {
+        // ── Pull: submit then poll ────────────────────────────────────────────
+        let query_result = scheduler
+            .execute_query(query)
             .await
             .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
             .into_inner();
-        let status = status.and_then(|s| s.status);
-        let wait_future = tokio::time::sleep(Duration::from_millis(50));
-        let has_status_change = prev_status != status;
-        match status {
-            None => {
-                if has_status_change {
-                    info!("Job {job_id} is in initialization ...");
-                }
-                wait_future.await;
-                prev_status = status;
-            }
-            Some(job_status::Status::Queued(_)) => {
-                if has_status_change {
-                    info!("Job {job_id} is queued...");
-                }
-                wait_future.await;
-                prev_status = status;
-            }
-            Some(job_status::Status::Running(_)) => {
-                if has_status_change {
-                    info!("Job {job_id} is running...");
-                }
-                wait_future.await;
-                prev_status = status;
-            }
-            Some(job_status::Status::Failed(err)) => {
-                let msg = format!("Job {} failed: {}", job_id, err.error);
-                error!("{msg}");
-                break Err(DataFusionError::Execution(msg));
-            }
-            Some(job_status::Status::Successful(SuccessfulJob {
-                queued_at,
-                started_at,
-                ended_at,
-                partition_location,
-                ..
-            })) => {
-                // Calculate job execution time (server-side execution)
-                let job_execution_ms = ended_at.saturating_sub(started_at);
-                let duration = Duration::from_millis(job_execution_ms);
 
-                info!("Job {job_id} finished executing in {duration:?} ");
-
-                // Calculate scheduling time (server-side queue time)
-                // This includes network latency and actual queue time
-                let scheduling_ms = started_at.saturating_sub(queued_at);
-
-                // Calculate total query time (end-to-end from client perspective)
-                let total_elapsed = query_start_time.elapsed();
-                let total_ms = total_elapsed.as_millis();
-
-                // Set timing metrics
-                let metric_job_execution = MetricBuilder::new(&metrics)
-                    .gauge("job_execution_time_ms", partition);
-                metric_job_execution.set(job_execution_ms as usize);
-
-                let metric_scheduling =
-                    MetricBuilder::new(&metrics).gauge("job_scheduling_in_ms", partition);
-                metric_scheduling.set(scheduling_ms as usize);
-
-                let metric_total_time =
-                    MetricBuilder::new(&metrics).gauge("total_query_time_ms", partition);
-                metric_total_time.set(total_ms as usize);
-
-                // Note: data_transfer_time_ms is not set here because partition fetching
-                // happens lazily when the stream is consumed, not during execute_query.
-                // This could be added in a future enhancement by wrapping the stream.
-
-                let streams = partition_location.into_iter().map(move |partition| {
-                    let f = fetch_partition(
-                        partition,
-                        max_message_size,
-                        true,
-                        scheduler_url.clone(),
-                        flight_proxy.clone(),
-                        customize_endpoint.clone(),
-                        use_tls,
-                    )
-                    .map_err(|e| ArrowError::ExternalError(Box::new(e)));
-
-                    futures::stream::once(f).try_flatten()
-                });
-
-                break Ok(futures::stream::iter(streams).flatten());
+        let success = match query_result.result.unwrap() {
+            execute_query_result::Result::Success(s) => s,
+            execute_query_result::Result::Failure(f) => {
+                return Err(DataFusionError::Execution(format!(
+                    "Fail to execute query due to {f:?}"
+                )));
             }
         };
-    }
-}
-/// After job is scheduled client waits
-/// for job updates, which are streamed back
-/// from server to client
-#[allow(clippy::too_many_arguments)]
-async fn execute_query_push(
-    scheduler_url: String,
-    query: ExecuteQueryParams,
-    max_message_size: usize,
-    grpc_config: GrpcClientConfig,
-    metrics: Arc<ExecutionPlanMetricsSet>,
-    partition: usize,
-    session_config: SessionConfig,
-) -> Result<impl Stream<Item = Result<RecordBatch>> + Send> {
-    let grpc_interceptor = session_config.ballista_grpc_interceptor();
-    let customize_endpoint =
-        session_config.ballista_override_create_grpc_client_endpoint();
-    let use_tls = session_config.ballista_use_tls();
 
-    // Capture query submission time for total_query_time_ms
-    let query_start_time = std::time::Instant::now();
+        assert_eq!(
+            session_id, success.session_id,
+            "Session id inconsistent between Client and Server side in DistributedQueryExec."
+        );
 
-    info!("Connecting to Ballista scheduler at {scheduler_url}");
-    // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
-    let mut endpoint =
-        create_grpc_client_endpoint(scheduler_url.clone(), Some(&grpc_config))
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+        let job_id = success.job_id;
+        let mut prev_status: Option<job_status::Status> = None;
 
-    if let Some(ref customize) = customize_endpoint {
-        endpoint = customize
-            .configure_endpoint(endpoint)
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-    }
+        loop {
+            let GetJobStatusResult {
+                status,
+                flight_proxy,
+            } = scheduler
+                .get_job_status(GetJobStatusParams {
+                    job_id: job_id.clone(),
+                })
+                .await
+                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+                .into_inner();
 
-    let connection = endpoint
-        .connect()
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            let status = status.and_then(|s| s.status);
+            let has_status_change = prev_status != status;
+            let wait_future = tokio::time::sleep(Duration::from_millis(50));
 
-    let mut scheduler = SchedulerGrpcClient::with_interceptor(
-        connection,
-        grpc_interceptor.as_ref().clone(),
-    )
-    .max_encoding_message_size(max_message_size)
-    .max_decoding_message_size(max_message_size);
-
-    let mut query_status_stream = scheduler
-        .execute_query_push(query)
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-        .into_inner();
-
-    let mut prev_status: Option<job_status::Status> = None;
-
-    loop {
-        let item = query_status_stream
-            .next()
+            match status {
+                None => {
+                    if has_status_change {
+                        info!("Job {job_id} is in initialization...");
+                    }
+                    wait_future.await;
+                    prev_status = status;
+                }
+                Some(job_status::Status::Queued(_)) => {
+                    if has_status_change {
+                        info!("Job {job_id} is queued...");
+                    }
+                    wait_future.await;
+                    prev_status = status;
+                }
+                Some(job_status::Status::Running(_)) => {
+                    if has_status_change {
+                        info!("Job {job_id} is running...");
+                    }
+                    wait_future.await;
+                    prev_status = status;
+                }
+                Some(job_status::Status::Failed(err)) => {
+                    let msg = format!("Job {} failed: {}", job_id, err.error);
+                    error!("{msg}");
+                    return Err(DataFusionError::Execution(msg));
+                }
+                Some(job_status::Status::Successful(SuccessfulJob {
+                    queued_at,
+                    started_at,
+                    ended_at,
+                    partition_location,
+                    ..
+                })) => {
+                    return Ok(CompletedJob {
+                        job_id,
+                        partition_location,
+                        flight_proxy,
+                        queued_at,
+                        started_at,
+                        ended_at,
+                        query_start_time,
+                    });
+                }
+            }
+        }
+    } else {
+        // ── Push: server-streams status updates ───────────────────────────────
+        let mut stream = scheduler
+            .execute_query_push(query)
             .await
-            .ok_or(DataFusionError::Execution(
-                "Stream closed without job completing".to_string(),
-            ))?
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+            .into_inner();
 
-        let GetJobStatusResult {
-            status,
-            flight_proxy,
-        } = item;
-        let job_id = status
-            .as_ref()
-            .map(|s| s.job_id.to_owned())
-            .unwrap_or("unknown_job_id".to_string()); // should not happen
-        let status = status.and_then(|s| s.status);
-        let has_status_change = prev_status != status;
-        match status {
-            None => {
-                if has_status_change {
-                    info!("Job {job_id} is in initialization ...");
-                }
-                prev_status = status;
-            }
-            Some(job_status::Status::Queued(_)) => {
-                if has_status_change {
-                    info!("Job {job_id} is queued...");
-                }
-                prev_status = status;
-            }
-            Some(job_status::Status::Running(_)) => {
-                if has_status_change {
-                    info!("Job {job_id} is running...");
-                }
-                prev_status = status;
-            }
-            Some(job_status::Status::Failed(err)) => {
-                let msg = format!("Job {} failed: {}", job_id, err.error);
-                error!("{msg}");
-                break Err(DataFusionError::Execution(msg));
-            }
-            Some(job_status::Status::Successful(SuccessfulJob {
-                queued_at,
-                started_at,
-                ended_at,
-                partition_location,
-                ..
-            })) => {
-                // Calculate job execution time (server-side execution)
-                let job_execution_ms = ended_at.saturating_sub(started_at);
-                let duration = Duration::from_millis(job_execution_ms);
+        let mut prev_status: Option<job_status::Status> = None;
 
-                info!("Job {job_id} finished executing in {duration:?} ");
-
-                // Calculate scheduling time (server-side queue time)
-                // This includes network latency and actual queue time
-                let scheduling_ms = started_at.saturating_sub(queued_at);
-
-                // Calculate total query time (end-to-end from client perspective)
-                let total_elapsed = query_start_time.elapsed();
-                let total_ms = total_elapsed.as_millis();
-
-                // Set timing metrics
-                let metric_job_execution = MetricBuilder::new(&metrics)
-                    .gauge("job_execution_time_ms", partition);
-                metric_job_execution.set(job_execution_ms as usize);
-
-                let metric_scheduling =
-                    MetricBuilder::new(&metrics).gauge("job_scheduling_in_ms", partition);
-                metric_scheduling.set(scheduling_ms as usize);
-
-                let metric_total_time =
-                    MetricBuilder::new(&metrics).gauge("total_query_time_ms", partition);
-                metric_total_time.set(total_ms as usize);
-
-                // Note: data_transfer_time_ms is not set here because partition fetching
-                // happens lazily when the stream is consumed, not during execute_query.
-                // This could be added in a future enhancement by wrapping the stream.
-
-                let streams = partition_location.into_iter().map(move |partition| {
-                    let f = fetch_partition(
-                        partition,
-                        max_message_size,
-                        true,
-                        scheduler_url.clone(),
-                        flight_proxy.clone(),
-                        customize_endpoint.clone(),
-                        use_tls,
+        loop {
+            let item = stream
+                .next()
+                .await
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "Stream closed without job completing".to_string(),
                     )
-                    .map_err(|e| ArrowError::ExternalError(Box::new(e)));
+                })?
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
-                    futures::stream::once(f).try_flatten()
-                });
+            let GetJobStatusResult {
+                status,
+                flight_proxy,
+            } = item;
+            let job_id = status
+                .as_ref()
+                .map(|s| s.job_id.to_owned())
+                .unwrap_or_else(|| "unknown_job_id".to_string());
+            let status = status.and_then(|s| s.status);
+            let has_status_change = prev_status != status;
 
-                break Ok(futures::stream::iter(streams).flatten());
+            match status {
+                None => {
+                    if has_status_change {
+                        info!("Job {job_id} is in initialization...");
+                    }
+                    prev_status = status;
+                }
+                Some(job_status::Status::Queued(_)) => {
+                    if has_status_change {
+                        info!("Job {job_id} is queued...");
+                    }
+                    prev_status = status;
+                }
+                Some(job_status::Status::Running(_)) => {
+                    if has_status_change {
+                        info!("Job {job_id} is running...");
+                    }
+                    prev_status = status;
+                }
+                Some(job_status::Status::Failed(err)) => {
+                    let msg = format!("Job {} failed: {}", job_id, err.error);
+                    error!("{msg}");
+                    return Err(DataFusionError::Execution(msg));
+                }
+                Some(job_status::Status::Successful(SuccessfulJob {
+                    queued_at,
+                    started_at,
+                    ended_at,
+                    partition_location,
+                    ..
+                })) => {
+                    return Ok(CompletedJob {
+                        job_id,
+                        partition_location,
+                        flight_proxy,
+                        queued_at,
+                        started_at,
+                        ended_at,
+                        query_start_time,
+                    });
+                }
             }
-        };
+        }
     }
 }
+
+// ── Internal utilities (unchanged) ────────────────────────────────────────────
 
 fn get_client_host_port(
     executor_metadata: &ExecutorMetadata,

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
 use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
 use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
@@ -27,6 +26,7 @@ use crate::serde::protobuf::{
 };
 use crate::serde::protobuf::{ExecutorMetadata, SuccessfulJob};
 use crate::utils::{GrpcClientConfig, create_grpc_client_endpoint};
+use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::{DataFusionError, Result};
@@ -54,13 +54,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use url::Url;
 
-// ── CompletedJob ──────────────────────────────────────────────────────────────
-
 /// All metadata available after a distributed job finishes successfully.
-///
-/// Every [`JobCompletionHandler`] receives this on completion and can use
-/// whichever fields it needs (e.g. `FetchResultsHandler` uses
-/// `partition_location`).
 pub struct CompletedJob {
     /// Scheduler-assigned job identifier.
     pub job_id: String,
@@ -78,13 +72,7 @@ pub struct CompletedJob {
     pub query_start_time: Instant,
 }
 
-// ── JobCompletionHandler trait ────────────────────────────────────────────────
-
-/// Determines what happens on the *client side* after a distributed job
-/// finishes.  The scheduler is completely unaware of this logic.
-///
-/// Implement this trait to add new post-job behaviors without touching the
-/// scheduler or the poll/push wait loops.
+/// Determines what happens on the client side after a distributed job finishes
 #[async_trait]
 pub(crate) trait JobCompletionHandler: Send {
     async fn handle(
@@ -93,10 +81,6 @@ pub(crate) trait JobCompletionHandler: Send {
     ) -> Result<SendableRecordBatchStream>;
 }
 
-// ── FetchResultsHandler ───────────────────────────────────────────────────────
-
-/// Fetches result partitions from executors via Arrow Flight and streams them
-/// back to the caller. This is the default handler for normal queries.
 pub(crate) struct FetchResultsHandler {
     scheduler_url: String,
     schema: SchemaRef,
@@ -125,9 +109,12 @@ impl JobCompletionHandler for FetchResultsHandler {
             session_config.ballista_override_create_grpc_client_endpoint();
         let use_tls = session_config.ballista_use_tls();
 
-        // ── Timing metrics ────────────────────────────────────────────────────
+        // Calculate job execution time (server-side execution)
         let job_execution_ms = completed.ended_at.saturating_sub(completed.started_at);
+        // Calculate scheduling time (server-side queue time)
+        // This includes network latency and actual queue time
         let scheduling_ms = completed.started_at.saturating_sub(completed.queued_at);
+        // Calculate total query time (end-to-end from client perspective)
         let total_ms = completed.query_start_time.elapsed().as_millis();
 
         info!(
@@ -150,7 +137,9 @@ impl JobCompletionHandler for FetchResultsHandler {
         let metric_total_bytes =
             MetricBuilder::new(&metrics).counter("transferred_bytes", partition);
 
-        // ── Partition streams ─────────────────────────────────────────────────
+        // Note: data_transfer_time_ms is not set here because partition fetching
+        // happens lazily when the stream is consumed, not during execute_query.
+        // This could be added in a future enhancement by wrapping the stream.
         let flight_proxy = completed.flight_proxy;
         let streams = completed.partition_location.into_iter().map(move |loc| {
             let f = fetch_partition(
@@ -183,24 +172,13 @@ impl JobCompletionHandler for FetchResultsHandler {
     }
 }
 
-// ── JobCompletionAction (public config) ───────────────────────────────────────
-
 /// Specifies which [`JobCompletionHandler`] to use after a distributed job
 /// finishes.
-///
-/// Stored in [`DistributedQueryExec`] so the struct can remain `Clone` and
-/// still produce the output schema before `execute()` is called.  Inside
-/// `execute()` the enum is matched to construct the concrete handler.
-///
-/// This keeps the scheduler unaware of callback logic: it always executes a
-/// plain job; the client decides how to interpret the result.
 #[derive(Debug, Clone)]
 pub enum JobCompletionAction {
     /// Fetch result partitions from executors and stream them back (normal query).
     FetchResults,
 }
-
-// ── DistributedQueryExec ──────────────────────────────────────────────────────
 
 /// This operator sends a logical plan to a Ballista scheduler for execution and
 /// polls the scheduler until the query is complete, then dispatches to a
@@ -221,7 +199,13 @@ pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     session_id: String,
     /// Plan properties
     properties: PlanProperties,
-    /// Execution metrics
+    /// Execution metrics, currently exposes:
+    /// - output_rows: Total number of rows returned
+    /// - transferred_bytes: Total bytes transferred from executors
+    /// - job_execution_time_ms: Time spent executing on the cluster (server-side)
+    /// - job_scheduling_in_ms: Time from query submission to job start (includes queue time)
+    /// - job_execution_time_ms: Time spent executing on the cluster (ended_at - started_at)
+    /// - job_scheduling_in_ms: Time job waited in scheduler queue (started_at - queued_at)
     metrics: ExecutionPlanMetricsSet,
     /// Which handler to invoke after the remote job completes.
     action: JobCompletionAction,
@@ -732,8 +716,6 @@ async fn execute_query_push(
         };
     }
 }
-
-// ── Internal utilities (unchanged) ────────────────────────────────────────────
 
 fn get_client_host_port(
     executor_metadata: &ExecutorMetadata,

--- a/ballista/core/src/execution_plans/job_callback_handler/fetch_results.rs
+++ b/ballista/core/src/execution_plans/job_callback_handler/fetch_results.rs
@@ -1,0 +1,276 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::client::BallistaClient;
+use crate::execution_plans::distributed_query::CompletedJob;
+use crate::execution_plans::job_callback_handler::JobCompletionHandler;
+use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
+use crate::serde::protobuf::get_job_status_result::FlightProxy;
+use crate::serde::protobuf::{ExecutorMetadata, PartitionLocation};
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::error::ArrowError;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::prelude::SessionConfig;
+use futures::{StreamExt, TryFutureExt, TryStreamExt};
+use std::sync::Arc;
+use url::Url;
+
+pub(crate) struct FetchResultsHandler {
+    pub(crate) scheduler_url: String,
+    pub(crate) schema: SchemaRef,
+    pub(crate) max_message_size: usize,
+    pub(crate) session_config: SessionConfig,
+    pub(crate) metrics: Arc<ExecutionPlanMetricsSet>,
+    pub(crate) partition: usize,
+}
+
+#[async_trait]
+impl JobCompletionHandler for FetchResultsHandler {
+    async fn handle(
+        self: Box<Self>,
+        completed: CompletedJob,
+    ) -> Result<SendableRecordBatchStream> {
+        let FetchResultsHandler {
+            scheduler_url,
+            schema,
+            max_message_size,
+            session_config,
+            metrics,
+            partition,
+        } = *self;
+
+        let customize_endpoint =
+            session_config.ballista_override_create_grpc_client_endpoint();
+        let use_tls = session_config.ballista_use_tls();
+
+        // Calculate job execution time (server-side execution)
+        let job_execution_ms = completed.ended_at.saturating_sub(completed.started_at);
+        // Calculate scheduling time (server-side queue time)
+        // This includes network latency and actual queue time
+        let scheduling_ms = completed.started_at.saturating_sub(completed.queued_at);
+        // Calculate total query time (end-to-end from client perspective)
+        let total_ms = completed.query_start_time.elapsed().as_millis();
+
+        log::info!(
+            "Job {} finished executing in {:?}",
+            completed.job_id,
+            std::time::Duration::from_millis(job_execution_ms)
+        );
+
+        MetricBuilder::new(&metrics)
+            .gauge("job_execution_time_ms", partition)
+            .set(job_execution_ms as usize);
+        MetricBuilder::new(&metrics)
+            .gauge("job_scheduling_in_ms", partition)
+            .set(scheduling_ms as usize);
+        MetricBuilder::new(&metrics)
+            .gauge("total_query_time_ms", partition)
+            .set(total_ms as usize);
+
+        let metric_row_count = MetricBuilder::new(&metrics).output_rows(partition);
+        let metric_total_bytes =
+            MetricBuilder::new(&metrics).counter("transferred_bytes", partition);
+
+        // Note: data_transfer_time_ms is not set here because partition fetching
+        // happens lazily when the stream is consumed, not during execute_query.
+        // This could be added in a future enhancement by wrapping the stream.
+        let flight_proxy = completed.flight_proxy;
+        let streams = completed.partition_location.into_iter().map(move |loc| {
+            let f = fetch_partition(
+                loc,
+                max_message_size,
+                true,
+                scheduler_url.clone(),
+                flight_proxy.clone(),
+                customize_endpoint.clone(),
+                use_tls,
+            )
+            .map_err(|e| ArrowError::ExternalError(Box::new(e)));
+
+            futures::stream::once(f).try_flatten()
+        });
+
+        let stream = futures::stream::iter(streams)
+            .flatten()
+            .inspect(move |batch| {
+                metric_total_bytes.add(
+                    batch
+                        .as_ref()
+                        .map(|b| b.get_array_memory_size())
+                        .unwrap_or(0),
+                );
+                metric_row_count.add(batch.as_ref().map(|b| b.num_rows()).unwrap_or(0));
+            });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+pub(crate) fn get_client_host_port(
+    executor_metadata: &ExecutorMetadata,
+    scheduler_url: &str,
+    flight_proxy: &Option<FlightProxy>,
+) -> Result<(String, u16)> {
+    fn split_host_port(address: &str) -> Result<(String, u16)> {
+        let url: Url = address.parse().map_err(|e| {
+            DataFusionError::Execution(format!(
+                "Cannot parse host:port in {address:?}: {e}"
+            ))
+        })?;
+        let host = url
+            .host_str()
+            .ok_or(DataFusionError::Execution(format!(
+                "No host in {address:?}"
+            )))?
+            .to_string();
+        let port: u16 = url.port().ok_or(DataFusionError::Execution(format!(
+            "No port in {address:?}"
+        )))?;
+        Ok((host, port))
+    }
+
+    match flight_proxy {
+        Some(FlightProxy::External(address)) => {
+            log::debug!("Fetching results from external flight proxy: {}", address);
+            split_host_port(format!("http://{address}").as_str())
+        }
+        Some(FlightProxy::Local(true)) => {
+            log::debug!("Fetching results from scheduler: {}", scheduler_url);
+            split_host_port(scheduler_url)
+        }
+        Some(FlightProxy::Local(false)) | None => {
+            log::debug!(
+                "Fetching results from executor: {}:{}",
+                executor_metadata.host,
+                executor_metadata.port
+            );
+            Ok((
+                executor_metadata.host.clone(),
+                executor_metadata.port as u16,
+            ))
+        }
+    }
+}
+
+pub(crate) async fn fetch_partition(
+    location: PartitionLocation,
+    max_message_size: usize,
+    flight_transport: bool,
+    scheduler_url: String,
+    flight_proxy: Option<FlightProxy>,
+    customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+    use_tls: bool,
+) -> Result<SendableRecordBatchStream> {
+    let metadata = location.executor_meta.ok_or_else(|| {
+        DataFusionError::Internal("Received empty executor metadata".to_owned())
+    })?;
+
+    let partition_id = location.partition_id.ok_or_else(|| {
+        DataFusionError::Internal("Received empty partition id".to_owned())
+    })?;
+    let host = metadata.host.as_str();
+    let port = metadata.port as u16;
+
+    let (client_host, client_port) =
+        get_client_host_port(&metadata, &scheduler_url, &flight_proxy)?;
+
+    let mut ballista_client = BallistaClient::try_new(
+        client_host.as_str(),
+        client_port,
+        max_message_size,
+        use_tls,
+        customize_endpoint,
+    )
+    .await
+    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    ballista_client
+        .fetch_partition_proxied(
+            &metadata.id,
+            &partition_id.into(),
+            host,
+            port,
+            &location.path,
+            flight_transport,
+        )
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))
+}
+
+#[cfg(test)]
+mod test {
+    use super::get_client_host_port;
+    use crate::serde::protobuf::ExecutorMetadata;
+    use crate::serde::protobuf::get_job_status_result::FlightProxy;
+
+    #[test]
+    fn test_client_host_port() {
+        let scheduler_host = "scheduler";
+        let scheduler_port: u16 = 5000;
+
+        let scheduler_url = format!("http://{scheduler_host}:{scheduler_port}");
+        let executor = ExecutorMetadata {
+            id: "test".to_string(),
+            host: "executor".to_string(),
+            port: 12345,
+            grpc_port: 1,
+            specification: None,
+        };
+
+        // no flight proxy -> client should fetch results from executor
+        assert_eq!(
+            get_client_host_port(&executor, &scheduler_url, &None).unwrap(),
+            (executor.host.clone(), executor.port as u16)
+        );
+
+        // same, no flight proxy
+        assert_eq!(
+            get_client_host_port(
+                &executor,
+                &scheduler_url,
+                &Some(FlightProxy::Local(false))
+            )
+            .unwrap(),
+            (executor.host.clone(), executor.port as u16)
+        );
+
+        // embedded flight proxy on scheduler
+        assert_eq!(
+            get_client_host_port(
+                &executor,
+                &scheduler_url,
+                &Some(FlightProxy::Local(true))
+            )
+            .unwrap(),
+            (scheduler_host.to_string(), scheduler_port)
+        );
+
+        // external proxy
+        assert_eq!(
+            get_client_host_port(
+                &executor,
+                &scheduler_url,
+                &Some(FlightProxy::External("proxy:1234".to_string()))
+            )
+            .unwrap(),
+            ("proxy".to_string(), 1234_u16)
+        );
+    }
+}

--- a/ballista/core/src/execution_plans/job_callback_handler/mod.rs
+++ b/ballista/core/src/execution_plans/job_callback_handler/mod.rs
@@ -15,22 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! This module contains execution plans that are needed to distribute DataFusion's execution plans into
-//! several Ballista executors.
+use crate::execution_plans::distributed_query::CompletedJob;
+use async_trait::async_trait;
+use datafusion::error::Result;
+use datafusion::physical_plan::SendableRecordBatchStream;
 
-mod distributed_query;
-mod job_callback_handler;
-mod shuffle_reader;
-mod shuffle_writer;
-mod shuffle_writer_trait;
-pub mod sort_shuffle;
-mod unresolved_shuffle;
+mod fetch_results;
+pub(crate) use fetch_results::FetchResultsHandler;
 
-pub use distributed_query::{CompletedJob, DistributedQueryExec};
-pub use job_callback_handler::JobCompletionAction;
-pub use shuffle_reader::ShuffleReaderExec;
-pub use shuffle_reader::{stats_for_partition, stats_for_partitions};
-pub use shuffle_writer::ShuffleWriterExec;
-pub use shuffle_writer_trait::ShuffleWriter;
-pub use sort_shuffle::SortShuffleWriterExec;
-pub use unresolved_shuffle::UnresolvedShuffleExec;
+/// Determines what happens on the client side after a distributed job finishes.
+#[async_trait]
+pub(crate) trait JobCompletionHandler: Send {
+    async fn handle(
+        self: Box<Self>,
+        completed: CompletedJob,
+    ) -> Result<SendableRecordBatchStream>;
+}
+
+/// Specifies which [`JobCompletionHandler`] to use after a distributed job
+/// finishes.
+#[derive(Debug, Clone)]
+pub enum JobCompletionAction {
+    /// Fetch result partitions from executors and stream them back (normal query).
+    FetchResults,
+}

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -25,7 +25,7 @@ mod shuffle_writer_trait;
 pub mod sort_shuffle;
 mod unresolved_shuffle;
 
-pub use distributed_query::DistributedQueryExec;
+pub use distributed_query::{CompletedJob, DistributedQueryExec, JobCompletionAction};
 pub use shuffle_reader::ShuffleReaderExec;
 pub use shuffle_reader::{stats_for_partition, stats_for_partitions};
 pub use shuffle_writer::ShuffleWriterExec;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1344 , as the Step 1 - Building the job-level dependency logic.

For the next step, we will apply `EXPLAIN ANALYZE` job as the first use case.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Ballista currently treats a single job as the atomic unit of scheduling, with no mechanism to run multiple jobs sequentially.

To support features like `EXPLAIN ANALYZE`, we need job callback mechanism. This PR refactor client side (`DistributedQueryExec`) to introduce a semantic like this
```
let job_a = job_a.and_then(|job_info| {
 job_b_definition(job_info).and_then(|...| {...}
}

submit (job_a)
```

# What changes are included in this PR?

<img width="5340" height="4673" alt="image" src="https://github.com/user-attachments/assets/c306239c-7bd9-4ebc-9475-044112fa1115" />

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No
