### PR TITLE
feat: Improve REST API adding task related info to job stages

### DIFF
--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -461,7 +461,7 @@ pub async fn get_query_stages<
                                     let task_status: TaskStatus = (&info.task_status).into();
 
                                     TaskSummary {
-                                        task_id: info.task_id,
+                                        id: info.task_id,
                                         partition_id: partition_id as u32,
                                         scheduled_time: info.scheduled_time as u64,
                                         launch_time: info.launch_time as u64,

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -106,9 +106,11 @@ pub struct TaskSummary {
     /// The time the Executor finish the task
     pub end_exec_time: u64,
     /// total execution time
-    pub total_exec_time: u64,
+    pub exec_duration: u64,
     /// Scheduler side finish time
     pub finish_time: u64,
+    /// Number of input rows
+    pub input_rows: usize,
     /// Number of output rows
     pub output_rows: usize,
 }
@@ -394,10 +396,19 @@ pub async fn get_query_stages<
                             .enumerate()
                             .map(|(partition_id, task_info)| {
                                 task_info.as_ref().map(|info| {
-                                    let output_rows = running_stage
+                                    let partition_metrics = running_stage
                                         .stage_metrics
                                         .as_deref()
-                                        .and_then(|m| m.get(partition_id))
+                                        .and_then(|m| m.get(partition_id));
+                                    let input_rows = partition_metrics
+                                        .map(|m| {
+                                            get_combined_count(
+                                                std::slice::from_ref(m),
+                                                "input_rows",
+                                            )
+                                        })
+                                        .unwrap_or(0);
+                                    let output_rows = partition_metrics
                                         .map(|m| {
                                             get_combined_count(
                                                 std::slice::from_ref(m),
@@ -415,8 +426,9 @@ pub async fn get_query_stages<
                                         launch_time: info.launch_time as u64,
                                         start_exec_time,
                                         end_exec_time,
-                                        total_exec_time: end_exec_time.saturating_sub(start_exec_time),
+                                        exec_duration: end_exec_time.saturating_sub(start_exec_time),
                                         finish_time: info.finish_time as u64,
+                                        input_rows,
                                         output_rows,
                                     }
                                 })
@@ -440,9 +452,17 @@ pub async fn get_query_stages<
                             .iter()
                             .enumerate()
                             .map(|(partition_id, task_info)| {
-                                let output_rows = completed_stage
-                                    .stage_metrics
-                                    .get(partition_id)
+                                let partition_metrics =
+                                    completed_stage.stage_metrics.get(partition_id);
+                                let input_rows = partition_metrics
+                                    .map(|m| {
+                                        get_combined_count(
+                                            std::slice::from_ref(m),
+                                            "input_rows",
+                                        )
+                                    })
+                                    .unwrap_or(0);
+                                let output_rows = partition_metrics
                                     .map(|m| {
                                         get_combined_count(
                                             std::slice::from_ref(m),
@@ -459,8 +479,9 @@ pub async fn get_query_stages<
                                     launch_time: task_info.launch_time as u64,
                                     start_exec_time,
                                     end_exec_time,
-                                    total_exec_time: end_exec_time.saturating_sub(start_exec_time),
+                                    exec_duration: end_exec_time.saturating_sub(start_exec_time),
                                     finish_time: task_info.finish_time as u64,
+                                    input_rows,
                                     output_rows,
                                 })
                             })

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -97,7 +97,7 @@ struct CancelJobResponse {
 #[derive(Debug, serde::Serialize)]
 pub struct TaskSummary {
     /// task id
-    pub task_id: usize,
+    pub id: usize,
     /// Task status
     pub task_status: TaskStatus,
     /// partition id

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -99,7 +99,7 @@ pub struct TaskSummary {
     /// task id
     pub id: usize,
     /// Task status
-    pub task_status: TaskStatus,
+    pub status: TaskStatus,
     /// partition id
     pub partition_id: u32,
     /// Scheduler schedule time

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -515,7 +515,7 @@ pub async fn get_query_stages<
                                 let end_exec_time = task_info.end_exec_time as u64;
                                 let task_status = (&task_info.task_status).into();
                                 Some(TaskSummary {
-                                    task_id: task_info.task_id,
+                                    id: task_info.task_id,
                                     partition_id: partition_id as u32,
                                     scheduled_time: task_info.scheduled_time as u64,
                                     launch_time: task_info.launch_time as u64,

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -92,12 +92,35 @@ struct CancelJobResponse {
 }
 
 #[derive(Debug, serde::Serialize)]
+pub struct TaskSummary {
+    /// task id
+    pub task_id: u32,
+    /// partition id
+    pub partition_id: u32,
+    /// Scheduler schedule time
+    pub scheduled_time: u64,
+    /// Scheduler launch time
+    pub launch_time: u64,
+    /// The time the Executor start to run the task
+    pub start_exec_time: u64,
+    /// The time the Executor finish the task
+    pub end_exec_time: u64,
+    /// total execution time
+    pub total_exec_time: u64,
+    /// Scheduler side finish time
+    pub finish_time: u64,
+    /// Number of output rows
+    pub output_rows: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
 pub struct QueryStageSummary {
     pub stage_id: String,
     pub stage_status: String,
     pub input_rows: usize,
     pub output_rows: usize,
     pub elapsed_compute: String,
+    pub tasks: Vec<Option<TaskSummary>>,
 }
 
 pub async fn get_scheduler_state<
@@ -346,6 +369,7 @@ pub async fn get_query_stages<
                     input_rows: 0,
                     output_rows: 0,
                     elapsed_compute: "".to_string(),
+                    tasks: vec![],
                 };
                 match stage {
                     ExecutionStage::Running(running_stage) => {
@@ -364,6 +388,40 @@ pub async fn get_query_stages<
                             .as_ref()
                             .map(|m| get_elapsed_compute_nanos(m.as_slice()))
                             .unwrap_or_default();
+                        summary.tasks = running_stage
+                            .task_infos
+                            .iter()
+                            .enumerate()
+                            .map(|(partition_id, task_info)| {
+                                task_info.as_ref().map(|info| {
+                                    let output_rows = running_stage
+                                        .stage_metrics
+                                        .as_deref()
+                                        .and_then(|m| m.get(partition_id))
+                                        .map(|m| {
+                                            get_combined_count(
+                                                std::slice::from_ref(m),
+                                                "output_rows",
+                                            )
+                                        })
+                                        .unwrap_or(0);
+
+                                    let start_exec_time = info.start_exec_time as u64;
+                                    let end_exec_time = info.end_exec_time as u64;
+                                    TaskSummary {
+                                        task_id: info.task_id as u32,
+                                        partition_id: partition_id as u32,
+                                        scheduled_time: info.scheduled_time as u64,
+                                        launch_time: info.launch_time as u64,
+                                        start_exec_time,
+                                        end_exec_time,
+                                        total_exec_time: end_exec_time.saturating_sub(start_exec_time),
+                                        finish_time: info.finish_time as u64,
+                                        output_rows,
+                                    }
+                                })
+                            })
+                            .collect();
                     }
                     ExecutionStage::Successful(completed_stage) => {
                         summary.input_rows = get_combined_count(
@@ -376,6 +434,37 @@ pub async fn get_query_stages<
                         );
                         summary.elapsed_compute =
                             get_elapsed_compute_nanos(&completed_stage.stage_metrics);
+
+                        summary.tasks = completed_stage
+                            .task_infos
+                            .iter()
+                            .enumerate()
+                            .map(|(partition_id, task_info)| {
+                                let output_rows = completed_stage
+                                    .stage_metrics
+                                    .get(partition_id)
+                                    .map(|m| {
+                                        get_combined_count(
+                                            std::slice::from_ref(m),
+                                            "output_rows",
+                                        )
+                                    })
+                                    .unwrap_or(0);
+                                let start_exec_time = task_info.start_exec_time as u64;
+                                let end_exec_time = task_info.end_exec_time as u64;
+                                Some(TaskSummary {
+                                    task_id: task_info.task_id as u32,
+                                    partition_id: partition_id as u32,
+                                    scheduled_time: task_info.scheduled_time as u64,
+                                    launch_time: task_info.launch_time as u64,
+                                    start_exec_time,
+                                    end_exec_time,
+                                    total_exec_time: end_exec_time.saturating_sub(start_exec_time),
+                                    finish_time: task_info.finish_time as u64,
+                                    output_rows,
+                                })
+                            })
+                            .collect();
                     }
                     _ => {}
                 }

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -525,7 +525,7 @@ pub async fn get_query_stages<
                                     finish_time: task_info.finish_time as u64,
                                     input_rows,
                                     output_rows,
-                                    task_status
+                                    status: task_status
                                 })
                             })
                             .collect();

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -22,6 +22,7 @@ use axum::{
 use ballista_core::BALLISTA_VERSION;
 use ballista_core::serde::protobuf::job_status::Status;
 use datafusion::DATAFUSION_VERSION;
+use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::{MetricValue, MetricsSet, Time};
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -131,6 +132,7 @@ pub struct QueryStageSummary {
     pub input_rows: usize,
     pub output_rows: usize,
     pub elapsed_compute: String,
+    pub stage_plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_duration_stats: Option<DurationStats>,
     pub tasks: Vec<Option<TaskSummary>>,
@@ -384,9 +386,11 @@ pub async fn get_query_stages<
                     elapsed_compute: "".to_string(),
                     tasks: vec![],
                     task_duration_stats: None,
+                    stage_plan: None
                 };
                 match stage {
                     ExecutionStage::Running(running_stage) => {
+                        summary.stage_plan = Some(displayable(running_stage.plan.as_ref()).indent(false).to_string());
                         summary.input_rows = running_stage
                             .stage_metrics
                             .as_ref()
@@ -448,6 +452,7 @@ pub async fn get_query_stages<
                             .collect();
                     }
                     ExecutionStage::Successful(completed_stage) => {
+                        summary.stage_plan = Some(displayable(completed_stage.plan.as_ref()).indent(false).to_string());
                         summary.input_rows = get_combined_count(
                             &completed_stage.stage_metrics,
                             "input_rows",

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -116,12 +116,23 @@ pub struct TaskSummary {
 }
 
 #[derive(Debug, serde::Serialize)]
+pub struct DurationStats {
+    pub min: u64,
+    pub p25: u64,
+    pub median: u64,
+    pub p75: u64,
+    pub max: u64,
+}
+
+#[derive(Debug, serde::Serialize)]
 pub struct QueryStageSummary {
     pub stage_id: String,
     pub stage_status: String,
     pub input_rows: usize,
     pub output_rows: usize,
     pub elapsed_compute: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_duration_stats: Option<DurationStats>,
     pub tasks: Vec<Option<TaskSummary>>,
 }
 
@@ -372,6 +383,7 @@ pub async fn get_query_stages<
                     output_rows: 0,
                     elapsed_compute: "".to_string(),
                     tasks: vec![],
+                    task_duration_stats: None,
                 };
                 match stage {
                     ExecutionStage::Running(running_stage) => {
@@ -489,6 +501,7 @@ pub async fn get_query_stages<
                     }
                     _ => {}
                 }
+                summary.task_duration_stats = task_duration_stats(&summary.tasks);
                 summary
             })
             .collect();
@@ -497,6 +510,30 @@ pub async fn get_query_stages<
     } else {
         Err(SchedulerErrorResponse::new(StatusCode::NOT_FOUND))
     }
+}
+
+fn percentile_duration(sorted: &[u64], pct: f64) -> u64 {
+    let idx = ((pct / 100.0) * (sorted.len() - 1) as f64).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn task_duration_stats(tasks: &[Option<TaskSummary>]) -> Option<DurationStats> {
+    let mut durations: Vec<u64> =
+        tasks.iter().flatten().map(|t| t.exec_duration).collect();
+
+    if durations.is_empty() {
+        return None;
+    }
+
+    durations.sort_unstable();
+
+    Some(DurationStats {
+        min: durations[0],
+        p25: percentile_duration(&durations, 25.0),
+        median: percentile_duration(&durations, 50.0),
+        p75: percentile_duration(&durations, 75.0),
+        max: *durations.last().unwrap(),
+    })
 }
 
 fn format_job_status(status: &Option<Status>, elapsed_ms: u64) -> (String, String) {

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -471,7 +471,7 @@ pub async fn get_query_stages<
                                         finish_time: info.finish_time as u64,
                                         input_rows,
                                         output_rows,
-                                        task_status
+                                        status: task_status
                                     }
                                 })
                             })

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -21,6 +21,7 @@ use axum::{
 };
 use ballista_core::BALLISTA_VERSION;
 use ballista_core::serde::protobuf::job_status::Status;
+use ballista_core::serde::protobuf::task_status;
 use datafusion::DATAFUSION_VERSION;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::{MetricValue, MetricsSet, Time};
@@ -33,6 +34,7 @@ use graphviz_rust::{
     printer::PrinterContext,
 };
 use http::{StatusCode, header::CONTENT_TYPE};
+use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -95,20 +97,22 @@ struct CancelJobResponse {
 #[derive(Debug, serde::Serialize)]
 pub struct TaskSummary {
     /// task id
-    pub task_id: u32,
+    pub task_id: usize,
+    /// Task status
+    pub task_status: TaskStatus,
     /// partition id
     pub partition_id: u32,
     /// Scheduler schedule time
     pub scheduled_time: u64,
-    /// Scheduler launch time
+    /// Scheduler launch time (ms since epoch)
     pub launch_time: u64,
-    /// The time the Executor start to run the task
+    /// The time the Executor start to run the task (ms since epoch)
     pub start_exec_time: u64,
-    /// The time the Executor finish the task
+    /// The time the Executor finish the task (ms since epoch)
     pub end_exec_time: u64,
-    /// total execution time
+    /// total execution time (ms)
     pub exec_duration: u64,
-    /// Scheduler side finish time
+    /// Scheduler side finish time (ms since epoch)
     pub finish_time: u64,
     /// Number of input rows
     pub input_rows: usize,
@@ -116,8 +120,25 @@ pub struct TaskSummary {
     pub output_rows: usize,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub enum TaskStatus {
+    Running,
+    Successful,
+    Failed,
+}
+
+impl From<&task_status::Status> for TaskStatus {
+    fn from(value: &task_status::Status) -> Self {
+        match value {
+            task_status::Status::Running(_) => TaskStatus::Running,
+            task_status::Status::Failed(_) => TaskStatus::Failed,
+            task_status::Status::Successful(_) => TaskStatus::Successful,
+        }
+    }
+}
+
 #[derive(Debug, serde::Serialize)]
-pub struct DurationStats {
+pub struct Percentiles {
     pub min: u64,
     pub p25: u64,
     pub median: u64,
@@ -132,9 +153,12 @@ pub struct QueryStageSummary {
     pub input_rows: usize,
     pub output_rows: usize,
     pub elapsed_compute: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stage_plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_duration_stats: Option<DurationStats>,
+    pub task_duration_percentiles: Option<Percentiles>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_input_percentiles: Option<Percentiles>,
     pub tasks: Vec<Option<TaskSummary>>,
 }
 
@@ -385,8 +409,9 @@ pub async fn get_query_stages<
                     output_rows: 0,
                     elapsed_compute: "".to_string(),
                     tasks: vec![],
-                    task_duration_stats: None,
-                    stage_plan: None
+                    task_duration_percentiles: None,
+                    task_input_percentiles: None,
+                    stage_plan: None,
                 };
                 match stage {
                     ExecutionStage::Running(running_stage) => {
@@ -416,27 +441,27 @@ pub async fn get_query_stages<
                                         .stage_metrics
                                         .as_deref()
                                         .and_then(|m| m.get(partition_id));
-                                    let input_rows = partition_metrics
-                                        .map(|m| {
-                                            get_combined_count(
-                                                std::slice::from_ref(m),
-                                                "input_rows",
-                                            )
-                                        })
-                                        .unwrap_or(0);
-                                    let output_rows = partition_metrics
-                                        .map(|m| {
-                                            get_combined_count(
-                                                std::slice::from_ref(m),
-                                                "output_rows",
-                                            )
-                                        })
-                                        .unwrap_or(0);
+                                    let (input_rows, output_rows) = partition_metrics
+                                    .map(|m| {
+                                        let input = get_combined_count(
+                                            std::slice::from_ref(m),
+                                            "input_rows",
+                                        );
+                                        let output = get_combined_count(
+                                            std::slice::from_ref(m),
+                                            "output_rows",
+                                        );
+                                        (input,output)
+                                    })
+                                    .unwrap_or((0,0));
 
                                     let start_exec_time = info.start_exec_time as u64;
                                     let end_exec_time = info.end_exec_time as u64;
+
+                                    let task_status: TaskStatus = (&info.task_status).into();
+
                                     TaskSummary {
-                                        task_id: info.task_id as u32,
+                                        task_id: info.task_id,
                                         partition_id: partition_id as u32,
                                         scheduled_time: info.scheduled_time as u64,
                                         launch_time: info.launch_time as u64,
@@ -446,6 +471,7 @@ pub async fn get_query_stages<
                                         finish_time: info.finish_time as u64,
                                         input_rows,
                                         output_rows,
+                                        task_status
                                     }
                                 })
                             })
@@ -471,26 +497,25 @@ pub async fn get_query_stages<
                             .map(|(partition_id, task_info)| {
                                 let partition_metrics =
                                     completed_stage.stage_metrics.get(partition_id);
-                                let input_rows = partition_metrics
+                                let (input_rows, output_rows) = partition_metrics
                                     .map(|m| {
-                                        get_combined_count(
+                                        let input = get_combined_count(
                                             std::slice::from_ref(m),
                                             "input_rows",
-                                        )
-                                    })
-                                    .unwrap_or(0);
-                                let output_rows = partition_metrics
-                                    .map(|m| {
-                                        get_combined_count(
+                                        );
+                                        let output = get_combined_count(
                                             std::slice::from_ref(m),
                                             "output_rows",
-                                        )
+                                        );
+                                        (input,output)
                                     })
-                                    .unwrap_or(0);
+                                    .unwrap_or((0,0));
+
                                 let start_exec_time = task_info.start_exec_time as u64;
                                 let end_exec_time = task_info.end_exec_time as u64;
+                                let task_status = (&task_info.task_status).into();
                                 Some(TaskSummary {
-                                    task_id: task_info.task_id as u32,
+                                    task_id: task_info.task_id,
                                     partition_id: partition_id as u32,
                                     scheduled_time: task_info.scheduled_time as u64,
                                     launch_time: task_info.launch_time as u64,
@@ -500,13 +525,15 @@ pub async fn get_query_stages<
                                     finish_time: task_info.finish_time as u64,
                                     input_rows,
                                     output_rows,
+                                    task_status
                                 })
                             })
                             .collect();
                     }
                     _ => {}
                 }
-                summary.task_duration_stats = task_duration_stats(&summary.tasks);
+                summary.task_duration_percentiles = task_duration_percentiles(&summary.tasks);
+                summary.task_input_percentiles = task_input_percentiles(&summary.tasks);
                 summary
             })
             .collect();
@@ -522,7 +549,29 @@ fn percentile_duration(sorted: &[u64], pct: f64) -> u64 {
     sorted[idx.min(sorted.len() - 1)]
 }
 
-fn task_duration_stats(tasks: &[Option<TaskSummary>]) -> Option<DurationStats> {
+fn task_input_percentiles(tasks: &[Option<TaskSummary>]) -> Option<Percentiles> {
+    let mut durations: Vec<u64> = tasks
+        .iter()
+        .flatten()
+        .map(|t| t.input_rows as u64)
+        .collect();
+
+    if durations.is_empty() {
+        return None;
+    }
+
+    durations.sort_unstable();
+
+    Some(Percentiles {
+        min: durations[0],
+        p25: percentile_duration(&durations, 25.0),
+        median: percentile_duration(&durations, 50.0),
+        p75: percentile_duration(&durations, 75.0),
+        max: *durations.last().unwrap(),
+    })
+}
+
+fn task_duration_percentiles(tasks: &[Option<TaskSummary>]) -> Option<Percentiles> {
     let mut durations: Vec<u64> =
         tasks.iter().flatten().map(|t| t.exec_duration).collect();
 
@@ -532,7 +581,7 @@ fn task_duration_stats(tasks: &[Option<TaskSummary>]) -> Option<DurationStats> {
 
     durations.sort_unstable();
 
-    Some(DurationStats {
+    Some(Percentiles {
         min: durations[0],
         p25: percentile_duration(&durations, 25.0),
         median: percentile_duration(&durations, 50.0),


### PR DESCRIPTION
# Which issue does this PR close?



Closes #.

 # Rationale for this change

Task related information is important to detect issues like skewed partitions, we already have task related information collected. 



# What changes are included in this PR?

Added ask related information to scheduler rest api. Stages will now display important information for finished tasks

```bash
curl http://localhost:50050/api/job/v4LClLC/stages
```

output changes from:

```json
{
  "stages": [
    {
      "stage_id": "1",
      "stage_status": "Successful",
      "input_rows": 1,
      "output_rows": 2,
      "elapsed_compute": "269.42µs"
}
]
```

to:

```json
{
  "stages": [
    {
      "stage_id": "1",
      "stage_status": "Successful",
      "input_rows": 1,
      "output_rows": 2,
      "elapsed_compute": "269.12µs",
      "stage_plan": "ShuffleWriterExec: partitioning: None\n  ProjectionExec: expr=[1 as Int64(1)]\n    PlaceholderRowExec\n",
      "task_duration_percentiles": {
        "min": 3,
        "p25": 3,
        "median": 3,
        "p75": 3,
        "max": 3
      },
      "task_input_percentiles": {
        "min": 1,
        "p25": 1,
        "median": 1,
        "p75": 1,
        "max": 1
      },
      "tasks": [
        {
          "task_id": 0,
          "task_status": "Successful",
          "partition_id": 0,
          "scheduled_time": 1775418772192,
          "launch_time": 1775418772192,
          "start_exec_time": 1775418772199,
          "end_exec_time": 1775418772202,
          "exec_duration": 3,
          "finish_time": 1775418772204,
          "input_rows": 1,
          "output_rows": 1
        }
      ]
    }
  ]
}
```

similar to spark it will print task execution distribution 

<img width="1373" height="90" alt="image" src="https://github.com/user-attachments/assets/195d29c7-c6ed-4b8b-9301-b0ba0f47a241" />


# Are there any user-facing changes?

no 