### PR TITLE
chore: Fix Clippy issues with Rust 1.95.0

### DIFF
--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -312,20 +312,14 @@ impl App {
                     self.sort_executors_by(ExecutorsSortColumn::LastSeen);
                 }
             }
-            KeyCode::Char('4') => {
-                if self.is_jobs_view() {
-                    self.sort_jobs_by(JobsSortColumn::StagesCompleted);
-                }
+            KeyCode::Char('4') if self.is_jobs_view() => {
+                self.sort_jobs_by(JobsSortColumn::StagesCompleted);
             }
-            KeyCode::Char('5') => {
-                if self.is_jobs_view() {
-                    self.sort_jobs_by(JobsSortColumn::PercentComplete);
-                }
+            KeyCode::Char('5') if self.is_jobs_view() => {
+                self.sort_jobs_by(JobsSortColumn::PercentComplete);
             }
-            KeyCode::Char('6') => {
-                if self.is_jobs_view() {
-                    self.sort_jobs_by(JobsSortColumn::StartTime);
-                }
+            KeyCode::Char('6') if self.is_jobs_view() => {
+                self.sort_jobs_by(JobsSortColumn::StartTime);
             }
             KeyCode::Char('c')
                 if self.is_jobs_view() && self.input_mode == InputMode::View =>
@@ -499,8 +493,10 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::tui::domain::{SchedulerState, jobs::Job};
+    use crate::tui::App;
+    use crate::tui::Settings;
+    use crate::tui::app::{ExecutorsSortColumn, JobsSortColumn, MetricsSortColumn};
+    use crate::tui::domain::{SchedulerState, SortOrder, jobs::Job};
 
     fn make_app() -> App {
         let settings =

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -64,7 +64,7 @@ impl HttpClient {
     pub async fn get_jobs(&self) -> TuiResult<Vec<Job>> {
         let url = self.url("jobs");
         self.json::<Vec<Job>>(&url).await.map(|mut jobs| {
-            jobs.sort_by(|a, b| b.start_time.cmp(&a.start_time)); // newest first
+            jobs.sort_by_key(|b| std::cmp::Reverse(b.start_time)); // newest first
             jobs
         })
     }

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -936,8 +936,8 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
     /// Return all currently running tasks along with the executor ID on which they are assigned
     fn running_tasks(&self) -> Vec<RunningTaskInfo> {
         self.stages
-            .iter()
-            .flat_map(|(_, stage)| {
+            .values()
+            .flat_map(|stage| {
                 if let ExecutionStage::Running(stage) = stage {
                     stage
                         .running_tasks()

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1129,8 +1129,8 @@ impl ExecutionGraph for StaticExecutionGraph {
     /// Return all currently running tasks along with the executor ID on which they are assigned
     fn running_tasks(&self) -> Vec<RunningTaskInfo> {
         self.stages
-            .iter()
-            .flat_map(|(_, stage)| {
+            .values()
+            .flat_map(|stage| {
                 if let ExecutionStage::Running(stage) = stage {
                     stage
                         .running_tasks()

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -439,8 +439,8 @@ impl ExecutorManager {
 
         self.cluster_state
             .executor_heartbeats()
-            .iter()
-            .filter_map(|(_exec, heartbeat)| {
+            .values()
+            .filter_map(|heartbeat| {
                 let terminating = matches!(
                     heartbeat
                         .status


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Rust 1.95.0 has been released and Clippy reports some new issues.
https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/
https://releases.rs/docs/1.95.0/

# What changes are included in this PR?

Applied suggestions by Clippy 1.95.0

# Are there any user-facing changes?
 
No