### PR TITLE
feat: Support `EXPLAIN ANALYZE` in Ballista

### DIFF
--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -25,11 +25,14 @@ mod supported {
     };
     use ballista_core::config::BallistaConfig;
 
+    use datafusion::arrow::array::StringArray;
+    use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::physical_plan::collect;
     use datafusion::prelude::*;
     use datafusion::{assert_batches_eq, prelude::SessionContext};
     use rstest::*;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[rstest::fixture]
     fn test_data() -> String {
@@ -1046,6 +1049,89 @@ mod supported {
             "+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
         ];
         assert_batches_eq!(expected, &result);
+    }
+
+    #[rstest]
+    #[case::standalone(standalone_context())]
+    #[case::remote(remote_context())]
+    #[tokio::test]
+    async fn should_execute_explain_analyze_query(
+        #[future(awt)]
+        #[case]
+        ctx: SessionContext,
+    ) -> datafusion::error::Result<()> {
+        let result = ctx
+            .sql(
+                "EXPLAIN ANALYZE select count(*), id from (select unnest([1,2,3,4,5]) as id) group by id",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        // Replace the metric values with "..." to keep the test stable.
+        let sanitized_plan_text = result[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0)
+            .lines()
+            .map(|line| {
+                if let Some(index) = line.find("metrics=[") {
+                    let prefix = &line[..index];
+                    let metrics = &line[index + "metrics=[".len()..];
+                    let sanitized_metrics = metrics.strip_suffix(']').map_or_else(
+                        || "...".to_string(),
+                        |body| {
+                            body.split(", ")
+                                .map(|metric| {
+                                    metric.split_once('=').map_or_else(
+                                        || "...".to_string(),
+                                        |(name, _)| format!("{name}=..."),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        },
+                    );
+                    format!("{prefix}metrics=[{sanitized_metrics}]")
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let sanitized = RecordBatch::try_new(
+            result[0].schema(),
+            vec![
+                result[0].column(0).clone(),
+                Arc::new(StringArray::from(vec![sanitized_plan_text])),
+            ],
+        )?;
+
+        let expected = [
+            "+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+            "| plan_type         | plan                                                                                                                                                                                                                                                                                                                                                                                              |",
+            "+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+            "| Plan with Metrics | =========SuccessfulStage[stage_id=1, partitions=1]=========                                                                                                                                                                                                                                                                                                                                       |",
+            "|                   | ShuffleWriterExec: partitioning: Hash([id@0], 16), metrics=[output_rows=..., input_rows=..., repart_time=..., write_time=...]                                                                                                                                                                                                                                                                     |",
+            "|                   |   AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))], metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=..., spill_count=..., spilled_bytes=..., spilled_rows=..., skipped_aggregation_rows=..., peak_mem_used=..., aggregate_arguments_time=..., aggregation_time=..., emitting_time=..., time_calculating_group_ids=..., reduction_factor=...] |",
+            "|                   |     ProjectionExec: expr=[__unnest_placeholder(make_array(Int64(1),Int64(2),Int64(3),Int64(4),Int64(5)),depth=1)@0 as id], metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=..., expr_0_eval_time=...]                                                                                                                                                             |",
+            "|                   |       UnnestExec, metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=..., input_batches=..., input_rows=...]                                                                                                                                                                                                                                                         |",
+            "|                   |         ProjectionExec: expr=[[1, 2, 3, 4, 5] as __unnest_placeholder(make_array(Int64(1),Int64(2),Int64(3),Int64(4),Int64(5)))], metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=..., expr_0_eval_time=...]                                                                                                                                                      |",
+            "|                   |           PlaceholderRowExec, metrics=[...]                                                                                                                                                                                                                                                                                                                                                       |",
+            "|                   |                                                                                                                                                                                                                                                                                                                                                                                                   |",
+            "|                   | =========SuccessfulStage[stage_id=2, partitions=16]=========                                                                                                                                                                                                                                                                                                                                      |",
+            "|                   | ShuffleWriterExec: partitioning: None, metrics=[output_rows=..., input_rows=..., repart_time=..., write_time=...]                                                                                                                                                                                                                                                                                 |",
+            "|                   |   ProjectionExec: expr=[count(Int64(1))@1 as count(*), id@0 as id], metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=..., expr_0_eval_time=..., expr_1_eval_time=...]                                                                                                                                                                                              |",
+            "|                   |     AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))], metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=..., spill_count=..., spilled_bytes=..., spilled_rows=..., peak_mem_used=..., aggregate_arguments_time=..., aggregation_time=..., emitting_time=..., time_calculating_group_ids=...]                                          |",
+            "|                   |       ShuffleReaderExec: partitioning: Hash([id@0], 16), metrics=[output_rows=..., elapsed_compute=..., output_bytes=..., output_batches=...]                                                                                                                                                                                                                                                     |",
+            "+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        ];
+        assert_batches_eq!(expected, &[sanitized]);
+
+        Ok(())
     }
 
     #[rstest]

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -671,6 +671,27 @@ message GetJobStatusParams {
   string job_id = 1;
 }
 
+message GetJobMetricsParams {
+  string job_id = 1;
+}
+
+message JobStageMetrics {
+  uint32 stage_id = 1;
+  uint32 partitions = 2;
+  repeated OperatorWithMetrics operators = 3;
+}
+
+message OperatorWithMetrics {
+  uint32 depth = 1;
+  string operator_type = 2;
+  string operator_desc = 3;
+  repeated OperatorMetric metrics = 4;
+}
+
+message GetJobMetricsResult {
+  repeated JobStageMetrics stages = 1;
+}
+
 message SuccessfulJob {
   repeated PartitionLocation partition_location = 1;
   uint64 queued_at = 2;
@@ -800,6 +821,8 @@ service SchedulerGrpc {
   rpc ExecuteQuery (ExecuteQueryParams) returns (ExecuteQueryResult) {}
 
   rpc GetJobStatus (GetJobStatusParams) returns (GetJobStatusResult) {}
+
+  rpc GetJobMetrics (GetJobMetricsParams) returns (GetJobMetricsResult) {}
 
   // Used by Executor to tell Scheduler it is stopped.
   rpc ExecutorStopped (ExecutorStoppedParams) returns (ExecutorStoppedResult) {}

--- a/ballista/core/src/execution_plans/distributed_explain_analyze.rs
+++ b/ballista/core/src/execution_plans/distributed_explain_analyze.rs
@@ -1,0 +1,385 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::execution_plans::DistributedQueryExec;
+use crate::extension::SessionConfigExt;
+use crate::serde::protobuf::{
+    self, GetJobMetricsParams, GetJobMetricsResult,
+    scheduler_grpc_client::SchedulerGrpcClient,
+};
+use crate::utils::{GrpcClientConfig, create_grpc_client_endpoint};
+use datafusion::arrow::array::StringBuilder;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, Result, internal_err};
+use datafusion::execution::context::TaskContext;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream,
+};
+use datafusion_proto::logical_plan::AsLogicalPlan;
+use futures::StreamExt;
+use std::any::Any;
+use std::convert::TryInto;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// This operator fetches stage metrics from the Ballista scheduler after the query has been executed in children (DistributedQueryExec).
+#[derive(Debug, Clone)]
+pub struct DistributedExplainAnalyzeExec<T: 'static + AsLogicalPlan> {
+    child: Arc<dyn ExecutionPlan>,
+    scheduler_url: String,
+    schema: SchemaRef,
+    verbose: bool,
+    properties: Arc<PlanProperties>,
+    phantom: PhantomData<T>,
+}
+
+impl<T: 'static + AsLogicalPlan> DistributedExplainAnalyzeExec<T> {
+    /// Creates a new explain-analyze wrapper around a distributed query exec.
+    pub fn new(
+        child: Arc<DistributedQueryExec<T>>,
+        scheduler_url: String,
+        schema: SchemaRef,
+        verbose: bool,
+    ) -> Self {
+        let properties = Arc::new(Self::compute_properties(Arc::clone(&schema)));
+        Self {
+            child,
+            scheduler_url,
+            schema,
+            verbose,
+            properties,
+            phantom: PhantomData,
+        }
+    }
+
+    fn compute_properties(schema: SchemaRef) -> PlanProperties {
+        PlanProperties::new(
+            EquivalenceProperties::new(schema),
+            Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        )
+    }
+}
+
+impl<T: 'static + AsLogicalPlan> DisplayAs for DistributedExplainAnalyzeExec<T> {
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "DistributedExplainAnalyzeExec: scheduler_url={}",
+                    self.scheduler_url
+                )
+            }
+            DisplayFormatType::TreeRender => {
+                writeln!(f, "scheduler_url={}", self.scheduler_url)
+            }
+        }
+    }
+}
+
+impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedExplainAnalyzeExec<T> {
+    fn name(&self) -> &str {
+        "DistributedExplainAnalyzeExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.child]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return internal_err!(
+                "DistributedExplainAnalyzeExec expected one child, got {}",
+                children.len()
+            );
+        }
+
+        let child = children.pop().unwrap();
+        if child
+            .as_any()
+            .downcast_ref::<DistributedQueryExec<T>>()
+            .is_some()
+        {
+            return Ok(Arc::new(Self {
+                child,
+                scheduler_url: self.scheduler_url.clone(),
+                schema: Arc::clone(&self.schema),
+                verbose: self.verbose,
+                properties: Arc::new(Self::compute_properties(Arc::clone(&self.schema))),
+                phantom: PhantomData,
+            }));
+        }
+
+        internal_err!(
+            "DistributedExplainAnalyzeExec requires a DistributedQueryExec child"
+        )
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        ctx: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        assert_eq!(0, partition);
+
+        let child = Arc::clone(&self.child);
+        let scheduler_url = self.scheduler_url.clone();
+        let schema = Arc::clone(&self.schema);
+        let verbose = self.verbose;
+        let stream_schema = Arc::clone(&self.schema);
+        let session_config = ctx.session_config().clone();
+
+        let stream = futures::stream::once(async move {
+            let mut child_stream = child.execute(partition, ctx)?;
+            while let Some(batch) = child_stream.next().await {
+                batch?;
+            }
+
+            let job_id = child
+                .as_any()
+                .downcast_ref::<DistributedQueryExec<T>>()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "DistributedExplainAnalyzeExec requires a DistributedQueryExec child"
+                            .into(),
+                    )
+                })?
+                .job_id()
+                .ok_or_else(|| {
+                DataFusionError::Internal(
+                    "Distributed query completed without exposing a job_id".into(),
+                )
+            })?;
+            let job_metrics =
+                fetch_job_metrics(&scheduler_url, &job_id, session_config).await?;
+            format_metrics_as_record_batch(&job_metrics, &job_id, schema, verbose)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            stream_schema,
+            stream,
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
+}
+
+async fn fetch_job_metrics(
+    scheduler_url: &str,
+    job_id: &str,
+    session_config: datafusion::prelude::SessionConfig,
+) -> Result<GetJobMetricsResult> {
+    let grpc_interceptor = session_config.ballista_grpc_interceptor();
+    let customize_endpoint =
+        session_config.ballista_override_create_grpc_client_endpoint();
+    let grpc_config = GrpcClientConfig::from(&session_config.ballista_config());
+
+    let mut endpoint =
+        create_grpc_client_endpoint(scheduler_url.to_string(), Some(&grpc_config))
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+    if let Some(ref customize) = customize_endpoint {
+        endpoint = customize
+            .configure_endpoint(endpoint)
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    }
+
+    let connection = endpoint
+        .connect()
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+    let max_message_size = session_config
+        .ballista_config()
+        .grpc_client_max_message_size();
+    let mut scheduler = SchedulerGrpcClient::with_interceptor(
+        connection,
+        grpc_interceptor.as_ref().clone(),
+    )
+    .max_encoding_message_size(max_message_size)
+    .max_decoding_message_size(max_message_size);
+
+    scheduler
+        .get_job_metrics(GetJobMetricsParams {
+            job_id: job_id.to_string(),
+        })
+        .await
+        .map(|response| response.into_inner())
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))
+}
+
+fn format_metrics_as_record_batch(
+    job_metrics: &GetJobMetricsResult,
+    _job_id: &str,
+    schema: SchemaRef,
+    _verbose: bool,
+) -> Result<RecordBatch> {
+    let plan = job_metrics
+        .stages
+        .iter()
+        .map(|stage| {
+            let mut stage_plan = Vec::with_capacity(stage.operators.len() + 1);
+            stage_plan.push(format!(
+                "=========SuccessfulStage[stage_id={}, partitions={}]=========",
+                stage.stage_id, stage.partitions
+            ));
+
+            for operator in &stage.operators {
+                let metrics_set: datafusion::physical_plan::metrics::MetricsSet =
+                    protobuf::OperatorMetricsSet {
+                        metrics: operator.metrics.clone(),
+                    }
+                    .try_into()
+                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+                let metrics = metrics_set
+                    .aggregate_by_name()
+                    .sorted_for_display()
+                    .timestamps_removed()
+                    .to_string();
+                let indent = "  ".repeat(operator.depth as usize);
+                stage_plan.push(format!(
+                    "{indent}{}, metrics=[{metrics}]",
+                    operator.operator_desc
+                ));
+            }
+
+            Ok(stage_plan.join("\n"))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .join("\n\n");
+
+    let mut type_builder = StringBuilder::with_capacity(1, "Plan with Metrics".len());
+    let mut plan_builder = StringBuilder::with_capacity(1, plan.len());
+
+    type_builder.append_value("Plan with Metrics");
+    plan_builder.append_value(plan);
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(type_builder.finish()),
+            Arc::new(plan_builder.finish()),
+        ],
+    )
+    .map_err(DataFusionError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_metrics_as_record_batch;
+    use datafusion::arrow::array::StringArray;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    use crate::serde::protobuf::{
+        GetJobMetricsResult, JobStageMetrics, OperatorMetric, OperatorWithMetrics,
+        operator_metric,
+    };
+
+    #[test]
+    fn test_format_metrics_as_record_batch() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("plan_type", DataType::Utf8, false),
+            Field::new("plan", DataType::Utf8, false),
+        ]));
+        let response = GetJobMetricsResult {
+            stages: vec![
+                JobStageMetrics {
+                    stage_id: 0,
+                    partitions: 1,
+                    operators: vec![OperatorWithMetrics {
+                        depth: 0,
+                        operator_type: "ProjectionExec".to_string(),
+                        operator_desc: "ProjectionExec: expr=[a]".to_string(),
+                        metrics: vec![
+                            OperatorMetric {
+                                metric: Some(operator_metric::Metric::OutputRows(4)),
+                            },
+                            OperatorMetric {
+                                metric: Some(operator_metric::Metric::ElapseTime(
+                                    15_000_000,
+                                )),
+                            },
+                        ],
+                    }],
+                },
+                JobStageMetrics {
+                    stage_id: 1,
+                    partitions: 2,
+                    operators: vec![OperatorWithMetrics {
+                        depth: 0,
+                        operator_type: "FilterExec".to_string(),
+                        operator_desc: "FilterExec: a@0 > 1".to_string(),
+                        metrics: vec![OperatorMetric {
+                            metric: Some(operator_metric::Metric::OutputRows(2)),
+                        }],
+                    }],
+                },
+            ],
+        };
+
+        let batch =
+            format_metrics_as_record_batch(&response, "job-1", schema, true).unwrap();
+
+        let plan_type = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let plan = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(plan_type.value(0), "Plan with Metrics");
+        let expected = [
+            "=========SuccessfulStage[stage_id=0, partitions=1]=========",
+            "ProjectionExec: expr=[a], metrics=[output_rows=4, elapsed_compute=15.00ms]",
+            "",
+            "=========SuccessfulStage[stage_id=1, partitions=2]=========",
+            "FilterExec: a@0 > 1, metrics=[output_rows=2]",
+        ]
+        .join("\n");
+        assert_eq!(plan.value(0), expected);
+    }
+}

--- a/ballista/core/src/execution_plans/distributed_explain_analyze.rs
+++ b/ballista/core/src/execution_plans/distributed_explain_analyze.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 /// This operator fetches stage metrics from the Ballista scheduler after the query has been executed in children (DistributedQueryExec).
 #[derive(Debug, Clone)]
 pub struct DistributedExplainAnalyzeExec<T: 'static + AsLogicalPlan> {
-    child: Arc<dyn ExecutionPlan>,
+    query_exec: Arc<dyn ExecutionPlan>,
     scheduler_url: String,
     schema: SchemaRef,
     verbose: bool,
@@ -55,14 +55,14 @@ pub struct DistributedExplainAnalyzeExec<T: 'static + AsLogicalPlan> {
 impl<T: 'static + AsLogicalPlan> DistributedExplainAnalyzeExec<T> {
     /// Creates a new explain-analyze wrapper around a distributed query exec.
     pub fn new(
-        child: Arc<DistributedQueryExec<T>>,
+        query_exec: Arc<DistributedQueryExec<T>>,
         scheduler_url: String,
         schema: SchemaRef,
         verbose: bool,
     ) -> Self {
         let properties = Arc::new(Self::compute_properties(Arc::clone(&schema)));
         Self {
-            child,
+            query_exec,
             scheduler_url,
             schema,
             verbose,
@@ -116,7 +116,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedExplainAnalyzeExec
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.child]
+        vec![&self.query_exec]
     }
 
     fn with_new_children(
@@ -130,14 +130,14 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedExplainAnalyzeExec
             );
         }
 
-        let child = children.pop().unwrap();
-        if child
+        let query_exec = children.pop().unwrap();
+        if query_exec
             .as_any()
             .downcast_ref::<DistributedQueryExec<T>>()
             .is_some()
         {
             return Ok(Arc::new(Self {
-                child,
+                query_exec,
                 scheduler_url: self.scheduler_url.clone(),
                 schema: Arc::clone(&self.schema),
                 verbose: self.verbose,
@@ -158,7 +158,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedExplainAnalyzeExec
     ) -> Result<SendableRecordBatchStream> {
         assert_eq!(0, partition);
 
-        let child = Arc::clone(&self.child);
+        let query_exec = Arc::clone(&self.query_exec);
         let scheduler_url = self.scheduler_url.clone();
         let schema = Arc::clone(&self.schema);
         let verbose = self.verbose;
@@ -166,12 +166,12 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedExplainAnalyzeExec
         let session_config = ctx.session_config().clone();
 
         let stream = futures::stream::once(async move {
-            let mut child_stream = child.execute(partition, ctx)?;
+            let mut child_stream = query_exec.execute(partition, ctx)?;
             while let Some(batch) = child_stream.next().await {
                 batch?;
             }
 
-            let job_id = child
+            let job_id = query_exec
                 .as_any()
                 .downcast_ref::<DistributedQueryExec<T>>()
                 .ok_or_else(|| {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -47,6 +47,7 @@ use datafusion_proto::logical_plan::{
 };
 use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
 use log::{debug, error, info};
+use parking_lot::Mutex;
 use std::any::Any;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -82,6 +83,8 @@ pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     /// - job_execution_time_ms: Time spent executing on the cluster (ended_at - started_at)
     /// - job_scheduling_in_ms: Time job waited in scheduler queue (started_at - queued_at)
     metrics: ExecutionPlanMetricsSet,
+    /// The scheduler job id after the query has been accepted.
+    job_id: Arc<Mutex<Option<String>>>,
 }
 
 impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
@@ -104,6 +107,7 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
             session_id,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+            job_id: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -127,7 +131,13 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
             session_id,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+            job_id: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Returns the scheduler job id after the query has been accepted.
+    pub fn job_id(&self) -> Option<String> {
+        self.job_id.lock().clone()
     }
 
     fn compute_properties(schema: SchemaRef) -> PlanProperties {
@@ -197,6 +207,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                 self.plan.schema().as_arrow().clone().into(),
             )),
             metrics: ExecutionPlanMetricsSet::new(),
+            job_id: Arc::clone(&self.job_id),
         }))
     }
 
@@ -258,6 +269,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                     self.config.grpc_client_max_message_size(),
                     GrpcClientConfig::from(&self.config),
                     Arc::new(self.metrics.clone()),
+                    Arc::clone(&self.job_id),
                     partition,
                     session_config,
                 )
@@ -285,6 +297,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                     self.config.grpc_client_max_message_size(),
                     GrpcClientConfig::from(&self.config),
                     Arc::new(self.metrics.clone()),
+                    Arc::clone(&self.job_id),
                     partition,
                     session_config,
                 )
@@ -323,6 +336,7 @@ async fn execute_query_pull(
     max_message_size: usize,
     grpc_config: GrpcClientConfig,
     metrics: Arc<ExecutionPlanMetricsSet>,
+    job_id_handle: Arc<Mutex<Option<String>>>,
     partition: usize,
     session_config: SessionConfig,
 ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send> {
@@ -381,6 +395,7 @@ async fn execute_query_pull(
     );
 
     let job_id = query_result.job_id;
+    *job_id_handle.lock() = Some(job_id.clone());
     let mut prev_status: Option<job_status::Status> = None;
 
     loop {
@@ -494,6 +509,7 @@ async fn execute_query_push(
     max_message_size: usize,
     grpc_config: GrpcClientConfig,
     metrics: Arc<ExecutionPlanMetricsSet>,
+    job_id_handle: Arc<Mutex<Option<String>>>,
     partition: usize,
     session_config: SessionConfig,
 ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send> {
@@ -556,6 +572,12 @@ async fn execute_query_push(
             .as_ref()
             .map(|s| s.job_id.to_owned())
             .unwrap_or("unknown_job_id".to_string()); // should not happen
+        if !job_id.starts_with("unknown_") {
+            let mut shared_job_id = job_id_handle.lock();
+            if shared_job_id.is_none() {
+                *shared_job_id = Some(job_id.clone());
+            }
+        }
         let status = status.and_then(|s| s.status);
         let has_status_change = prev_status != status;
         match status {
@@ -739,9 +761,16 @@ async fn fetch_partition(
 
 #[cfg(test)]
 mod test {
-    use crate::execution_plans::distributed_query::get_client_host_port;
+    use crate::config::BallistaConfig;
+    use crate::execution_plans::distributed_query::{
+        DistributedQueryExec, get_client_host_port,
+    };
     use crate::serde::protobuf::ExecutorMetadata;
     use crate::serde::protobuf::get_job_status_result::FlightProxy;
+    use datafusion::logical_expr::LogicalPlan;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion_proto::protobuf::LogicalPlanNode;
+    use std::sync::Arc;
 
     #[test]
     fn test_client_host_port() {
@@ -796,5 +825,24 @@ mod test {
             .unwrap(),
             ("proxy".to_string(), 1234_u16)
         );
+    }
+
+    #[test]
+    fn test_create_distributed_query_exec_with_job_id() {
+        let exec = Arc::new(DistributedQueryExec::<LogicalPlanNode>::new(
+            "http://scheduler:50050".to_string(),
+            BallistaConfig::default(),
+            LogicalPlan::default(),
+            "session".to_string(),
+        ));
+        *exec.job_id.lock() = Some("job-123".to_string());
+
+        let new_exec = exec.clone().with_new_children(vec![]).unwrap();
+        let new_exec = new_exec
+            .as_any()
+            .downcast_ref::<DistributedQueryExec<LogicalPlanNode>>()
+            .unwrap();
+
+        assert_eq!(new_exec.job_id().as_deref(), Some("job-123"));
     }
 }

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -18,6 +18,7 @@
 //! This module contains execution plans that are needed to distribute DataFusion's execution plans into
 //! several Ballista executors.
 
+mod distributed_explain_analyze;
 mod distributed_query;
 mod shuffle_reader;
 mod shuffle_writer;
@@ -28,6 +29,7 @@ mod unresolved_shuffle;
 use std::path::{Path, PathBuf};
 
 use datafusion::common::exec_err;
+pub use distributed_explain_analyze::DistributedExplainAnalyzeExec;
 pub use distributed_query::DistributedQueryExec;
 pub use shuffle_reader::ShuffleReaderExec;
 pub use shuffle_reader::{stats_for_partition, stats_for_partitions};

--- a/ballista/core/src/planner.rs
+++ b/ballista/core/src/planner.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::config::BallistaConfig;
-use crate::execution_plans::DistributedQueryExec;
+use crate::execution_plans::{DistributedExplainAnalyzeExec, DistributedQueryExec};
 use crate::serde::BallistaLogicalExtensionCodec;
 
 use async_trait::async_trait;
@@ -128,6 +128,27 @@ impl<T: 'static + AsLogicalPlan> QueryPlanner for BallistaQueryPlanner<T> {
                     log::debug!("create_physical_plan - handling empty exec");
                     Ok(Arc::new(EmptyExec::new(Arc::new(Schema::empty()))))
                 }
+                LogicalPlan::Analyze(analyze) => {
+                    log::debug!(
+                        "create_physical_plan - handling explain analyze statement"
+                    );
+                    let inner_plan = analyze.input.as_ref().clone();
+                    let distributed_query_exec =
+                        Arc::new(DistributedQueryExec::<T>::with_extension(
+                            self.scheduler_url.clone(),
+                            self.config.clone(),
+                            inner_plan,
+                            self.extension_codec.clone(),
+                            session_state.session_id().to_string(),
+                        ));
+
+                    Ok(Arc::new(DistributedExplainAnalyzeExec::new(
+                        distributed_query_exec,
+                        self.scheduler_url.clone(),
+                        Arc::clone(analyze.schema.inner()),
+                        analyze.verbose,
+                    )))
+                }
                 _ => {
                     log::debug!("create_physical_plan - handling general statement");
 
@@ -183,11 +204,18 @@ mod test {
     use datafusion::{
         common::tree_node::TreeNode,
         error::Result,
-        execution::{SessionStateBuilder, runtime_env::RuntimeEnvBuilder},
+        execution::{
+            SessionStateBuilder, context::QueryPlanner, runtime_env::RuntimeEnvBuilder,
+        },
+        logical_expr::LogicalPlan,
+        physical_plan::ExecutionPlan,
         prelude::{SessionConfig, SessionContext},
     };
+    use datafusion_proto::protobuf::LogicalPlanNode;
 
-    use super::LocalRun;
+    use super::{BallistaQueryPlanner, LocalRun};
+    use crate::config::BallistaConfig;
+    use crate::execution_plans::{DistributedExplainAnalyzeExec, DistributedQueryExec};
 
     fn context() -> SessionContext {
         let runtime_environment = RuntimeEnvBuilder::new().build().unwrap();
@@ -262,6 +290,33 @@ mod test {
 
         assert!(!local_run.can_be_local);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_create_distributed_explain_analyze_exec() -> Result<()> {
+        let ctx = context();
+        ctx.sql("CREATE TABLE tt (c0 INT)").await?.show().await?;
+        let analyze_df = ctx.sql("EXPLAIN ANALYZE SELECT * FROM tt").await?;
+        let planner = BallistaQueryPlanner::<LogicalPlanNode>::new(
+            "http://localhost:50050".to_string(),
+            BallistaConfig::default(),
+        );
+        let plan = planner
+            .create_physical_plan(analyze_df.logical_plan(), &ctx.state())
+            .await?;
+
+        assert!(matches!(analyze_df.logical_plan(), LogicalPlan::Analyze(_)));
+        let explain = plan
+            .as_any()
+            .downcast_ref::<DistributedExplainAnalyzeExec<LogicalPlanNode>>()
+            .unwrap();
+        assert!(
+            explain.children()[0]
+                .as_any()
+                .downcast_ref::<DistributedQueryExec<LogicalPlanNode>>()
+                .is_some()
+        );
         Ok(())
     }
 }

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1019,6 +1019,36 @@ pub struct GetJobStatusParams {
     #[prost(string, tag = "1")]
     pub job_id: ::prost::alloc::string::String,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetJobMetricsParams {
+    #[prost(string, tag = "1")]
+    pub job_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct JobStageMetrics {
+    #[prost(uint32, tag = "1")]
+    pub stage_id: u32,
+    #[prost(uint32, tag = "2")]
+    pub partitions: u32,
+    #[prost(message, repeated, tag = "3")]
+    pub operators: ::prost::alloc::vec::Vec<OperatorWithMetrics>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OperatorWithMetrics {
+    #[prost(uint32, tag = "1")]
+    pub depth: u32,
+    #[prost(string, tag = "2")]
+    pub operator_type: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub operator_desc: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "4")]
+    pub metrics: ::prost::alloc::vec::Vec<OperatorMetric>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetJobMetricsResult {
+    #[prost(message, repeated, tag = "1")]
+    pub stages: ::prost::alloc::vec::Vec<JobStageMetrics>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessfulJob {
     #[prost(message, repeated, tag = "1")]
@@ -1512,6 +1542,32 @@ pub mod scheduler_grpc_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn get_job_metrics(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetJobMetricsParams>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetJobMetricsResult>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/ballista.protobuf.SchedulerGrpc/GetJobMetrics",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("ballista.protobuf.SchedulerGrpc", "GetJobMetrics"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
         /// Used by Executor to tell Scheduler it is stopped.
         pub async fn executor_stopped(
             &mut self,
@@ -1668,6 +1724,13 @@ pub mod scheduler_grpc_server {
             request: tonic::Request<super::GetJobStatusParams>,
         ) -> std::result::Result<
             tonic::Response<super::GetJobStatusResult>,
+            tonic::Status,
+        >;
+        async fn get_job_metrics(
+            &self,
+            request: tonic::Request<super::GetJobMetricsParams>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetJobMetricsResult>,
             tonic::Status,
         >;
         /// Used by Executor to tell Scheduler it is stopped.
@@ -2165,6 +2228,51 @@ pub mod scheduler_grpc_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetJobStatusSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/ballista.protobuf.SchedulerGrpc/GetJobMetrics" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetJobMetricsSvc<T: SchedulerGrpc>(pub Arc<T>);
+                    impl<
+                        T: SchedulerGrpc,
+                    > tonic::server::UnaryService<super::GetJobMetricsParams>
+                    for GetJobMetricsSvc<T> {
+                        type Response = super::GetJobMetricsResult;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetJobMetricsParams>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as SchedulerGrpc>::get_job_metrics(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetJobMetricsSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -568,11 +568,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                     format!("Error fetching execution graph for job {job_id}: {e:?}");
                 error!("{msg}");
                 Status::internal(msg)
+            })?
+            .ok_or_else(|| {
+                Status::not_found(format!("Execution graph not found for job {job_id}"))
             })?;
-
-        let graph = graph.ok_or_else(|| {
-            Status::not_found(format!("Execution graph not found for job {job_id}"))
-        })?;
 
         let mut stage_metrics_list = graph
             .stages()

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -26,11 +26,12 @@ use ballista_core::serde::protobuf::{
     CleanJobDataResult, CreateUpdateSessionParams, CreateUpdateSessionResult,
     ExecuteQueryFailureResult, ExecuteQueryParams, ExecuteQueryResult,
     ExecuteQuerySuccessResult, ExecutorHeartbeat, ExecutorStoppedParams,
-    ExecutorStoppedResult, GetJobStatusParams, GetJobStatusResult, HeartBeatParams,
-    HeartBeatResult, JobStatus, KeyValuePair, PollWorkParams, PollWorkResult,
-    RegisterExecutorParams, RegisterExecutorResult, RemoveSessionParams,
-    RemoveSessionResult, UpdateTaskStatusParams, UpdateTaskStatusResult,
-    execute_query_failure_result, execute_query_result, executor_metric::Metric,
+    ExecutorStoppedResult, GetJobMetricsParams, GetJobMetricsResult, GetJobStatusParams,
+    GetJobStatusResult, HeartBeatParams, HeartBeatResult, JobStatus, KeyValuePair,
+    PollWorkParams, PollWorkResult, RegisterExecutorParams, RegisterExecutorResult,
+    RemoveSessionParams, RemoveSessionResult, UpdateTaskStatusParams,
+    UpdateTaskStatusResult, execute_query_failure_result, execute_query_result,
+    executor_metric::Metric,
 };
 use ballista_core::serde::scheduler::ExecutorMetadata;
 use datafusion_proto::logical_plan::AsLogicalPlan;
@@ -53,6 +54,7 @@ use crate::config::TaskDistributionPolicy;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use ballista_core::serde::protobuf::get_job_status_result::FlightProxy;
 use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 use datafusion::prelude::SessionContext;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -547,6 +549,135 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                 Err(Status::internal(msg))
             }
         }
+    }
+
+    async fn get_job_metrics(
+        &self,
+        request: Request<GetJobMetricsParams>,
+    ) -> Result<Response<GetJobMetricsResult>, Status> {
+        let job_id = request.into_inner().job_id;
+        trace!("Received get_job_metrics request for job {}", job_id);
+
+        let graph = self
+            .state
+            .task_manager
+            .get_job_execution_graph(&job_id)
+            .await
+            .map_err(|e| {
+                let msg =
+                    format!("Error fetching execution graph for job {job_id}: {e:?}");
+                error!("{msg}");
+                Status::internal(msg)
+            })?;
+
+        let graph = graph.ok_or_else(|| {
+            Status::not_found(format!("Execution graph not found for job {job_id}"))
+        })?;
+
+        let mut stage_metrics_list = graph
+            .stages()
+            .iter()
+            .filter_map(|(stage_id, stage)| {
+                let successful = match stage {
+                    crate::state::execution_graph::ExecutionStage::Successful(stage) => {
+                        stage
+                    }
+                    _ => return None,
+                };
+
+                let raw_metrics = &successful.stage_metrics;
+                let mut operators = Vec::with_capacity(raw_metrics.len());
+                let mut metric_index = 0;
+                let operators = (|| -> Result<
+                    Vec<ballista_core::serde::protobuf::OperatorWithMetrics>,
+                    BallistaError,
+                > {
+                    let mut stack = vec![(successful.plan.as_ref(), 0_u32)];
+
+                    while let Some((plan, depth)) = stack.pop() {
+                        let operator_desc = {
+                            struct DisplayableOperator<'a> {
+                                plan: &'a dyn ExecutionPlan,
+                            }
+
+                            impl std::fmt::Display for DisplayableOperator<'_> {
+                                fn fmt(
+                                    &self,
+                                    f: &mut std::fmt::Formatter<'_>,
+                                ) -> std::fmt::Result {
+                                    self.plan.fmt_as(DisplayFormatType::Default, f)
+                                }
+                            }
+
+                            DisplayableOperator { plan }.to_string()
+                        };
+                        let metrics = if plan.metrics().is_some() {
+                            let metrics: ballista_core::serde::protobuf::OperatorMetricsSet =
+                                raw_metrics
+                                    .get(metric_index)
+                                    .ok_or_else(|| {
+                                        BallistaError::Internal(format!(
+                                            "Missing metrics for operator {} at depth {}",
+                                            plan.name(),
+                                            depth
+                                        ))
+                                    })?
+                                    .clone()
+                                    .try_into()?;
+                            metric_index += 1;
+                            metrics.metrics
+                        } else {
+                            vec![]
+                        };
+
+                        operators.push(
+                            ballista_core::serde::protobuf::OperatorWithMetrics {
+                                depth,
+                                operator_type: plan.name().to_string(),
+                                operator_desc,
+                                metrics,
+                            },
+                        );
+
+                        for child in plan.children().into_iter().rev() {
+                            stack.push((child.as_ref(), depth + 1));
+                        }
+                    }
+
+                    Ok(operators)
+                })()
+                .and_then(|operators| {
+                    if metric_index == raw_metrics.len() {
+                        Ok(operators)
+                    } else {
+                        Err(BallistaError::Internal(format!(
+                            "Stage metrics size mismatch for job {job_id} stage {stage_id}: operators {} != stage metrics {}",
+                            metric_index,
+                            raw_metrics.len()
+                        )))
+                    }
+                })
+                .map_err(|e| {
+                    Status::internal(format!(
+                        "Error serializing job metrics for job {job_id} stage {stage_id}: {e:?}"
+                    ))
+                });
+
+                Some(operators.map(|operators| {
+                    ballista_core::serde::protobuf::JobStageMetrics {
+                        stage_id: *stage_id as u32,
+                        partitions: successful.partitions as u32,
+                        operators,
+                    }
+                }))
+            })
+            .collect::<Result<Vec<_>, Status>>()?;
+
+        stage_metrics_list.sort_by_key(|stage| stage.stage_id);
+
+        Ok(Response::new(GetJobMetricsResult {
+            stages: stage_metrics_list,
+        }))
     }
 
     async fn executor_stopped(

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -378,7 +378,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
     /// Get the execution graph of of a job. First look in the active cache.
     /// If no one found, then in the Active/Completed jobs.
-    #[cfg(feature = "rest-api")]
     pub(crate) async fn get_job_execution_graph(
         &self,
         job_id: &str,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1344

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Ballista already supported `EXPLAIN` #1293 , but the `EXPLAIN ANALYZE` portion is not implemented yet, and this PR introduces 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

<img width="6841" height="1874" alt="image" src="https://github.com/user-attachments/assets/c47f1106-0bd2-47d9-9e08-db09e9605e3b" />

### Client side

`EXPLAIN ANALYZE` runs in two steps on the client:

1. Execute the query through `DistributedQueryExec`
2. Fetch stage metrics for the submitted job

Pipeline:

DistributedExplainAnalyzeExec -> DistributedQueryExec

To support this, `DistributedQueryExec` needs to expose the `job_id` to its parent, `DistributedExplainAnalyzeExec`.

### Scheduler

Add a new gRPC API to fetch stage metrics by `job_id`.



# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
