### PR TITLE
feat: add SchedulerEventListener for executor lifecycle events

### DIFF
--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -28,11 +28,23 @@
 use crate::SessionBuilder;
 use crate::cluster::DistributionPolicy;
 use ballista_core::extension::EndpointOverrideFn;
+use ballista_core::serde::scheduler::ExecutorMetadata;
 use ballista_core::{ConfigProducer, config::TaskSchedulingPolicy};
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use std::fmt::Display;
 use std::sync::Arc;
+
+/// Listener for scheduler-level executor lifecycle events.
+///
+/// Implement this trait to react to executor join/leave events.
+/// Used by external plugins to observe executor topology changes.
+pub trait SchedulerEventListener: Send + Sync {
+    /// Called when a new executor registers with the scheduler.
+    fn on_executor_registered(&self, metadata: &ExecutorMetadata);
+    /// Called when an executor is removed or lost.
+    fn on_executor_lost(&self, executor_id: &str);
+}
 
 /// Command-line configuration for the scheduler binary.
 #[cfg(feature = "build-binary")]
@@ -237,6 +249,8 @@ pub struct SchedulerConfig {
     pub override_create_grpc_client_endpoint: Option<EndpointOverrideFn>,
     /// Whether to use TLS when connecting to executors (for flight proxy)
     pub use_tls: bool,
+    /// Event listeners for executor lifecycle events (join/leave).
+    pub event_listeners: Vec<Arc<dyn SchedulerEventListener>>,
     #[cfg(feature = "rest-api")]
     /// Should the rest api be disabled
     pub disable_rest_api: bool,
@@ -268,6 +282,7 @@ impl Default for SchedulerConfig {
             override_physical_codec: None,
             override_create_grpc_client_endpoint: None,
             use_tls: false,
+            event_listeners: vec![],
             #[cfg(feature = "rest-api")]
             disable_rest_api: false,
         }
@@ -405,6 +420,15 @@ impl SchedulerConfig {
         self.use_tls = use_tls;
         self
     }
+
+    /// Adds an event listener for executor lifecycle events (join/leave).
+    pub fn with_event_listener(
+        mut self,
+        listener: Arc<dyn SchedulerEventListener>,
+    ) -> Self {
+        self.event_listeners.push(listener);
+        self
+    }
 }
 
 /// Policy of distributing tasks to available executor slots
@@ -494,6 +518,7 @@ impl TryFrom<Config> for SchedulerConfig {
             override_session_builder: None,
             override_create_grpc_client_endpoint: None,
             use_tls: false,
+            event_listeners: vec![],
             #[cfg(feature = "rest-api")]
             disable_rest_api: opt.disable_rest_api,
         };

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -312,6 +312,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 self.state.revive_offers(event_sender).await?;
             }
             QueryStageSchedulerEvent::ExecutorLost(executor_id, _) => {
+                // Notify event listeners about executor loss
+                for listener in &self.config.event_listeners {
+                    listener.on_executor_lost(&executor_id);
+                }
+
                 match self.state.task_manager.executor_lost(&executor_id).await {
                     Ok(tasks) => {
                         if !tasks.is_empty()

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -271,7 +271,26 @@ impl ExecutorManager {
             "save executor metadata {} with {} task slots (pull-based registration)",
             metadata.id, metadata.specification.task_slots
         );
-        self.cluster_state.save_executor_metadata(metadata).await
+
+        // Check if this is a new executor (not seen before)
+        let is_new = self
+            .cluster_state
+            .get_executor_metadata(&metadata.id)
+            .await
+            .is_err();
+
+        self.cluster_state
+            .save_executor_metadata(metadata.clone())
+            .await?;
+
+        // Notify event listeners only for newly registered executors
+        if is_new {
+            for listener in &self.config.event_listeners {
+                listener.on_executor_registered(&metadata);
+            }
+        }
+
+        Ok(())
     }
 
     /// Registers the executor with the scheduler for push-based task scheduling.
@@ -291,8 +310,13 @@ impl ExecutorManager {
         ExecutorManager::test_connectivity(&metadata).await?;
 
         self.cluster_state
-            .register_executor(metadata, specification)
+            .register_executor(metadata.clone(), specification)
             .await?;
+
+        // Notify event listeners about the new executor
+        for listener in &self.config.event_listeners {
+            listener.on_executor_registered(&metadata);
+        }
 
         Ok(())
     }

--- a/examples/examples/custom-scheduler.rs
+++ b/examples/examples/custom-scheduler.rs
@@ -19,17 +19,36 @@ use ballista_core::error::BallistaError;
 use ballista_core::object_store::{
     session_config_with_s3_support, session_state_with_s3_support,
 };
+use ballista_core::serde::scheduler::ExecutorMetadata;
 
 use ballista_scheduler::cluster::BallistaCluster;
-use ballista_scheduler::config::SchedulerConfig;
+use ballista_scheduler::config::{SchedulerConfig, SchedulerEventListener};
 use ballista_scheduler::scheduler_process::start_server;
+use log::info;
 use std::net::AddrParseError;
 use std::sync::Arc;
+
+/// Example event listener that logs executor lifecycle events.
+struct LoggingEventListener;
+
+impl SchedulerEventListener for LoggingEventListener {
+    fn on_executor_registered(&self, metadata: &ExecutorMetadata) {
+        info!(
+            "Executor registered: {} at {}:{}",
+            metadata.id, metadata.host, metadata.port
+        );
+    }
+
+    fn on_executor_lost(&self, executor_id: &str) {
+        info!("Executor lost: {executor_id}");
+    }
+}
 
 ///
 /// # Custom Ballista Scheduler
 ///
-/// This example demonstrates how to crate custom ballista schedulers.
+/// This example demonstrates how to create custom ballista schedulers
+/// with overridden config, session builder, and event listeners.
 ///
 #[tokio::main]
 async fn main() -> ballista_core::error::Result<()> {
@@ -46,7 +65,9 @@ async fn main() -> ballista_core::error::Result<()> {
         // runtime environment and session state.
         override_session_builder: Some(Arc::new(session_state_with_s3_support)),
         ..Default::default()
-    };
+    }
+    // add event listener for executor lifecycle events
+    .with_event_listener(Arc::new(LoggingEventListener));
 
     let addr = format!("{}:{}", config.bind_host, config.bind_port);
     let addr = addr


### PR DESCRIPTION
Add SchedulerConfig::event_listeners to observe executor join/leave without modifying core. Notifies on both pull-based and push-based registration, and on executor loss.

For example, [Kubeflow Data Cache](https://www.kubeflow.org/docs/components/trainer/user-guides/data-cache/) when implemented as a ballista extension, it can use this to redistribute cached dataset shards when executors join or leave the cluster on kubernetes

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
There is currently no way for external plugins to observe executor join/leave events. Plugins that manage distributed state (e.g., in-memory data caches) need to react when executors are added or removed to rebalance data. This change adds a minimal, non-breaking extension point for executor lifecycle observation.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
New SchedulerEventListener trait and event_listeners field on SchedulerConfig with builder method. Listeners are notified on executor registration (pull + push), removal, and loss.
  Updated custom-scheduler example with usage.
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
New optional field on SchedulerConfig. Default is empty — no behavior change for existing users. No breaking changes to public APIs.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
