### PR TITLE
[TUI] Change the key binding for job's plans

### DIFF
--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -271,7 +271,7 @@ impl App {
             KeyCode::Char('g') if self.is_jobs_view() => {
                 self.load_job_dot_data().await;
             }
-            KeyCode::Char('D') if self.is_jobs_view() => {
+            KeyCode::Char('p') if self.is_jobs_view() => {
                 self.open_job_plan_popup();
             }
             KeyCode::Char('e') if self.is_scheduler_up() => {

--- a/ballista-cli/src/tui/ui/footer.rs
+++ b/ballista-cli/src/tui/ui/footer.rs
@@ -47,7 +47,7 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                     page_key_bindings.push(Span::from("[c] Cancel job, "));
                 }
                 if app.has_selected_completed_job() {
-                    page_key_bindings.push(Span::from("[D] View job plans, "));
+                    page_key_bindings.push(Span::from("[p] View job plans, "));
                 }
                 if !page_key_bindings.is_empty() {
                     page_key_bindings.insert(0, Span::from("Jobs key bindings: "));

--- a/ballista-cli/src/tui/ui/help_overlay.rs
+++ b/ballista-cli/src/tui/ui/help_overlay.rs
@@ -21,7 +21,7 @@ use ratatui::prelude::{Color, Line, Modifier, Span, Style};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 pub(crate) fn render_help_overlay(f: &mut Frame, app: &App) {
-    let area = crate::tui::ui::centered_rect(25, 50, f.area());
+    let area = crate::tui::ui::centered_rect(45, 50, f.area());
 
     f.render_widget(Clear, area);
 
@@ -62,7 +62,7 @@ pub(crate) fn render_help_overlay(f: &mut Frame, app: &App) {
             style,
         )),
         Line::from(Span::styled(
-            "  D       View plans if a completed job is selected",
+            "  p       View plans if a completed job is selected",
             style,
         )),
         Line::from(Span::styled(


### PR DESCRIPTION

# Which issue does this PR close?

N/A

# Rationale for this change

Requested by @milenkovicm  at
https://github.com/apache/datafusion-ballista/issues/1551#issuecomment-4311739921

# What changes are included in this PR?

Change the key binding from 'D' to 'p'.

Make the help popup a bit wider to show the help messages on one line

# Are there any user-facing changes?

Yes, the TUI app now will open the selected job's plan when the user presses the `p` key