### PR TITLE
feat: make ballista client retry policy configurable 

### DIFF
--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -1143,4 +1143,43 @@ mod supported {
 
         Ok(())
     }
+
+    #[rstest]
+    #[case::standalone(standalone_context())]
+    #[case::remote(remote_context())]
+    #[tokio::test]
+    async fn should_set_io_retry_config(
+        #[future(awt)]
+        #[case]
+        ctx: SessionContext,
+    ) -> datafusion::error::Result<()> {
+        ctx.sql("SET ballista.client.io_retries_times = 5")
+            .await?
+            .show()
+            .await?;
+
+        ctx.sql("SET ballista.client.io_retry_wait_time_ms = 1500")
+            .await?
+            .show()
+            .await?;
+
+        let result = ctx
+            .sql("select name, value from information_schema.df_settings where name like 'ballista.client.io_%' order by name")
+            .await?
+            .collect()
+            .await?;
+
+        let expected = [
+            "+---------------------------------------+-------+",
+            "| name                                  | value |",
+            "+---------------------------------------+-------+",
+            "| ballista.client.io_retries_times      | 5     |",
+            "| ballista.client.io_retry_wait_time_ms | 1500  |",
+            "+---------------------------------------+-------+",
+        ];
+
+        assert_batches_eq!(expected, &result);
+
+        Ok(())
+    }
 }

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -55,11 +55,9 @@ pub struct BallistaClient {
     host: String,
     port: u16,
     flight_client: FlightServiceClient<tonic::transport::channel::Channel>,
+    io_retries_times: u8,
+    io_retry_wait_time_ms: u64,
 }
-
-//TODO make this configurable
-const IO_RETRIES_TIMES: u8 = 3;
-const IO_RETRY_WAIT_TIME_MS: u64 = 3000;
 
 impl BallistaClient {
     /// Create a new BallistaClient to connect to the executor listening on the specified
@@ -70,6 +68,8 @@ impl BallistaClient {
         max_message_size: usize,
         use_tls: bool,
         customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+        io_retries_times: u8,
+        io_retry_wait_time_ms: u64,
     ) -> BResult<Self> {
         let scheme = if use_tls { "https" } else { "http" };
 
@@ -109,6 +109,8 @@ impl BallistaClient {
             flight_client,
             host: host.to_string(),
             port,
+            io_retries_times,
+            io_retry_wait_time_ms,
         })
     }
 
@@ -211,13 +213,15 @@ impl BallistaClient {
             .encode(&mut buf)
             .map_err(|e| BallistaError::GrpcActionError(format!("{e:?}")))?;
 
-        for i in 0..IO_RETRIES_TIMES {
+        let io_retries_times = self.io_retries_times;
+        let io_retry_wait_time_ms = self.io_retry_wait_time_ms;
+        for i in 0..io_retries_times {
             if i > 0 {
                 warn!(
-                    "Remote shuffle read fail, retry {i} times, sleep {IO_RETRY_WAIT_TIME_MS} ms."
+                    "Remote shuffle read fail, retry {i} times, sleep {io_retry_wait_time_ms} ms."
                 );
                 tokio::time::sleep(std::time::Duration::from_millis(
-                    IO_RETRY_WAIT_TIME_MS,
+                    io_retry_wait_time_ms,
                 ))
                 .await;
             }
@@ -231,7 +235,7 @@ impl BallistaClient {
                 Err(ref err) => {
                     // IO related error like connection timeout, reset... will warp with Code::Unknown
                     // This means IO related error will retry.
-                    if i == IO_RETRIES_TIMES - 1 || err.code() != Code::Unknown {
+                    if i == io_retries_times - 1 || err.code() != Code::Unknown {
                         return BallistaError::GrpcActionError(format!(
                             "{:?}",
                             result.unwrap_err()
@@ -260,7 +264,7 @@ impl BallistaClient {
                     };
                 }
                 Err(e) => {
-                    if i == IO_RETRIES_TIMES - 1 || e.code() != Code::Unknown {
+                    if i == io_retries_times - 1 || e.code() != Code::Unknown {
                         return BallistaError::GrpcActionError(format!(
                             "{:?}",
                             e.to_string()
@@ -290,13 +294,15 @@ impl BallistaClient {
             .encode(&mut buf)
             .map_err(|e| BallistaError::GrpcActionError(format!("{e:?}")))?;
 
-        for i in 0..IO_RETRIES_TIMES {
+        let io_retries_times = self.io_retries_times;
+        let io_retry_wait_time_ms = self.io_retry_wait_time_ms;
+        for i in 0..io_retries_times {
             if i > 0 {
                 warn!(
-                    "Remote shuffle read fail, retry {i} times, sleep {IO_RETRY_WAIT_TIME_MS} ms."
+                    "Remote shuffle read fail, retry {i} times, sleep {io_retry_wait_time_ms} ms."
                 );
                 tokio::time::sleep(std::time::Duration::from_millis(
-                    IO_RETRY_WAIT_TIME_MS,
+                    io_retry_wait_time_ms,
                 ))
                 .await;
             }
@@ -311,7 +317,7 @@ impl BallistaClient {
                 Err(ref err) => {
                     // IO related error like connection timeout, reset... will warp with Code::Unknown
                     // This means IO related error will retry.
-                    if i == IO_RETRIES_TIMES - 1 || err.code() != Code::Unknown {
+                    if i == io_retries_times - 1 || err.code() != Code::Unknown {
                         return BallistaError::GrpcActionError(format!(
                             "{:?}",
                             result.unwrap_err()

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -79,6 +79,10 @@ pub const BALLISTA_SHUFFLE_SORT_BASED_BATCH_SIZE: &str =
 pub const BALLISTA_CLIENT_PULL: &str = "ballista.client.pull";
 /// Should client use tls connection
 pub const BALLISTA_CLIENT_USE_TLS: &str = "ballista.client.use_tls";
+/// Number of retries for IO operations in the Ballista client
+pub const BALLISTA_IO_RETRIES_TIMES: &str = "ballista.client.io_retries_times";
+/// Wait time in milliseconds between IO retries in the Ballista client
+pub const BALLISTA_IO_RETRY_WAIT_TIME_MS: &str = "ballista.client.io_retry_wait_time_ms";
 
 /// Result type for configuration parsing operations.
 pub type ParseResult<T> = result::Result<T, String>;
@@ -163,7 +167,15 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
         ConfigEntry::new(BALLISTA_CLIENT_USE_TLS.to_string(),
                          "Should connection between client, scheduler, and executors use TLS.".to_string(),
                          DataType::Boolean,
-                         Some(false.to_string()))
+                         Some(false.to_string())),
+        ConfigEntry::new(BALLISTA_IO_RETRIES_TIMES.to_string(),
+                         "Number of retries for IO operations in the Ballista client.".to_string(),
+                         DataType::UInt16,
+                         Some(3.to_string())),
+        ConfigEntry::new(BALLISTA_IO_RETRY_WAIT_TIME_MS.to_string(),
+                         "Wait time in milliseconds between IO retries in the Ballista client.".to_string(),
+                         DataType::UInt64,
+                         Some(3000.to_string()))
     ];
     entries
         .into_iter()
@@ -377,6 +389,16 @@ impl BallistaConfig {
     /// should client use TLS to communicate with ballista cluster
     pub fn client_use_tls(&self) -> bool {
         self.get_bool_setting(BALLISTA_CLIENT_USE_TLS)
+    }
+
+    /// Returns the number of retries for IO operations in the Ballista client.
+    pub fn io_retries_times(&self) -> usize {
+        self.get_usize_setting(BALLISTA_IO_RETRIES_TIMES)
+    }
+
+    /// Returns the wait time in milliseconds between IO retries in the Ballista client.
+    pub fn io_retry_wait_time_ms(&self) -> usize {
+        self.get_usize_setting(BALLISTA_IO_RETRY_WAIT_TIME_MS)
     }
 
     fn get_usize_setting(&self, key: &str) -> usize {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -330,6 +330,8 @@ async fn execute_query_pull(
     let customize_endpoint =
         session_config.ballista_override_create_grpc_client_endpoint();
     let use_tls = session_config.ballista_use_tls();
+    let io_retries_times = grpc_config.io_retries_times;
+    let io_retry_wait_time_ms = grpc_config.io_retry_wait_time_ms;
 
     // Capture query submission time for total_query_time_ms
     let query_start_time = std::time::Instant::now();
@@ -469,6 +471,8 @@ async fn execute_query_pull(
                         flight_proxy.clone(),
                         customize_endpoint.clone(),
                         use_tls,
+                        io_retries_times,
+                        io_retry_wait_time_ms,
                     )
                     .map_err(|e| ArrowError::ExternalError(Box::new(e)));
 
@@ -497,6 +501,8 @@ async fn execute_query_push(
     let customize_endpoint =
         session_config.ballista_override_create_grpc_client_endpoint();
     let use_tls = session_config.ballista_use_tls();
+    let io_retries_times = grpc_config.io_retries_times;
+    let io_retry_wait_time_ms = grpc_config.io_retry_wait_time_ms;
 
     // Capture query submission time for total_query_time_ms
     let query_start_time = std::time::Instant::now();
@@ -623,6 +629,8 @@ async fn execute_query_push(
                         flight_proxy.clone(),
                         customize_endpoint.clone(),
                         use_tls,
+                        io_retries_times,
+                        io_retry_wait_time_ms,
                     )
                     .map_err(|e| ArrowError::ExternalError(Box::new(e)));
 
@@ -679,7 +687,7 @@ fn get_client_host_port(
         }
     }
 }
-
+#[allow(clippy::too_many_arguments)]
 async fn fetch_partition(
     location: PartitionLocation,
     max_message_size: usize,
@@ -688,6 +696,8 @@ async fn fetch_partition(
     flight_proxy: Option<FlightProxy>,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
     use_tls: bool,
+    io_retries_times: u8,
+    io_retry_wait_time_ms: u64,
 ) -> Result<SendableRecordBatchStream> {
     let metadata = location.executor_meta.ok_or_else(|| {
         DataFusionError::Internal("Received empty executor metadata".to_owned())
@@ -708,6 +718,8 @@ async fn fetch_partition(
         max_message_size,
         use_tls,
         customize_endpoint,
+        io_retries_times,
+        io_retry_wait_time_ms,
     )
     .await
     .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -475,9 +475,19 @@ async fn new_ballista_client(
 ) -> result::Result<BallistaClient, BallistaError> {
     let max_message_size = config.max_message_size;
     let use_tls = config.use_tls;
+    let io_retries_times = config.io_retries_times;
+    let io_retry_wait_time_ms = config.io_retry_wait_time_ms;
 
-    BallistaClient::try_new(host, port, max_message_size, use_tls, customize_endpoint)
-        .await
+    BallistaClient::try_new(
+        host,
+        port,
+        max_message_size,
+        use_tls,
+        customize_endpoint,
+        io_retries_times,
+        io_retry_wait_time_ms,
+    )
+    .await
 }
 
 async fn fetch_partition_remote(

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -67,6 +67,10 @@ pub struct GrpcClientConfig {
     pub use_tls: bool,
     /// Returns the maximum message size for gRPC clients in bytes.
     pub max_message_size: usize,
+    /// Number of retries for IO operations.
+    pub io_retries_times: u8,
+    /// Wait time in milliseconds between IO retries.
+    pub io_retry_wait_time_ms: u64,
 }
 
 impl From<&BallistaConfig> for GrpcClientConfig {
@@ -80,6 +84,8 @@ impl From<&BallistaConfig> for GrpcClientConfig {
                 as u64,
             use_tls: config.client_use_tls(),
             max_message_size: config.grpc_client_max_message_size(),
+            io_retries_times: config.io_retries_times() as u8,
+            io_retry_wait_time_ms: config.io_retry_wait_time_ms() as u64,
         }
     }
 }
@@ -93,6 +99,8 @@ impl Default for GrpcClientConfig {
             http2_keepalive_interval_seconds: 300,
             use_tls: false,
             max_message_size: 16 * 1024 * 1024,
+            io_retries_times: 3,
+            io_retry_wait_time_ms: 3000,
         }
     }
 }
@@ -343,6 +351,8 @@ mod tests {
             http2_keepalive_interval_seconds: 150,
             use_tls: false,
             max_message_size: 16 * 1024 * 1024,
+            io_retries_times: 3,
+            io_retry_wait_time_ms: 3000,
         };
         let result = create_grpc_client_endpoint("http://localhost:50051", Some(&config));
         assert!(result.is_ok());

--- a/examples/examples/standalone-substrait.rs
+++ b/examples/examples/standalone-substrait.rs
@@ -277,6 +277,8 @@ impl SubstraitSchedulerClient {
             successful_job.partition_location,
             self.max_message_size,
             self.use_flight_transport,
+            self.grpc_config.io_retries_times,
+            self.grpc_config.io_retry_wait_time_ms,
         )
         .await?;
 
@@ -376,12 +378,16 @@ impl SubstraitSchedulerClient {
         partition_locations: Vec<PartitionLocation>,
         max_message_size: usize,
         use_flight_transport: bool,
+        io_retries_times: u8,
+        io_retry_wait_time_ms: u64,
     ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>> {
         let streams = partition_locations.into_iter().map(move |partition| {
             let f = Self::fetch_partition_internal(
                 partition,
                 max_message_size,
                 use_flight_transport,
+                io_retries_times,
+                io_retry_wait_time_ms,
             )
             .map_err(|e| ArrowError::ExternalError(Box::new(e)));
 
@@ -395,6 +401,8 @@ impl SubstraitSchedulerClient {
         location: PartitionLocation,
         max_message_size: usize,
         flight_transport: bool,
+        io_retries_times: u8,
+        io_retry_wait_time_ms: u64,
     ) -> Result<SendableRecordBatchStream> {
         let metadata = location.executor_meta.ok_or_else(|| {
             DataFusionError::Internal("Received empty executor metadata".to_owned())
@@ -406,10 +414,17 @@ impl SubstraitSchedulerClient {
         let host = metadata.host.as_str();
         let port = metadata.port as u16;
 
-        let mut ballista_client =
-            BallistaClient::try_new(host, port, max_message_size, false, None)
-                .await
-                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+        let mut ballista_client = BallistaClient::try_new(
+            host,
+            port,
+            max_message_size,
+            false,
+            None,
+            io_retries_times,
+            io_retry_wait_time_ms,
+        )
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
         ballista_client
             .fetch_partition(


### PR DESCRIPTION
# Which issue does this PR close?

changes to support configurable IO settings.

Closes #.

 # Rationale for this change

IO Configurations are static; it would be better to make them more configurable.

# What changes are included in this PR?

Modified certain constants to configurable parameters and updated the code to support the configurations

# Are there any user-facing changes?
No