### PR TITLE
fix: allow S3 access without explicit credentials

### DIFF
--- a/ballista/core/src/object_store.rs
+++ b/ballista/core/src/object_store.rs
@@ -194,10 +194,6 @@ impl CustomObjectStoreRegistry {
             if let Some(session_token) = session_token {
                 builder = builder.with_token(session_token);
             }
-        } else {
-            return config_err!(
-                "'s3.access_key_id' & 's3.secret_access_key' must be configured"
-            );
         }
 
         if let Some(region) = region {


### PR DESCRIPTION
## Summary

Removes the `else` branch in `CustomObjectStoreRegistry::s3_object_store_builder` that returned a hard error when `s3.access_key_id` and `s3.secret_access_key` were not explicitly set via SQL `SET` commands.

`AmazonS3Builder::from_env()` already supports the full AWS credential chain — environment variables, IRSA web identity tokens, instance profiles, etc. The explicit credential check was redundant and prevented these standard mechanisms from working.

Fixes #1583

## Test plan

- [ ] Deploy scheduler + executor with `AWS_REGION` set and credentials provided via instance profile or IRSA (no explicit `SET s3.*` commands)
- [ ] Verify S3 tables can be registered and queried successfully
- [ ] Verify explicit credentials via `SET s3.access_key_id` / `SET s3.secret_access_key` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)