### PR TITLE
fix: route collect/show/to_pandas through Ballista cluster

### DIFF
--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -35,6 +35,18 @@ import pathlib
 # class used to redefine DataFrame object
 # intercepting execution methods and methods
 # which returns `DataFrame`
+EXECUTION_METHODS = [
+    "collect",
+    "collect_partitioned",
+    "show",
+    "count",
+    "to_arrow_table",
+    "to_pandas",
+    "to_polars",
+    "write_json",
+]
+
+
 class RedefiningDataFrameMeta(type):
     def __new__(cls, name, bases, attrs):
         # wrapper function intercept all execution functions
@@ -74,6 +86,13 @@ class RedefiningDataFrameMeta(type):
                 #
                 attrs[base_name] = __wrap_dataframe_result(base_value)
 
+        # Wrap execution methods to route through _to_internal_df() so they
+        # execute on the Ballista cluster rather than locally. Skip any method
+        # already explicitly defined on the subclass.
+        for func in EXECUTION_METHODS:
+            if func not in attrs:
+                attrs[func] = __wrap_dataframe_execution(func)
+
         return super().__new__(cls, name, bases, attrs)
 
 
@@ -111,7 +130,7 @@ class RedefiningSessionContextMeta(type):
 # serialize it and invoke ballista client to execute it
 #
 # this class keeps reference to remote ballista
-class DistributedDataFrame(DataFrame, metaclass=type):
+class DistributedDataFrame(DataFrame, metaclass=RedefiningDataFrameMeta):
     def __init__(self, df: DataFrame, session_id: str, address: str):
         super().__init__(df.df)
         self.address = address


### PR DESCRIPTION
## Summary

`DistributedDataFrame.collect()`, `show()`, `count()`, `to_pandas()` and other execution methods were running locally in the client process instead of on the Ballista cluster.

**Root cause:** PR #1513 (jupyter notebook support) changed `DistributedDataFrame` from `metaclass=RedefiningDataFrameMeta` to `metaclass=type`. `RedefiningDataFrameMeta` was responsible for wrapping execution methods to route through `_to_internal_df()` before executing. With plain `metaclass=type`, those methods were inherited directly from DataFusion's `DataFrame` and ran locally. Only `write_csv` and `write_parquet` were manually re-added as overrides, so writes worked but reads did not.

**Fix:**
- Add `EXECUTION_METHODS` list to `RedefiningDataFrameMeta` covering `collect`, `collect_partitioned`, `show`, `count`, `to_arrow_table`, `to_pandas`, `to_polars`, `write_json`
- In `__new__`, wrap each of those methods to call `_to_internal_df()` first — skipping any method already explicitly overridden on the subclass (e.g. `write_parquet`)
- Switch `DistributedDataFrame` back to `metaclass=RedefiningDataFrameMeta`

Fixes #1582

## Test plan

- [ ] `df.collect()` executes on the cluster (verify executor logs show activity)
- [ ] `df.show()` executes on the cluster
- [ ] `df.to_pandas()` executes on the cluster
- [ ] `df.write_parquet()` still works (explicit override not clobbered by metaclass)
- [ ] Existing Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)