### PR TITLE
fix: [Python] serialize optimized logical plan to fix subquery support

### DIFF
--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -121,7 +121,7 @@ class DistributedDataFrame(DataFrame, metaclass=type):
     # session context, and ballista planner.
     #
     def _to_internal_df(self):
-        blob_plan = self.logical_plan().to_proto()
+        blob_plan = self.optimized_logical_plan().to_proto()
         df = create_ballista_data_frame(blob_plan, self.address, self._session_id)
         return df
 


### PR DESCRIPTION
## Summary

Fixes TPC-H Q2 (and any query using subqueries) failing in the Python client with:

```
Proto serialization error: Expr::ScalarSubquery(_) | Expr::InSubquery(_) | Expr::Exists { .. } | Expr::OuterReferenceColumn not supported
```

**Root cause:** `_to_internal_df()` was calling `logical_plan().to_proto()`, which serializes the *unoptimized* plan. Subquery expressions (`ScalarSubquery`, `InSubquery`, `Exists`, `OuterReferenceColumn`) are not supported by DataFusion's proto serializer, and they're still present in the unoptimized plan.

The Rust client is unaffected because DataFusion's query optimizer runs *before* `BallistaQueryPlanner::create_physical_plan()` is called — `DecorrelatePredicateSubquery` converts subqueries into joins first, so the plan handed to the serializer contains no subquery nodes.

**Fix:** one line — use `optimized_logical_plan().to_proto()` so the Python client serializes the same optimizer output that the Rust path sends to the scheduler.

Fixes #1581

## Test plan

I confirmed that this fixed the issue