### PR TITLE
fix: warn and document scheduler --external-host default in cluster deploys

### DIFF
--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -40,7 +40,7 @@ use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
 use http::StatusCode;
-use log::info;
+use log::{info, warn};
 use std::{net::SocketAddr, sync::Arc};
 use tonic::service::RoutesBuilder;
 /// Creates as initialized scheduler service
@@ -57,6 +57,17 @@ pub async fn create_scheduler<
         "Starting Scheduler grpc server with task scheduling policy of {:?}",
         config.scheduling_policy
     );
+
+    if config.bind_host != "127.0.0.1" && config.external_host == "localhost" {
+        warn!(
+            "Scheduler is bound to {} but --external-host is still the default 'localhost'. \
+             Executors will be told to call back to 'localhost:{}' for task status and \
+             heartbeats, which is unlikely to be reachable from other hosts or pods. \
+             Set --external-host to a hostname or IP that executors can resolve to this \
+             scheduler.",
+            config.bind_host, config.bind_port
+        );
+    }
 
     let codec_logical = config
         .override_logical_codec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build:
       dockerfile: dev/docker/ballista-scheduler.Dockerfile
       context: .
-    command: "--bind-host 0.0.0.0"
+    command: "--bind-host 0.0.0.0 --external-host ballista-scheduler"
     ports:
       - "50050:50050"
     environment:

--- a/docs/source/user-guide/deployment/docker-compose.md
+++ b/docs/source/user-guide/deployment/docker-compose.md
@@ -48,6 +48,12 @@ ballista-executor_1   | INFO ballista_executor: Ballista v52.0.0 Rust Executor l
 
 The scheduler listens on port 50050 and this is the port that clients will need to connect to.
 
+Note that the scheduler is started with `--external-host ballista-scheduler` so
+that it advertises the Compose service name to executors. Executors call back to
+that address to report task status; if it is left at the default of `localhost`,
+status updates fail because executors try to dial `localhost:50050` inside their
+own container.
+
 ## Connect from the Ballista CLI
 
 ```shell

--- a/docs/source/user-guide/deployment/kubernetes.md
+++ b/docs/source/user-guide/deployment/kubernetes.md
@@ -106,6 +106,14 @@ persistentvolumeclaim/data-pv-claim created
 
 Copy the following yaml to a `cluster.yaml` file and change `<your-image>` with the name of your Ballista Docker image.
 
+The scheduler is started with `--external-host=ballista-scheduler` so that it
+advertises the cluster-internal Service DNS name to executors. Executors call
+back to that address to report task status and heartbeats; if it is left at the
+default of `localhost`, executors will try to dial `localhost:50050` inside
+their own pod and fail with `Fail to connect to scheduler localhost:50050`.
+Replace `ballista-scheduler` with whatever Service name resolves to the
+scheduler in your namespace.
+
 ```yaml
 apiVersion: v1
 kind: Service
@@ -140,7 +148,9 @@ spec:
       containers:
         - name: ballista-scheduler
           image: <your-repo>/datafusion-ballista-scheduler:latest
-          args: ["--bind-port=50050"]
+          args:
+            - "--bind-port=50050"
+            - "--external-host=ballista-scheduler"
           ports:
             - containerPort: 50050
               name: flight


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1587.

# Rationale for this change

When the scheduler launches tasks it embeds its own advertised address in `LaunchTaskParams.scheduler_id`, and executors use that string to dial back for task status and heartbeats (`executor_server.rs::get_scheduler_client` literally does `format!(\"http://{scheduler_id}\")`). The advertised address is built from `SchedulerConfig::scheduler_name()` = `format!(\"{external_host}:{bind_port}\")`, and `external_host` defaults to `\"localhost\"` with no env-var binding.

The Kubernetes deployment example in the user guide and the in-tree `docker-compose.yml` both omit `--external-host`, so any cluster deployed from those templates inherits the default. The executor's outgoing connection works because it is configured separately on the executor side via `--scheduler-host`, but every status report and heartbeat tries to dial `localhost:50050` inside the executor's own pod and fails with `Fail to connect to scheduler localhost:50050`. The failure mode is undocumented today.

# What changes are included in this PR?

- **Kubernetes deployment guide**: scheduler args now include `--external-host=ballista-scheduler`, with a paragraph explaining why and what the symptom looks like if it is omitted.
- **`docker-compose.yml`**: scheduler `command:` now sets `--external-host ballista-scheduler` to match the Compose service name.
- **Docker Compose deployment guide**: short note added describing why the scheduler advertises its Compose service name to executors.
- **`ballista/scheduler/src/scheduler_process.rs`**: emit a `WARN` at scheduler startup when `bind_host` is non-loopback but `external_host` is still the default `\"localhost\"`. This fires only on misconfigured cluster deploys (single-machine runs with the all-defaults `bind_host=127.0.0.1` are unaffected) and gives operators a clear diagnostic instead of waiting for the first task-status callback to fail.

# Are there any user-facing changes?

No API changes. Operators of misconfigured clusters will see a new `WARN` log at scheduler startup; deployments using the updated example manifests will work without status-callback failures.