### PR TITLE
fix: propagate session config from Python client to Ballista cluster

### DIFF
--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -19,6 +19,7 @@ from datafusion import SessionContext, DataFrame, ParquetWriterOptions
 from datafusion.dataframe import Compression
 
 from typing import (
+    Dict,
     List,
     Union,
     Optional,
@@ -81,10 +82,14 @@ class RedefiningSessionContextMeta(type):
     def __new__(cls, name, bases, attrs):
         def __wrap_dataframe_result(func):
             def method_wrapper(*args, **kwargs):
-                address = args[0].address
-                session_id = args[0].session_id
+                ctx = args[0]
                 df = func(*args, **kwargs)
-                return DistributedDataFrame(df, session_id, address)
+                return DistributedDataFrame(
+                    df,
+                    ctx.session_id,
+                    ctx.address,
+                    ctx.cluster_config,
+                )
 
             return method_wrapper
 
@@ -112,17 +117,29 @@ class RedefiningSessionContextMeta(type):
 #
 # this class keeps reference to remote ballista
 class DistributedDataFrame(DataFrame, metaclass=type):
-    def __init__(self, df: DataFrame, session_id: str, address: str):
+    def __init__(
+        self,
+        df: DataFrame,
+        session_id: str,
+        address: str,
+        cluster_config: Optional[Dict[str, str]] = None,
+    ):
         super().__init__(df.df)
         self.address = address
         self._session_id = session_id
+        self.cluster_config = cluster_config
     #
     # this will create a ballista dataframe, which has ballista
     # session context, and ballista planner.
     #
     def _to_internal_df(self):
         blob_plan = self.logical_plan().to_proto()
-        df = create_ballista_data_frame(blob_plan, self.address, self._session_id)
+        df = create_ballista_data_frame(
+            blob_plan,
+            self.address,
+            self._session_id,
+            self.cluster_config,
+        )
         return df
 
     def write_csv(self, path, with_header=False):
@@ -498,16 +515,35 @@ class BallistaSessionContext(SessionContext, metaclass=RedefiningSessionContextM
         >>> df = ctx.sql("SELECT * FROM my_table LIMIT 10")
         >>> df.show()
 
+    To override DataFusion / Ballista session settings on the cluster
+    (e.g. the number of target partitions used by the scheduler):
+
+        >>> ctx = BallistaSessionContext(
+        ...     "df://localhost:50050",
+        ...     cluster_config={"datafusion.execution.target_partitions": "256"},
+        ... )
+
     For Jupyter notebook users:
         >>> %load_ext ballista.jupyter
         >>> %ballista connect df://localhost:50050
         >>> %sql SELECT * FROM my_table
     """
 
-    def __init__(self, address: str, config=None, runtime=None):
+    def __init__(
+        self,
+        address: str,
+        config=None,
+        runtime=None,
+        cluster_config: Optional[Dict[str, str]] = None,
+    ):
         super().__init__(config, runtime)
         self.address = address
-        self.session_id_internal = super().session_id() 
+        self.session_id_internal = super().session_id()
+        self.cluster_config = (
+            {str(k): str(v) for k, v in cluster_config.items()}
+            if cluster_config is not None
+            else None
+        )
 
     @property
     def session_id(self):

--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datafusion import SessionContext, DataFrame, ParquetWriterOptions
+from datafusion import SessionConfig, SessionContext, DataFrame, ParquetWriterOptions
 from datafusion.dataframe import Compression
 
 from typing import (
@@ -555,14 +555,23 @@ class BallistaSessionContext(SessionContext, metaclass=RedefiningSessionContextM
         runtime=None,
         cluster_config: Optional[Dict[str, str]] = None,
     ):
-        super().__init__(config, runtime)
-        self.address = address
-        self.session_id_internal = super().session_id()
         self.cluster_config = (
             {str(k): str(v) for k, v in cluster_config.items()}
             if cluster_config is not None
             else None
         )
+        # Apply overrides to the local SessionContext too: some settings
+        # (e.g. datafusion.execution.listing_table_factory_infer_partitions)
+        # are consulted during local table registration / planning, before
+        # the plan is shipped to the scheduler.
+        if self.cluster_config:
+            if config is None:
+                config = SessionConfig()
+            for key, value in self.cluster_config.items():
+                config = config.set(key, value)
+        super().__init__(config, runtime)
+        self.address = address
+        self.session_id_internal = super().session_id()
 
     @property
     def session_id(self):

--- a/python/python/tests/test_context.py
+++ b/python/python/tests/test_context.py
@@ -73,3 +73,21 @@ def test_read_dataframe_api(ctx):
 
     assert result.column(0) == pa.array([3, 4, 5])
     assert result.column(1) == pa.array([-4, -5, -6])
+
+
+def test_cluster_config_propagates_to_distributed_dataframe():
+    """The cluster_config dict should be passed to DistributedDataFrame
+    instances created through the BallistaSessionContext, so it can be
+    forwarded to the scheduler-side session.
+    """
+    (address, port) = setup_test_cluster()
+    overrides = {"datafusion.execution.target_partitions": "256"}
+    ctx = BallistaSessionContext(
+        address=f"df://{address}:{port}",
+        cluster_config=overrides,
+    )
+
+    assert ctx.cluster_config == overrides
+
+    df = ctx.sql("SELECT 1")
+    assert df.cluster_config == overrides

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -17,11 +17,14 @@
 
 use crate::utils::wait_for_future;
 use ballista::prelude::*;
+use ballista_core::extension::SessionConfigHelperExt;
+use ballista_core::serde::protobuf::KeyValuePair;
 use cluster::{PyExecutor, PyScheduler};
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::*;
 use datafusion_proto::bytes::logical_plan_from_bytes;
 use pyo3::prelude::*;
+use std::collections::HashMap;
 
 mod cluster;
 mod utils;
@@ -50,15 +53,36 @@ fn _internal_ballista(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
 
 /// Creates a DataFrame which runs on ballista session context.
 ///
-/// Returned DataFrame will executed plan on ballista.
+/// `config_overrides` is an optional dictionary of DataFusion / Ballista
+/// configuration keys (e.g. `datafusion.execution.target_partitions`) that
+/// will be applied on top of `SessionConfig::new_with_ballista()` and
+/// propagated to the scheduler-side session.
+///
+/// Returned DataFrame will execute its plan on ballista.
 #[pyfunction]
+#[pyo3(signature = (plan_blob, url, session_id, config_overrides=None))]
 fn create_ballista_data_frame(
     py: Python,
     plan_blob: &[u8],
     url: &str,
     session_id: &str,
+    config_overrides: Option<HashMap<String, String>>,
 ) -> PyResult<datafusion_python::dataframe::PyDataFrame> {
-    let state = SessionStateBuilder::new_with_default_features()
+    let mut session_config = SessionConfig::new_with_ballista();
+    if let Some(overrides) = config_overrides {
+        let pairs: Vec<KeyValuePair> = overrides
+            .into_iter()
+            .map(|(key, value)| KeyValuePair {
+                key,
+                value: Some(value),
+            })
+            .collect();
+        session_config.update_from_key_value_pair_mut(&pairs);
+    }
+
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_config(session_config)
         .with_session_id(session_id.to_string())
         .build();
 


### PR DESCRIPTION
Closes #1591.

# Rationale

The Python `BallistaSessionContext` had no way to override DataFusion / Ballista session settings (e.g. `target_partitions`). Worse, the Rust entry point built the remote session from `SessionStateBuilder::new_with_default_features()`, whose `target_partitions` defaults to the client pod's CPU count and was then shipped wholesale to the scheduler — overriding the scheduler's own defaults.

# Changes

- `python/src/lib.rs`: `create_ballista_data_frame` now starts the remote session from `SessionConfig::new_with_ballista()` and accepts an optional dict of overrides applied via `update_from_key_value_pair_mut`.
- `python/python/ballista/extension.py`: `BallistaSessionContext` accepts `cluster_config: dict[str, str]`. The dict is applied both to the local `SessionConfig` (needed for settings consulted during table registration / planning, e.g. `listing_table_factory_infer_partitions`) and forwarded through every `DistributedDataFrame._to_internal_df()` to the remote session.

# User-facing change

```python
ctx = BallistaSessionContext(
    "df://localhost:50050",
    cluster_config={"datafusion.execution.target_partitions": "256"},
)
```

New optional kwarg; existing call sites are unaffected.