### PR TITLE
docs: add Ballista TUI documentation

### DIFF
--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -160,14 +160,14 @@ The TUI provides the following views:
 
 ### TUI Navigation
 
-| Key | Action |
-|-----|--------|
-| `Tab` | Switch between Executors, Jobs, and Metrics tabs |
-| `↑` / `↓` | Navigate rows in the current table |
-| `←` / `→` | Change sort column |
-| `Enter` | Open details popup for the selected job |
-| `Esc` | Close popup or quit details view |
-| `q` | Quit the TUI |
-| `?` | Show help overlay with all key bindings |
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `Tab`     | Switch between Executors, Jobs, and Metrics tabs |
+| `↑` / `↓` | Navigate rows in the current table               |
+| `←` / `→` | Change sort column                               |
+| `Enter`   | Open details popup for the selected job          |
+| `Esc`     | Close popup or quit details view                 |
+| `q`       | Quit the TUI                                     |
+| `?`       | Show help overlay with all key bindings          |
 
 The TUI connects to the scheduler via HTTP and refreshes data automatically every few seconds.

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -160,14 +160,16 @@ The TUI provides the following views:
 
 ### TUI Navigation
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `Tab`     | Switch between Executors, Jobs, and Metrics tabs |
-| `↑` / `↓` | Navigate rows in the current table               |
-| `←` / `→` | Change sort column                               |
-| `Enter`   | Open details popup for the selected job          |
-| `Esc`     | Close popup or quit details view                 |
-| `q`       | Quit the TUI                                     |
-| `?`       | Show help overlay with all key bindings          |
+| Key             | Action                                           |
+| --------------- | ------------------------------------------------ |
+| `j`             | Switch to Jobs tab                               |
+| `e`             | Switch to Executors tab                          |
+| `m`             | Switch to Metrics tab                            |
+| `↑` / `↓`       | Navigate rows in the current table               |
+| `1` / `2` / `3` | Toggle sort by column (press again to reverse)   |
+| `Enter`         | Open details popup for the selected job          |
+| `Esc`           | Close popup or quit details view                 |
+| `q`             | Quit the TUI                                     |
+| `?`             | Show help overlay with all key bindings          |
 
 The TUI connects to the scheduler via HTTP and refreshes data automatically every few seconds.

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -28,6 +28,12 @@ Use Cargo to install:
 cargo install ballista-cli
 ```
 
+To install with the Terminal User Interface (TUI) feature enabled:
+
+```bash
+cargo install ballista-cli --features tui
+```
+
 ## Usage
 
 ```
@@ -45,6 +51,7 @@ OPTIONS:
         --port <PORT>                Ballista scheduler port
     -q, --quiet                      Reduce printing other than the results and work quietly
     -r, --rc <RC>...                 Run the provided files on startup instead of ~/.ballistarc
+        --tui                        Enables terminal user interface (requires `tui` feature)
     -V, --version                    Print version information
 ```
 
@@ -130,3 +137,37 @@ Available commands inside Ballista CLI are:
 ```bash
 > \h function_table
 ```
+
+## Terminal User Interface (TUI)
+
+When Ballista CLI is built with the `tui` feature, you can launch an interactive terminal user interface
+that provides a visual overview of the Ballista cluster.
+
+### Launching the TUI
+
+```bash
+ballista-cli --tui
+```
+
+### TUI Features
+
+The TUI provides the following views:
+
+- **Executors**: Lists all registered executors with their host, port, CPU cores, memory, and current job count. Supports sorting by any column.
+- **Jobs**: Displays active and completed jobs with their status, start time, and duration. Supports sorting and shows job details on selection.
+- **Metrics**: Fetches and displays Prometheus metrics from the scheduler, including query execution statistics.
+- **Scheduler Info**: Shows the current scheduler state and configuration.
+
+### TUI Navigation
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Switch between Executors, Jobs, and Metrics tabs |
+| `↑` / `↓` | Navigate rows in the current table |
+| `←` / `→` | Change sort column |
+| `Enter` | Open details popup for the selected job |
+| `Esc` | Close popup or quit details view |
+| `q` | Quit the TUI |
+| `?` | Show help overlay with all key bindings |
+
+The TUI connects to the scheduler via HTTP and refreshes data automatically every few seconds.

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -28,12 +28,6 @@ Use Cargo to install:
 cargo install ballista-cli
 ```
 
-The TUI feature is enabled by default. To install without it:
-
-```bash
-cargo install ballista-cli --no-default-features
-```
-
 ## Usage
 
 ```
@@ -145,8 +139,19 @@ that provides a visual overview of the Ballista cluster.
 
 ### Launching the TUI
 
+There are two ways to start the TUI:
+
+1. Directly via command-line flag:
+
 ```bash
 ballista-cli --tui
+```
+
+2. From within the Ballista CLI interactive shell:
+
+```bash
+ballista-cli
+> \tui
 ```
 
 ### TUI Features
@@ -156,7 +161,7 @@ The TUI provides the following views:
 - **Executors**: Lists all registered executors with their host, port, CPU cores, memory, and current job count. Supports sorting by any column.
 - **Jobs**: Displays active and completed jobs with their status, start time, and duration. Supports sorting, job search (`/`), and shows job details on selection.
 - **Job Stages**: When viewing a job, press `Enter` to see its execution stages with input/output rows, elapsed compute, and task percentiles.
-- **Stage Tasks & Plan**: Within the Job Stages view, press `t` to see individual task details or `p` to view the stage execution plan.
+- **Stage Tasks & Plan**: Within the Job Stages view, press `Enter` to see individual task details or `p` to view the stage execution plan.
 - **Job Plans**: For completed jobs, press `p` to view the Stage, Physical, or Logical query plans.
 - **Job Stages Graph**: Press `g` to visualize the job's stage execution graph.
 - **Metrics**: Fetches and displays Prometheus metrics from the scheduler, including query execution statistics.
@@ -177,15 +182,15 @@ The TUI provides the following views:
 
 #### Jobs View Keybindings
 
-| Key             | Action                                                                                  |
-| --------------- | --------------------------------------------------------------------------------------- |
-| `↑` / `↓`       | Navigate rows in the jobs table                                                         |
-| `1` / `2` / `3` | Sort by first/second/third column (press again to reverse, third press removes sorting) |
-| `/`             | Search jobs                                                                             |
-| `Enter`         | Open Job Stages popup for the selected job                                              |
-| `g`             | View job stages graph (DOT visualization)                                               |
-| `c`             | Cancel the selected job (if cancelable)                                                 |
-| `p`             | View job plans (Stage / Physical / Logical) for completed jobs                          |
+| Key                   | Action                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `↑` / `↓`             | Navigate rows in the jobs table                                                             |
+| `1` / `2` / `3` / ... | Sort by first/second/third/... column (press again to reverse, third press removes sorting) |
+| `/`                   | Search jobs                                                                                 |
+| `Enter`               | Open Job Stages popup for the selected job                                                  |
+| `g`                   | View job stages graph (DOT visualization) for completed jobs                                |
+| `c`                   | Cancel the selected job (if cancelable)                                                     |
+| `p`                   | View job plans (Stage / Physical / Logical) for completed jobs                              |
 
 #### Job Stages Popup Keybindings
 
@@ -198,9 +203,16 @@ The TUI provides the following views:
 
 #### Stage Tasks / Plan Popup Keybindings
 
-| Key   | Action      |
-| ----- | ----------- |
-| `Esc` | Close popup |
+| Key   | Action                     |
+| ----- | -------------------------- |
+| `Esc` | Return to Job Stages popup |
+
+#### Job Stages Graph Popup Keybindings
+
+| Key       | Action         |
+| --------- | -------------- |
+| `↑` / `↓` | Scroll up/down |
+| `Esc`     | Close popup    |
 
 #### Job Plans Popup Keybindings
 

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -28,10 +28,10 @@ Use Cargo to install:
 cargo install ballista-cli
 ```
 
-To install with the Terminal User Interface (TUI) feature enabled:
+The TUI feature is enabled by default. To install without it:
 
 ```bash
-cargo install ballista-cli --features tui
+cargo install ballista-cli --no-default-features
 ```
 
 ## Usage
@@ -154,20 +154,74 @@ ballista-cli --tui
 The TUI provides the following views:
 
 - **Executors**: Lists all registered executors with their host, port, CPU cores, memory, and current job count. Supports sorting by any column.
-- **Jobs**: Displays active and completed jobs with their status, start time, and duration. Supports sorting and shows job details on selection.
+- **Jobs**: Displays active and completed jobs with their status, start time, and duration. Supports sorting, job search (`/`), and shows job details on selection.
+- **Job Stages**: When viewing a job, press `Enter` to see its execution stages with input/output rows, elapsed compute, and task percentiles.
+- **Stage Tasks & Plan**: Within the Job Stages view, press `t` to see individual task details or `p` to view the stage execution plan.
+- **Job Plans**: For completed jobs, press `p` to view the Stage, Physical, or Logical query plans.
+- **Job Stages Graph**: Press `g` to visualize the job's stage execution graph.
 - **Metrics**: Fetches and displays Prometheus metrics from the scheduler, including query execution statistics.
 - **Scheduler Info**: Shows the current scheduler state and configuration.
 
 ### TUI Navigation
 
+#### Global Keybindings
+
 | Key       | Action                                           |
 | --------- | ------------------------------------------------ |
-| `Tab`     | Switch between Executors, Jobs, and Metrics tabs |
-| `↑` / `↓` | Navigate rows in the current table               |
-| `←` / `→` | Change sort column                               |
-| `Enter`   | Open details popup for the selected job          |
-| `Esc`     | Close popup or quit details view                 |
-| `q`       | Quit the TUI                                     |
-| `?`       | Show help overlay with all key bindings          |
+| `j`       | Switch to Jobs view                              |
+| `e`       | Switch to Executors view                         |
+| `m`       | Switch to Metrics view                           |
+| `i`       | Show Scheduler Info popup                        |
+| `?` / `h` | Show help overlay with all key bindings          |
+| `q` / `Esc`| Quit the TUI                                    |
+
+#### Jobs View Keybindings
+
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `↑` / `↓` | Navigate rows in the jobs table                  |
+| `1` / `2` / `3` | Sort by first/second/third column (press again to reverse, third press removes sorting) |
+| `/`       | Search jobs                                      |
+| `Enter`   | Open Job Stages popup for the selected job       |
+| `g`       | View job stages graph (DOT visualization)      |
+| `c`       | Cancel the selected job (if cancelable)          |
+| `p`       | View job plans (Stage / Physical / Logical) for completed jobs |
+
+#### Job Stages Popup Keybindings
+
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `↑` / `↓` | Navigate stages                                  |
+| `Enter`   | View tasks for the selected stage                |
+| `p`       | View execution plan for the selected stage       |
+| `Esc`     | Close popup                                      |
+
+#### Stage Tasks / Plan Popup Keybindings
+
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `Esc`     | Close popup                                      |
+
+#### Job Plans Popup Keybindings
+
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `s`       | Show Stage plan                                  |
+| `p`       | Show Physical plan                               |
+| `l`       | Show Logical plan                                |
+| `↑` / `↓` | Scroll up/down                                   |
+| `Esc`     | Close popup                                      |
+
+#### Executors View Keybindings
+
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `1` / `2` / `3` | Sort by first/second/third column              |
+
+#### Metrics View Keybindings
+
+| Key       | Action                                           |
+| --------- | ------------------------------------------------ |
+| `/`       | Search metrics                                   |
 
 The TUI connects to the scheduler via HTTP and refreshes data automatically every few seconds.

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -166,62 +166,62 @@ The TUI provides the following views:
 
 #### Global Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `j`       | Switch to Jobs view                              |
-| `e`       | Switch to Executors view                         |
-| `m`       | Switch to Metrics view                           |
-| `i`       | Show Scheduler Info popup                        |
-| `?` / `h` | Show help overlay with all key bindings          |
-| `q` / `Esc`| Quit the TUI                                    |
+| Key         | Action                                  |
+| ----------- | --------------------------------------- |
+| `j`         | Switch to Jobs view                     |
+| `e`         | Switch to Executors view                |
+| `m`         | Switch to Metrics view                  |
+| `i`         | Show Scheduler Info popup               |
+| `?` / `h`   | Show help overlay with all key bindings |
+| `q` / `Esc` | Quit the TUI                            |
 
 #### Jobs View Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `↑` / `↓` | Navigate rows in the jobs table                  |
+| Key             | Action                                                                                  |
+| --------------- | --------------------------------------------------------------------------------------- |
+| `↑` / `↓`       | Navigate rows in the jobs table                                                         |
 | `1` / `2` / `3` | Sort by first/second/third column (press again to reverse, third press removes sorting) |
-| `/`       | Search jobs                                      |
-| `Enter`   | Open Job Stages popup for the selected job       |
-| `g`       | View job stages graph (DOT visualization)      |
-| `c`       | Cancel the selected job (if cancelable)          |
-| `p`       | View job plans (Stage / Physical / Logical) for completed jobs |
+| `/`             | Search jobs                                                                             |
+| `Enter`         | Open Job Stages popup for the selected job                                              |
+| `g`             | View job stages graph (DOT visualization)                                               |
+| `c`             | Cancel the selected job (if cancelable)                                                 |
+| `p`             | View job plans (Stage / Physical / Logical) for completed jobs                          |
 
 #### Job Stages Popup Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `↑` / `↓` | Navigate stages                                  |
-| `Enter`   | View tasks for the selected stage                |
-| `p`       | View execution plan for the selected stage       |
-| `Esc`     | Close popup                                      |
+| Key       | Action                                     |
+| --------- | ------------------------------------------ |
+| `↑` / `↓` | Navigate stages                            |
+| `Enter`   | View tasks for the selected stage          |
+| `p`       | View execution plan for the selected stage |
+| `Esc`     | Close popup                                |
 
 #### Stage Tasks / Plan Popup Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `Esc`     | Close popup                                      |
+| Key   | Action      |
+| ----- | ----------- |
+| `Esc` | Close popup |
 
 #### Job Plans Popup Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `s`       | Show Stage plan                                  |
-| `p`       | Show Physical plan                               |
-| `l`       | Show Logical plan                                |
-| `↑` / `↓` | Scroll up/down                                   |
-| `Esc`     | Close popup                                      |
+| Key       | Action             |
+| --------- | ------------------ |
+| `s`       | Show Stage plan    |
+| `p`       | Show Physical plan |
+| `l`       | Show Logical plan  |
+| `↑` / `↓` | Scroll up/down     |
+| `Esc`     | Close popup        |
 
 #### Executors View Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `1` / `2` / `3` | Sort by first/second/third column              |
+| Key             | Action                            |
+| --------------- | --------------------------------- |
+| `1` / `2` / `3` | Sort by first/second/third column |
 
 #### Metrics View Keybindings
 
-| Key       | Action                                           |
-| --------- | ------------------------------------------------ |
-| `/`       | Search metrics                                   |
+| Key | Action         |
+| --- | -------------- |
+| `/` | Search metrics |
 
 The TUI connects to the scheduler via HTTP and refreshes data automatically every few seconds.

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -236,4 +236,36 @@ The TUI provides the following views:
 | --- | -------------- |
 | `/` | Search metrics |
 
+### TUI Configuration
+
+The TUI reads its configuration from a YAML file located at the platform-specific config directory:
+
+| Platform | Example Path                                      |
+| -------- | ------------------------------------------------- |
+| Linux    | `~/.config/ballista/tui.yaml`                     |
+| macOS    | `~/Library/Application Support/ballista/tui.yaml` |
+| Windows  | `%LOCALAPPDATA%\ballista\tui.yaml`                |
+
+Create the file manually if it does not exist. The following settings are available:
+
+```yaml
+tick_interval_ms: 2000
+
+scheduler:
+  url: http://localhost:50050
+
+http:
+  timeout: 2000
+```
+
+- `tick_interval_ms`: How often the TUI refreshes data from the scheduler (milliseconds).
+- `scheduler.url`: The Ballista scheduler HTTP endpoint.
+- `http.timeout`: HTTP request timeout in milliseconds.
+
+Environment variables prefixed with `BALLISTA_` also override these values. For example:
+
+```bash
+BALLISTA_SCHEDULER_URL=http://localhost:50051 ballista-cli --tui
+```
+
 The TUI connects to the scheduler via HTTP and refreshes data automatically every few seconds.


### PR DESCRIPTION
## Summary
Adds documentation for the Ballista Terminal User Interface (TUI) feature.

## Changes
- Document how to install the CLI with the tui feature enabled
- Add --tui flag to the usage section
- Add a comprehensive TUI section covering launch instructions, feature overview, and navigation key bindings

Fixes #1559