### PR TITLE
feat: split disk_write_time from write_time in sort shuffle writer

### DIFF
--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -23,6 +23,7 @@ mod shuffle_reader;
 mod shuffle_writer;
 mod shuffle_writer_trait;
 pub mod sort_shuffle;
+pub(crate) mod timed_write;
 mod unresolved_shuffle;
 
 use std::path::{Path, PathBuf};

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -35,6 +35,7 @@ use super::config::SortShuffleConfig;
 use super::index::ShuffleIndex;
 use super::spill::SpillManager;
 use crate::execution_plans::create_shuffle_path;
+use crate::execution_plans::timed_write::TimedWrite;
 use crate::serde::protobuf::ShuffleWritePartition;
 
 use datafusion::arrow::array::{
@@ -91,6 +92,10 @@ pub struct SortShuffleWriterExec {
 struct SortShuffleWriteMetrics {
     /// Time spent writing batches to the output file
     write_time: metrics::Time,
+    /// Time spent in raw byte-pump calls (`Write::write` + `Write::flush`)
+    /// against the output file. Subset of `write_time`; the difference
+    /// approximates Arrow IPC encode + compress cost.
+    disk_write_time: metrics::Time,
     /// Time spent partitioning input batches
     repart_time: metrics::Time,
     /// Time spent spilling to disk
@@ -109,6 +114,8 @@ impl SortShuffleWriteMetrics {
     fn new(partition: usize, metrics: &ExecutionPlanMetricsSet) -> Self {
         Self {
             write_time: MetricBuilder::new(metrics).subset_time("write_time", partition),
+            disk_write_time: MetricBuilder::new(metrics)
+                .subset_time("disk_write_time", partition),
             repart_time: MetricBuilder::new(metrics)
                 .subset_time("repart_time", partition),
             spill_time: MetricBuilder::new(metrics).subset_time("spill_time", partition),
@@ -279,6 +286,7 @@ impl SortShuffleWriterExec {
                 &mut spill_manager,
                 &schema,
                 &config,
+                metrics.disk_write_time.clone(),
             )?;
             timer.done();
 
@@ -377,6 +385,7 @@ fn finalize_output(
     spill_manager: &mut SpillManager,
     schema: &SchemaRef,
     config: &SortShuffleConfig,
+    disk_write_time: metrics::Time,
 ) -> Result<FinalizeResult> {
     let num_partitions = buffers.len();
     let mut index = ShuffleIndex::new(num_partitions);
@@ -394,9 +403,11 @@ fn finalize_output(
 
     debug!("Writing consolidated shuffle output to {:?}", data_path);
 
-    // Use FileWriter for random access support via FileReader
+    // Use FileWriter for random access support via FileReader. Wrap the
+    // buffered file in `TimedWrite` so per-call elapsed time is recorded into
+    // `disk_write_time`, separate from the surrounding IPC encode cost.
     let file = File::create(&data_path)?;
-    let mut buffered = BufWriter::new(file);
+    let mut buffered = TimedWrite::new(BufWriter::new(file), disk_write_time);
 
     let options =
         IpcWriteOptions::default().try_with_compression(Some(config.compression))?;
@@ -735,6 +746,46 @@ mod tests {
         let output_dir = work_dir.path().join("job1").join("1").join("0");
         assert!(output_dir.join("data.arrow").exists());
         assert!(output_dir.join("data.arrow.index").exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sort_shuffle_writer_records_disk_write_time() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let input_plan = Arc::new(CoalescePartitionsExec::new(create_test_input()?));
+        let work_dir = TempDir::new()?;
+
+        let writer = SortShuffleWriterExec::try_new(
+            "job1".to_string(),
+            1,
+            input_plan,
+            work_dir.path().to_str().unwrap().to_string(),
+            Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 2),
+            SortShuffleConfig::default(),
+        )?;
+
+        let mut stream = writer.execute(0, task_ctx)?;
+        let _: Vec<RecordBatch> = stream
+            .by_ref()
+            .try_collect()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+        // After writing output, disk_write_time must be reported as a distinct
+        // metric so we can split byte-pump cost from Arrow IPC encode cost.
+        let metrics = writer.metrics().expect("metrics should be set");
+        let disk = metrics
+            .iter()
+            .find(|m| m.value().name() == "disk_write_time")
+            .expect("disk_write_time metric should be present");
+        assert!(
+            disk.value().as_usize() > 0,
+            "disk_write_time should be > 0, got {}",
+            disk.value().as_usize()
+        );
 
         Ok(())
     }

--- a/ballista/core/src/execution_plans/timed_write.rs
+++ b/ballista/core/src/execution_plans/timed_write.rs
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`TimedWrite`] wraps an underlying [`Write`] and records elapsed time on
+//! every `write` / `flush` call into a DataFusion [`Time`] metric.
+//!
+//! Used by the shuffle writers to separate raw byte-pump cost from the surrounding
+//! Arrow IPC encoding cost. Outer timer covers encode + write; inner [`Time`]
+//! covers only the byte-pump.
+
+use std::io::{self, Write};
+use std::time::Instant;
+
+use datafusion::physical_plan::metrics::Time;
+
+/// `Write` adapter that records elapsed time of inner `write` / `flush` calls.
+pub struct TimedWrite<W: Write> {
+    inner: W,
+    time: Time,
+}
+
+impl<W: Write> TimedWrite<W> {
+    /// Wraps `inner`, accumulating elapsed write time into `time`.
+    pub fn new(inner: W, time: Time) -> Self {
+        Self { inner, time }
+    }
+}
+
+impl<W: Write> Write for TimedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let start = Instant::now();
+        let result = self.inner.write(buf);
+        self.time.add_duration(start.elapsed());
+        result
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let start = Instant::now();
+        let result = self.inner.flush();
+        self.time.add_duration(start.elapsed());
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder};
+
+    fn time_metric() -> Time {
+        let set = ExecutionPlanMetricsSet::new();
+        MetricBuilder::new(&set).subset_time("disk_write_time", 0)
+    }
+
+    #[test]
+    fn passes_bytes_through_to_inner() {
+        let mut sink: Vec<u8> = Vec::new();
+        {
+            let mut writer = TimedWrite::new(&mut sink, time_metric());
+            writer.write_all(b"hello world").unwrap();
+            writer.flush().unwrap();
+        }
+        assert_eq!(sink, b"hello world");
+    }
+
+    #[test]
+    fn records_nonzero_elapsed_after_many_writes() {
+        let time = time_metric();
+        let mut writer = TimedWrite::new(Vec::new(), time.clone());
+
+        // Many small writes ensure cumulative elapsed clears clock resolution
+        // even on very fast machines.
+        for _ in 0..10_000 {
+            writer.write_all(b"abcdefghij").unwrap();
+        }
+
+        assert!(
+            time.value() > 0,
+            "expected non-zero recorded write time, got {}",
+            time.value()
+        );
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

N/A — small diagnostic / observability change.

# Rationale for this change

The standalone shuffle benchmark in #1600 reports ~98% of sort-shuffle wall time inside the existing `write_time` metric (e.g. `write_time: 44.268s` of a 45s run, with `repart_time: 0.006s` and `spill_time: 0.000s`). That timer wraps the entire `sort_shuffle::finalize_output` block — Arrow IPC encoding, dictionary tracking, LZ4/Zstd compression, and `BufWriter::write_all` — fused into a single number. There is no seam where a timer can sit between "encode" and "disk", so it is impossible to tell whether `finalize_output` is CPU-bound or I/O-bound from the metrics alone.

This becomes a blocker for evaluating optimizations like Comet's `BufBatchWriter` IPC-block coalescing. Without splitting encode from disk, you can't measure whether such a port helps or just shifts cost between phases.

# What changes are included in this PR?

- **New module** `ballista/core/src/execution_plans/timed_write.rs`: a `TimedWrite<W: Write>` adapter that records the elapsed time of each `write` / `flush` call into a `metrics::Time`. Two unit tests cover byte-through-pass behaviour and non-zero accumulation.
- **`sort_shuffle/writer.rs`**: adds a `disk_write_time` metric to `SortShuffleWriteMetrics` and threads it into `finalize_output`. The consolidated output `BufWriter<File>` is wrapped in `TimedWrite` so the inner-byte-pump cost is recorded separately. The outer `write_time` timer is unchanged, so `write_time - disk_write_time ≈ encode + compress` cost.
- **New test** `test_sort_shuffle_writer_records_disk_write_time` runs the writer end-to-end and asserts the new metric is reported with a non-zero value.

The hash-path `ShuffleWriterExec` and the sort-shuffle `SpillManager` are intentionally untouched — neither is on the hot path the bench identified, and keeping the change scoped makes it easier to review and revert if the diagnostic reveals the gap is elsewhere.

# Are there any user-facing changes?

A new metric `disk_write_time` is reported by `SortShuffleWriterExec`. Existing metrics (`write_time`, `repart_time`, `spill_time`, etc.) are unchanged in name and semantics. No public API or wire-format changes.