### PR TITLE
feat: default to sort-based shuffle writer [WIP]

### DIFF
--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -847,6 +847,13 @@ mod supported {
             .show()
             .await?;
 
+        // The block-transport remote reader does not support sort-based
+        // shuffle output, so this test exercises the hash-based writer.
+        ctx.sql("SET ballista.shuffle.sort_based.enabled = false")
+            .await?
+            .show()
+            .await?;
+
         let result = ctx
             .sql("select name, value from information_schema.df_settings where name like 'ballista.shuffle.force_remote_read' order by name limit 1")
             .await?
@@ -1000,6 +1007,15 @@ mod supported {
         #[case]
         ctx: SessionContext,
     ) {
+        // Pin the writer so the EXPLAIN output is stable regardless of the
+        // session-level shuffle default.
+        ctx.sql("SET ballista.shuffle.sort_based.enabled = false")
+            .await
+            .unwrap()
+            .show()
+            .await
+            .unwrap();
+
         let result = ctx
             .sql("EXPLAIN select count(*), id from (select unnest([1,2,3,4,5]) as id) group by id")
             .await

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -144,7 +144,7 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
         ConfigEntry::new(BALLISTA_SHUFFLE_SORT_BASED_ENABLED.to_string(),
                          "Enable sort-based shuffle which writes consolidated files with index".to_string(),
                          DataType::Boolean,
-                         Some(false.to_string())),
+                         Some(true.to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_SORT_BASED_BUFFER_SIZE.to_string(),
                          "Per-partition buffer size in bytes for sort shuffle".to_string(),
                          DataType::UInt64,

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -92,18 +92,18 @@ let expected = [
 
 The following session-level keys control Ballista's shuffle behavior. See
 the [tuning guide](tuning-guide.md#shuffle-implementation) for an
-explanation of the hash-based (default) and sort-based shuffle writers.
+explanation of the sort-based (default) and hash-based shuffle writers.
 
-| key                                           | type    | default   | description                                                                                                                                                         |
-| --------------------------------------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ballista.shuffle.max_concurrent_read_requests | UInt64  | 64        | Maximum number of concurrent fetch requests the shuffle reader will issue.                                                                                          |
-| ballista.shuffle.force_remote_read            | Boolean | false     | Forces the shuffle reader to fetch every partition through Arrow Flight, even when the data is local. Intended for testing.                                         |
-| ballista.shuffle.remote_read_prefer_flight    | Boolean | false     | For remote reads, prefer the Arrow Flight reader over the block reader. The block reader is generally faster.                                                       |
-| ballista.shuffle.sort_based.enabled           | Boolean | false     | Enables the sort-based shuffle writer (consolidated data file per input partition with an index, instead of one file per (input partition, output partition) pair). |
-| ballista.shuffle.sort_based.buffer_size       | UInt64  | 1048576   | Per-partition buffer size in bytes for the sort-based writer (1 MiB default).                                                                                       |
-| ballista.shuffle.sort_based.memory_limit      | UInt64  | 268435456 | Total in-memory budget across all output-partition buffers for the sort-based writer (256 MiB default).                                                             |
-| ballista.shuffle.sort_based.spill_threshold   | Utf8    | "0.8"     | Fraction of `memory_limit` at which the largest buffers spill to disk. Must be in the range 0–1.                                                                    |
-| ballista.shuffle.sort_based.batch_size        | UInt64  | 8192      | Target row count when coalescing buffered batches before they are written or spilled.                                                                               |
+| key                                           | type    | default   | description                                                                                                                                                                                                               |
+| --------------------------------------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ballista.shuffle.max_concurrent_read_requests | UInt64  | 64        | Maximum number of concurrent fetch requests the shuffle reader will issue.                                                                                                                                                |
+| ballista.shuffle.force_remote_read            | Boolean | false     | Forces the shuffle reader to fetch every partition through Arrow Flight, even when the data is local. Intended for testing.                                                                                               |
+| ballista.shuffle.remote_read_prefer_flight    | Boolean | false     | For remote reads, prefer the Arrow Flight reader over the block reader. The block reader is generally faster.                                                                                                             |
+| ballista.shuffle.sort_based.enabled           | Boolean | true      | Enables the sort-based shuffle writer (consolidated data file per input partition with an index, instead of one file per (input partition, output partition) pair). Set to `false` to fall back to the hash-based writer. |
+| ballista.shuffle.sort_based.buffer_size       | UInt64  | 1048576   | Per-partition buffer size in bytes for the sort-based writer (1 MiB default).                                                                                                                                             |
+| ballista.shuffle.sort_based.memory_limit      | UInt64  | 268435456 | Total in-memory budget across all output-partition buffers for the sort-based writer (256 MiB default).                                                                                                                   |
+| ballista.shuffle.sort_based.spill_threshold   | Utf8    | "0.8"     | Fraction of `memory_limit` at which the largest buffers spill to disk. Must be in the range 0–1.                                                                                                                          |
+| ballista.shuffle.sort_based.batch_size        | UInt64  | 8192      | Target row count when coalescing buffered batches before they are written or spilled.                                                                                                                                     |
 
 ## Ballista Scheduler Configuration Settings
 

--- a/docs/source/user-guide/tuning-guide.md
+++ b/docs/source/user-guide/tuning-guide.md
@@ -74,48 +74,47 @@ upstream task to local files, which downstream tasks read either from disk
 available, with different trade-offs around file count, memory use, and
 write latency.
 
-### Hash-based shuffle (default)
+### Sort-based shuffle (default)
 
-The default writer hashes each incoming `RecordBatch` and immediately
-encodes the per-partition slices to Arrow IPC, streaming them into one
-file per `(input_partition, output_partition)` pair. Nothing is buffered
-in memory across batches.
-
-This is simple and low latency, but for `N` input partitions and `M`
-output partitions it produces `N × M` files. Wide shuffles can therefore
-generate a large number of small files.
-
-### Sort-based shuffle (opt-in)
-
-The sort-based writer accumulates batches in a per-output-partition
+The default writer accumulates batches in a per-output-partition
 in-memory buffer. When the total buffered size crosses a threshold, the
 largest buffers are spilled to disk. After the input stream finishes, the
 remaining in-memory data and any spilled batches are merged and written
 into a single consolidated Arrow IPC file per input partition, alongside
 an index file that lets readers seek directly to a given output partition.
 
-This produces `2 × N` files instead of `N × M`, coalesces small batches
-to a target size before writing, and bounds shuffle memory use via
-spilling — at the cost of higher write latency than the hash writer.
-Consider enabling it for queries with high partition fan-out or when
-file-count pressure on local storage is a concern.
-
-The sort-based writer is disabled by default and is enabled per session:
-
-```rust
-let session_config = SessionConfig::new_with_ballista()
-    .set_bool("ballista.shuffle.sort_based.enabled", true);
-```
+For `N` input partitions and `M` output partitions this produces `2 × N`
+files instead of `N × M`, coalesces small batches to a target size before
+writing, and bounds shuffle memory use via spilling — at the cost of
+higher write latency than the hash writer. This is the right default for
+most workloads, especially queries with high partition fan-out.
 
 The following session-level keys tune its behavior:
 
 | key                                         | type    | default   | description                                                                                               |
 | ------------------------------------------- | ------- | --------- | --------------------------------------------------------------------------------------------------------- |
-| ballista.shuffle.sort_based.enabled         | Boolean | false     | Enables the sort-based shuffle writer.                                                                    |
+| ballista.shuffle.sort_based.enabled         | Boolean | true      | Enables the sort-based shuffle writer. Set to `false` to use the hash-based writer instead.               |
 | ballista.shuffle.sort_based.buffer_size     | UInt64  | 1048576   | Per-partition buffer size in bytes (1 MiB default).                                                       |
 | ballista.shuffle.sort_based.memory_limit    | UInt64  | 268435456 | Total in-memory budget across all output-partition buffers (256 MiB default).                             |
 | ballista.shuffle.sort_based.spill_threshold | Utf8    | "0.8"     | Fraction of `memory_limit` at which the largest buffers begin spilling to disk. Must be in the range 0–1. |
 | ballista.shuffle.sort_based.batch_size      | UInt64  | 8192      | Target row count when coalescing buffered batches before they are written or spilled.                     |
+
+### Hash-based shuffle (opt-in)
+
+The hash-based writer hashes each incoming `RecordBatch` and immediately
+encodes the per-partition slices to Arrow IPC, streaming them into one
+file per `(input_partition, output_partition)` pair. Nothing is buffered
+in memory across batches.
+
+This is simple and low latency, but for `N` input partitions and `M`
+output partitions it produces `N × M` files. Wide shuffles can therefore
+generate a large number of small files. The hash writer can be selected
+per session:
+
+```rust
+let session_config = SessionConfig::new_with_ballista()
+    .set_bool("ballista.shuffle.sort_based.enabled", false);
+```
 
 ## Push-based vs Pull-based Task Scheduling
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

The sort-based shuffle writer (added recently and documented in #1595) is ~50x faster than the current default hash-based shuffle for real-world TPC workloads, as shown in https://github.com/apache/datafusion-ballista/pull/1600.

# What changes are included in this PR?

- Flip the default of `ballista.shuffle.sort_based.enabled` from `false` to `true` in `ballista/core/src/config.rs`.
- Update `docs/source/user-guide/configs.md` to show the new default and a note about falling back to the hash writer.
- Restructure the "Shuffle Implementation" section of `docs/source/user-guide/tuning-guide.md` so sort-based is presented as the default and hash-based as the opt-in fallback.

# Are there any user-facing changes?

Yes. New sessions will use the sort-based shuffle writer by default. Users who want the previous behavior can set `ballista.shuffle.sort_based.enabled=false` per session.