### PR TITLE
ci: drop Intel macOS Python wheel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,55 +170,6 @@ jobs:
           name: dist-${{ matrix.os  }}
           path: python/target/wheels/*
 
-  build-macos-x86_64:
-    needs: [generate-license]
-    name: Mac x86_64
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - run: rm LICENSE.txt
-      - name: Download LICENSE.txt
-        uses: actions/download-artifact@v8
-        with:
-          name: python-wheel-license
-          path: .
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          version: "27.4"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Build Python package
-        run: |
-          cd python
-          uv sync --dev --no-install-package ballista
-          uv run --no-project maturin build --release --strip
-
-      - name: List Mac wheels
-        run: find python/target/wheels/
-
-      - name: Archive wheels
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist-macos-aarch64
-          path: python/target/wheels/*
-
   build-manylinux-x86_64:
     needs: [generate-license]
     name: Manylinux x86_64
@@ -347,7 +298,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-python-mac-win
-      - build-macos-x86_64
       - build-manylinux-x86_64
       - build-manylinux-aarch64
       - build-sdist


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1608.

# Rationale for this change

The `build-macos-x86_64` job in `.github/workflows/build.yml` runs on `macos-latest`, which has resolved to arm64 since GitHub's 2024 runner change. As a result it has been producing a duplicate macOS arm64 wheel rather than an x86_64 wheel, and no Intel macOS wheel has been published. Rather than restoring an Intel macOS build (e.g. by pinning to `macos-13` or cross-compiling), this PR drops Intel macOS as a published wheel target. Users on Intel Macs can still install via the source distribution.

# What changes are included in this PR?

- Remove the `build-macos-x86_64` job from `.github/workflows/build.yml`.
- Remove its entry from the `needs` list of `merge-build-artifacts`.

The macOS arm64 wheel continues to be produced by the macOS leg of `build-python-mac-win`.

# Are there any user-facing changes?

Yes: starting with the next release, no prebuilt wheel will be published for Intel macOS (`macosx_*_x86_64`). Intel macOS users will need to install from sdist, which requires `protoc` and a Rust toolchain locally.