### PR TITLE
fix(python): ignore ballista-namespaced cluster_config keys locally

### DIFF
--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -563,11 +563,15 @@ class BallistaSessionContext(SessionContext, metaclass=RedefiningSessionContextM
         # Apply overrides to the local SessionContext too: some settings
         # (e.g. datafusion.execution.listing_table_factory_infer_partitions)
         # are consulted during local table registration / planning, before
-        # the plan is shipped to the scheduler.
+        # the plan is shipped to the scheduler. Ballista-namespaced keys
+        # are not understood by the local SessionConfig and are forwarded
+        # to the scheduler only.
         if self.cluster_config:
             if config is None:
                 config = SessionConfig()
             for key, value in self.cluster_config.items():
+                if key.startswith("ballista."):
+                    continue
                 config = config.set(key, value)
         super().__init__(config, runtime)
         self.address = address

--- a/python/python/tests/test_context.py
+++ b/python/python/tests/test_context.py
@@ -91,3 +91,26 @@ def test_cluster_config_propagates_to_distributed_dataframe():
 
     df = ctx.sql("SELECT 1")
     assert df.cluster_config == overrides
+
+
+def test_cluster_config_accepts_ballista_namespaced_keys():
+    """Ballista-namespaced keys (e.g. ``ballista.shuffle.sort_based.enabled``)
+    are not understood by the local DataFusion ``SessionConfig`` and used to
+    panic when applied to it. They are forwarded to the scheduler only and
+    must be ignored locally rather than crashing context construction.
+    """
+    (address, port) = setup_test_cluster()
+    overrides = {
+        "datafusion.execution.target_partitions": "8",
+        "ballista.shuffle.sort_based.enabled": "true",
+    }
+    ctx = BallistaSessionContext(
+        address=f"df://{address}:{port}",
+        cluster_config=overrides,
+    )
+
+    assert ctx.cluster_config == overrides
+
+    df = ctx.sql("SELECT 1")
+    assert df.cluster_config == overrides
+    assert len(df.collect()) == 1


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1607

# Rationale for this change

`BallistaSessionContext` accepts a `cluster_config` dict that is intended to be forwarded to the scheduler-side session (e.g. `ballista.shuffle.sort_based.enabled`). The constructor also applies every entry to the local DataFusion `SessionConfig` so that DataFusion-namespaced keys (e.g. `datafusion.execution.target_partitions`) are honored during local table registration and planning.

The problem is that the local `SessionConfig` built inside `BallistaSessionContext` does not have the `BallistaConfig` extension registered, so any `ballista.*` key blows up with:

```
PanicException: Configuration("Could not find config namespace \"ballista\"")
```

This makes the documented `cluster_config` parameter effectively unusable for any Ballista-specific tuning from Python.

# What changes are included in this PR?

- `python/python/ballista/extension.py`: skip `ballista.*` keys in the local-apply loop. The full dict is still stored on the context and forwarded to the scheduler via `create_ballista_data_frame`, so scheduler-side behavior is unchanged.
- `python/python/tests/test_context.py`: new `test_cluster_config_accepts_ballista_namespaced_keys` covering both a DataFusion key and a Ballista key in the same `cluster_config` and asserting that context construction and a trivial query both succeed.

# Are there any user-facing changes?

Yes, but only in the sense that a previously panicking call now works. No public API shape changes.