### PR TITLE
feat(sort-shuffle): byte-copy spill files and enable block-IO transport

### DIFF
--- a/ballista/client/tests/sort_shuffle.rs
+++ b/ballista/client/tests/sort_shuffle.rs
@@ -46,8 +46,12 @@ mod sort_shuffle_tests {
     enum ReadMode {
         /// Read shuffle data locally (default)
         Local,
-        /// Read shuffle data via flight service (remote read)
+        /// Read shuffle data via the flight service over gRPC (`do_get`)
         RemoteFlight,
+        /// Read shuffle data via the block-IO transport over gRPC (`do_action`
+        /// with `IO_BLOCK_TRANSPORT`). The server streams the partition's
+        /// byte range directly without decode/re-encode.
+        RemoteBlockIo,
     }
 
     /// Creates a standalone session context with sort-based shuffle enabled.
@@ -63,6 +67,11 @@ mod sort_shuffle_tests {
                 config = config
                     .set_str(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, "true")
                     .set_str(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, "true");
+            }
+            ReadMode::RemoteBlockIo => {
+                config = config
+                    .set_str(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, "true")
+                    .set_str(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, "false");
             }
         }
 
@@ -125,6 +134,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_group_by_single_column(
         #[case] read_mode: ReadMode,
@@ -152,6 +162,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_group_by_multiple_columns(
         #[case] read_mode: ReadMode,
@@ -179,6 +190,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_aggregate_sum(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -201,6 +213,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_aggregate_avg(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -223,6 +236,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_aggregate_count(
         #[case] read_mode: ReadMode,
@@ -247,6 +261,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_aggregate_min_max(
         #[case] read_mode: ReadMode,
@@ -329,6 +344,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_empty_result(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -346,6 +362,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_single_partition(
         #[case] read_mode: ReadMode,
@@ -364,6 +381,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_multiple_aggregates(
         #[case] read_mode: ReadMode,
@@ -397,6 +415,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_having_clause(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -424,6 +443,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_subquery(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -448,6 +468,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_union(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -473,6 +494,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_order_by(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -493,6 +515,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_order_by_desc(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;
@@ -513,6 +536,7 @@ mod sort_shuffle_tests {
     #[rstest]
     #[case::local(ReadMode::Local)]
     #[case::remote_flight(ReadMode::RemoteFlight)]
+    #[case::remote_block_io(ReadMode::RemoteBlockIo)]
     #[tokio::test]
     async fn test_sort_shuffle_limit(#[case] read_mode: ReadMode) -> Result<()> {
         let ctx = create_sort_shuffle_context(read_mode).await;

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -555,6 +555,11 @@ impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> Stream
     }
 }
 
+/// Detects the `ArrowError` that `arrow_ipc::reader::stream::StreamDecoder`
+/// emits when bytes arrive after a clean EOS marker (its `DecoderState::Finished`
+/// arm in `arrow-ipc/src/reader/stream.rs` returns `IpcError("Unexpected EOS")`).
+/// `should_process_concatenated_streams` will fail if that string ever changes
+/// upstream, so a future arrow-ipc bump that breaks the contract is visible.
 fn is_post_eos_error(e: &ArrowError) -> bool {
     matches!(e, ArrowError::IpcError(msg) if msg == "Unexpected EOS")
 }

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -516,52 +516,47 @@ impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> Stream
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        match self.decode() {
-            //
-            // if there is a batch to be read from state buffer return it
-            //
-            Ok(Some(batch)) => std::task::Poll::Ready(Some(Ok(batch))),
-            //
-            // there is no batch in the state buffer, try to pull new data
-            // from remote ipc decode it try to return next batch
-            //
-            Ok(None) => match self.ipc_stream.poll_next_unpin(cx) {
-                std::task::Poll::Ready(Some(flight_data_result)) => {
-                    match flight_data_result {
-                        Ok(blob) => {
-                            self.extend_bytes(blob);
-
-                            match self.decode() {
-                                Ok(Some(batch)) => {
-                                    std::task::Poll::Ready(Some(Ok(batch)))
-                                }
-                                Ok(None) => {
-                                    cx.waker().wake_by_ref();
-                                    std::task::Poll::Pending
-                                }
-                                Err(e) => std::task::Poll::Ready(Some(Err(
-                                    ArrowError::IpcError(e.to_string()).into(),
-                                ))),
-                            }
-                        }
-                        Err(e) => std::task::Poll::Ready(Some(Err(
-                            ArrowError::IpcError(e.to_string()).into(),
-                        ))),
-                    }
+        loop {
+            match self.decode() {
+                Ok(Some(batch)) => return std::task::Poll::Ready(Some(Ok(batch))),
+                Ok(None) => {} // buffer drained, pull more bytes below
+                Err(e) if is_post_eos_error(&e) => {
+                    // Decoder reached EOS but the byte stream contains more
+                    // sub-streams (e.g. sort-shuffle's leading schema-header
+                    // stream followed by the requested partition's streams).
+                    // Reset the decoder; the schema captured at construction
+                    // time stays authoritative for downstream consumers.
+                    self.decoder = StreamDecoder::new();
+                    continue;
                 }
-                //
-                // end of IPC stream
-                //
-                std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-                // its expected that underlying stream will register waker callback
-                std::task::Poll::Pending => std::task::Poll::Pending,
-            },
-            Err(e) => std::task::Poll::Ready(Some(Err(ArrowError::IpcError(
-                e.to_string(),
-            )
-            .into()))),
+                Err(e) => {
+                    return std::task::Poll::Ready(Some(Err(ArrowError::IpcError(
+                        e.to_string(),
+                    )
+                    .into())));
+                }
+            }
+
+            match self.ipc_stream.poll_next_unpin(cx) {
+                std::task::Poll::Ready(Some(Ok(blob))) => {
+                    self.extend_bytes(blob);
+                    continue;
+                }
+                std::task::Poll::Ready(Some(Err(e))) => {
+                    return std::task::Poll::Ready(Some(Err(ArrowError::IpcError(
+                        e.to_string(),
+                    )
+                    .into())));
+                }
+                std::task::Poll::Ready(None) => return std::task::Poll::Ready(None),
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+            }
         }
     }
+}
+
+fn is_post_eos_error(e: &ArrowError) -> bool {
+    matches!(e, ArrowError::IpcError(msg) if msg == "Unexpected EOS")
 }
 
 impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> RecordBatchStream
@@ -667,6 +662,48 @@ mod tests {
                 .await;
 
         assert_eq!(batches, result.unwrap())
+    }
+
+    #[tokio::test]
+    async fn should_process_concatenated_streams() {
+        let batches = generate_batches();
+
+        // Two complete IPC streams concatenated, mirroring the sort-shuffle
+        // block-IO payload `[schema-header stream][partition streams]`.
+        let mut blob = generate_ipc_stream(&batches[..1]);
+        blob.extend(generate_ipc_stream(&batches[1..]));
+        let stream = futures::stream::iter(vec![Ok(Bytes::from(blob))]);
+
+        let result: datafusion::error::Result<Vec<RecordBatch>> =
+            BlockDataStream::try_new(stream)
+                .await
+                .unwrap()
+                .try_collect()
+                .await;
+
+        assert_eq!(batches, result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn should_process_schema_only_leading_stream() {
+        // Empty-partition shape: the receiver only sees the leading
+        // schema-header stream (schema + EOS, no batches), then EOF.
+        let batches = generate_batches();
+        let schema = batches[0].schema();
+        let mut header = vec![];
+        StreamWriter::try_new(&mut header, &schema)
+            .unwrap()
+            .finish()
+            .unwrap();
+        let stream = futures::stream::iter(vec![Ok(Bytes::from(header))]);
+
+        let bds = BlockDataStream::try_new(stream).await.unwrap();
+        let result_schema = bds.schema.clone();
+        let collected: datafusion::error::Result<Vec<RecordBatch>> =
+            bds.try_collect().await;
+
+        assert_eq!(result_schema.as_ref(), schema.as_ref());
+        assert!(collected.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/ballista/core/src/execution_plans/sort_shuffle/index.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/index.rs
@@ -25,9 +25,12 @@
 //! ```
 //!
 //! - All values are little-endian i64
-//! - `offset_i` = byte offset where partition `i` starts
-//! - Last entry is total file length
-//! - Partition `i` data spans `[offset_i, offset_{i+1})`
+//! - `offset_i` is the absolute byte position where partition `i` starts
+//!   inside the data file
+//! - The leading bytes of the data file (before `offset_0`) hold a small
+//!   schema-header stream used by the reader to recover the schema
+//! - The last entry is the total file length
+//! - Partition `i` data spans the byte range `[offset_i, offset_{i+1})`
 
 use crate::error::{BallistaError, Result};
 use std::fs::File;

--- a/ballista/core/src/execution_plans/sort_shuffle/index.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/index.rs
@@ -85,6 +85,13 @@ impl ShuffleIndex {
         (self.offsets[partition_id], self.offsets[partition_id + 1])
     }
 
+    /// Returns the byte position where partition data begins, i.e. the byte
+    /// just past the leading schema-header IPC stream. Equivalent to
+    /// `get_partition_range(0).0` but names the intent.
+    pub fn header_end_offset(&self) -> i64 {
+        self.offsets[0]
+    }
+
     /// Returns the size in bytes for the given partition.
     pub fn get_partition_size(&self, partition_id: usize) -> i64 {
         let (start, end) = self.get_partition_range(partition_id);

--- a/ballista/core/src/execution_plans/sort_shuffle/mod.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/mod.rs
@@ -33,6 +33,7 @@ mod buffer;
 mod config;
 mod index;
 mod partitioned_batch_iterator;
+mod multi_stream_reader;
 mod reader;
 mod spill;
 mod writer;

--- a/ballista/core/src/execution_plans/sort_shuffle/mod.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/mod.rs
@@ -32,8 +32,8 @@
 mod buffer;
 mod config;
 mod index;
-mod partitioned_batch_iterator;
 mod multi_stream_reader;
+mod partitioned_batch_iterator;
 mod reader;
 mod spill;
 mod writer;

--- a/ballista/core/src/execution_plans/sort_shuffle/mod.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! This module provides an alternative to the hash-based shuffle. It writes
 //! a single consolidated file per input partition (sorted by output partition ID)
-//! along with an index file mapping partition IDs to batch ranges.
+//! along with an index file mapping partition IDs to byte ranges.
 //!
 //! This approach reduces file count from `N × M` (N input partitions × M output partitions)
 //! to `2 × N` files (one data + one index per input partition).

--- a/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
@@ -33,8 +33,6 @@ use std::task::{Context, Poll};
 
 /// Reads `RecordBatch`es from `[start_offset, end_offset)` of `data_path`,
 /// where the byte range contains zero or more concatenated Arrow IPC streams.
-// TODO: remove the `dead_code` allow once Task 3 wires this into reader.rs.
-#[allow(dead_code)]
 pub(crate) struct MultiStreamPartitionStream {
     data_path: PathBuf,
     schema: SchemaRef,
@@ -47,7 +45,6 @@ pub(crate) struct MultiStreamPartitionStream {
     finished: bool,
 }
 
-#[allow(dead_code)]
 impl MultiStreamPartitionStream {
     /// Creates a new bounded multi-stream reader. `schema` is the schema of
     /// the partition data; the caller must obtain it from the data file's

--- a/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Reader that yields `RecordBatch`es from a byte range of a sort-shuffle
+//! data file, transparently spanning multiple concatenated Arrow IPC streams.
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::ipc::reader::StreamReader;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::DataFusionError;
+use datafusion::physical_plan::RecordBatchStream;
+use futures::Stream;
+use std::fs::File;
+use std::io::{Seek, SeekFrom};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Reads `RecordBatch`es from `[start_offset, end_offset)` of `data_path`,
+/// where the byte range contains zero or more concatenated Arrow IPC streams.
+pub(crate) struct MultiStreamPartitionStream {
+    data_path: PathBuf,
+    schema: SchemaRef,
+    end_offset: u64,
+    /// Active sub-stream reader, or `None` between sub-streams.
+    reader: Option<StreamReader<File>>,
+    /// Absolute byte position to seek to for the next sub-stream. `None`
+    /// while `reader` is `Some` (the position is held inside the reader).
+    next_offset: Option<u64>,
+    finished: bool,
+}
+
+impl MultiStreamPartitionStream {
+    /// Creates a new bounded multi-stream reader. `schema` is the schema of
+    /// the partition data; the caller must obtain it from the data file's
+    /// leading schema-header stream.
+    pub(crate) fn new(
+        data_path: PathBuf,
+        schema: SchemaRef,
+        start_offset: u64,
+        end_offset: u64,
+    ) -> Self {
+        let finished = start_offset >= end_offset;
+        Self {
+            data_path,
+            schema,
+            end_offset,
+            reader: None,
+            next_offset: Some(start_offset),
+            finished,
+        }
+    }
+
+    /// Synchronous core: pulls the next batch, advancing across sub-stream
+    /// boundaries as needed.
+    fn next_batch(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
+        loop {
+            if self.finished {
+                return Ok(None);
+            }
+
+            if let Some(reader) = self.reader.as_mut() {
+                match reader.next() {
+                    Some(Ok(batch)) => return Ok(Some(batch)),
+                    Some(Err(e)) => return Err(e),
+                    None => {
+                        // EOS for this sub-stream: capture position and drop
+                        // the reader so we can construct the next one.
+                        let pos = reader
+                            .get_mut()
+                            .stream_position()
+                            .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
+                        self.next_offset = Some(pos);
+                        self.reader = None;
+                    }
+                }
+            }
+
+            let next = self
+                .next_offset
+                .expect("invariant: next_offset is Some when reader is None");
+            if next >= self.end_offset {
+                self.finished = true;
+                return Ok(None);
+            }
+
+            let mut file = File::open(&self.data_path)
+                .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
+            file.seek(SeekFrom::Start(next))
+                .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
+            let reader = StreamReader::try_new(file, None)?;
+            self.reader = Some(reader);
+            self.next_offset = None;
+        }
+    }
+}
+
+impl Stream for MultiStreamPartitionStream {
+    type Item = Result<RecordBatch, DataFusionError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.next_batch() {
+            Ok(Some(batch)) => Poll::Ready(Some(Ok(batch))),
+            Ok(None) => Poll::Ready(None),
+            Err(e) => Poll::Ready(Some(Err(DataFusionError::ArrowError(
+                Box::new(e),
+                None,
+            )))),
+        }
+    }
+}
+
+impl RecordBatchStream for MultiStreamPartitionStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::ipc::writer::{IpcWriteOptions, StreamWriter};
+    use futures::StreamExt;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn batch(schema: &SchemaRef, values: Vec<i32>) -> RecordBatch {
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(values))])
+            .unwrap()
+    }
+
+    /// Writes an IPC stream containing `batches` to `path`, appending if
+    /// the file already exists. Returns the number of bytes written.
+    fn append_stream(
+        path: &std::path::Path,
+        schema: &SchemaRef,
+        batches: &[RecordBatch],
+    ) -> u64 {
+        // Determine the current file size before opening in append mode.
+        // We cannot rely on stream_position() after open with O_APPEND because
+        // on some platforms the fd starts at position 0 even when the file
+        // already has content, so `end - start` would count from 0 rather than
+        // from the true start of this append.
+        let start = if path.exists() {
+            std::fs::metadata(path).unwrap().len()
+        } else {
+            0
+        };
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        let opts = IpcWriteOptions::default();
+        {
+            let mut writer = StreamWriter::try_new_with_options(&mut file, schema, opts)
+                .unwrap();
+            for b in batches {
+                writer.write(b).unwrap();
+            }
+            writer.finish().unwrap();
+        }
+        file.flush().unwrap();
+        let end = std::fs::metadata(path).unwrap().len();
+        end - start
+    }
+
+    #[tokio::test]
+    async fn yields_batches_from_single_stream() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.arrow");
+        let s = schema();
+        let len = append_stream(&path, &s, &[batch(&s, vec![1, 2]), batch(&s, vec![3])]);
+
+        let mut stream = MultiStreamPartitionStream::new(path, s.clone(), 0, len);
+        let mut rows = vec![];
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            let arr = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            rows.extend(arr.values().iter().copied());
+        }
+        assert_eq!(rows, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn yields_batches_across_two_concatenated_streams() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.arrow");
+        let s = schema();
+        let mut total = 0;
+        total += append_stream(&path, &s, &[batch(&s, vec![1, 2])]);
+        total += append_stream(&path, &s, &[batch(&s, vec![3]), batch(&s, vec![4, 5])]);
+
+        let mut stream = MultiStreamPartitionStream::new(path, s.clone(), 0, total);
+        let mut rows = vec![];
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            let arr = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            rows.extend(arr.values().iter().copied());
+        }
+        assert_eq!(rows, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn empty_range_returns_no_batches() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.arrow");
+        // Touch the file so it exists but is empty.
+        std::fs::write(&path, b"").unwrap();
+        let s = schema();
+
+        let mut stream = MultiStreamPartitionStream::new(path, s.clone(), 0, 0);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn respects_end_offset_when_more_bytes_follow() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.arrow");
+        let s = schema();
+        let len_first = append_stream(&path, &s, &[batch(&s, vec![1, 2])]);
+        // Append a second stream whose bytes must NOT be read.
+        append_stream(&path, &s, &[batch(&s, vec![99])]);
+
+        let mut stream = MultiStreamPartitionStream::new(path, s.clone(), 0, len_first);
+        let mut rows = vec![];
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            let arr = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            rows.extend(arr.values().iter().copied());
+        }
+        assert_eq!(rows, vec![1, 2]);
+    }
+}

--- a/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
@@ -125,10 +125,9 @@ impl Stream for MultiStreamPartitionStream {
         match self.next_batch() {
             Ok(Some(batch)) => Poll::Ready(Some(Ok(batch))),
             Ok(None) => Poll::Ready(None),
-            Err(e) => Poll::Ready(Some(Err(DataFusionError::ArrowError(
-                Box::new(e),
-                None,
-            )))),
+            Err(e) => {
+                Poll::Ready(Some(Err(DataFusionError::ArrowError(Box::new(e), None))))
+            }
         }
     }
 }
@@ -184,8 +183,8 @@ mod tests {
             .unwrap();
         let opts = IpcWriteOptions::default();
         {
-            let mut writer = StreamWriter::try_new_with_options(&mut file, schema, opts)
-                .unwrap();
+            let mut writer =
+                StreamWriter::try_new_with_options(&mut file, schema, opts).unwrap();
             for b in batches {
                 writer.write(b).unwrap();
             }
@@ -207,11 +206,7 @@ mod tests {
         let mut rows = vec![];
         while let Some(b) = stream.next().await {
             let b = b.unwrap();
-            let arr = b
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
+            let arr = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
             rows.extend(arr.values().iter().copied());
         }
         assert_eq!(rows, vec![1, 2, 3]);
@@ -230,11 +225,7 @@ mod tests {
         let mut rows = vec![];
         while let Some(b) = stream.next().await {
             let b = b.unwrap();
-            let arr = b
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
+            let arr = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
             rows.extend(arr.values().iter().copied());
         }
         assert_eq!(rows, vec![1, 2, 3, 4, 5]);
@@ -265,11 +256,7 @@ mod tests {
         let mut rows = vec![];
         while let Some(b) = stream.next().await {
             let b = b.unwrap();
-            let arr = b
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
+            let arr = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
             rows.extend(arr.values().iter().copied());
         }
         assert_eq!(rows, vec![1, 2]);
@@ -293,11 +280,7 @@ mod tests {
         let mut rows = vec![];
         while let Some(b) = stream.next().await {
             let b = b.unwrap();
-            let arr = b
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
+            let arr = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
             rows.extend(arr.values().iter().copied());
         }
         assert_eq!(rows, vec![10, 20]);

--- a/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
@@ -33,6 +33,8 @@ use std::task::{Context, Poll};
 
 /// Reads `RecordBatch`es from `[start_offset, end_offset)` of `data_path`,
 /// where the byte range contains zero or more concatenated Arrow IPC streams.
+// TODO: remove the `dead_code` allow once Task 3 wires this into reader.rs.
+#[allow(dead_code)]
 pub(crate) struct MultiStreamPartitionStream {
     data_path: PathBuf,
     schema: SchemaRef,
@@ -45,6 +47,7 @@ pub(crate) struct MultiStreamPartitionStream {
     finished: bool,
 }
 
+#[allow(dead_code)]
 impl MultiStreamPartitionStream {
     /// Creates a new bounded multi-stream reader. `schema` is the schema of
     /// the partition data; the caller must obtain it from the data file's
@@ -77,7 +80,10 @@ impl MultiStreamPartitionStream {
             if let Some(reader) = self.reader.as_mut() {
                 match reader.next() {
                     Some(Ok(batch)) => return Ok(Some(batch)),
-                    Some(Err(e)) => return Err(e),
+                    Some(Err(e)) => {
+                        self.finished = true;
+                        return Err(e);
+                    }
                     None => {
                         // EOS for this sub-stream: capture position and drop
                         // the reader so we can construct the next one.
@@ -99,6 +105,7 @@ impl MultiStreamPartitionStream {
                 return Ok(None);
             }
 
+            self.finished = true;
             let mut file = File::open(&self.data_path)
                 .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
             file.seek(SeekFrom::Start(next))
@@ -106,6 +113,7 @@ impl MultiStreamPartitionStream {
             let reader = StreamReader::try_new(file, None)?;
             self.reader = Some(reader);
             self.next_offset = None;
+            self.finished = false;
         }
     }
 }
@@ -268,5 +276,33 @@ mod tests {
             rows.extend(arr.values().iter().copied());
         }
         assert_eq!(rows, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn starts_at_non_zero_offset() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.arrow");
+        let s = schema();
+        // Two streams in sequence; the test reads only the second.
+        let len_first = append_stream(&path, &s, &[batch(&s, vec![1, 2, 3])]);
+        let len_second = append_stream(&path, &s, &[batch(&s, vec![10, 20])]);
+
+        let mut stream = MultiStreamPartitionStream::new(
+            path,
+            s.clone(),
+            len_first,
+            len_first + len_second,
+        );
+        let mut rows = vec![];
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            let arr = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            rows.extend(arr.values().iter().copied());
+        }
+        assert_eq!(rows, vec![10, 20]);
     }
 }

--- a/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/multi_stream_reader.rs
@@ -37,12 +37,16 @@ pub(crate) struct MultiStreamPartitionStream {
     data_path: PathBuf,
     schema: SchemaRef,
     end_offset: u64,
-    /// Active sub-stream reader, or `None` between sub-streams.
-    reader: Option<StreamReader<File>>,
-    /// Absolute byte position to seek to for the next sub-stream. `None`
-    /// while `reader` is `Some` (the position is held inside the reader).
-    next_offset: Option<u64>,
-    finished: bool,
+    state: State,
+}
+
+enum State {
+    /// Next sub-stream begins at this absolute byte offset.
+    Pending(u64),
+    /// Currently draining a sub-stream.
+    Reading(StreamReader<File>),
+    /// Range exhausted or an error has terminated the stream.
+    Done,
 }
 
 impl MultiStreamPartitionStream {
@@ -55,62 +59,49 @@ impl MultiStreamPartitionStream {
         start_offset: u64,
         end_offset: u64,
     ) -> Self {
-        let finished = start_offset >= end_offset;
+        let state = if start_offset >= end_offset {
+            State::Done
+        } else {
+            State::Pending(start_offset)
+        };
         Self {
             data_path,
             schema,
             end_offset,
-            reader: None,
-            next_offset: Some(start_offset),
-            finished,
+            state,
         }
     }
 
     /// Synchronous core: pulls the next batch, advancing across sub-stream
-    /// boundaries as needed.
+    /// boundaries as needed. Any error path leaves `state == Done`, so a
+    /// repeated poll after an error returns `Ok(None)` rather than retrying
+    /// the failed offset.
     fn next_batch(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
         loop {
-            if self.finished {
-                return Ok(None);
-            }
-
-            if let Some(reader) = self.reader.as_mut() {
-                match reader.next() {
-                    Some(Ok(batch)) => return Ok(Some(batch)),
-                    Some(Err(e)) => {
-                        self.finished = true;
-                        return Err(e);
+            match std::mem::replace(&mut self.state, State::Done) {
+                State::Done => return Ok(None),
+                State::Reading(mut reader) => match reader.next() {
+                    Some(Ok(batch)) => {
+                        self.state = State::Reading(reader);
+                        return Ok(Some(batch));
                     }
+                    Some(Err(e)) => return Err(e),
                     None => {
-                        // EOS for this sub-stream: capture position and drop
-                        // the reader so we can construct the next one.
-                        let pos = reader
-                            .get_mut()
-                            .stream_position()
-                            .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
-                        self.next_offset = Some(pos);
-                        self.reader = None;
+                        let pos = reader.get_mut().stream_position()?;
+                        if pos < self.end_offset {
+                            self.state = State::Pending(pos);
+                        }
                     }
+                },
+                State::Pending(next) => {
+                    if next >= self.end_offset {
+                        return Ok(None);
+                    }
+                    let mut file = File::open(&self.data_path)?;
+                    file.seek(SeekFrom::Start(next))?;
+                    self.state = State::Reading(StreamReader::try_new(file, None)?);
                 }
             }
-
-            let next = self
-                .next_offset
-                .expect("invariant: next_offset is Some when reader is None");
-            if next >= self.end_offset {
-                self.finished = true;
-                return Ok(None);
-            }
-
-            self.finished = true;
-            let mut file = File::open(&self.data_path)
-                .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
-            file.seek(SeekFrom::Start(next))
-                .map_err(|e| ArrowError::IoError(format!("{e}"), e))?;
-            let reader = StreamReader::try_new(file, None)?;
-            self.reader = Some(reader);
-            self.next_offset = None;
-            self.finished = false;
         }
     }
 }

--- a/ballista/core/src/execution_plans/sort_shuffle/reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/reader.rs
@@ -18,22 +18,19 @@
 //! Reader for sort-based shuffle output files.
 //!
 //! Reads partition data from the consolidated data file using the index
-//! file to locate partition boundaries. Uses Arrow IPC FileReader for
-//! efficient random access to specific batches.
+//! file to locate each partition's byte range. Within a partition's range
+//! the bytes are zero or more concatenated Arrow IPC streams; the leading
+//! bytes of the data file hold a schema-header stream so the schema is
+//! always recoverable.
 
 use crate::error::{BallistaError, Result};
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::ipc::reader::FileReader;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::DataFusionError;
+use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use std::fs::File;
 use std::path::Path;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use super::index::ShuffleIndex;
+use super::multi_stream_reader::MultiStreamPartitionStream;
 
 /// Checks if a shuffle output uses the sort-based format by looking for
 /// the index file.
@@ -47,78 +44,15 @@ pub fn get_index_path(data_path: &Path) -> std::path::PathBuf {
     data_path.with_extension("arrow.index")
 }
 
-/// A stream that reads batches from a sort shuffle partition lazily.
-///
-/// Wraps an Arrow FileReader and yields batches one at a time without
-/// loading them all into memory upfront.
-struct SortShufflePartitionStream {
-    reader: FileReader<File>,
-    schema: SchemaRef,
-    remaining: usize,
-}
-
-impl SortShufflePartitionStream {
-    fn new(reader: FileReader<File>, schema: SchemaRef, num_batches: usize) -> Self {
-        Self {
-            reader,
-            schema,
-            remaining: num_batches,
-        }
-    }
-}
-
-impl futures::Stream for SortShufflePartitionStream {
-    type Item = std::result::Result<RecordBatch, DataFusionError>;
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        if self.remaining == 0 {
-            return Poll::Ready(None);
-        }
-
-        match self.reader.next() {
-            Some(Ok(batch)) => {
-                self.remaining -= 1;
-                Poll::Ready(Some(Ok(batch)))
-            }
-            Some(Err(e)) => {
-                self.remaining = 0;
-                Poll::Ready(Some(Err(DataFusionError::ArrowError(Box::new(e), None))))
-            }
-            None => {
-                self.remaining = 0;
-                Poll::Ready(None)
-            }
-        }
-    }
-}
-
-impl datafusion::physical_plan::RecordBatchStream for SortShufflePartitionStream {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-}
-
-/// Returns a stream of record batches for a specific partition from a sort shuffle data file.
-///
-/// Unlike `read_sort_shuffle_partition`, this returns a lazy stream that reads batches
-/// on-demand rather than loading all batches into memory upfront.
-///
-/// # Arguments
-/// * `data_path` - Path to the consolidated data file (Arrow IPC File format)
-/// * `index_path` - Path to the index file
-/// * `partition_id` - The partition to read
-///
-/// # Returns
-/// A stream of record batches for the requested partition.
+/// Returns a stream of record batches for `partition_id` from a sort-shuffle
+/// data file. Reads the schema from the leading schema-header stream and
+/// then yields batches from the partition's byte range, transparently
+/// crossing concatenated IPC stream boundaries within that range.
 pub fn stream_sort_shuffle_partition(
     data_path: &Path,
     index_path: &Path,
     partition_id: usize,
 ) -> Result<SendableRecordBatchStream> {
-    // Load the index
     let index = ShuffleIndex::read_from_file(index_path)?;
 
     if partition_id >= index.partition_count() {
@@ -128,37 +62,28 @@ pub fn stream_sort_shuffle_partition(
         )));
     }
 
-    // Open the data file to get the schema
-    let file = File::open(data_path).map_err(BallistaError::IoError)?;
-    let reader = FileReader::try_new(file, None)?;
-    let schema = reader.schema();
+    // Read the schema from the leading header stream.
+    let header_file = File::open(data_path).map_err(BallistaError::IoError)?;
+    let header_reader = StreamReader::try_new(header_file, None)
+        .map_err(|e| BallistaError::General(format!("read schema header: {e}")))?;
+    let schema = header_reader.schema();
+    drop(header_reader);
 
-    // Check if partition has data
-    if !index.partition_has_data(partition_id) {
-        // Return empty stream with the schema
-        let empty_stream = futures::stream::empty();
-        return Ok(Box::pin(RecordBatchStreamAdapter::new(
-            schema,
-            empty_stream,
+    let (start, end) = index.get_partition_range(partition_id);
+    if start < 0 || end < start {
+        return Err(BallistaError::General(format!(
+            "Invalid partition byte range for partition {partition_id}: ({start}, {end})"
         )));
     }
 
-    // Get the batch range for this partition
-    let (start_batch, end_batch) = index.get_partition_range(partition_id);
-    let start_batch = start_batch as usize;
-    let end_batch = end_batch as usize;
-    let num_batches = end_batch - start_batch;
-
-    // Re-open and position the reader at the start batch
-    let file = File::open(data_path).map_err(BallistaError::IoError)?;
-    let mut reader = FileReader::try_new(file, None)?;
-    reader.set_index(start_batch)?;
-
-    Ok(Box::pin(SortShufflePartitionStream::new(
-        reader,
+    let stream = MultiStreamPartitionStream::new(
+        data_path.to_path_buf(),
         schema,
-        num_batches,
-    )))
+        start as u64,
+        end as u64,
+    );
+
+    Ok(Box::pin(stream))
 }
 
 #[cfg(test)]

--- a/ballista/core/src/execution_plans/sort_shuffle/reader.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/reader.rs
@@ -63,11 +63,8 @@ pub fn stream_sort_shuffle_partition(
     }
 
     // Read the schema from the leading header stream.
-    let header_file = File::open(data_path).map_err(BallistaError::IoError)?;
-    let header_reader = StreamReader::try_new(header_file, None)
-        .map_err(|e| BallistaError::General(format!("read schema header: {e}")))?;
-    let schema = header_reader.schema();
-    drop(header_reader);
+    let header_file = File::open(data_path)?;
+    let schema = StreamReader::try_new(header_file, None)?.schema();
 
     let (start, end) = index.get_partition_range(partition_id);
     if start < 0 || end < start {

--- a/ballista/core/src/execution_plans/sort_shuffle/spill.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/spill.rs
@@ -129,7 +129,10 @@ impl SpillManager {
         let bytes_written = batch.get_array_memory_size() as u64;
         writer.write(batch)?;
 
-        let entry = self.partition_counters.entry(partition_id).or_insert((0, 0, 0));
+        let entry = self
+            .partition_counters
+            .entry(partition_id)
+            .or_insert((0, 0, 0));
         entry.0 += 1;
         entry.1 += batch.num_rows() as u64;
         entry.2 += bytes_written;
@@ -354,9 +357,18 @@ mod tests {
         assert_eq!((b1, r1), (1, 1));
         assert_eq!((b2, r2), (0, 0));
 
-        assert!(bytes0 > 0, "spilled partition should have non-zero bytes counter");
-        assert!(bytes1 > 0, "spilled partition should have non-zero bytes counter");
-        assert_eq!(bytes2, 0, "never-spilled partition should have zero bytes counter");
+        assert!(
+            bytes0 > 0,
+            "spilled partition should have non-zero bytes counter"
+        );
+        assert!(
+            bytes1 > 0,
+            "spilled partition should have non-zero bytes counter"
+        );
+        assert_eq!(
+            bytes2, 0,
+            "never-spilled partition should have zero bytes counter"
+        );
 
         assert!(manager.spill_path(0).is_some());
         assert!(manager.spill_path(1).is_some());

--- a/ballista/core/src/execution_plans/sort_shuffle/spill.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/spill.rs
@@ -30,7 +30,7 @@ use log::debug;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Manages spill files for sort-based shuffle.
 ///
@@ -54,6 +54,8 @@ pub struct SpillManager {
     total_spills: usize,
     /// Total bytes spilled
     total_bytes_spilled: u64,
+    /// Per-partition counters: partition_id -> (batches, rows, bytes)
+    partition_counters: HashMap<usize, (u64, u64, u64)>,
 }
 
 impl SpillManager {
@@ -90,6 +92,7 @@ impl SpillManager {
             compression,
             total_spills: 0,
             total_bytes_spilled: 0,
+            partition_counters: HashMap::new(),
         })
     }
 
@@ -104,7 +107,7 @@ impl SpillManager {
         }
 
         if !self.active_writers.contains_key(&partition_id) {
-            let spill_path = self.spill_path(partition_id);
+            let spill_path = self.spill_file_path(partition_id);
             debug!(
                 "Creating spill file for partition {} at {:?}",
                 partition_id, spill_path
@@ -125,6 +128,11 @@ impl SpillManager {
         let writer = self.active_writers.get_mut(&partition_id).unwrap();
         let bytes_written = batch.get_array_memory_size() as u64;
         writer.write(batch)?;
+
+        let entry = self.partition_counters.entry(partition_id).or_insert((0, 0, 0));
+        entry.0 += 1;
+        entry.1 += batch.num_rows() as u64;
+        entry.2 += bytes_written;
 
         self.total_spills += 1;
         self.total_bytes_spilled += bytes_written;
@@ -184,8 +192,24 @@ impl SpillManager {
         self.total_bytes_spilled
     }
 
+    /// Returns (batches, rows, bytes) spilled for the given partition. Zeros
+    /// if the partition never spilled.
+    pub fn partition_stats(&self, partition_id: usize) -> (u64, u64, u64) {
+        self.partition_counters
+            .get(&partition_id)
+            .copied()
+            .unwrap_or((0, 0, 0))
+    }
+
+    /// Returns the path to a partition's spill file, or `None` if no batches
+    /// were ever spilled for that partition. `finish_writers` must be called
+    /// before this path is read by another process.
+    pub fn spill_path(&self, partition_id: usize) -> Option<&Path> {
+        self.spill_files.get(&partition_id).map(PathBuf::as_path)
+    }
+
     /// Returns the spill file path for a partition.
-    fn spill_path(&self, partition_id: usize) -> PathBuf {
+    fn spill_file_path(&self, partition_id: usize) -> PathBuf {
         self.spill_dir.join(format!("part-{partition_id}.arrow"))
     }
 }
@@ -296,6 +320,39 @@ mod tests {
             .collect::<std::result::Result<Vec<_>, _>>()?;
         assert_eq!(r0.len(), 1);
         assert_eq!(r1.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_per_partition_stats() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let mut manager = SpillManager::new(
+            temp_dir.path().to_str().unwrap(),
+            "job1",
+            1,
+            0,
+            schema.clone(),
+            CompressionType::LZ4_FRAME,
+        )?;
+
+        manager.spill(0, &create_test_batch(&schema, vec![1, 2, 3]))?;
+        manager.spill(0, &create_test_batch(&schema, vec![4, 5]))?;
+        manager.spill(1, &create_test_batch(&schema, vec![6]))?;
+
+        let (b0, r0, _bytes0) = manager.partition_stats(0);
+        let (b1, r1, _bytes1) = manager.partition_stats(1);
+        let (b2, r2, _bytes2) = manager.partition_stats(2);
+
+        assert_eq!((b0, r0), (2, 5));
+        assert_eq!((b1, r1), (1, 1));
+        assert_eq!((b2, r2), (0, 0));
+
+        assert!(manager.spill_path(0).is_some());
+        assert!(manager.spill_path(1).is_some());
+        assert!(manager.spill_path(2).is_none());
 
         Ok(())
     }

--- a/ballista/core/src/execution_plans/sort_shuffle/spill.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/spill.rs
@@ -17,8 +17,9 @@
 
 //! Spill manager for sort-based shuffle.
 //!
-//! Handles writing partition buffers to disk when memory pressure is high,
-//! and reading them back during the finalization phase.
+//! Handles writing partition buffers to disk when memory pressure is high.
+//! At finalization, the spill bytes are concatenated verbatim into the
+//! consolidated output file alongside the in-memory remainder.
 
 use crate::error::{BallistaError, Result};
 use datafusion::arrow::datatypes::SchemaRef;
@@ -35,10 +36,10 @@ use std::path::{Path, PathBuf};
 /// Manages spill files for sort-based shuffle.
 ///
 /// When partition buffers exceed memory limits, they are spilled to disk
-/// as Arrow IPC files. Each output partition has at most one spill file
+/// as Arrow IPC streams. Each output partition has at most one spill file
 /// that is appended to across multiple spill calls. During finalization,
-/// these spill files are read back and merged into the consolidated
-/// output file.
+/// the spill file bytes are concatenated directly into the consolidated
+/// output file (no decode/re-encode round-trip).
 pub struct SpillManager {
     /// Base directory for spill files
     spill_dir: PathBuf,

--- a/ballista/core/src/execution_plans/sort_shuffle/spill.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/spill.rs
@@ -192,8 +192,12 @@ impl SpillManager {
         self.total_bytes_spilled
     }
 
-    /// Returns (batches, rows, bytes) spilled for the given partition. Zeros
-    /// if the partition never spilled.
+    /// Returns `(batches, rows, bytes)` spilled for the given partition, or
+    /// `(0, 0, 0)` if the partition never spilled.
+    ///
+    /// The `bytes` value is the Arrow in-memory buffer size of each batch
+    /// at the time of the spill call (`RecordBatch::get_array_memory_size`).
+    /// It is **not** the compressed on-disk size.
     pub fn partition_stats(&self, partition_id: usize) -> (u64, u64, u64) {
         self.partition_counters
             .get(&partition_id)
@@ -342,13 +346,17 @@ mod tests {
         manager.spill(0, &create_test_batch(&schema, vec![4, 5]))?;
         manager.spill(1, &create_test_batch(&schema, vec![6]))?;
 
-        let (b0, r0, _bytes0) = manager.partition_stats(0);
-        let (b1, r1, _bytes1) = manager.partition_stats(1);
-        let (b2, r2, _bytes2) = manager.partition_stats(2);
+        let (b0, r0, bytes0) = manager.partition_stats(0);
+        let (b1, r1, bytes1) = manager.partition_stats(1);
+        let (b2, r2, bytes2) = manager.partition_stats(2);
 
         assert_eq!((b0, r0), (2, 5));
         assert_eq!((b1, r1), (1, 1));
         assert_eq!((b2, r2), (0, 0));
+
+        assert!(bytes0 > 0, "spilled partition should have non-zero bytes counter");
+        assert!(bytes1 > 0, "spilled partition should have non-zero bytes counter");
+        assert_eq!(bytes2, 0, "never-spilled partition should have zero bytes counter");
 
         assert!(manager.spill_path(0).is_some());
         assert!(manager.spill_path(1).is_some());

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -401,17 +401,14 @@ fn finalize_output(
     let file = File::create(&data_path)?;
     let mut output = BufWriter::new(file);
 
-    let opts = IpcWriteOptions::default()
-        .try_with_compression(Some(config.compression))?;
+    let opts =
+        IpcWriteOptions::default().try_with_compression(Some(config.compression))?;
 
     // Leading schema-header stream (schema message + EOS, no batches) so the
     // reader can recover the schema even when the requested partition is empty.
     {
-        let mut header = StreamWriter::try_new_with_options(
-            &mut output,
-            schema,
-            opts.clone(),
-        )?;
+        let mut header =
+            StreamWriter::try_new_with_options(&mut output, schema, opts.clone())?;
         header.finish()?;
     }
 
@@ -442,11 +439,8 @@ fn finalize_output(
                 partition_indices,
                 config.batch_size,
             );
-            let mut writer = StreamWriter::try_new_with_options(
-                &mut output,
-                schema,
-                opts.clone(),
-            )?;
+            let mut writer =
+                StreamWriter::try_new_with_options(&mut output, schema, opts.clone())?;
             for result in iter {
                 let batch = result?;
                 mem_rows += batch.num_rows() as u64;
@@ -898,10 +892,7 @@ mod tests {
             1,
             input,
             work_dir.path().to_str().unwrap().to_string(),
-            Partitioning::Hash(
-                vec![Arc::new(Column::new("k", 0))],
-                num_partitions,
-            ),
+            Partitioning::Hash(vec![Arc::new(Column::new("k", 0))], num_partitions),
             SortShuffleConfig::default(),
         )?;
 
@@ -941,12 +932,9 @@ mod tests {
         let mut seen: HashSet<i64> = HashSet::new();
         let total_rows = num_batches * rows_per_batch;
         for partition_id in 0..num_partitions {
-            let mut s = stream_sort_shuffle_partition(
-                &data_path,
-                &index_path,
-                partition_id,
-            )
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            let mut s =
+                stream_sort_shuffle_partition(&data_path, &index_path, partition_id)
+                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
             while let Some(batch_result) = s.next().await {
                 let batch = batch_result?;
                 let arr = batch
@@ -1069,8 +1057,9 @@ mod tests {
 
         let mut row_counts = Vec::with_capacity(num_partitions);
         for partition_id in 0..num_partitions {
-            let mut s = stream_sort_shuffle_partition(&data_path, &index_path, partition_id)
-                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            let mut s =
+                stream_sort_shuffle_partition(&data_path, &index_path, partition_id)
+                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
             let mut count = 0_usize;
             while let Some(batch_result) = s.next().await {
                 let batch = batch_result?;
@@ -1083,7 +1072,10 @@ mod tests {
         assert_eq!(total_seen, total_rows, "round-trip lost rows");
         let non_empty = row_counts.iter().filter(|c| **c > 0).count();
         assert!(non_empty >= 1, "expected at least one non-empty partition");
-        assert!(non_empty < num_partitions, "expected at least one empty partition");
+        assert!(
+            non_empty < num_partitions,
+            "expected at least one empty partition"
+        );
 
         Ok(())
     }

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -24,7 +24,7 @@
 use std::any::Any;
 use std::fs::File;
 use std::future::Future;
-use std::io::BufWriter;
+use std::io::{BufWriter, Seek, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -43,7 +43,7 @@ use datafusion::arrow::array::{
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::ipc::writer::{FileWriter, IpcWriteOptions};
+use datafusion::arrow::ipc::writer::{IpcWriteOptions, StreamWriter};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::hash_utils::create_hashes;
 use datafusion::error::{DataFusionError, Result};
@@ -399,68 +399,75 @@ fn finalize_output(
     debug!("Writing consolidated shuffle output to {:?}", data_path);
 
     let file = File::create(&data_path)?;
-    let mut buffered_writer = BufWriter::new(file);
+    let mut output = BufWriter::new(file);
 
-    let options =
-        IpcWriteOptions::default().try_with_compression(Some(config.compression))?;
-    let mut writer =
-        FileWriter::try_new_with_options(&mut buffered_writer, schema, options)?;
+    let opts = IpcWriteOptions::default()
+        .try_with_compression(Some(config.compression))?;
 
-    let mut cumulative_batch_count: i64 = 0;
+    // Leading schema-header stream (schema message + EOS, no batches) so the
+    // reader can recover the schema even when the requested partition is empty.
+    {
+        let mut header = StreamWriter::try_new_with_options(
+            &mut output,
+            schema,
+            opts.clone(),
+        )?;
+        header.finish()?;
+    }
 
-    // Take ownership of the in-memory state once. After this we can iterate
-    // each partition's indices independently without borrow-checker grief.
     let (in_memory_batches, in_memory_indices) = buffered.take();
 
     for (partition_id, partition_indices) in in_memory_indices.iter().enumerate() {
-        index.set_offset(partition_id, cumulative_batch_count);
+        // Stream position before this partition's bytes start.
+        output.flush()?;
+        let partition_start = output.get_mut().stream_position()? as i64;
+        index.set_offset(partition_id, partition_start);
 
-        let mut partition_rows: u64 = 0;
-        let mut partition_batches: u64 = 0;
-        let mut partition_bytes: u64 = 0;
+        let (spill_batches, spill_rows, spill_bytes) =
+            spill_manager.partition_stats(partition_id);
 
-        // First, stream any spill file for this partition.
-        if let Some(reader) = spill_manager
-            .open_spill_reader(partition_id)
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-        {
-            for batch_result in reader {
-                let batch = batch_result?;
-                partition_rows += batch.num_rows() as u64;
-                partition_bytes += batch.get_array_memory_size() as u64;
-                partition_batches += 1;
-                writer.write(&batch)?;
-            }
+        // 1) Byte-copy the spill file (if any) directly into the output.
+        if let Some(spill_path) = spill_manager.spill_path(partition_id) {
+            let mut spill_file = File::open(spill_path)?;
+            std::io::copy(&mut spill_file, output.get_mut())?;
         }
 
-        // Then write the in-memory remainder via interleave_record_batch.
+        // 2) Append in-memory remainder as a fresh IPC stream.
+        let mut mem_batches: u64 = 0;
+        let mut mem_rows: u64 = 0;
+        let mut mem_bytes: u64 = 0;
         if !partition_indices.is_empty() {
             let iter = PartitionedBatchIterator::new(
                 &in_memory_batches,
                 partition_indices,
                 config.batch_size,
             );
+            let mut writer = StreamWriter::try_new_with_options(
+                &mut output,
+                schema,
+                opts.clone(),
+            )?;
             for result in iter {
                 let batch = result?;
-                partition_rows += batch.num_rows() as u64;
-                partition_bytes += batch.get_array_memory_size() as u64;
-                partition_batches += 1;
+                mem_rows += batch.num_rows() as u64;
+                mem_bytes += batch.get_array_memory_size() as u64;
+                mem_batches += 1;
                 writer.write(&batch)?;
             }
+            writer.finish()?;
         }
 
         partition_stats.push((
             partition_id,
-            partition_batches,
-            partition_rows,
-            partition_bytes,
+            spill_batches + mem_batches,
+            spill_rows + mem_rows,
+            spill_bytes + mem_bytes,
         ));
-
-        cumulative_batch_count += partition_batches as i64;
     }
 
-    writer.finish()?;
-    index.set_total_length(cumulative_batch_count);
+    output.flush()?;
+    let total = output.get_mut().stream_position()? as i64;
+    index.set_total_length(total);
     index
         .write_to_file(&index_path)
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
@@ -824,8 +831,8 @@ mod tests {
 
     #[tokio::test]
     async fn spills_under_memory_pressure_and_round_trips() -> Result<()> {
+        use super::super::reader::stream_sort_shuffle_partition;
         use datafusion::arrow::array::Int64Array;
-        use datafusion::arrow::ipc::reader::FileReader;
         use datafusion::execution::memory_pool::FairSpillPool;
         use datafusion::execution::runtime_env::RuntimeEnvBuilder;
         use std::collections::HashSet;
@@ -903,26 +910,33 @@ mod tests {
             "expected spilling under tight memory pool, got spill_count={spill_count}"
         );
 
-        // Round-trip: read back the consolidated file via Arrow IPC FileReader and
-        // verify all keys are present.
+        // Round-trip: read back the consolidated file via the sort-shuffle
+        // reader and verify all keys are present across all output partitions.
         let data_path = work_dir
             .path()
             .join("spill_test_job")
             .join("1")
             .join("0")
             .join("data.arrow");
-        let file = std::fs::File::open(&data_path)?;
-        let reader = FileReader::try_new(file, None)?;
+        let index_path = data_path.with_extension("arrow.index");
         let mut seen: HashSet<i64> = HashSet::new();
-        for batch_result in reader {
-            let batch = batch_result?;
-            let arr = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .unwrap();
-            for v in arr.values() {
-                seen.insert(*v);
+        for partition_id in 0..4 {
+            let mut stream = stream_sort_shuffle_partition(
+                &data_path,
+                &index_path,
+                partition_id,
+            )
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            while let Some(batch_result) = stream.next().await {
+                let batch = batch_result?;
+                let arr = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap();
+                for v in arr.values() {
+                    seen.insert(*v);
+                }
             }
         }
         assert_eq!(seen.len(), 10 * 8192);

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -415,7 +415,9 @@ fn finalize_output(
     let (in_memory_batches, in_memory_indices) = buffered.take();
 
     for (partition_id, partition_indices) in in_memory_indices.iter().enumerate() {
-        // Stream position before this partition's bytes start.
+        // Flush before reading the kernel position so the BufWriter buffer
+        // is empty; std::io::copy below also writes directly to the inner
+        // File and would land after any pending buffered bytes otherwise.
         output.flush()?;
         let partition_start = output.get_mut().stream_position()? as i64;
         index.set_offset(partition_id, partition_start);
@@ -423,13 +425,11 @@ fn finalize_output(
         let (spill_batches, spill_rows, spill_bytes) =
             spill_manager.partition_stats(partition_id);
 
-        // 1) Byte-copy the spill file (if any) directly into the output.
         if let Some(spill_path) = spill_manager.spill_path(partition_id) {
             let mut spill_file = File::open(spill_path)?;
             std::io::copy(&mut spill_file, output.get_mut())?;
         }
 
-        // 2) Append in-memory remainder as a fresh IPC stream.
         let mut mem_batches: u64 = 0;
         let mut mem_rows: u64 = 0;
         let mut mem_bytes: u64 = 0;

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -829,25 +829,37 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn spills_under_memory_pressure_and_round_trips() -> Result<()> {
+    /// Shared helper for round-trip tests. Builds `num_batches` batches of
+    /// `rows_per_batch` rows each with schema `(k: Int64, v: Int64)`, writes
+    /// them through `SortShuffleWriterExec` into `num_partitions` output
+    /// partitions with a `memory_limit_bytes` pool, reads every partition back
+    /// via `stream_sort_shuffle_partition`, and asserts:
+    ///   - Every input key `0..total_rows` is present exactly once in the union
+    ///     of partition outputs.
+    ///   - `spill_count > 0` iff `expect_spills` is `true`.
+    ///   - The memory pool has `reserved == 0` after completion.
+    async fn run_round_trip(
+        num_batches: usize,
+        rows_per_batch: usize,
+        num_partitions: usize,
+        memory_limit_bytes: usize,
+        expect_spills: bool,
+    ) -> Result<()> {
         use super::super::reader::stream_sort_shuffle_partition;
         use datafusion::arrow::array::Int64Array;
         use datafusion::execution::memory_pool::FairSpillPool;
         use datafusion::execution::runtime_env::RuntimeEnvBuilder;
         use std::collections::HashSet;
 
-        // Build an input plan with many wide rows so memory growth is noticeable.
         let schema = Arc::new(Schema::new(vec![
             Field::new("k", DataType::Int64, false),
             Field::new("v", DataType::Int64, false),
         ]));
 
-        // 10 batches of 8192 rows each. With a 512 KiB pool, this forces spilling.
-        let batches: Vec<RecordBatch> = (0..10)
+        let batches: Vec<RecordBatch> = (0..num_batches)
             .map(|b| {
-                let start = b * 8192_i64;
-                let keys: Vec<i64> = (start..start + 8192).collect();
+                let start = (b * rows_per_batch) as i64;
+                let keys: Vec<i64> = (start..start + rows_per_batch as i64).collect();
                 let values: Vec<i64> = keys.iter().map(|k| k * 2).collect();
                 RecordBatch::try_new(
                     schema.clone(),
@@ -868,10 +880,9 @@ mod tests {
         let input: Arc<dyn ExecutionPlan> =
             Arc::new(DataSourceExec::new(memory_data_source));
 
-        // Tight memory pool to force spills.
         let runtime_env = Arc::new(
             RuntimeEnvBuilder::new()
-                .with_memory_pool(Arc::new(FairSpillPool::new(512 * 1024)))
+                .with_memory_pool(Arc::new(FairSpillPool::new(memory_limit_bytes)))
                 .build()?,
         );
         let session_ctx = SessionContext::new_with_config_rt(
@@ -883,11 +894,14 @@ mod tests {
         let work_dir = TempDir::new()?;
 
         let writer = SortShuffleWriterExec::try_new(
-            "spill_test_job".to_string(),
+            "round_trip_job".to_string(),
             1,
             input,
             work_dir.path().to_str().unwrap().to_string(),
-            Partitioning::Hash(vec![Arc::new(Column::new("k", 0))], 4),
+            Partitioning::Hash(
+                vec![Arc::new(Column::new("k", 0))],
+                num_partitions,
+            ),
             SortShuffleConfig::default(),
         )?;
 
@@ -905,29 +919,35 @@ mod tests {
             .find(|m| m.value().name() == "spill_count")
             .map(|m| m.value().as_usize())
             .unwrap_or(0);
-        assert!(
-            spill_count > 0,
-            "expected spilling under tight memory pool, got spill_count={spill_count}"
-        );
+        if expect_spills {
+            assert!(
+                spill_count > 0,
+                "expected spilling under tight memory pool, got spill_count={spill_count}"
+            );
+        } else {
+            assert_eq!(
+                spill_count, 0,
+                "expected no spills with generous memory pool, got spill_count={spill_count}"
+            );
+        }
 
-        // Round-trip: read back the consolidated file via the sort-shuffle
-        // reader and verify all keys are present across all output partitions.
         let data_path = work_dir
             .path()
-            .join("spill_test_job")
+            .join("round_trip_job")
             .join("1")
             .join("0")
             .join("data.arrow");
         let index_path = data_path.with_extension("arrow.index");
         let mut seen: HashSet<i64> = HashSet::new();
-        for partition_id in 0..4 {
-            let mut stream = stream_sort_shuffle_partition(
+        let total_rows = num_batches * rows_per_batch;
+        for partition_id in 0..num_partitions {
+            let mut s = stream_sort_shuffle_partition(
                 &data_path,
                 &index_path,
                 partition_id,
             )
             .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-            while let Some(batch_result) = stream.next().await {
+            while let Some(batch_result) = s.next().await {
                 let batch = batch_result?;
                 let arr = batch
                     .column(0)
@@ -939,20 +959,131 @@ mod tests {
                 }
             }
         }
-        assert_eq!(seen.len(), 10 * 8192);
-        for k in 0..(10 * 8192_i64) {
+        assert_eq!(seen.len(), total_rows);
+        for k in 0..total_rows as i64 {
             assert!(seen.contains(&k), "key {k} missing from round-trip");
         }
 
-        // (c) Confirm the writer's MemoryReservation was freed.
-        // The reservation is registered on the pool during execute_shuffle_write
-        // and freed when the future completes, so the pool should now report no
-        // reserved bytes from any source.
         let pool_reserved = session_ctx.runtime_env().memory_pool.reserved();
         assert_eq!(
             pool_reserved, 0,
             "expected MemoryReservation freed after finalization, but pool reports {pool_reserved} bytes still reserved"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn spills_under_memory_pressure_and_round_trips() -> Result<()> {
+        // 10 batches of 8192 rows each. With a 512 KiB pool, this forces spilling.
+        run_round_trip(
+            /* num_batches */ 10,
+            /* rows_per_batch */ 8192,
+            /* num_partitions */ 4,
+            /* memory_limit_bytes */ 512 * 1024,
+            /* expect_spills */ true,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn multi_spill_round_trips() -> Result<()> {
+        // Larger total payload + tighter pool than the baseline test, so we
+        // expect multiple spill events per partition. The byte-copy finalize
+        // path should produce a partition section that is `spill_stream ||
+        // in_memory_stream` (two concatenated IPC streams), and the reader
+        // must yield every input row regardless.
+        run_round_trip(
+            /* num_batches */ 20,
+            /* rows_per_batch */ 8192,
+            /* num_partitions */ 2,
+            /* memory_limit_bytes */ 256 * 1024,
+            /* expect_spills */ true,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn in_memory_only_round_trips() -> Result<()> {
+        // Generous memory pool so no partition spills. Validates the path
+        // where each partition section is exactly one in-memory IPC stream.
+        run_round_trip(
+            /* num_batches */ 4,
+            /* rows_per_batch */ 1024,
+            /* num_partitions */ 4,
+            /* memory_limit_bytes */ 64 * 1024 * 1024,
+            /* expect_spills */ false,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn empty_partitions_round_trip() -> Result<()> {
+        use super::super::reader::stream_sort_shuffle_partition;
+        use datafusion::arrow::array::Int64Array;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("k", DataType::Int64, false)]));
+        let total_rows = 256;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![0_i64; total_rows]))],
+        )
+        .unwrap();
+        let partitions = vec![vec![batch]];
+        let memory_data_source = Arc::new(MemorySourceConfig::try_new(
+            &partitions,
+            schema.clone(),
+            None,
+        )?);
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(DataSourceExec::new(memory_data_source));
+
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let work_dir = TempDir::new()?;
+
+        let num_partitions = 8;
+        let writer = SortShuffleWriterExec::try_new(
+            "empty_partitions_job".to_string(),
+            1,
+            input,
+            work_dir.path().to_str().unwrap().to_string(),
+            Partitioning::Hash(vec![Arc::new(Column::new("k", 0))], num_partitions),
+            SortShuffleConfig::default(),
+        )?;
+
+        let mut stream = writer.execute(0, task_ctx)?;
+        let _summary: Vec<RecordBatch> = stream
+            .by_ref()
+            .try_collect()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+        let data_path = work_dir
+            .path()
+            .join("empty_partitions_job")
+            .join("1")
+            .join("0")
+            .join("data.arrow");
+        let index_path = data_path.with_extension("arrow.index");
+
+        let mut row_counts = Vec::with_capacity(num_partitions);
+        for partition_id in 0..num_partitions {
+            let mut s = stream_sort_shuffle_partition(&data_path, &index_path, partition_id)
+                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            let mut count = 0_usize;
+            while let Some(batch_result) = s.next().await {
+                let batch = batch_result?;
+                count += batch.num_rows();
+            }
+            row_counts.push(count);
+        }
+
+        let total_seen: usize = row_counts.iter().sum();
+        assert_eq!(total_seen, total_rows, "round-trip lost rows");
+        let non_empty = row_counts.iter().filter(|c| **c > 0).count();
+        assert!(non_empty >= 1, "expected at least one non-empty partition");
+        assert!(non_empty < num_partitions, "expected at least one empty partition");
 
         Ok(())
     }

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -345,8 +345,7 @@ async fn stream_whole_file(
         path,
         file.metadata().await?.len()
     );
-    let reader = tokio::io::BufReader::with_capacity(BLOCK_BUFFER_CAPACITY, file);
-    let file_stream = ReaderStream::with_capacity(reader, BLOCK_BUFFER_CAPACITY);
+    let file_stream = ReaderStream::with_capacity(file, BLOCK_BUFFER_CAPACITY);
     Ok(Box::pin(file_stream.map(|result| {
         result
             .map(|bytes| arrow_flight::Result { body: bytes })
@@ -361,8 +360,8 @@ async fn stream_sort_shuffle_block(
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
     let index_path = get_index_path(data_path);
-    let index = ShuffleIndex::read_from_file(&index_path)
-        .map_err(|e| Status::internal(format!("read shuffle index: {e}")))?;
+    let index =
+        ShuffleIndex::read_from_file(&index_path).map_err(|e| from_ballista_err(&e))?;
 
     if partition_id >= index.partition_count() {
         return Err(Status::out_of_range(format!(
@@ -372,30 +371,32 @@ async fn stream_sort_shuffle_block(
     }
 
     // The leading [0, header_end) bytes hold the schema-header IPC stream.
-    // The partition's byte range is [start, end). We send both, in that
-    // order, so the receiver always recovers the schema even when the
-    // partition is empty.
-    let header_end = index.get_partition_range(0).0 as u64;
+    // We always prepend it to the partition's byte range so the receiver
+    // recovers the schema even when the partition is empty.
+    let header_end = index.header_end_offset() as u64;
     let (start, end) = index.get_partition_range(partition_id);
     let (start, end) = (start as u64, end as u64);
 
+    // One open + dup gives us two independent file cursors over the same
+    // inode: one reads the header from offset 0, the other seeks to the
+    // partition. `chain` and `take` consume their readers by value, so two
+    // cursors are unavoidable here.
     let header_file = tokio::fs::File::open(data_path)
         .await
         .map_err(|e| Status::internal(format!("Failed to open file: {e}")))?;
-    let header = header_file.take(header_end);
-
-    let mut partition_file = tokio::fs::File::open(data_path)
+    let mut partition_file = header_file
+        .try_clone()
         .await
-        .map_err(|e| Status::internal(format!("Failed to open file: {e}")))?;
+        .map_err(|e| Status::internal(format!("dup file handle: {e}")))?;
     partition_file
         .seek(std::io::SeekFrom::Start(start))
         .await
         .map_err(|e| Status::internal(format!("seek partition: {e}")))?;
-    let partition = partition_file.take(end - start);
 
-    let combined = header.chain(partition);
-    let buffered = tokio::io::BufReader::with_capacity(BLOCK_BUFFER_CAPACITY, combined);
-    let file_stream = ReaderStream::with_capacity(buffered, BLOCK_BUFFER_CAPACITY);
+    let combined = header_file
+        .take(header_end)
+        .chain(partition_file.take(end - start));
+    let file_stream = ReaderStream::with_capacity(combined, BLOCK_BUFFER_CAPACITY);
     Ok(Box::pin(file_stream.map(|result| {
         result
             .map(|bytes| arrow_flight::Result { body: bytes })

--- a/ballista/executor/src/flight_service.rs
+++ b/ballista/executor/src/flight_service.rs
@@ -28,7 +28,7 @@ use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
 use ballista_core::error::BallistaError;
 use ballista_core::execution_plans::sort_shuffle::{
-    get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
+    ShuffleIndex, get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
 };
 use ballista_core::serde::decode_protobuf;
 use ballista_core::serde::scheduler::Action as BallistaAction;
@@ -283,42 +283,18 @@ impl FlightService for BallistaFlightService {
 
                         debug!("FetchPartition reading {path:?}");
 
-                        // Block transport doesn't support sort-based shuffle because it
-                        // transfers the entire file, which contains all partitions.
-                        // Use flight transport (do_get) for sort-based shuffle.
-                        if is_sort_shuffle_output(&path) {
-                            return Err(Status::unimplemented(
-                                "IO_BLOCK_TRANSPORT does not support sort-based shuffle. \
-                                 Set ballista.shuffle.remote_read_prefer_flight=true to use \
-                                 flight transport instead.",
-                            ));
-                        }
+                        let stream = if is_sort_shuffle_output(&path) {
+                            // Sort-shuffle: stream the leading schema-header
+                            // bytes followed by the requested partition's
+                            // byte range. The receiver (BlockDataStream) walks
+                            // the resulting concatenated IPC streams.
+                            stream_sort_shuffle_block(&path, *partition_id).await?
+                        } else {
+                            // Hash-shuffle: file contains exactly one partition.
+                            stream_whole_file(&path).await?
+                        };
 
-                        let file = tokio::fs::File::open(&path).await.map_err(|e| {
-                            Status::internal(format!("Failed to open file: {e}"))
-                        })?;
-
-                        debug!(
-                            "streaming file: {:?} with size: {}",
-                            path,
-                            file.metadata().await?.len()
-                        );
-                        let reader = tokio::io::BufReader::with_capacity(
-                            BLOCK_BUFFER_CAPACITY,
-                            file,
-                        );
-                        let file_stream =
-                            ReaderStream::with_capacity(reader, BLOCK_BUFFER_CAPACITY);
-
-                        let flight_data_stream = file_stream.map(|result| {
-                            result
-                                .map(|bytes| arrow_flight::Result { body: bytes })
-                                .map_err(|e| Status::internal(format!("I/O error: {e}")))
-                        });
-
-                        Ok(Response::new(
-                            Box::pin(flight_data_stream) as Self::DoActionStream
-                        ))
+                        Ok(Response::new(stream))
                     }
                 }
             }
@@ -356,6 +332,75 @@ impl FlightService for BallistaFlightService {
     ) -> Result<Response<PollInfo>, Status> {
         Err(Status::unimplemented("poll_flight_info"))
     }
+}
+
+async fn stream_whole_file(
+    path: &std::path::Path,
+) -> Result<<BallistaFlightService as FlightService>::DoActionStream, Status> {
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| Status::internal(format!("Failed to open file: {e}")))?;
+    debug!(
+        "streaming file: {:?} with size: {}",
+        path,
+        file.metadata().await?.len()
+    );
+    let reader = tokio::io::BufReader::with_capacity(BLOCK_BUFFER_CAPACITY, file);
+    let file_stream = ReaderStream::with_capacity(reader, BLOCK_BUFFER_CAPACITY);
+    Ok(Box::pin(file_stream.map(|result| {
+        result
+            .map(|bytes| arrow_flight::Result { body: bytes })
+            .map_err(|e| Status::internal(format!("I/O error: {e}")))
+    })))
+}
+
+async fn stream_sort_shuffle_block(
+    data_path: &std::path::Path,
+    partition_id: usize,
+) -> Result<<BallistaFlightService as FlightService>::DoActionStream, Status> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    let index_path = get_index_path(data_path);
+    let index = ShuffleIndex::read_from_file(&index_path)
+        .map_err(|e| Status::internal(format!("read shuffle index: {e}")))?;
+
+    if partition_id >= index.partition_count() {
+        return Err(Status::out_of_range(format!(
+            "partition_id {partition_id} not found in index (max: {})",
+            index.partition_count()
+        )));
+    }
+
+    // The leading [0, header_end) bytes hold the schema-header IPC stream.
+    // The partition's byte range is [start, end). We send both, in that
+    // order, so the receiver always recovers the schema even when the
+    // partition is empty.
+    let header_end = index.get_partition_range(0).0 as u64;
+    let (start, end) = index.get_partition_range(partition_id);
+    let (start, end) = (start as u64, end as u64);
+
+    let header_file = tokio::fs::File::open(data_path)
+        .await
+        .map_err(|e| Status::internal(format!("Failed to open file: {e}")))?;
+    let header = header_file.take(header_end);
+
+    let mut partition_file = tokio::fs::File::open(data_path)
+        .await
+        .map_err(|e| Status::internal(format!("Failed to open file: {e}")))?;
+    partition_file
+        .seek(std::io::SeekFrom::Start(start))
+        .await
+        .map_err(|e| Status::internal(format!("seek partition: {e}")))?;
+    let partition = partition_file.take(end - start);
+
+    let combined = header.chain(partition);
+    let buffered = tokio::io::BufReader::with_capacity(BLOCK_BUFFER_CAPACITY, combined);
+    let file_stream = ReaderStream::with_capacity(buffered, BLOCK_BUFFER_CAPACITY);
+    Ok(Box::pin(file_stream.map(|result| {
+        result
+            .map(|bytes| arrow_flight::Result { body: bytes })
+            .map_err(|e| Status::internal(format!("I/O error: {e}")))
+    })))
 }
 
 fn read_partition<T>(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Sort-shuffle finalize previously decoded every spilled batch and re-emitted it through an IPC `FileWriter`, paying decompress + Arrow allocation + recompress for every spilled byte. This PR replaces that round-trip with a `std::io::copy` of the spill file straight into the consolidated output. On Linux this engages `copy_file_range` / `sendfile`, so spilled bytes never re-enter user space.

The same byte-offset index also lifts the restriction that sort-shuffle remote reads must use Arrow Flight: the executor can now serve sort-shuffle partitions through `IO_BLOCK_TRANSPORT` (the existing block-IO action), bypassing decode/re-encode on the server.

# What changes are included in this PR?

The on-disk format for sort-shuffle output changes:

- **Data file**: was a single IPC File with a footer of batch-block offsets. Now it is a leading schema-header IPC stream followed by per-partition byte ranges, each holding zero or more concatenated self-contained IPC streams.
- **Index file**: was little-endian i64 cumulative batch indices (despite the docstring already promising byte offsets). Now it stores actual little-endian i64 byte offsets, matching what the docstring always claimed.
- **Reader**: `stream_sort_shuffle_partition` recovers the schema from the leading header stream and uses a new bounded multi-stream reader that crosses concatenated stream EOS markers within a partition's byte range.
- **Block-IO transport**: `do_action`'s `IO_BLOCK_TRANSPORT` arm now serves sort-shuffle by streaming `[schema-header bytes ++ partition byte range]`. The client's `BlockDataStream` resets its `StreamDecoder` on EOS so it walks the concatenated payload.

Hash-based shuffle is intentionally untouched. Public API of `is_sort_shuffle_output`, `get_index_path`, and `stream_sort_shuffle_partition` is unchanged, so `ShuffleReaderExec` and the executor's Arrow Flight service work without modification.

New tests cover multi-spill, in-memory-only, and empty-partition round-trips on the writer/reader side, plus concatenated-stream and schema-only-leading-stream round-trips on the block-IO client.

# Are there any user-facing changes?

No public-API changes. The sort-shuffle on-disk format changes — it is executor-internal, but in-flight files written by older binaries are not readable by this version.