### PR TITLE
feat: SchedulerConfig improvement

### DIFF
--- a/ballista/scheduler/src/cluster/event/mod.rs
+++ b/ballista/scheduler/src/cluster/event/mod.rs
@@ -26,9 +26,6 @@ use std::task::{Context, Poll, Waker};
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::TryRecvError;
 
-// TODO make configurable
-const EVENT_BUFFER_SIZE: usize = 256;
-
 static ID_GEN: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Default)]
@@ -112,7 +109,7 @@ impl<T: Clone> ClusterEventSender<T> {
 
 impl<T: Clone> Default for ClusterEventSender<T> {
     fn default() -> Self {
-        Self::new(EVENT_BUFFER_SIZE)
+        Self::new(256)
     }
 }
 

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -19,6 +19,7 @@ use crate::cluster::{
     BoundTask, ClusterState, ExecutorSlot, JobState, JobStateEvent, JobStateEventStream,
     JobStatus, TaskDistributionPolicy, bind_task_bias, bind_task_round_robin,
 };
+use crate::config::SchedulerConfig;
 use crate::state::execution_graph::ExecutionGraphBox;
 use async_trait::async_trait;
 use ballista_core::error::{BallistaError, Result};
@@ -61,6 +62,18 @@ pub struct InMemoryClusterState {
     heartbeats: DashMap<String, ExecutorHeartbeat>,
     /// Broadcast sender for cluster state change events.
     cluster_event_sender: ClusterEventSender<ClusterStateEvent>,
+}
+
+impl InMemoryClusterState {
+    /// Creating new cluster state in memory from the scheduler's config
+    pub fn new(config: &SchedulerConfig) -> Self {
+        Self {
+            cluster_event_sender: ClusterEventSender::new(
+                config.event_sender_buffer_capacity,
+            ),
+            ..Default::default()
+        }
+    }
 }
 
 #[async_trait]

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -93,9 +93,10 @@ impl BallistaCluster {
         scheduler: impl Into<String>,
         session_builder: SessionBuilder,
         config_producer: ConfigProducer,
+        scheduler_config: &SchedulerConfig,
     ) -> Self {
         Self {
-            cluster_state: Arc::new(InMemoryClusterState::default()),
+            cluster_state: Arc::new(InMemoryClusterState::new(scheduler_config)),
             job_state: Arc::new(InMemoryJobState::new(
                 scheduler,
                 session_builder,
@@ -122,6 +123,7 @@ impl BallistaCluster {
             scheduler,
             session_builder,
             config_producer,
+            config,
         ))
     }
 

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -187,6 +187,13 @@ pub struct Config {
         help = "Number of attempts before stage is considered failed."
     )]
     pub stage_max_failures: usize,
+    /// Cluster's event sender buffer capacity
+    #[arg(
+        long,
+        default_value_t = 256,
+        help = "Cluster's event sender buffer capacity."
+    )]
+    pub event_sender_buffer_capacity: usize,
     #[cfg(feature = "rest-api")]
     /// Should the rest api be disabled
     #[arg(
@@ -253,6 +260,8 @@ pub struct SchedulerConfig {
     pub task_max_failures: usize,
     /// Number of failures attempts before stage is considered failed
     pub stage_max_failures: usize,
+    /// Cluster's event sender buffer capacity
+    pub event_sender_buffer_capacity: usize,
     #[cfg(feature = "rest-api")]
     /// Should the rest api be disabled
     pub disable_rest_api: bool,
@@ -286,6 +295,7 @@ impl Default for SchedulerConfig {
             use_tls: false,
             task_max_failures: 4,
             stage_max_failures: 4,
+            event_sender_buffer_capacity: 256,
             #[cfg(feature = "rest-api")]
             disable_rest_api: false,
         }
@@ -427,6 +437,7 @@ impl SchedulerConfig {
 
 /// Policy of distributing tasks to available executor slots
 ///
+/// Is this enum necessary? Seems like an older copy of the TaskDistributionPolicy
 #[derive(Clone, Copy, Debug, serde::Deserialize, Default)]
 #[cfg_attr(feature = "build-binary", derive(clap::ValueEnum))]
 pub enum TaskDistribution {
@@ -514,6 +525,7 @@ impl TryFrom<Config> for SchedulerConfig {
             use_tls: false,
             task_max_failures: opt.task_max_failures,
             stage_max_failures: opt.stage_max_failures,
+            event_sender_buffer_capacity: opt.event_sender_buffer_capacity,
             #[cfg(feature = "rest-api")]
             disable_rest_api: opt.disable_rest_api,
         };

--- a/ballista/scheduler/src/standalone.rs
+++ b/ballista/scheduler/src/standalone.rs
@@ -81,8 +81,12 @@ pub async fn new_standalone_scheduler_with_builder(
 ) -> Result<SocketAddr> {
     let config = config_producer();
 
-    let cluster =
-        BallistaCluster::new_memory("localhost:50050", session_builder, config_producer);
+    let cluster = BallistaCluster::new_memory(
+        "localhost:50050",
+        session_builder,
+        config_producer,
+        &SchedulerConfig::default(),
+    );
 
     let metrics_collector = default_metrics_collector()?;
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -136,6 +136,7 @@ pub fn test_cluster_context() -> BallistaCluster {
         TEST_SCHEDULER_NAME,
         Arc::new(default_session_builder),
         Arc::new(default_config_producer),
+        &SchedulerConfig::default(),
     )
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change
Improving Scheduler's configuration when setting up the Ballista cluster

# What changes are included in this PR?
Moving the buffer capacity of the cluster's event sender to the config rather than a separate constant

# Are there any user-facing changes?
Yes, another CLA added: `--event-sender-buffer-capacity`