### PR TITLE
docs: add Python client build-from-source section to contributor guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ logs/
 # Claude Code guidance file (local only)
 CLAUDE.md
 .claude/
+
+# git worktrees (local only)
+.worktrees/

--- a/docs/source/contributors-guide/development.md
+++ b/docs/source/contributors-guide/development.md
@@ -66,6 +66,82 @@ cd examples
 cargo run --example standalone_sql --features=ballista/standalone
 ```
 
+## Building the Python Client from Source
+
+The Python client (`ballista` on PyPI) lives in the `python/` directory and is versioned and released
+independently from the main Ballista project, so it is intentionally not part of the default Cargo
+workspace. Building it from source uses [maturin](https://www.maturin.rs/) to compile the Rust
+extension module and install it into a Python virtual environment.
+
+### Prerequisites
+
+- Python 3.8 or newer
+- The Rust toolchain (see [Development Environment](#development-environment))
+- [`protoc`](https://protobuf.dev/downloads/) on your `PATH`
+
+All commands in this section are run from the `python/` directory:
+
+```shell
+cd python
+```
+
+### Create a virtual environment
+
+Using `pip`:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
+```
+
+Using [`uv`](https://docs.astral.sh/uv/):
+
+```shell
+uv sync --dev --no-install-package ballista
+```
+
+### Build and install
+
+`maturin develop` compiles the Rust extension and installs it into the active virtual environment
+as an editable package, so subsequent Python imports pick up your local changes.
+
+Using `pip`:
+
+```shell
+maturin develop            # debug build
+maturin develop --release  # release build (slower to compile, faster at runtime)
+```
+
+Using `uv`:
+
+```shell
+uv run --no-project maturin develop --uv
+```
+
+To produce a wheel without installing it (for example, to share or publish):
+
+```shell
+uv run --no-project maturin build --release --strip
+```
+
+### Run the tests
+
+Using `pip`:
+
+```shell
+python3 -m pytest
+```
+
+Using `uv`:
+
+```shell
+uv run --no-project pytest
+```
+
+For more detail on the underlying workflow, including tips for improving build speed, see the
+[DataFusion Python contributor guide](https://datafusion.apache.org/python/contributor-guide/introduction.html).
+
 ## Benchmarking
 
 For performance testing and benchmarking with TPC-H and other datasets, see the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md).

--- a/docs/source/contributors-guide/development.md
+++ b/docs/source/contributors-guide/development.md
@@ -75,7 +75,7 @@ extension module and install it into a Python virtual environment.
 
 ### Prerequisites
 
-- Python 3.8 or newer
+- Python 3.10 or newer
 - The Rust toolchain (see [Development Environment](#development-environment))
 - [`protoc`](https://protobuf.dev/downloads/) on your `PATH`
 
@@ -92,8 +92,12 @@ Using `pip`:
 ```shell
 python3 -m venv .venv
 source .venv/bin/activate
+pip3 install --upgrade pip
 pip3 install -r requirements.txt
 ```
+
+The `pip` upgrade is required because `maturin develop` invokes `pip install --group`, which
+needs pip 25.1 or newer. The pip shipped with `python3 -m venv` is often older than that.
 
 Using [`uv`](https://docs.astral.sh/uv/):
 


### PR DESCRIPTION
# Which issue does this PR close?

<!-- No linked issue. -->

# Rationale for this change

The contributor guide explains how to build the Rust workspace but doesn't mention the Python client (`python/`), which is intentionally outside the default Cargo workspace and uses a separate `maturin`-based workflow. New contributors landing on the contributor guide currently have no pointer to those steps and have to discover the `python/README.md` on their own.

# What changes are included in this PR?

Adds a "Building the Python Client from Source" section to `docs/source/contributors-guide/development.md` covering:

- Prerequisites (Python, Rust toolchain, `protoc`)
- Creating a virtual environment with both `pip` and `uv`
- Building and installing via `maturin develop` (debug and release)
- Building a wheel without installing
- Running the Python test suite
- A pointer to the DataFusion Python contributor guide for deeper detail

The content mirrors the existing `python/README.md` but presents it in the place a new contributor is most likely to look first.

# Are there any user-facing changes?

Documentation only. No code changes.