### PR TITLE
feat(executor): bound executor memory via --memory-pool-size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ logs/
 # Claude Code guidance file (local only)
 CLAUDE.md
 .claude/
+
+# git worktrees (local only)
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "ballista-core",
+ "bytesize",
  "clap 4.6.1",
  "dashmap",
  "datafusion",
@@ -1420,6 +1421,12 @@ dependencies = [
  "bytes",
  "either",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "bzip2"

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -43,6 +43,7 @@ arrow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 ballista-core = { path = "../core", version = "53.0.0" }
+bytesize = "2"
 clap = { workspace = true, optional = true }
 dashmap = { workspace = true }
 datafusion = { workspace = true }

--- a/ballista/executor/src/config.rs
+++ b/ballista/executor/src/config.rs
@@ -179,6 +179,7 @@ impl TryFrom<Config> for ExecutorProcessConfig {
             grpc_server_config: ballista_core::utils::GrpcServerConfig::default(),
             executor_heartbeat_interval_seconds: opt.executor_heartbeat_interval_seconds,
             metric_collection_policy: opt.metric_collection_policy,
+            memory_pool_size: None,
             override_execution_engine: None,
             override_function_registry: None,
             override_config_producer: None,

--- a/ballista/executor/src/config.rs
+++ b/ballista/executor/src/config.rs
@@ -173,34 +173,6 @@ pub struct Config {
     pub memory_pool_size: Option<u64>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::parse_memory_pool_size;
-
-    #[test]
-    fn parse_decimal_suffix() {
-        assert_eq!(parse_memory_pool_size("8GB").unwrap(), 8_000_000_000);
-        assert_eq!(parse_memory_pool_size("1KB").unwrap(), 1_000);
-    }
-
-    #[test]
-    fn parse_binary_suffix() {
-        assert_eq!(parse_memory_pool_size("512MiB").unwrap(), 512 * 1024 * 1024);
-        assert_eq!(parse_memory_pool_size("1KiB").unwrap(), 1024);
-    }
-
-    #[test]
-    fn parse_plain_integer_is_bytes() {
-        assert_eq!(parse_memory_pool_size("1024").unwrap(), 1024);
-    }
-
-    #[test]
-    fn parse_rejects_invalid() {
-        assert!(parse_memory_pool_size("banana").is_err());
-        assert!(parse_memory_pool_size("").is_err());
-    }
-}
-
 impl TryFrom<Config> for ExecutorProcessConfig {
     type Error = BallistaError;
 
@@ -237,5 +209,33 @@ impl TryFrom<Config> for ExecutorProcessConfig {
             override_arrow_flight_service: None,
             override_create_grpc_client_endpoint: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_memory_pool_size;
+
+    #[test]
+    fn parse_decimal_suffix() {
+        assert_eq!(parse_memory_pool_size("8GB").unwrap(), 8_000_000_000);
+        assert_eq!(parse_memory_pool_size("1KB").unwrap(), 1_000);
+    }
+
+    #[test]
+    fn parse_binary_suffix() {
+        assert_eq!(parse_memory_pool_size("512MiB").unwrap(), 512 * 1024 * 1024);
+        assert_eq!(parse_memory_pool_size("1KiB").unwrap(), 1024);
+    }
+
+    #[test]
+    fn parse_plain_integer_is_bytes() {
+        assert_eq!(parse_memory_pool_size("1024").unwrap(), 1024);
+    }
+
+    #[test]
+    fn parse_rejects_invalid() {
+        assert!(parse_memory_pool_size("banana").is_err());
+        assert!(parse_memory_pool_size("").is_err());
     }
 }

--- a/ballista/executor/src/config.rs
+++ b/ballista/executor/src/config.rs
@@ -31,6 +31,17 @@ use ballista_core::error::BallistaError;
 use crate::executor_process::ExecutorProcessConfig;
 use crate::metrics::ExecutorMetricCollectionPolicy;
 
+/// Parse a human-readable size string into a byte count.
+///
+/// Accepts decimal SI suffixes (`KB`, `MB`, `GB`) where 1KB = 1000 bytes,
+/// binary IEC suffixes (`KiB`, `MiB`, `GiB`) where 1KiB = 1024 bytes, and
+/// plain integers (interpreted as bytes).
+fn parse_memory_pool_size(s: &str) -> Result<u64, String> {
+    s.parse::<bytesize::ByteSize>()
+        .map(|b| b.as_u64())
+        .map_err(|e| format!("invalid byte size '{s}': {e}"))
+}
+
 /// Command-line arguments for configuring a Ballista executor.
 ///
 /// This struct is parsed from command-line arguments using clap and contains
@@ -151,6 +162,43 @@ pub struct Config {
         help = "Metric collection policy of this executor instance"
     )]
     pub metric_collection_policy: ExecutorMetricCollectionPolicy,
+    /// Optional total memory budget for the executor. Accepts human-readable
+    /// values like "8GB", "512MiB", or a plain byte count. When set, every
+    /// task gets a FairSpillPool of size `memory_pool_size / concurrent_tasks`.
+    #[arg(
+        long,
+        value_parser = parse_memory_pool_size,
+        help = "Optional total executor memory budget (e.g. \"8GB\", \"512MiB\"). Each concurrent task receives an equal share."
+    )]
+    pub memory_pool_size: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_memory_pool_size;
+
+    #[test]
+    fn parse_decimal_suffix() {
+        assert_eq!(parse_memory_pool_size("8GB").unwrap(), 8_000_000_000);
+        assert_eq!(parse_memory_pool_size("1KB").unwrap(), 1_000);
+    }
+
+    #[test]
+    fn parse_binary_suffix() {
+        assert_eq!(parse_memory_pool_size("512MiB").unwrap(), 512 * 1024 * 1024);
+        assert_eq!(parse_memory_pool_size("1KiB").unwrap(), 1024);
+    }
+
+    #[test]
+    fn parse_plain_integer_is_bytes() {
+        assert_eq!(parse_memory_pool_size("1024").unwrap(), 1024);
+    }
+
+    #[test]
+    fn parse_rejects_invalid() {
+        assert!(parse_memory_pool_size("banana").is_err());
+        assert!(parse_memory_pool_size("").is_err());
+    }
 }
 
 impl TryFrom<Config> for ExecutorProcessConfig {
@@ -179,7 +227,7 @@ impl TryFrom<Config> for ExecutorProcessConfig {
             grpc_server_config: ballista_core::utils::GrpcServerConfig::default(),
             executor_heartbeat_interval_seconds: opt.executor_heartbeat_interval_seconds,
             metric_collection_policy: opt.metric_collection_policy,
-            memory_pool_size: None,
+            memory_pool_size: opt.memory_pool_size,
             override_execution_engine: None,
             override_function_registry: None,
             override_config_producer: None,

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -74,7 +74,8 @@ use crate::shutdown::ShutdownNotifier;
 use crate::{ArrowFlightServerProvider, terminate};
 use crate::{execution_loop, executor_server};
 
-/// Wrap a [`RuntimeProducer`] so that every produced [`RuntimeEnv`] carries a
+/// Wrap a [`RuntimeProducer`] so that every produced
+/// [`RuntimeEnv`](datafusion::execution::runtime_env::RuntimeEnv) carries a
 /// fresh [`FairSpillPool`] of size `total_bytes / concurrent_tasks`.
 ///
 /// Returns an error if the per-task share would be zero (i.e. `total_bytes <

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -41,7 +41,9 @@ use tokio::task::JoinHandle;
 use tokio::{fs, time};
 use uuid::Uuid;
 
+use datafusion::execution::memory_pool::{FairSpillPool, MemoryPool};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::prelude::SessionConfig;
 
 use ballista_core::config::{LogRotationPolicy, TaskSchedulingPolicy};
 use ballista_core::error::BallistaError;
@@ -71,6 +73,33 @@ use crate::shutdown::Shutdown;
 use crate::shutdown::ShutdownNotifier;
 use crate::{ArrowFlightServerProvider, terminate};
 use crate::{execution_loop, executor_server};
+
+/// Wrap a [`RuntimeProducer`] so that every produced [`RuntimeEnv`] carries a
+/// fresh [`FairSpillPool`] of size `total_bytes / concurrent_tasks`.
+///
+/// Returns an error if the per-task share would be zero (i.e. `total_bytes <
+/// concurrent_tasks`). The inner env's disk manager, cache manager, and
+/// object store registry are preserved via [`RuntimeEnvBuilder::from_runtime_env`].
+#[allow(dead_code)]
+pub(crate) fn wrap_runtime_producer_with_memory_pool(
+    inner: RuntimeProducer,
+    total_bytes: u64,
+    concurrent_tasks: usize,
+) -> Result<RuntimeProducer, BallistaError> {
+    let per_task = (total_bytes / concurrent_tasks as u64) as usize;
+    if per_task == 0 {
+        return Err(BallistaError::Configuration(format!(
+            "memory_pool_size ({total_bytes} bytes) is smaller than concurrent_tasks ({concurrent_tasks})"
+        )));
+    }
+    Ok(Arc::new(move |session_config: &SessionConfig| {
+        let inner_env = inner(session_config)?;
+        let pool: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(per_task));
+        RuntimeEnvBuilder::from_runtime_env(&inner_env)
+            .with_memory_pool(pool)
+            .build_arc()
+    }))
+}
 
 /// Configuration for the executor process.
 ///
@@ -932,5 +961,65 @@ mod tests {
             fs::create_dir(&path).unwrap();
         }
         path
+    }
+}
+
+#[cfg(test)]
+mod memory_pool_tests {
+    use super::*;
+    use datafusion::execution::memory_pool::MemoryLimit;
+    use datafusion::execution::object_store::DefaultObjectStoreRegistry;
+    use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+    use std::sync::Arc;
+
+    fn baseline_producer() -> RuntimeProducer {
+        Arc::new(|_| Ok(Arc::new(RuntimeEnv::default())))
+    }
+
+    #[test]
+    fn returns_error_when_total_smaller_than_concurrent_tasks() {
+        let inner = baseline_producer();
+        let result = wrap_runtime_producer_with_memory_pool(inner, 4, 8);
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
+        assert!(msg.contains("memory_pool_size"));
+        assert!(msg.contains("concurrent_tasks"));
+    }
+
+    #[test]
+    fn produces_runtime_with_fair_spill_pool_of_per_task_size() {
+        let total = 8u64 * 1024 * 1024 * 1024;
+        let concurrent = 8usize;
+        let expected_per_task = (total / concurrent as u64) as usize;
+
+        let wrapped =
+            wrap_runtime_producer_with_memory_pool(baseline_producer(), total, concurrent)
+                .unwrap();
+        let env = wrapped(&SessionConfig::new()).unwrap();
+
+        match env.memory_pool.memory_limit() {
+            MemoryLimit::Finite(n) => assert_eq!(n, expected_per_task),
+            MemoryLimit::Infinite => panic!("expected Finite limit, got Infinite"),
+            MemoryLimit::Unknown => panic!("expected Finite limit, got Unknown"),
+        }
+    }
+
+    #[test]
+    fn preserves_inner_object_store_registry() {
+        let registry: Arc<dyn datafusion::execution::object_store::ObjectStoreRegistry> =
+            Arc::new(DefaultObjectStoreRegistry::new());
+        let registry_for_inner = registry.clone();
+        let inner: RuntimeProducer = Arc::new(move |_| {
+            let env = RuntimeEnvBuilder::new()
+                .with_object_store_registry(registry_for_inner.clone())
+                .build()?;
+            Ok(Arc::new(env))
+        });
+
+        let wrapped =
+            wrap_runtime_producer_with_memory_pool(inner, 1024, 1).unwrap();
+        let env = wrapped(&SessionConfig::new()).unwrap();
+
+        assert!(Arc::ptr_eq(&env.object_store_registry, &registry));
     }
 }

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -120,6 +120,11 @@ pub struct ExecutorProcessConfig {
     pub executor_heartbeat_interval_seconds: u64,
     /// Metric collection policy of this executor instance
     pub metric_collection_policy: ExecutorMetricCollectionPolicy,
+    /// Optional total memory pool size in bytes. When set, every task's
+    /// runtime env receives a FairSpillPool of size
+    /// `memory_pool_size / concurrent_tasks`. When `None`, no pool is
+    /// installed and DataFusion falls back to its unbounded default.
+    pub memory_pool_size: Option<u64>,
     /// Optional execution engine to use to execute physical plans, will default to
     /// DataFusion if none is provided.
     pub override_execution_engine: Option<Arc<dyn ExecutionEngine>>,
@@ -176,6 +181,7 @@ impl Default for ExecutorProcessConfig {
             grpc_server_config: Default::default(),
             executor_heartbeat_interval_seconds: 60,
             metric_collection_policy: ExecutorMetricCollectionPolicy::default(),
+            memory_pool_size: None,
             override_execution_engine: None,
             override_function_registry: None,
             override_runtime_producer: None,

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -80,8 +80,7 @@ use crate::{execution_loop, executor_server};
 /// Returns an error if the per-task share would be zero (i.e. `total_bytes <
 /// concurrent_tasks`). The inner env's disk manager, cache manager, and
 /// object store registry are preserved via [`RuntimeEnvBuilder::from_runtime_env`].
-#[allow(dead_code)]
-pub(crate) fn wrap_runtime_producer_with_memory_pool(
+fn wrap_runtime_producer_with_memory_pool(
     inner: RuntimeProducer,
     total_bytes: u64,
     concurrent_tasks: usize,
@@ -295,6 +294,21 @@ pub async fn start_executor_process(
                 Ok(Arc::new(runtime_env))
             })
         });
+
+    let runtime_producer = if let Some(total) = opt.memory_pool_size {
+        let producer = wrap_runtime_producer_with_memory_pool(
+            runtime_producer,
+            total,
+            concurrent_tasks,
+        )?;
+        let per_task = total / concurrent_tasks as u64;
+        info!(
+            "Memory pool: total {total} bytes split into {concurrent_tasks} tasks ({per_task} bytes each)"
+        );
+        producer
+    } else {
+        runtime_producer
+    };
 
     let logical = opt
         .override_logical_codec
@@ -992,9 +1006,12 @@ mod memory_pool_tests {
         let concurrent = 8usize;
         let expected_per_task = (total / concurrent as u64) as usize;
 
-        let wrapped =
-            wrap_runtime_producer_with_memory_pool(baseline_producer(), total, concurrent)
-                .unwrap();
+        let wrapped = wrap_runtime_producer_with_memory_pool(
+            baseline_producer(),
+            total,
+            concurrent,
+        )
+        .unwrap();
         let env = wrapped(&SessionConfig::new()).unwrap();
 
         match env.memory_pool.memory_limit() {
@@ -1016,8 +1033,7 @@ mod memory_pool_tests {
             Ok(Arc::new(env))
         });
 
-        let wrapped =
-            wrap_runtime_producer_with_memory_pool(inner, 1024, 1).unwrap();
+        let wrapped = wrap_runtime_producer_with_memory_pool(inner, 1024, 1).unwrap();
         let env = wrapped(&SessionConfig::new()).unwrap();
 
         assert!(Arc::ptr_eq(&env.object_store_registry, &registry));

--- a/docs/source/user-guide/tuning-guide.md
+++ b/docs/source/user-guide/tuning-guide.md
@@ -63,8 +63,33 @@ Increasing this configuration setting will increase the number of tasks that eac
 this will also mean that the executor will use more memory. If executors are failing due to out-of-memory errors then
 decreasing the number of concurrent tasks may help.
 
-In the future, Ballista will have better support for tracking memory usage and allocating tasks based on available
-memory, as well as supporting spill-to-disk to reduce memory pressure.
+## Configuring Executor Memory Pool
+
+By default the executor uses DataFusion's unbounded memory pool, so spillable
+operators (sort, hash join, hash aggregate) grow until the host runs out of
+memory. To bound executor memory and let those operators spill to disk under
+pressure, pass `--memory-pool-size` when starting the executor:
+
+```sh
+ballista-executor --memory-pool-size 8GB --concurrent-tasks 8
+```
+
+The argument accepts human-readable sizes (`8GB`, `512MiB`) or a plain byte
+count. SI suffixes (`KB`/`MB`/`GB`) are powers of 10; IEC suffixes
+(`KiB`/`MiB`/`GiB`) are powers of 2.
+
+The total budget is divided equally across concurrent task slots: each task
+receives its own `FairSpillPool` of size `memory_pool_size / concurrent_tasks`.
+With `--memory-pool-size 8GB --concurrent-tasks 8`, every task sees a 1 GB
+pool, fully isolated from other tasks. Idle slots do not lend their share to
+busy ones, which keeps task memory predictable at the cost of some unused
+capacity when the executor is under-utilized.
+
+The executor refuses to start if the per-task share would round to zero (i.e.
+`memory_pool_size < concurrent_tasks`).
+
+When `--memory-pool-size` is not set, the executor behaves as before with no
+memory pool installed.
 
 ## Shuffle Implementation
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1563

# Rationale for this change

The executor today builds a `RuntimeEnv` with no `MemoryPool`, so DataFusion uses its unbounded default and spillable operators (sort, hash join, hash agg) grow until the host OOMs. There is no way to bound executor memory or trigger spilling. The `tuning-guide.md` already flagged this as future work.

# What changes are included in this PR?

Adds an opt-in `--memory-pool-size <SIZE>` flag (e.g. `8GB`, `512MiB`, plain bytes) on the executor binary. When set, every task receives an isolated `FairSpillPool` of size `total / concurrent_tasks`. Wrapping is applied after the base `RuntimeProducer` is resolved, so it composes with embedder-supplied producers (including the existing S3 helper) and preserves their `DiskManager`, `CacheManager`, and `ObjectStoreRegistry`. Hard error at startup if the per-task share would round to zero.

Adds `bytesize` as a dep on `ballista-executor` for size parsing. No public API changes outside the executor crate.

# Are there any user-facing changes?

Yes. New optional CLI flag and a new section in `docs/source/user-guide/tuning-guide.md`. Default behavior is unchanged when the flag is omitted.
