### PR TITLE
feat(benchmarks): add --config to tpch datafusion + contributor guide

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -164,6 +164,13 @@ struct DataFusionBenchmarkOpt {
     /// Path to output directory where JSON summary file should be written to
     #[structopt(parse(from_os_str), short = "o", long = "output")]
     output_path: Option<PathBuf>,
+
+    /// Configuration overrides in key=value format.
+    /// Can be specified multiple times, e.g.
+    /// -c datafusion.execution.target_partitions=16
+    /// -c datafusion.execution.batch_size=8192
+    #[structopt(short = "c", long = "config", number_of_values = 1)]
+    config_overrides: Vec<String>,
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -290,9 +297,24 @@ async fn main() -> Result<()> {
 #[allow(clippy::await_holding_lock)]
 async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
     println!("Running benchmarks with the following options: {opt:?}");
-    let config = SessionConfig::new()
+    let mut config = SessionConfig::new()
         .with_target_partitions(opt.partitions)
         .with_batch_size(opt.batch_size);
+
+    for kv in &opt.config_overrides {
+        if let Some((key, value)) = kv.split_once('=') {
+            if let Err(e) = config.options_mut().set(key.trim(), value.trim()) {
+                println!("Warning: could not set config '{}': {}", kv, e);
+            }
+        } else {
+            println!(
+                "Warning: ignoring invalid config override '{}'. \
+                 Expected format: key=value",
+                kv
+            );
+        }
+    }
+
     let ctx = SessionContext::new_with_config(config);
 
     // register tables
@@ -1740,6 +1762,7 @@ mod tests {
                 file_format: "tbl".to_string(),
                 mem_table: false,
                 output_path: None,
+                config_overrides: vec![],
             };
             let actual = benchmark_datafusion(opt).await?;
             let expected_schema = get_answer_schema(n);

--- a/docs/source/contributors-guide/benchmarking.md
+++ b/docs/source/contributors-guide/benchmarking.md
@@ -50,6 +50,32 @@ To run against a real Ballista cluster, use `benchmark ballista` and pass `--hos
 
 While iterating, pick a representative single query rather than running the full suite. Common picks: `--query 1` (aggregation-heavy), `--query 5` (joins), `--query 22` (correlated subquery). Use `--iterations 3` so you can look at min/avg/max and ignore the first cold run.
 
+## Setting session configs
+
+Both subcommands accept repeatable `-c key=value` (or `--config key=value`) flags to override DataFusion or Ballista session config keys. Each occurrence of `-c` overrides one key:
+
+```shell
+cargo run --release --bin tpch -- benchmark datafusion \
+    --query 1 --path /tmp/tpch-sf10 --format parquet --iterations 3 \
+    -c datafusion.execution.target_partitions=16 \
+    -c datafusion.execution.batch_size=16384
+```
+
+Common keys worth tuning when benchmarking:
+
+| Key | Effect |
+|-----|--------|
+| `datafusion.execution.target_partitions` | Number of partitions DataFusion uses for parallel execution |
+| `datafusion.execution.batch_size` | Rows per batch flowing through operators |
+| `datafusion.execution.collect_statistics` | Whether to collect file-level statistics during planning |
+| `ballista.shuffle.sort_based.enabled` | Use the sort-based shuffle writer (default: true) |
+| `ballista.shuffle.sort_based.batch_size` | Rows per batch when materializing buffered shuffle output |
+| `ballista.shuffle.max_concurrent_read_requests` | Concurrent shuffle-read requests per executor |
+
+`benchmark ballista` propagates these to the executors via the session config, so an override set on the client takes effect on the workers. `benchmark datafusion` applies them to the in-process `SessionContext` directly.
+
+Unknown keys are skipped with a `Warning: could not set config '...'` message rather than failing the run, so check stdout if a config you set seems to have no effect.
+
 ## Reading metrics
 
 The TPC-H binary prints per-iteration timings and per-query results. For a deeper look at where time is going inside a stage, ask DataFusion for the executed physical plan with metrics. The scheduler's REST API exposes per-stage metrics for distributed runs, and an explain plan with `analyze` shows them for the in-process runs. The [Metrics user guide](../user-guide/metrics.md) lists what each metric name means.

--- a/docs/source/contributors-guide/benchmarking.md
+++ b/docs/source/contributors-guide/benchmarking.md
@@ -1,0 +1,175 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Benchmarking
+
+This page is a guide for contributors who want to measure the performance of a change, hunt down a regression, or compare Ballista against another engine. It covers what each benchmark in the repo is for, how to run it, how to read the output, and how to profile when something is unexpectedly slow.
+
+The comprehensive setup notes for end-to-end TPC-H runs (data generation, docker-compose, Spark comparison) live in the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md). This page focuses on the contributor workflow.
+
+## Choosing the right benchmark
+
+| Goal | Benchmark | Where it lives |
+|------|-----------|----------------|
+| End-to-end query latency on TPC-H | `tpch` binary | `benchmarks/src/bin/tpch.rs` |
+| End-to-end on a real-world dataset | `nyctaxi` binary | `benchmarks/src/bin/nyctaxi.rs` |
+| Single-component shuffle write timing on Parquet input | `shuffle_bench` binary | `benchmarks/src/bin/shuffle_bench.rs` |
+| Repeatable micro-benchmark for sort-shuffle (Criterion) | `sort_shuffle` Criterion bench | `benchmarks/benches/sort_shuffle.rs` |
+
+A rough decision guide:
+
+- **End-to-end SQL workloads.** If you are evaluating planner, scheduler, or whole-query changes, run the TPC-H binary. Pick a representative query rather than the full suite while iterating.
+- **Hunting a perf regression in a single operator.** Use the closest binary or Criterion bench. The standalone shuffle binary is the right tool for shuffle-write changes because it isolates that stage from query planning, scheduling, and Flight transport.
+- **Verifying a fix landed without regressing baseline.** Run the Criterion bench before and after with `--save-baseline` / `--baseline`. Criterion produces statistical confidence intervals, which the binaries do not.
+
+## Generating TPC-H input
+
+Both `tpch` and `shuffle_bench` need TPC-H Parquet files. Generate them with [tpchgen-rs](https://github.com/clflushopt/tpchgen-rs):
+
+```shell
+cargo install tpchgen-cli
+tpchgen-cli -s 10 --format parquet --output-dir /tmp/tpch-sf10
+```
+
+Increase `-s` for larger scale factors (each unit is ~1 GB of raw input). Use SF=1 for fast iteration, SF=10 or SF=100 to see meaningful throughput numbers.
+
+## Running TPC-H
+
+The full TPC-H runner lives in `benchmarks/src/bin/tpch.rs`. To run against an in-process DataFusion (no scheduler, no executor), use the `datafusion` subcommand:
+
+```shell
+cargo run --release --bin tpch -- benchmark datafusion \
+    --query 1 \
+    --path /tmp/tpch-sf10 \
+    --format parquet \
+    --iterations 3
+```
+
+To run against a real Ballista cluster, use `benchmark ballista` and pass `--host`/`--port` for the scheduler. See the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md) for the full distributed setup, including docker-compose and Spark comparison.
+
+## Standalone shuffle benchmark
+
+`shuffle_bench` drives the shuffle writer end-to-end on a Parquet input without going through the scheduler, which makes it the fastest way to iterate on shuffle-side changes and to capture flame graphs.
+
+```shell
+cargo run --release --bin shuffle_bench -- \
+    --input /tmp/tpch-sf10/lineitem \
+    --writer sort \
+    --partitions 200 \
+    --hash-columns 0
+```
+
+Useful flags:
+
+- `--writer hash|sort` selects the hash-based or sort-based shuffle writer.
+- `--memory-limit <bytes>` sets the runtime memory pool. With the sort writer this controls when spilling kicks in. Leave unset for an in-memory run.
+- `--limit <rows>` caps rows read from Parquet, which is handy when iterating without waiting for full SF=10/100.
+- `--iterations N --warmup M` runs `M` warmup iterations followed by `N` timed ones and prints min/avg/max.
+
+The binary calls `env_logger::init()` at startup with a default `info` filter, so the sort-shuffle writer's per-spill log lines appear inline. Override with `RUST_LOG=debug` or `RUST_LOG=ballista_core=trace` for more detail.
+
+## Sort-shuffle Criterion bench
+
+`benchmarks/benches/sort_shuffle.rs` is a synthetic micro-benchmark with a fixed 100-column schema and an in-memory input. It measures sort-shuffle write throughput without I/O variability from Parquet. Run it with:
+
+```shell
+cargo bench --bench sort_shuffle
+```
+
+Use Criterion's baseline support to compare before and after a change:
+
+```shell
+git checkout main
+cargo bench --bench sort_shuffle -- --save-baseline before
+
+git checkout my-feature-branch
+cargo bench --bench sort_shuffle -- --baseline before
+```
+
+The HTML report lands in `target/criterion/`.
+
+## NYC taxi
+
+`benchmarks/src/bin/nyctaxi.rs` runs a small set of analytical queries on the NYC taxi dataset. It is useful for reproducing user-reported issues that surface only on real-world data shapes. See the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md#nyc-taxi-benchmark) for download instructions.
+
+## Reading metrics
+
+Both binaries print DataFusion `ExecutionPlan` metrics for the last timed iteration. The shuffle binary's output for a sort-writer run looks like:
+
+```
+Shuffle metrics (last iteration):
+  input_rows: 1000000
+  output_rows: 1000000
+  repart_time: 0.007s (0.1%)
+  write_time: 0.323s (66.2%)
+  spill_time: 0.000s (0.0%)
+  spill_count: 0
+  spill_bytes: 0
+```
+
+What to look at:
+
+- **`input_rows` / `output_rows`** must match. A mismatch indicates rows were dropped or duplicated.
+- **`write_time` percentage** is the share of wall-clock spent in IPC encoding plus disk write. A value near 100% on an unspilled run usually means the materialized batches are larger than they should be (e.g. uncompacted view arrays).
+- **`spill_count`** counts spill events (one per memory-pressure flush), not per-partition batches. `spill_bytes` is the in-memory size of what was spilled, before compression.
+- **`repart_time`** is the per-row hash partitioning cost. If this dominates, the regression is in `compute_partition_indices`, not the writer.
+
+For end-to-end TPC-H runs, the per-stage metrics are accessible via the scheduler's REST API and via the explain plan. The [Metrics user guide](../user-guide/metrics.md) lists what each metric means.
+
+## Profiling
+
+When the binaries surface a slow path, capture a CPU profile to find the hot function. Both `cargo flamegraph` and `samply` work well for native Ballista code.
+
+### cargo flamegraph
+
+```shell
+cargo install flamegraph
+
+cargo flamegraph --release --bin shuffle_bench -- \
+    --input /tmp/tpch-sf10/lineitem \
+    --writer sort --partitions 200 --hash-columns 0
+```
+
+The SVG opens in a browser. Click into stack frames to drill down. On Linux, `flamegraph` requires `perf` and may need `kernel.perf_event_paranoid` lowered. On macOS it uses `dtrace`, which needs `sudo`.
+
+### samply
+
+[samply](https://github.com/mstange/samply) is a cross-platform alternative that uses the Firefox profiler UI. Build with debuginfo, then:
+
+```shell
+cargo install samply
+
+cargo build --release --bin shuffle_bench
+samply record ./target/release/shuffle_bench \
+    --input /tmp/tpch-sf10/lineitem \
+    --writer sort --partitions 200 --hash-columns 0
+```
+
+samply opens a browser with the loaded profile. The flame graph view is similar to `cargo flamegraph`, with the addition of a timeline that's helpful for spotting tail-latency events like spills.
+
+### Tips for useful profiles
+
+- Build with `--release` so the profile reflects production performance. Debug builds inline differently and produce misleading hot spots.
+- Add `[profile.release] debug = "line-tables-only"` (or `debug = true`) to `Cargo.toml` if symbols are missing in the flame graph.
+- Start with a short input (e.g. `--limit 1000000`) so the profile finishes quickly. Hot paths show up just as clearly with 1M rows as with 100M.
+- If a single iteration is too short to sample reliably, use `--iterations 5 --warmup 1`.
+
+## Writing new benchmarks
+
+When adding a new benchmark, prefer a Criterion bench in `benchmarks/benches/` for anything that can be exercised on synthetic in-memory input. Reserve a binary in `benchmarks/src/bin/` for cases that need real Parquet files, end-to-end orchestration, or external configuration. Keep the synthetic data generator deterministic (seeded RNG) so results are reproducible across runs.

--- a/docs/source/contributors-guide/benchmarking.md
+++ b/docs/source/contributors-guide/benchmarking.md
@@ -28,7 +28,6 @@ The comprehensive setup notes for end-to-end TPC-H runs (data generation, docker
 | Goal | Benchmark | Where it lives |
 |------|-----------|----------------|
 | End-to-end query latency on TPC-H | `tpch` binary | `benchmarks/src/bin/tpch.rs` |
-| End-to-end on a real-world dataset | `nyctaxi` binary | `benchmarks/src/bin/nyctaxi.rs` |
 | Single-component shuffle write timing on Parquet input | `shuffle_bench` binary | `benchmarks/src/bin/shuffle_bench.rs` |
 | Repeatable micro-benchmark for sort-shuffle (Criterion) | `sort_shuffle` Criterion bench | `benchmarks/benches/sort_shuffle.rs` |
 
@@ -103,10 +102,6 @@ cargo bench --bench sort_shuffle -- --baseline before
 ```
 
 The HTML report lands in `target/criterion/`.
-
-## NYC taxi
-
-`benchmarks/src/bin/nyctaxi.rs` runs a small set of analytical queries on the NYC taxi dataset. It is useful for reproducing user-reported issues that surface only on real-world data shapes. See the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md#nyc-taxi-benchmark) for download instructions.
 
 ## Reading metrics
 

--- a/docs/source/contributors-guide/benchmarking.md
+++ b/docs/source/contributors-guide/benchmarking.md
@@ -19,27 +19,13 @@
 
 # Benchmarking
 
-This page is a guide for contributors who want to measure the performance of a change, hunt down a regression, or compare Ballista against another engine. It covers what each benchmark in the repo is for, how to run it, how to read the output, and how to profile when something is unexpectedly slow.
+This page is a guide for contributors who want to measure the performance of a change against TPC-H, hunt down a regression, or compare Ballista against another engine. It covers how to generate input data, how to run the TPC-H benchmark binary against in-process DataFusion or against a Ballista cluster, how to read the metrics, and how to profile when something is unexpectedly slow.
 
-The comprehensive setup notes for end-to-end TPC-H runs (data generation, docker-compose, Spark comparison) live in the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md). This page focuses on the contributor workflow.
-
-## Choosing the right benchmark
-
-| Goal | Benchmark | Where it lives |
-|------|-----------|----------------|
-| End-to-end query latency on TPC-H | `tpch` binary | `benchmarks/src/bin/tpch.rs` |
-| Single-component shuffle write timing on Parquet input | `shuffle_bench` binary | `benchmarks/src/bin/shuffle_bench.rs` |
-| Repeatable micro-benchmark for sort-shuffle (Criterion) | `sort_shuffle` Criterion bench | `benchmarks/benches/sort_shuffle.rs` |
-
-A rough decision guide:
-
-- **End-to-end SQL workloads.** If you are evaluating planner, scheduler, or whole-query changes, run the TPC-H binary. Pick a representative query rather than the full suite while iterating.
-- **Hunting a perf regression in a single operator.** Use the closest binary or Criterion bench. The standalone shuffle binary is the right tool for shuffle-write changes because it isolates that stage from query planning, scheduling, and Flight transport.
-- **Verifying a fix landed without regressing baseline.** Run the Criterion bench before and after with `--save-baseline` / `--baseline`. Criterion produces statistical confidence intervals, which the binaries do not.
+The comprehensive setup notes for end-to-end TPC-H runs (docker-compose, Spark comparison, load testing) live in the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md). This page focuses on the contributor workflow.
 
 ## Generating TPC-H input
 
-Both `tpch` and `shuffle_bench` need TPC-H Parquet files. Generate them with [tpchgen-rs](https://github.com/clflushopt/tpchgen-rs):
+Generate TPC-H Parquet files with [tpchgen-rs](https://github.com/clflushopt/tpchgen-rs):
 
 ```shell
 cargo install tpchgen-cli
@@ -50,7 +36,7 @@ Increase `-s` for larger scale factors (each unit is ~1 GB of raw input). Use SF
 
 ## Running TPC-H
 
-The full TPC-H runner lives in `benchmarks/src/bin/tpch.rs`. To run against an in-process DataFusion (no scheduler, no executor), use the `datafusion` subcommand:
+The TPC-H runner lives in `benchmarks/src/bin/tpch.rs`. To run against an in-process DataFusion (no scheduler, no executor), use the `datafusion` subcommand:
 
 ```shell
 cargo run --release --bin tpch -- benchmark datafusion \
@@ -62,98 +48,49 @@ cargo run --release --bin tpch -- benchmark datafusion \
 
 To run against a real Ballista cluster, use `benchmark ballista` and pass `--host`/`--port` for the scheduler. See the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md) for the full distributed setup, including docker-compose and Spark comparison.
 
-## Standalone shuffle benchmark
-
-`shuffle_bench` drives the shuffle writer end-to-end on a Parquet input without going through the scheduler, which makes it the fastest way to iterate on shuffle-side changes and to capture flame graphs.
-
-```shell
-cargo run --release --bin shuffle_bench -- \
-    --input /tmp/tpch-sf10/lineitem \
-    --writer sort \
-    --partitions 200 \
-    --hash-columns 0
-```
-
-Useful flags:
-
-- `--writer hash|sort` selects the hash-based or sort-based shuffle writer.
-- `--memory-limit <bytes>` sets the runtime memory pool. With the sort writer this controls when spilling kicks in. Leave unset for an in-memory run.
-- `--limit <rows>` caps rows read from Parquet, which is handy when iterating without waiting for full SF=10/100.
-- `--iterations N --warmup M` runs `M` warmup iterations followed by `N` timed ones and prints min/avg/max.
-
-The binary calls `env_logger::init()` at startup with a default `info` filter, so the sort-shuffle writer's per-spill log lines appear inline. Override with `RUST_LOG=debug` or `RUST_LOG=ballista_core=trace` for more detail.
-
-## Sort-shuffle Criterion bench
-
-`benchmarks/benches/sort_shuffle.rs` is a synthetic micro-benchmark with a fixed 100-column schema and an in-memory input. It measures sort-shuffle write throughput without I/O variability from Parquet. Run it with:
-
-```shell
-cargo bench --bench sort_shuffle
-```
-
-Use Criterion's baseline support to compare before and after a change:
-
-```shell
-git checkout main
-cargo bench --bench sort_shuffle -- --save-baseline before
-
-git checkout my-feature-branch
-cargo bench --bench sort_shuffle -- --baseline before
-```
-
-The HTML report lands in `target/criterion/`.
+While iterating, pick a representative single query rather than running the full suite. Common picks: `--query 1` (aggregation-heavy), `--query 5` (joins), `--query 22` (correlated subquery). Use `--iterations 3` so you can look at min/avg/max and ignore the first cold run.
 
 ## Reading metrics
 
-Both binaries print DataFusion `ExecutionPlan` metrics for the last timed iteration. The shuffle binary's output for a sort-writer run looks like:
+The TPC-H binary prints per-iteration timings and per-query results. For a deeper look at where time is going inside a stage, ask DataFusion for the executed physical plan with metrics. The scheduler's REST API exposes per-stage metrics for distributed runs, and an explain plan with `analyze` shows them for the in-process runs. The [Metrics user guide](../user-guide/metrics.md) lists what each metric name means.
 
-```
-Shuffle metrics (last iteration):
-  input_rows: 1000000
-  output_rows: 1000000
-  repart_time: 0.007s (0.1%)
-  write_time: 0.323s (66.2%)
-  spill_time: 0.000s (0.0%)
-  spill_count: 0
-  spill_bytes: 0
-```
+What to look at first when chasing a regression:
 
-What to look at:
-
-- **`input_rows` / `output_rows`** must match. A mismatch indicates rows were dropped or duplicated.
-- **`write_time` percentage** is the share of wall-clock spent in IPC encoding plus disk write. A value near 100% on an unspilled run usually means the materialized batches are larger than they should be (e.g. uncompacted view arrays).
-- **`spill_count`** counts spill events (one per memory-pressure flush), not per-partition batches. `spill_bytes` is the in-memory size of what was spilled, before compression.
-- **`repart_time`** is the per-row hash partitioning cost. If this dominates, the regression is in `compute_partition_indices`, not the writer.
-
-For end-to-end TPC-H runs, the per-stage metrics are accessible via the scheduler's REST API and via the explain plan. The [Metrics user guide](../user-guide/metrics.md) lists what each metric means.
+- **`input_rows` / `output_rows`** at each stage. A mismatch usually means a planner change altered semantics, not just performance.
+- **`elapsed_compute`** vs **wall time** at the operator level. A wide gap implies the operator is waiting on input (upstream is the bottleneck), not doing work itself.
+- **Shuffle stage timings** (`write_time`, `spill_count`, `spill_bytes`) when shuffle stages dominate. Spilling has a large effect on tail latency.
 
 ## Profiling
 
-When the binaries surface a slow path, capture a CPU profile to find the hot function. Both `cargo flamegraph` and `samply` work well for native Ballista code.
+When the TPC-H binary surfaces a slow query, capture a CPU profile to find the hot function. Both `cargo flamegraph` and `samply` work well for native Ballista code.
 
 ### cargo flamegraph
 
 ```shell
 cargo install flamegraph
 
-cargo flamegraph --release --bin shuffle_bench -- \
-    --input /tmp/tpch-sf10/lineitem \
-    --writer sort --partitions 200 --hash-columns 0
+cargo flamegraph --release --bin tpch -- benchmark datafusion \
+    --query 1 \
+    --path /tmp/tpch-sf10 \
+    --format parquet \
+    --iterations 3
 ```
 
 The SVG opens in a browser. Click into stack frames to drill down. On Linux, `flamegraph` requires `perf` and may need `kernel.perf_event_paranoid` lowered. On macOS it uses `dtrace`, which needs `sudo`.
 
 ### samply
 
-[samply](https://github.com/mstange/samply) is a cross-platform alternative that uses the Firefox profiler UI. Build with debuginfo, then:
+[samply](https://github.com/mstange/samply) is a cross-platform alternative that uses the Firefox profiler UI.
 
 ```shell
 cargo install samply
 
-cargo build --release --bin shuffle_bench
-samply record ./target/release/shuffle_bench \
-    --input /tmp/tpch-sf10/lineitem \
-    --writer sort --partitions 200 --hash-columns 0
+cargo build --release --bin tpch
+samply record ./target/release/tpch benchmark datafusion \
+    --query 1 \
+    --path /tmp/tpch-sf10 \
+    --format parquet \
+    --iterations 3
 ```
 
 samply opens a browser with the loaded profile. The flame graph view is similar to `cargo flamegraph`, with the addition of a timeline that's helpful for spotting tail-latency events like spills.
@@ -162,9 +99,5 @@ samply opens a browser with the loaded profile. The flame graph view is similar 
 
 - Build with `--release` so the profile reflects production performance. Debug builds inline differently and produce misleading hot spots.
 - Add `[profile.release] debug = "line-tables-only"` (or `debug = true`) to `Cargo.toml` if symbols are missing in the flame graph.
-- Start with a short input (e.g. `--limit 1000000`) so the profile finishes quickly. Hot paths show up just as clearly with 1M rows as with 100M.
-- If a single iteration is too short to sample reliably, use `--iterations 5 --warmup 1`.
-
-## Writing new benchmarks
-
-When adding a new benchmark, prefer a Criterion bench in `benchmarks/benches/` for anything that can be exercised on synthetic in-memory input. Reserve a binary in `benchmarks/src/bin/` for cases that need real Parquet files, end-to-end orchestration, or external configuration. Keep the synthetic data generator deterministic (seeded RNG) so results are reproducible across runs.
+- Start small (SF=1 or SF=10) so the profile finishes quickly. Hot paths show up just as clearly at small scale.
+- If a single iteration is too short to sample reliably, raise `--iterations`.

--- a/docs/source/contributors-guide/development.md
+++ b/docs/source/contributors-guide/development.md
@@ -148,11 +148,4 @@ For more detail on the underlying workflow, including tips for improving build s
 
 ## Benchmarking
 
-For performance testing and benchmarking with TPC-H and other datasets, see the [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md).
-
-This includes instructions for:
-
-- Generating TPC-H test data
-- Running benchmarks against DataFusion and Ballista
-- Comparing performance with Apache Spark
-- Running load tests
+See the [Benchmarking guide](benchmarking.md) for which benchmark to reach for, how to run each one, how to read the metrics they print, and how to capture a flame graph when something is unexpectedly slow. The [benchmarks README](https://github.com/apache/datafusion-ballista/blob/main/benchmarks/README.md) has the comprehensive setup details for end-to-end TPC-H runs and Spark comparison.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,7 @@ Table of content
    contributors-guide/architecture
    contributors-guide/code-organization
    contributors-guide/development
+   contributors-guide/benchmarking
    Source code <https://github.com/apache/datafusion-ballista/>
 
 .. _toc.community:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Two related gaps for contributors who want to benchmark Ballista:

1. The `tpch benchmark datafusion` subcommand has no way to override DataFusion session config keys. The `tpch benchmark ballista` subcommand has had a `-c key=value` flag for this since #1486 era, but the in-process DataFusion path requires editing source to change a single config. That makes apples-to-apples comparisons between the two modes hard.
2. The contributor development guide currently has a one-paragraph `Benchmarking` section that links out to `benchmarks/README.md`. The README covers cluster setup but not the day-to-day contributor workflow: which subcommand to use, how to override configs, how to read the metrics, and how to capture a flame graph when something is unexpectedly slow.

# What changes are included in this PR?

- **Code:** `benchmarks/src/bin/tpch.rs` adds a repeatable `-c`/`--config key=value` flag to the `datafusion` subcommand, mirroring the one already on `ballista`. Overrides are applied to the `SessionConfig` before constructing the `SessionContext`. Invalid keys log a warning and are skipped, matching the existing behavior on the ballista path.
- **Docs:** New page `docs/source/contributors-guide/benchmarking.md` covering:
  - Generating TPC-H input with `tpchgen-rs`
  - Running the `tpch` binary in `benchmark datafusion` (in-process) and `benchmark ballista` (against a cluster) modes, with notes on picking a representative single query while iterating
  - Setting session configs via `-c key=value`, with a table of commonly tuned `datafusion.*` and `ballista.*` keys
  - Reading metrics and a pointer to the existing Metrics user guide
  - Profiling with `cargo flamegraph` and `samply`
- The `Benchmarking` section in `contributors-guide/development.md` now points at the new page and keeps the link to `benchmarks/README.md`
- The new page is registered in the `index.rst` toctree under Contributors Guide

# Are there any user-facing changes?

`tpch benchmark datafusion` accepts a new `-c`/`--config` flag. No existing flags or defaults change, so prior invocations behave the same.