### PR TITLE
fix(sort-shuffle): bound writer memory with per-task spill threshold

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -75,6 +75,10 @@ pub const BALLISTA_SHUFFLE_SORT_BASED_ENABLED: &str =
 /// Configuration key for sort shuffle target batch size in rows.
 pub const BALLISTA_SHUFFLE_SORT_BASED_BATCH_SIZE: &str =
     "ballista.shuffle.sort_based.batch_size";
+/// Configuration key for the per-task buffered-bytes budget at which the
+/// sort shuffle writer spills its in-memory batches to disk.
+pub const BALLISTA_SHUFFLE_SORT_BASED_MEMORY_LIMIT_PER_TASK_BYTES: &str =
+    "ballista.shuffle.sort_based.memory_limit_per_task_bytes";
 
 /// Result type for configuration parsing operations.
 pub type ParseResult<T> = result::Result<T, String>;
@@ -140,6 +144,13 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          "Target batch size in rows for coalescing small batches in sort shuffle".to_string(),
                          DataType::UInt64,
                          Some((8192).to_string())),
+        ConfigEntry::new(BALLISTA_SHUFFLE_SORT_BASED_MEMORY_LIMIT_PER_TASK_BYTES.to_string(),
+                         "Per-task buffered-bytes budget at which the sort shuffle writer spills its \
+                         in-memory batches to disk. Counted independently of the runtime memory pool, so \
+                         spilling kicks in even when the pool is unbounded. Total worst-case sort shuffle \
+                         memory per executor is approximately concurrent_tasks * this value.".to_string(),
+                         DataType::UInt64,
+                         Some((256 * 1024 * 1024).to_string())),
         ConfigEntry::new(BALLISTA_CLIENT_PULL.to_string(),
                          "Should client employ pull or push job tracking. In pull mode client will make a request to server in the loop, until job finishes. Pull mode is kept for legacy clients.".to_string(),
                          DataType::Boolean,
@@ -344,6 +355,12 @@ impl BallistaConfig {
     /// Returns the target batch size for sort-based shuffle.
     pub fn shuffle_sort_based_batch_size(&self) -> usize {
         self.get_usize_setting(BALLISTA_SHUFFLE_SORT_BASED_BATCH_SIZE)
+    }
+
+    /// Returns the per-task buffered-bytes budget at which the sort shuffle
+    /// writer spills its in-memory batches to disk.
+    pub fn shuffle_sort_based_memory_limit_per_task_bytes(&self) -> usize {
+        self.get_usize_setting(BALLISTA_SHUFFLE_SORT_BASED_MEMORY_LIMIT_PER_TASK_BYTES)
     }
 
     /// Should client employ pull or push job tracking strategy

--- a/ballista/core/src/execution_plans/sort_shuffle/config.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/config.rs
@@ -29,6 +29,10 @@ pub struct SortShuffleConfig {
     /// Target batch size in rows when materializing buffered indices via
     /// `interleave_record_batch` (default: 8192).
     pub batch_size: usize,
+    /// Per-task buffered-bytes budget at which the writer spills its in-memory
+    /// batches to disk. Counted independently of the runtime `MemoryPool`, so
+    /// spilling kicks in even when the pool is unbounded.
+    pub memory_limit_per_task_bytes: usize,
 }
 
 impl Default for SortShuffleConfig {
@@ -37,18 +41,26 @@ impl Default for SortShuffleConfig {
             enabled: false,
             compression: CompressionType::LZ4_FRAME,
             batch_size: 8192,
+            memory_limit_per_task_bytes: 256 * 1024 * 1024,
         }
     }
 }
 
 impl SortShuffleConfig {
-    /// Creates a new configuration.
+    /// Creates a new configuration with the default per-task memory limit.
     pub fn new(enabled: bool, compression: CompressionType, batch_size: usize) -> Self {
         Self {
             enabled,
             compression,
             batch_size,
+            memory_limit_per_task_bytes: Self::default().memory_limit_per_task_bytes,
         }
+    }
+
+    /// Sets the per-task buffered-bytes budget.
+    pub fn with_memory_limit_per_task_bytes(mut self, bytes: usize) -> Self {
+        self.memory_limit_per_task_bytes = bytes;
+        self
     }
 }
 
@@ -62,6 +74,7 @@ mod tests {
         assert!(!config.enabled);
         assert!(matches!(config.compression, CompressionType::LZ4_FRAME));
         assert_eq!(config.batch_size, 8192);
+        assert_eq!(config.memory_limit_per_task_bytes, 256 * 1024 * 1024);
     }
 
     #[test]
@@ -70,5 +83,12 @@ mod tests {
         assert!(config.enabled);
         assert!(matches!(config.compression, CompressionType::LZ4_FRAME));
         assert_eq!(config.batch_size, 4096);
+        assert_eq!(config.memory_limit_per_task_bytes, 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_with_memory_limit_per_task_bytes() {
+        let config = SortShuffleConfig::default().with_memory_limit_per_task_bytes(1024);
+        assert_eq!(config.memory_limit_per_task_bytes, 1024);
     }
 }

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -240,6 +240,11 @@ impl SortShuffleWriterExec {
 
             let mut hash_buffer: Vec<u64> = Vec::new();
             let mut spill_events: u64 = 0;
+            // Absolute buffered-bytes counter, independent of the runtime
+            // `MemoryPool`. Drives spill decisions so the writer bounds its
+            // RSS even when the pool is unbounded.
+            let mut buffered_bytes: usize = 0;
+            let memory_limit = config.memory_limit_per_task_bytes;
 
             while let Some(result) = stream.next().await {
                 let input_batch = result?;
@@ -262,7 +267,14 @@ impl SortShuffleWriterExec {
                 let after = buffered.indices_allocated_size();
                 growth += after.saturating_sub(before);
 
-                if reservation.try_grow(growth).is_err() {
+                // Mirror the growth in the runtime pool reservation so the pool
+                // sees this writer's memory usage. Best-effort: if the pool is
+                // bounded and rejects the grow, that's fine — the absolute
+                // counter below still triggers a spill.
+                let _ = reservation.try_grow(growth);
+                buffered_bytes = buffered_bytes.saturating_add(growth);
+
+                if buffered_bytes >= memory_limit {
                     let spill_timer = metrics.spill_time.timer();
                     let (event_batches, event_bytes) = spill_all_partitions(
                         &mut buffered,
@@ -271,6 +283,7 @@ impl SortShuffleWriterExec {
                         config.batch_size,
                     )?;
                     spill_timer.done();
+                    buffered_bytes = 0;
 
                     if event_batches > 0 {
                         spill_events += 1;
@@ -856,8 +869,9 @@ mod tests {
     /// Shared helper for round-trip tests. Builds `num_batches` batches of
     /// `rows_per_batch` rows each with schema `(k: Int64, v: Int64)`, writes
     /// them through `SortShuffleWriterExec` into `num_partitions` output
-    /// partitions with a `memory_limit_bytes` pool, reads every partition back
-    /// via `stream_sort_shuffle_partition`, and asserts:
+    /// partitions with a per-task buffered-bytes budget of
+    /// `sort_shuffle_memory_limit_bytes`, reads every partition back via
+    /// `stream_sort_shuffle_partition`, and asserts:
     ///   - Every input key `0..total_rows` is present exactly once in the union
     ///     of partition outputs.
     ///   - `spill_count > 0` iff `expect_spills` is `true`.
@@ -866,7 +880,7 @@ mod tests {
         num_batches: usize,
         rows_per_batch: usize,
         num_partitions: usize,
-        memory_limit_bytes: usize,
+        sort_shuffle_memory_limit_bytes: usize,
         expect_spills: bool,
     ) -> Result<()> {
         use super::super::reader::stream_sort_shuffle_partition;
@@ -904,9 +918,13 @@ mod tests {
         let input: Arc<dyn ExecutionPlan> =
             Arc::new(DataSourceExec::new(memory_data_source));
 
+        // The runtime pool is sized generously: spill decisions are now driven
+        // by `SortShuffleConfig::memory_limit_per_task_bytes`, but we keep a
+        // bounded pool so the post-test `pool.reserved() == 0` assertion still
+        // checks that the writer releases its `MemoryReservation`.
         let runtime_env = Arc::new(
             RuntimeEnvBuilder::new()
-                .with_memory_pool(Arc::new(FairSpillPool::new(memory_limit_bytes)))
+                .with_memory_pool(Arc::new(FairSpillPool::new(64 * 1024 * 1024)))
                 .build()?,
         );
         let session_ctx = SessionContext::new_with_config_rt(
@@ -923,7 +941,8 @@ mod tests {
             input,
             work_dir.path().to_str().unwrap().to_string(),
             Partitioning::Hash(vec![Arc::new(Column::new("k", 0))], num_partitions),
-            SortShuffleConfig::default(),
+            SortShuffleConfig::default()
+                .with_memory_limit_per_task_bytes(sort_shuffle_memory_limit_bytes),
         )?;
 
         let mut stream = writer.execute(0, task_ctx)?;
@@ -943,12 +962,12 @@ mod tests {
         if expect_spills {
             assert!(
                 spill_count > 0,
-                "expected spilling under tight memory pool, got spill_count={spill_count}"
+                "expected spilling under tight per-task buffer budget, got spill_count={spill_count}"
             );
         } else {
             assert_eq!(
                 spill_count, 0,
-                "expected no spills with generous memory pool, got spill_count={spill_count}"
+                "expected no spills with generous per-task buffer budget, got spill_count={spill_count}"
             );
         }
 
@@ -993,12 +1012,13 @@ mod tests {
 
     #[tokio::test]
     async fn spills_under_memory_pressure_and_round_trips() -> Result<()> {
-        // 10 batches of 8192 rows each. With a 512 KiB pool, this forces spilling.
+        // 10 batches of 8192 rows each. With a 512 KiB per-task buffer budget,
+        // this forces spilling.
         run_round_trip(
             /* num_batches */ 10,
             /* rows_per_batch */ 8192,
             /* num_partitions */ 4,
-            /* memory_limit_bytes */ 512 * 1024,
+            /* sort_shuffle_memory_limit_bytes */ 512 * 1024,
             /* expect_spills */ true,
         )
         .await
@@ -1006,16 +1026,16 @@ mod tests {
 
     #[tokio::test]
     async fn multi_spill_round_trips() -> Result<()> {
-        // Larger total payload + tighter pool than the baseline test, so we
-        // expect multiple spill events per partition. The byte-copy finalize
-        // path should produce a partition section that is `spill_stream ||
-        // in_memory_stream` (two concatenated IPC streams), and the reader
-        // must yield every input row regardless.
+        // Larger total payload + tighter buffer budget than the baseline test,
+        // so we expect multiple spill events per partition. The byte-copy
+        // finalize path should produce a partition section that is
+        // `spill_stream || in_memory_stream` (two concatenated IPC streams),
+        // and the reader must yield every input row regardless.
         run_round_trip(
             /* num_batches */ 20,
             /* rows_per_batch */ 8192,
             /* num_partitions */ 2,
-            /* memory_limit_bytes */ 256 * 1024,
+            /* sort_shuffle_memory_limit_bytes */ 256 * 1024,
             /* expect_spills */ true,
         )
         .await
@@ -1023,13 +1043,14 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_only_round_trips() -> Result<()> {
-        // Generous memory pool so no partition spills. Validates the path
-        // where each partition section is exactly one in-memory IPC stream.
+        // Generous per-task buffer budget so no partition spills. Validates
+        // the path where each partition section is exactly one in-memory IPC
+        // stream.
         run_round_trip(
             /* num_batches */ 4,
             /* rows_per_batch */ 1024,
             /* num_partitions */ 4,
-            /* memory_limit_bytes */ 64 * 1024 * 1024,
+            /* sort_shuffle_memory_limit_bytes */ 64 * 1024 * 1024,
             /* expect_spills */ false,
         )
         .await

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -345,6 +345,9 @@ fn create_shuffle_writer_with_config(
                 true,
                 datafusion::arrow::ipc::CompressionType::LZ4_FRAME,
                 ballista_config.shuffle_sort_based_batch_size(),
+            )
+            .with_memory_limit_per_task_bytes(
+                ballista_config.shuffle_sort_based_memory_limit_per_task_bytes(),
             );
 
             return Ok(Arc::new(SortShuffleWriterExec::try_new(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

This fixes performance of sort-based shuffle when running the TPC-H benchmarks.

Previously, memory was unbounded so all input data was getting accumulated up to the memory pool limit, and the executor was not imposing a limit.

This PR introduces a configurable memory limit per task (default 256 MB) so that spilling gets triggered and keeps memory under control.

# Performance

Benchmark command:

```
$ ./target/release/tpch benchmark ballista --host localhost --port 50050 --path /mnt/bigdata/tpch/sf100 --format parquet --iterations 1 --config ballista.shuffle.sort_based.enabled=true
```

Performance on main branch with sort-based shuffle with 2 output partitions (which is unrealistic, IMO, but is the default in the current benchmark):

```
Query 1 took 19147.2 ms and returned 4 rows
Query 2 took 10234.8 ms and returned 100 rows
Query 3 took 73433.7 ms and returned 10 rows
Query 4 took 15675.1 ms and returned 5 rows
Query 5 took 190789.9 ms and returned 5 rows
...
```

This was clearly no good.

With this PR :

```
Query 1 took 19227.0 ms and returned 4 rows
Query 2 took 9125.7 ms and returned 100 rows
Query 3 took 15806.4 ms and returned 10 rows
Query 4 took 7513.4 ms and returned 5 rows
Query 5 took 36166.8 ms and returned 5 rows
Query 6 took 4570.0 ms and returned 1 rows
Query 7 took 51075.8 ms and returned 4 rows
Query 8 took 37977.7 ms and returned 2 rows
Query 9 took 62603.1 ms and returned 175 rows
Query 10 took 17951.8 ms and returned 20 rows
Query 11 took 6616.2 ms and returned 0 rows
Query 12 took 10176.2 ms and returned 2 rows
Query 13 took 18517.7 ms and returned 45 rows
Query 14 took 5043.6 ms and returned 1 rows
Query 15 took 6152.1 ms and returned 0 rows
Query 16 took 4255.7 ms and returned 27840 rows
Query 17 took 52557.4 ms and returned 1 rows
Query 18 took 52189.7 ms and returned 100 rows
Query 19 took 13621.3 ms and returned 1 rows
Query 20 took 11598.2 ms and returned 17971 rows
Query 21 took 63261.7 ms and returned 100 rows
Query 22 took 4083.3 ms and returned 7 rows
```

This is now closer hash-based shuffle, which does better with small number of partitions :

```
$ ./target/release/tpch benchmark ballista --host localhost --port 50050 --path /mnt/bigdata/tpch/sf100 --format parquet --iterations 1 --config ballista.shuffle.sort_based.enabled=false

Query 1 took 19134.7 ms and returned 4 rows
Query 2 took 7295.9 ms and returned 100 rows
Query 3 took 12959.0 ms and returned 10 rows
Query 4 took 6147.2 ms and returned 5 rows
Query 5 took 28714.4 ms and returned 5 rows
Query 6 took 4544.4 ms and returned 1 rows
Query 7 took 40825.0 ms and returned 4 rows

```

With 200 partitions (Spark's default), performance is much better for many queries with sort-based shuffle:

sort-based:

```
$ ./target/release/tpch benchmark ballista --host localhost --port 50050 --path /mnt/bigdata/tpch/sf100 --format parquet --iterations 1 --config ballista.shuffle.sort_based.enabled=true --partitions 200

Query 1 took 3607.3 ms and returned 4 rows
Query 2 took 10533.4 ms and returned 100 rows
Query 3 took 9143.9 ms and returned 10 rows
Query 4 took 5031.2 ms and returned 5 rows
Query 5 took 16945.4 ms and returned 5 rows
...
```

With hash-based and 200 output partitions, I hit the file handle limit due to separate files per output partition. I cannot increase file handles beyond 8192 using `ulimit`.

```
$ ulimit -n 8192
$ ./target/release/tpch benchmark ballista --host localhost --port 50050 --path /mnt/bigdata/tpch/sf100 --format parquet --iterations 1 --config ballista.shuffle.sort_based.enabled=false --partitions 200
Running benchmarks with the following options: BallistaBenchmarkOpt { query: None, debug: false, expected_results: None, iterations: 1, batch_size: 8192, path: "/mnt/bigdata/tpch/sf100", file_format: "parquet", partitions: 200, host: Some("localhost"), port: Some(50050), output_path: None, config_overrides: ["ballista.shuffle.sort_based.enabled=false"] }
Query 1 took 3446.2 ms and returned 4 rows
[2026-05-01T03:31:48Z ERROR ballista_core::execution_plans::distributed_query] Job DRCZ6hQ failed: Job failed due to stage 5 failed: Task failed due to runtime execution error: DataFusionError(ParquetError(General("Failed to fetch metadata for file mnt/bigdata/tpch/sf100/partsupp.parquet/part10.parquet: Parquet error: External: Generic LocalFileSystem error: Unable to open file /mnt/bigdata/tpch/sf100/partsupp.parquet/part10.parquet: Too many open files (os error 24)")))
```

# What changes are included in this PR?

- New config `ballista.shuffle.sort_based.memory_limit_per_task_bytes` (default 256 MB).
- `SortShuffleConfig` carries the limit, plumbed from `BallistaConfig` through the planner.
- `SortShuffleWriterExec` tracks its own buffered-bytes counter and spills when the counter crosses the configured threshold, independently of the runtime `MemoryPool`. The `MemoryReservation` registration is kept (best-effort `try_grow`) so the pool still sees this writer as a memory citizen for visibility purposes.
- Existing spill round-trip tests rewired to drive spilling via the new per-task budget rather than via a tight `FairSpillPool` size; pool size in tests is now generous so the post-test `pool.reserved() == 0` assertion still validates that the writer releases its reservation.
- Total worst-case sort shuffle memory per executor is approximately `concurrent_tasks * memory_limit_per_task_bytes`. At the default 256 MB × 8 slots that's ~2 GB, which is safe on a laptop running multiple executors and still leaves the runtime pool free for other operators.

# Are there any user-facing changes?

A new configuration key `ballista.shuffle.sort_based.memory_limit_per_task_bytes` is added with a default of 256 MB. Users running queries that previously fit comfortably in unbounded memory may now see spilling — set this higher if avoiding spills matters more than bounding memory.

