### PR TITLE
feat(executor): use default memory pool in executor if no config provided

### DIFF
--- a/ballista/executor/src/config.rs
+++ b/ballista/executor/src/config.rs
@@ -165,10 +165,11 @@ pub struct Config {
     /// Optional total memory budget for the executor. Accepts human-readable
     /// values like "8GB", "512MiB", or a plain byte count. When set, every
     /// task gets a FairSpillPool of size `memory_pool_size / concurrent_tasks`.
+    /// When unset, defaults to `concurrent_tasks * 1 GiB`.
     #[arg(
         long,
         value_parser = parse_memory_pool_size,
-        help = "Optional total executor memory budget (e.g. \"8GB\", \"512MiB\"). Each concurrent task receives an equal share."
+        help = "Optional total executor memory budget (e.g. \"8GB\", \"512MiB\"). Each concurrent task receives an equal share. Defaults to concurrent_tasks * 1 GiB."
     )]
     pub memory_pool_size: Option<u64>,
 }

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -74,6 +74,18 @@ use crate::shutdown::ShutdownNotifier;
 use crate::{ArrowFlightServerProvider, terminate};
 use crate::{execution_loop, executor_server};
 
+/// Default memory budget per concurrent task slot, used when the operator
+/// does not provide an explicit `--memory-pool-size`.
+///
+/// At the executor level the total budget is `concurrent_tasks` ×
+/// this value; that total is then split equally across the per-task
+/// `FairSpillPool`s by [`wrap_runtime_producer_with_memory_pool`]. Sized
+/// to keep a default 8-slot executor under ~8 GiB of headroom so a
+/// laptop running multiple executors does not over-commit, while still
+/// giving each task enough room to materialise reasonable batches before
+/// spilling.
+pub const DEFAULT_MEMORY_POOL_BYTES_PER_TASK: u64 = 1024 * 1024 * 1024;
+
 /// Wrap a [`RuntimeProducer`] so that every produced
 /// [`RuntimeEnv`](datafusion::execution::runtime_env::RuntimeEnv) carries a
 /// fresh [`FairSpillPool`] of size `total_bytes / concurrent_tasks`.
@@ -151,8 +163,9 @@ pub struct ExecutorProcessConfig {
     pub metric_collection_policy: ExecutorMetricCollectionPolicy,
     /// Optional total memory pool size in bytes. When set, every task's
     /// runtime env receives a FairSpillPool of size
-    /// `memory_pool_size / concurrent_tasks`. When `None`, no pool is
-    /// installed and DataFusion falls back to its unbounded default.
+    /// `memory_pool_size / concurrent_tasks`. When `None`, defaults to
+    /// `concurrent_tasks * DEFAULT_MEMORY_POOL_BYTES_PER_TASK` (1 GiB per
+    /// task slot).
     pub memory_pool_size: Option<u64>,
     /// Optional execution engine to use to execute physical plans, will default to
     /// DataFusion if none is provided.
@@ -296,20 +309,22 @@ pub async fn start_executor_process(
             })
         });
 
-    let runtime_producer = if let Some(total) = opt.memory_pool_size {
-        let producer = wrap_runtime_producer_with_memory_pool(
-            runtime_producer,
-            total,
-            concurrent_tasks,
-        )?;
-        let per_task = total / concurrent_tasks as u64;
-        info!(
-            "Memory pool: total {total} bytes split into {concurrent_tasks} tasks ({per_task} bytes each)"
-        );
-        producer
-    } else {
-        runtime_producer
+    let (total, source) = match opt.memory_pool_size {
+        Some(t) => (t, "explicit"),
+        None => (
+            concurrent_tasks as u64 * DEFAULT_MEMORY_POOL_BYTES_PER_TASK,
+            "default",
+        ),
     };
+    let runtime_producer = wrap_runtime_producer_with_memory_pool(
+        runtime_producer,
+        total,
+        concurrent_tasks,
+    )?;
+    let per_task = total / concurrent_tasks as u64;
+    info!(
+        "Memory pool ({source}): total {total} bytes split into {concurrent_tasks} tasks ({per_task} bytes each)"
+    );
 
     let logical = opt
         .override_logical_codec


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

`--memory-pool-size` is optional today: when not provided, the executor installs no memory pool and DataFusion falls back to its unbounded default. Operators that respect the pool (aggregates, sorts, joins, sort shuffle writer) therefore never spill and just keep growing — until the OS starts swapping. On TPC-H Q3 against SF100 with `--partitions 2`, this caused executor RSS to reach ~24 GB and the query to take ~49s (vs ~13s for hash shuffle).

The fix in #1636 patches the sort shuffle writer specifically, but every other memory-pool-aware operator still benefits from a sensible bounded default. New users on a laptop or in a small VM should not have to read the docs to learn that a flag is effectively required to keep the executor from blowing past physical RAM.

# What changes are included in this PR?

- New constant `DEFAULT_MEMORY_POOL_BYTES_PER_TASK = 1 GiB`.
- When `--memory-pool-size` is not provided, default the total pool to `concurrent_tasks * DEFAULT_MEMORY_POOL_BYTES_PER_TASK`. With the default 8 task slots that's an 8 GiB total budget, split into 8 × 1 GiB per-task `FairSpillPool`s.
- The startup log line now distinguishes `Memory pool (explicit)` vs `Memory pool (default)` so it's obvious which path is in effect.
- CLI help text and `ExecutorProcessConfig::memory_pool_size` doc comment updated to describe the new default.

# Are there any user-facing changes?

The executor now always installs a bounded memory pool. Users who relied on the old unbounded default and have queries that run within physical RAM will see the same behaviour; users whose queries previously over-committed memory will start seeing operators spill instead. The new total budget is `concurrent_tasks * 1 GiB`; pass `--memory-pool-size` to override.

## Verification

TPC-H Q3 against `/opt/tpch/sf100`, executor started with `--concurrent-tasks 8` and **no** `--memory-pool-size`:

| `--partitions` | Sort before | Sort after | Hash (unchanged) |
| --- | --- | --- | --- |
| 2 | 49.1s (~24 GB RSS) | 16.9s (~10 GB RSS) | 13.3s |
| 4 | 14.1s | 10.8s | 8.2s |
| 8 | 7.7s | 7.9s | 7.1s |
| 16 | 6.3s | 8.8s | 11.2s |

Startup log confirms the new default is taking effect:

```
INFO ballista_executor::executor_process: Memory pool (default): total 8589934592 bytes split into 8 tasks (1073741824 bytes each)
```

`cargo test --release -p ballista-executor --lib` passes (22/22).