### PR TITLE
docs: document experimental Adaptive Query Execution in tuning guide

### DIFF
--- a/docs/source/user-guide/tuning-guide.md
+++ b/docs/source/user-guide/tuning-guide.md
@@ -66,6 +66,62 @@ decreasing the number of concurrent tasks may help.
 In the future, Ballista will have better support for tracking memory usage and allocating tasks based on available
 memory, as well as supporting spill-to-disk to reduce memory pressure.
 
+## Adaptive Query Execution (Experimental)
+
+Ballista has experimental support for adaptive query execution (AQE), where the
+scheduler re-runs the DataFusion physical optimizer between query stages. This
+lets the planner make decisions using statistics collected from completed
+stages rather than relying solely on pre-execution estimates.
+
+AQE is disabled by default. To enable it, set
+`ballista.planner.adaptive.enabled` to `true` on your `SessionConfig`:
+
+```rust
+let session_config = SessionConfig::new_with_ballista()
+    .set_bool("ballista.planner.adaptive.enabled", true);
+```
+
+When AQE is enabled, the scheduler logs a warning at job submission so it is
+clear that AQE was used:
+
+```
+Adaptive Query Planning is EXPERIMENTAL, should be used for testing purposes only!
+```
+
+### Configuration
+
+| key                                    | type    | default | description                                                    |
+| -------------------------------------- | ------- | ------- | -------------------------------------------------------------- |
+| ballista.planner.adaptive.enabled      | Boolean | false   | Enables the adaptive planner. Experimental.                    |
+| ballista.planner.adaptive.planner_pass | UInt64  | 3       | Maximum optimizer passes the adaptive planner runs per replan. |
+
+### What AQE does today
+
+When AQE is enabled, the scheduler builds the stage DAG incrementally. As each
+shuffle stage completes, the planner re-optimizes the remaining plan and emits
+the next set of runnable stages. Two adaptive optimizations are currently
+implemented:
+
+- **Join reordering.** Uses runtime row counts from completed stages so the
+  smaller side drives the join.
+- **Empty stage elimination.** When a completed stage produces zero rows, its
+  downstream exchange is replaced with an empty execution node, and emptiness
+  is propagated up the plan so downstream stages are skipped entirely.
+
+### Current limitations
+
+The implementation covers the happy path only. The following are known to be
+missing or incomplete:
+
+- Executor failure handling on the AQE path
+- Dynamic coalescing of shuffle partitions
+- Switching from hash join to sort-merge join based on runtime statistics
+- Switching from streaming aggregation to hash aggregation based on runtime statistics
+
+Until these gaps are closed, AQE should be used for testing and experimentation
+rather than production workloads. See [issue #387](https://github.com/apache/datafusion-ballista/issues/387)
+for the tracking issue and ongoing work.
+
 ## Push-based vs Pull-based Task Scheduling
 
 Ballista supports both push-based and pull-based task scheduling. It is recommended that you try both to determine


### PR DESCRIPTION
# Which issue does this PR close?

Related to #387.

# Rationale for this change

The adaptive query execution (AQE) planner landed in #1372 but is not yet covered in the user guide. Without documentation, users have no way to discover the feature, learn how to enable it, or understand its current scope and limitations. Documenting it now also makes it explicit that the feature is experimental and not production-ready.

# What changes are included in this PR?

Adds an "Adaptive Query Execution (Experimental)" section to `docs/source/user-guide/tuning-guide.md` covering:

- A short description of what AQE does and how it differs from the static planner
- How to enable it via `ballista.planner.adaptive.enabled`
- A configuration table for the two AQE session keys (`enabled`, `planner_pass`)
- The two adaptive optimizations currently implemented (join reordering and empty stage elimination)
- The known limitations (executor failure handling, dynamic partition coalescing, hash to sort-merge join switch, streaming to hash aggregation switch)
- A pointer to the tracking issue (#387)

# Are there any user-facing changes?

Documentation only. No code or behavior changes.