### PR TITLE
fix(metrics): avoid stage metrics inflation by tracking partition snapshots

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -157,7 +157,14 @@ impl ExecutionPlan for ShuffleReaderExec {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.is_empty() {
-            Ok(self)
+            Ok(Arc::new(Self {
+                stage_id: self.stage_id,
+                schema: self.schema.clone(),
+                partition: self.partition.clone(),
+                metrics: ExecutionPlanMetricsSet::new(),
+                properties: self.properties.clone(),
+                work_dir: self.work_dir.clone(),
+            }))
         } else {
             Err(DataFusionError::Plan(
                 "Ballista ShuffleReaderExec does not support children plans".to_owned(),

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -522,23 +522,13 @@ pub async fn get_query_stages<
                             .enumerate()
                             .map(|(partition_id, task_info)| {
                                 task_info.as_ref().map(|info| {
-                                    let partition_metrics = running_stage
+                                    let (input_rows, output_rows) = running_stage
                                         .stage_metrics
                                         .as_deref()
-                                        .and_then(|m| m.get(partition_id));
-                                    let (input_rows, output_rows) = partition_metrics
-                                    .map(|m| {
-                                        let input = get_combined_count(
-                                            std::slice::from_ref(m),
-                                            "input_rows",
-                                        );
-                                        let output = get_combined_count(
-                                            std::slice::from_ref(m),
-                                            "output_rows",
-                                        );
-                                        (input,output)
-                                    })
-                                    .unwrap_or((0,0));
+                                        .map(|metrics| {
+                                            get_partition_counts(metrics, partition_id)
+                                        })
+                                        .unwrap_or((0, 0));
 
                                     let start_exec_time = info.start_exec_time as u64;
                                     let end_exec_time = info.end_exec_time as u64;
@@ -580,21 +570,10 @@ pub async fn get_query_stages<
                             .iter()
                             .enumerate()
                             .map(|(partition_id, task_info)| {
-                                let partition_metrics =
-                                    completed_stage.stage_metrics.get(partition_id);
-                                let (input_rows, output_rows) = partition_metrics
-                                    .map(|m| {
-                                        let input = get_combined_count(
-                                            std::slice::from_ref(m),
-                                            "input_rows",
-                                        );
-                                        let output = get_combined_count(
-                                            std::slice::from_ref(m),
-                                            "output_rows",
-                                        );
-                                        (input,output)
-                                    })
-                                    .unwrap_or((0,0));
+                                let (input_rows, output_rows) = get_partition_counts(
+                                    &completed_stage.stage_metrics,
+                                    partition_id,
+                                );
 
                                 let start_exec_time = task_info.start_exec_time as u64;
                                 let end_exec_time = task_info.end_exec_time as u64;
@@ -724,6 +703,29 @@ fn get_elapsed_compute_nanos(metrics: &[MetricsSet]) -> String {
     let t = Time::new();
     t.add_duration(Duration::from_nanos(nanos as u64));
     t.to_string()
+}
+
+fn get_partition_counts(metrics: &[MetricsSet], partition_id: usize) -> (usize, usize) {
+    let input_rows = get_partition_count(metrics, partition_id, "input_rows");
+    let output_rows = get_partition_count(metrics, partition_id, "output_rows");
+    (input_rows, output_rows)
+}
+
+fn get_partition_count(metrics: &[MetricsSet], partition_id: usize, name: &str) -> usize {
+    metrics
+        .iter()
+        .flat_map(|vec| {
+            vec.iter().map(|metric| {
+                let metric_value = metric.value();
+                if metric.partition() == Some(partition_id) && metric_value.name() == name
+                {
+                    metric_value.as_usize()
+                } else {
+                    0
+                }
+            })
+        })
+        .sum()
 }
 
 fn get_combined_count(metrics: &[MetricsSet], name: &str) -> usize {

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -687,7 +687,7 @@ impl RunningStage {
         true
     }
 
-    /// update and combine the task metrics to the stage metrics
+    /// update and upsert the task metrics to the stage metrics
     pub fn update_task_metrics(
         &mut self,
         partition: usize,
@@ -711,25 +711,24 @@ impl RunningStage {
             }
             let metrics_values_array = metrics
                 .into_iter()
-                .map(|ms| {
-                    ms.metrics
-                        .into_iter()
-                        .map(|m| m.try_into())
-                        .collect::<Result<Vec<_>>>()
-                })
+                .map(|ms| Self::metrics_set_from_task_metrics(ms, partition))
                 .collect::<Result<Vec<_>>>()?;
 
             combined_metrics
                 .iter_mut()
                 .zip(metrics_values_array)
-                .map(|(first, second)| {
-                    Self::combine_metrics_set(first, second, partition)
+                .map(|(existing_metrics, new_partition_metrics)| {
+                    Self::upsert_metrics_set_for_partition(
+                        existing_metrics,
+                        new_partition_metrics,
+                        partition,
+                    )
                 })
                 .collect()
         } else {
             metrics
                 .into_iter()
-                .map(|ms| ms.try_into())
+                .map(|ms| Self::metrics_set_from_task_metrics(ms, partition))
                 .collect::<Result<Vec<_>>>()?
         };
         self.stage_metrics = Some(new_metrics_set);
@@ -737,18 +736,36 @@ impl RunningStage {
         Ok(())
     }
 
-    /// Combines metrics from a completed task into the stage's aggregate metrics.
-    pub fn combine_metrics_set(
-        first: &mut MetricsSet,
-        second: Vec<MetricValue>,
+    /// Converts task metrics into a metrics set for a specific partition
+    fn metrics_set_from_task_metrics(
+        metrics: OperatorMetricsSet,
+        partition: usize,
+    ) -> Result<MetricsSet> {
+        let mut metrics_set = MetricsSet::new();
+        for metric in metrics.metrics {
+            let metric_value: MetricValue = metric.try_into()?;
+            metrics_set.push(Arc::new(Metric::new(metric_value, Some(partition))));
+        }
+        Ok(metrics_set)
+    }
+
+    /// Upserts raw metrics from a completed task into the stage metrics
+    pub fn upsert_metrics_set_for_partition(
+        existing_metrics: &mut MetricsSet,
+        new_partition_metrics: MetricsSet,
         partition: usize,
     ) -> MetricsSet {
-        for metric_value in second {
-            // TODO recheck the lable logic
-            let new_metric = Arc::new(Metric::new(metric_value, Some(partition)));
-            first.push(new_metric);
+        let mut updated_metrics = MetricsSet::new();
+        // Task metrics are snapshots, so replace any prior metrics for this partition.
+        for metric in existing_metrics.iter() {
+            if metric.partition() != Some(partition) {
+                updated_metrics.push(metric.clone());
+            }
         }
-        first.aggregate_by_name()
+        for metric in new_partition_metrics.iter() {
+            updated_metrics.push(metric.clone());
+        }
+        updated_metrics
     }
 
     /// Returns the number of times the task for the given partition has failed.
@@ -1058,7 +1075,9 @@ impl StageOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ballista_core::serde::protobuf::{SuccessfulTask, TaskStatus, task_status};
+    use ballista_core::serde::protobuf::{
+        OperatorMetric, SuccessfulTask, TaskStatus, operator_metric, task_status,
+    };
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::prelude::SessionConfig;
     use std::collections::HashMap;
@@ -1092,6 +1111,24 @@ mod tests {
                 partitions: vec![],
             })),
             metrics: vec![],
+        }
+    }
+
+    fn make_operator_metrics_set(
+        output_rows: u64,
+        elapsed_compute_nanos: u64,
+    ) -> OperatorMetricsSet {
+        OperatorMetricsSet {
+            metrics: vec![
+                OperatorMetric {
+                    metric: Some(operator_metric::Metric::OutputRows(output_rows)),
+                },
+                OperatorMetric {
+                    metric: Some(operator_metric::Metric::ElapseTime(
+                        elapsed_compute_nanos,
+                    )),
+                },
+            ],
         }
     }
 
@@ -1171,5 +1208,78 @@ mod tests {
 
         // Should gracefully reject the update, not panic.
         assert!(!result);
+    }
+
+    #[test]
+    fn test_update_task_metrics_keeps_raw_partition_snapshots() {
+        let mut stage = make_running_stage(3);
+
+        stage
+            .update_task_metrics(0, vec![make_operator_metrics_set(100, 10)])
+            .unwrap();
+
+        let metrics = stage.stage_metrics.as_ref().unwrap();
+        assert_eq!(metrics.len(), 1);
+
+        let operator_metrics = &metrics[0];
+        assert_eq!(operator_metrics.iter().count(), 2);
+        assert!(
+            operator_metrics
+                .iter()
+                .all(|metric| metric.partition() == Some(0))
+        );
+
+        let aggregated = operator_metrics.aggregate_by_name();
+        assert_eq!(aggregated.output_rows(), Some(100));
+        assert_eq!(aggregated.elapsed_compute().unwrap(), 10);
+
+        stage
+            .update_task_metrics(1, vec![make_operator_metrics_set(200, 20)])
+            .unwrap();
+        stage
+            .update_task_metrics(2, vec![make_operator_metrics_set(300, 30)])
+            .unwrap();
+
+        let metrics = stage.stage_metrics.as_ref().unwrap();
+        let operator_metrics = &metrics[0];
+        assert_eq!(operator_metrics.iter().count(), 6);
+
+        let partitions = operator_metrics
+            .iter()
+            .filter(|metric| matches!(metric.value(), MetricValue::OutputRows(_)))
+            .map(|metric| metric.partition())
+            .collect::<Vec<_>>();
+        assert_eq!(partitions, vec![Some(0), Some(1), Some(2)]);
+
+        let aggregated = operator_metrics.aggregate_by_name();
+        assert_eq!(aggregated.output_rows(), Some(600));
+        assert_eq!(aggregated.elapsed_compute().unwrap(), 60);
+
+        stage
+            .update_task_metrics(1, vec![make_operator_metrics_set(250, 25)])
+            .unwrap();
+
+        let metrics = stage.stage_metrics.as_ref().unwrap();
+        let operator_metrics = &metrics[0];
+        assert_eq!(operator_metrics.iter().count(), 6);
+
+        let mut output_rows = operator_metrics
+            .iter()
+            .filter_map(|metric| match metric.value() {
+                MetricValue::OutputRows(value) => {
+                    Some((metric.partition(), value.value()))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        output_rows.sort_by_key(|(partition, _)| *partition);
+        assert_eq!(
+            output_rows,
+            vec![(Some(0), 100), (Some(1), 250), (Some(2), 300)]
+        );
+
+        let aggregated = operator_metrics.aggregate_by_name();
+        assert_eq!(aggregated.output_rows(), Some(650));
+        assert_eq!(aggregated.elapsed_compute().unwrap(), 65);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes  #1635

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

There are two cause for this issue

1. Executor side
In `reset_metrics_for_execution_plan`, the function invokes `with_new_children` on ShuffleReadExec. However, in its current implementation, the metrics are not actually reset:
```
if children.is_empty() {
   Ok(self)
}
```
Since the metrics are stored as `Arc<Mutex<MetricsSet>>` and shared across multiple jobs, leading to inflated values at the data source level.

2. Scheduler side
Scheduler stage metrics were aggregated by name each time a task/partition reported metrics. This could cause already-aggregated stage metrics to be calculated multiple times when metrics from the same task/partition reported more than once.

for example:
```
partition 0 reports output_rows=100
stage_metrics stores output_rows=100, partition=None

partition 1 reports output_rows=100
stage_metrics stores output_rows=200, partition=None

partition 0 is processed again with output_rows=100
stage_metrics stores output_rows=300, partition=None  # should still be 200
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


1. Executor side
Reset metrics in `with_new_children` for shuffle reader exec

2. Scheduler side
After:
```
partition 0 reports output_rows=100
  output_rows=100, partition=0

partition 1 reports output_rows=100
  output_rows=100, partition=0
  output_rows=100, partition=1
```
Metrics from the same partition replace the previous snapshot, and aggregate_by_name() is only called in display / formatting paths.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No