### PR TITLE
[TUI] Configurable tick interval

### DIFF
--- a/ballista-cli/src/tui/infrastructure/config.rs
+++ b/ballista-cli/src/tui/infrastructure/config.rs
@@ -49,7 +49,7 @@ http:
 
 impl Settings {
     pub(crate) fn new() -> Result<Self, ConfigError> {
-        let config_dir = dirs::config_dir()
+        let config_dir = dirs::config_local_dir()
             .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
             .unwrap_or_else(|| std::path::PathBuf::from(".config"))
             .join("ballista");
@@ -59,13 +59,14 @@ impl Settings {
             .add_source(File::from_str(DEFAULT_CONFIG, FileFormat::Yaml))
             // Add in user's config file
             .add_source(
-                File::with_name(&format!("{}/config", config_dir.display()))
+                File::with_name(&format!("{}/tui", config_dir.display()))
+                    .format(FileFormat::Yaml)
                     .required(false),
             )
             // Add in settings from the environment (with a prefix of BALLISTA_)
             // E.g. `BALLISTA_SCHEDULER_URL=http://localhost:50051 ballista_cli`
             // would set the scheduler url key
-            .add_source(Environment::with_prefix("BALLISTA"))
+            .add_source(Environment::with_prefix("BALLISTA").separator("_"))
             .build()?;
 
         s.try_deserialize()

--- a/ballista-cli/src/tui/infrastructure/config.rs
+++ b/ballista-cli/src/tui/infrastructure/config.rs
@@ -34,11 +34,11 @@ pub struct Settings {
     pub scheduler: SchedulerSettings,
     pub http: HttpSettings,
     /// How often to refresh the UI. In millis.
-    pub tick_interval: u64,
+    pub tick_interval_ms: u64,
 }
 
 const DEFAULT_CONFIG: &str = r#"
-tick_interval: 2000
+tick_interval_ms: 2000
 
 scheduler:
   url: http://localhost:50050

--- a/ballista-cli/src/tui/infrastructure/config.rs
+++ b/ballista-cli/src/tui/infrastructure/config.rs
@@ -33,9 +33,13 @@ pub struct HttpSettings {
 pub struct Settings {
     pub scheduler: SchedulerSettings,
     pub http: HttpSettings,
+    /// How often to refresh the UI. In millis.
+    pub tick_interval: u64,
 }
 
 const DEFAULT_CONFIG: &str = r#"
+tick_interval: 2000
+
 scheduler:
   url: http://localhost:50050
 

--- a/ballista-cli/src/tui/mod.rs
+++ b/ballista-cli/src/tui/mod.rs
@@ -44,9 +44,10 @@ pub async fn tui_main() -> TuiResult<()> {
     tracing::info!("Starting the Ballista TUI application");
 
     let config = Settings::new()?;
+    tracing::debug!("TUI configuration: {:?}", config);
 
     let mut tui_wrapper = TuiWrapper::new()?;
-    let mut events = EventHandler::new(Duration::from_millis(config.tick_interval));
+    let mut events = EventHandler::new(Duration::from_millis(config.tick_interval_ms));
     let mut app = App::new(config)?;
 
     let (app_tx, mut app_rx) = tokio::sync::mpsc::channel(16);

--- a/ballista-cli/src/tui/mod.rs
+++ b/ballista-cli/src/tui/mod.rs
@@ -46,8 +46,8 @@ pub async fn tui_main() -> TuiResult<()> {
     let config = Settings::new()?;
 
     let mut tui_wrapper = TuiWrapper::new()?;
+    let mut events = EventHandler::new(Duration::from_millis(config.tick_interval));
     let mut app = App::new(config)?;
-    let mut events = EventHandler::new(Duration::from_millis(2000));
 
     let (app_tx, mut app_rx) = tokio::sync::mpsc::channel(16);
     app.set_event_tx(app_tx);


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Make it possible to use a custom tick interval for the UI updates.

# What changes are included in this PR?

* Added a new setting in the TUI config: `tick_interval` with default value of 2000ms.
* Change the config dir to `dirs::config_local_dir()`
* Rename the config file from `.../ballista/config.yaml` to `.../ballista/tui.yaml`

Example full paths:
```
|Platform | Example                                  |
| ------- | ---------------------------------------- |
| Linux   | /home/alice/.config/ballista/tui.yaml                      |
| macOS   | /Users/Alice/Library/Application Support/ballista/tui.yaml |
| Windows | C:\Users\Alice\AppData\Local\ballista\tui.yaml             |
```

All config settings could be overwritten with env vars:
* BALLISTA_HTTP_TIMEOUT=30000
* BALLISTA_SCHEDULER_URL=https://example.com:50050/
* BALLISTA_TICK_INTERVAL=1000

# Are there any user-facing changes?

The config file is renamed and a new setting is added.