### PR TITLE
fix: remove double-counting of write_time in shuffle writer

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_writer.rs
+++ b/ballista/core/src/execution_plans/shuffle_writer.rs
@@ -211,8 +211,6 @@ impl ShuffleWriterExec {
 
             match output_partitioning {
                 None => {
-                    let timer = write_metrics.write_time.timer();
-
                     let path = create_shuffle_path(
                         &self.work_dir,
                         &self.job_id,
@@ -229,6 +227,8 @@ impl ShuffleWriterExec {
                     debug!("Writing results to {path:?}");
 
                     // stream results to disk
+                    // write_stream_to_disk measures write_time internally per batch,
+                    // so no outer timer is needed here
                     let stats = utils::write_stream_to_disk(
                         &mut stream,
                         path.as_path(),
@@ -243,7 +243,6 @@ impl ShuffleWriterExec {
                     write_metrics
                         .output_rows
                         .add(stats.num_rows.unwrap_or(0) as usize);
-                    timer.done();
 
                     info!(
                         "Executed partition {} in {} seconds. Statistics: {}",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #631

# Rationale for this change

`write_time` in `ShuffleWriterExec` reports the total stream duration instead of actual write time. The `None` partitioning branch wraps the entire `write_stream_to_disk` call in a timer, but `write_stream_to_disk` already records `write_time` internally per batch. The outer timer double-counts every batch write and also includes time spent waiting for upstream data.

# What changes are included in this PR?

Removed the outer `write_time` timer in the `None` partitioning branch of `ShuffleWriterExec::execute_shuffle_write`. `write_stream_to_disk` handles its own `write_time` measurement per batch, so the outer timer was redundant.

# Are there any user-facing changes?

`write_time` now accurately reflects disk write duration rather than total stream processing time.