### PR TITLE
fix(join-selection): guard CollectLeft swap when right has multiple partitions

### DIFF
--- a/ballista/scheduler/src/physical_optimizer/join_selection.rs
+++ b/ballista/scheduler/src/physical_optimizer/join_selection.rs
@@ -237,11 +237,17 @@ pub(crate) fn try_collect_left(
             threshold_num_rows,
         );
 
+    // Swapping into `CollectLeft` puts the current right onto the build side,
+    // and `HashJoinExec` requires the build side to have exactly one partition
+    // in that mode. Ballista has no post-`JoinSelection` distribution pass to
+    // fix this, so any swap that would break the invariant must be skipped.
+    let right_one_partition = right.output_partitioning().partition_count() == 1;
     match (left_can_collect, right_can_collect) {
         (true, true) => {
             // Don't swap null-aware anti joins as they have specific side requirements
             if hash_join.join_type().supports_swap()
                 && !hash_join.null_aware
+                && right_one_partition
                 && should_swap_join_order(&**left, &**right)?
             {
                 Ok(Some(hash_join.swap_inputs(PartitionMode::CollectLeft)?))
@@ -262,7 +268,10 @@ pub(crate) fn try_collect_left(
         ))),
         (false, true) => {
             // Don't swap null-aware anti joins as they have specific side requirements
-            if hash_join.join_type().supports_swap() && !hash_join.null_aware {
+            if hash_join.join_type().supports_swap()
+                && !hash_join.null_aware
+                && right_one_partition
+            {
                 hash_join.swap_inputs(PartitionMode::CollectLeft).map(Some)
             } else {
                 Ok(None)
@@ -746,6 +755,108 @@ mod test {
 
     /// Create join filter for NLJoinExec with expression `big_col > small_col`
     /// where both columns are 0-indexed and come from left and right inputs respectively
+    // Regression for https://github.com/apache/datafusion-ballista/issues/1681
+    //
+    // `JoinSelection` must not swap a `HashJoinExec(CollectLeft)` join's
+    // inputs in a way that puts a multi-partition reader on the build side.
+    // Ballista's pipeline has no `EnforceDistribution` pass after this rule,
+    // so the swapped plan reaches the executor unchanged and trips
+    // `HashJoinExec::execute`'s assertion that `left_partitions == 1` in
+    // `CollectLeft` mode.
+    #[tokio::test]
+    async fn collect_left_swap_preserves_one_partition_build() {
+        use datafusion::{
+            common::NullEquality,
+            config::ConfigOptions,
+            physical_expr::expressions::Column,
+            physical_optimizer::PhysicalOptimizerRule,
+            physical_plan::{
+                ExecutionPlanProperties, coalesce_partitions::CoalescePartitionsExec,
+                joins::HashJoinExec, joins::PartitionMode,
+            },
+        };
+
+        use crate::physical_optimizer::join_selection::JoinSelection;
+
+        let schema = Schema::new(vec![Field::new("k", DataType::Int32, false)]);
+
+        // Build side: 1 logical partition (e.g. a Ballista broadcast
+        // ShuffleReaderExec) but BIG total_byte_size.
+        let big_inner = Arc::new(StatisticsExec::new(
+            Statistics {
+                num_rows: Precision::Exact(10_000),
+                total_byte_size: Precision::Exact(1_000_000),
+                column_statistics: vec![ColumnStatistics::new_unknown()],
+            },
+            schema.clone(),
+        ));
+        let left =
+            Arc::new(CoalescePartitionsExec::new(big_inner)) as Arc<dyn ExecutionPlan>;
+        assert_eq!(left.output_partitioning().partition_count(), 1);
+
+        // Probe side: 2 partitions (the raw StatisticsExec default), SMALL
+        // total_byte_size. Stand-in for a multi-partition hash shuffle reader.
+        let right = Arc::new(StatisticsExec::new(
+            Statistics {
+                num_rows: Precision::Exact(3_000),
+                total_byte_size: Precision::Exact(200_000),
+                column_statistics: vec![ColumnStatistics::new_unknown()],
+            },
+            schema.clone(),
+        )) as Arc<dyn ExecutionPlan>;
+        assert!(right.output_partitioning().partition_count() > 1);
+
+        let on = vec![(
+            Arc::new(Column::new_with_schema("k", &left.schema()).unwrap()) as _,
+            Arc::new(Column::new_with_schema("k", &right.schema()).unwrap()) as _,
+        )];
+
+        let join = Arc::new(
+            HashJoinExec::try_new(
+                Arc::clone(&left),
+                Arc::clone(&right),
+                on,
+                None,
+                &JoinType::Inner,
+                None,
+                PartitionMode::CollectLeft,
+                NullEquality::NullEqualsNothing,
+                false,
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+
+        let optimized = JoinSelection::new()
+            .optimize(join, &ConfigOptions::new())
+            .unwrap();
+
+        // `swap_inputs` for Inner wraps the join in a ProjectionExec to
+        // restore the output column order. Walk the tree to find the join.
+        fn find_hash_join(plan: &Arc<dyn ExecutionPlan>) -> Option<&HashJoinExec> {
+            if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+                return Some(hj);
+            }
+            for child in plan.children() {
+                if let Some(hj) = find_hash_join(child) {
+                    return Some(hj);
+                }
+            }
+            None
+        }
+
+        let hj =
+            find_hash_join(&optimized).expect("HashJoinExec missing from optimized plan");
+
+        assert_eq!(*hj.partition_mode(), PartitionMode::CollectLeft);
+        assert_eq!(
+            hj.left().output_partitioning().partition_count(),
+            1,
+            "JoinSelection swapped a CollectLeft join's inputs and ended up \
+             with a multi-partition reader on the build side, which violates \
+             CollectLeft's invariant",
+        );
+    }
+
     fn nl_join_filter() -> Option<JoinFilter> {
         let column_indices = vec![
             ColumnIndex {

--- a/ballista/scheduler/src/physical_optimizer/join_selection.rs
+++ b/ballista/scheduler/src/physical_optimizer/join_selection.rs
@@ -752,9 +752,6 @@ mod test {
             optimizer_options.hash_join_single_partition_threshold,
         )
     }
-
-    /// Create join filter for NLJoinExec with expression `big_col > small_col`
-    /// where both columns are 0-indexed and come from left and right inputs respectively
     // Regression for https://github.com/apache/datafusion-ballista/issues/1681
     //
     // `JoinSelection` must not swap a `HashJoinExec(CollectLeft)` join's
@@ -855,8 +852,17 @@ mod test {
              with a multi-partition reader on the build side, which violates \
              CollectLeft's invariant",
         );
+        assert_eq!(
+            hj.right().output_partitioning().partition_count(),
+            2,
+            "JoinSelection swapped a CollectLeft join's inputs and ended up \
+             with a multi-partition reader on the build side, which violates \
+             CollectLeft's invariant",
+        );
     }
 
+    /// Create join filter for NLJoinExec with expression `big_col > small_col`
+    /// where both columns are 0-indexed and come from left and right inputs respectively
     fn nl_join_filter() -> Option<JoinFilter> {
         let column_indices = vec![
             ColumnIndex {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1681

# Rationale for this change

TPC-H Q2 with `prefer_hash_join=true` fails on latest `main` with:

```
Invalid HashJoinExec, the output partition count of the left child must be 1
in CollectLeft mode, consider using CoalescePartitionsExec or the
EnforceDistribution rule
```

The Ballista-customized `JoinSelection` rule in
`ballista/scheduler/src/physical_optimizer/join_selection.rs` calls
`try_collect_left(..., ignore_threshold=true, 0, 0)` on already-resolved
`HashJoinExec(CollectLeft)` joins. When `should_swap_join_order(left, right)`
returns `true` (left has bigger byte-size than right), the `(true, true)` arm
calls `hash_join.swap_inputs(PartitionMode::CollectLeft)`. `swap_inputs`
keeps `mode = CollectLeft` and swaps the children, so if the old right was a
multi-partition shuffle reader (e.g. `Hash([…], 14)`), the new left ends up
with 14 partitions while still in `CollectLeft` mode. Ballista has no
post-`JoinSelection` `EnforceDistribution` pass to reshape this, so the
invalid plan is serialized to the executor and the assertion fires at
`HashJoinExec::execute`.

The bug is reachable today because PR #1647's broadcast-style hash join
lowering produces `HashJoinExec(CollectLeft)` joins where the build side
is a broadcast `ShuffleReaderExec` (1 logical partition). On TPC-H Q2 SF1,
stage 11's broadcast reader (full supplier row, 7 columns × 10K rows ≈
1 MB) happens to be heavier in bytes than its hash probe reader
(post-join 3K rows × 4 columns ≈ 230 KB), so the swap triggers and the
plan becomes invalid. Stage 22 has the same join shape but a smaller
broadcast side, so it doesn't swap and runs fine. The existing comment in
`execution_stage.rs:386–392` already flags this category of risk:

```rust
// ballista specific JoinSelection, as datafusion rule can't be used here.
// Datafusion JoinSelection may produce plans which need change of partitions
// in order to be valid.
```

# What changes are included in this PR?

- `try_collect_left`: guard the `(true, true)` and `(false, true)` swap
  arms with `right.output_partitioning().partition_count() == 1`. A swap
  into `CollectLeft` is only safe when the would-be new left will have a
  single partition. The non-swap rebuild paths are untouched.
- Regression test
  `collect_left_swap_preserves_one_partition_build`: builds a
  `HashJoinExec(CollectLeft)` with a 1-partition, heavier left and a
  2-partition, lighter right, runs `JoinSelection::optimize`, and asserts
  the resulting join still has a 1-partition build side. The test fails
  on `main` and passes with this change.

Verified end-to-end: TPC-H Q2 SF1 with `prefer_hash_join=true` and
`target_partitions=14` now returns 100 rows instead of failing at stage 11.
Other queries in a sanity sweep (Q1, Q3, Q5, Q7, Q9, Q18, Q21 under
sort-merge default) continue to pass. There is a separate, pre-existing
correctness issue where Q21 with `prefer_hash_join=true` returns 0 rows; it
is independent of this assertion bug and out of scope here.

# Are there any user-facing changes?

No public API changes. Plans that previously crashed at the executor with
the `CollectLeft` assertion will now keep the original (1-partition build)
shape instead of being swapped into an invalid form.