### PR TITLE
Fix REST API panic on job list/detail when end_time < start_time

### DIFF
--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -330,8 +330,10 @@ pub async fn get_jobs<
     let jobs: Vec<JobResponse> = jobs
         .iter()
         .map(|job| {
-            let (plain_status, job_status) =
-                format_job_status(&job.status.status, job.end_time - job.start_time);
+            let (plain_status, job_status) = format_job_status(
+                &job.status.status,
+                job_elapsed_ms(job.start_time, job.end_time),
+            );
 
             // calculate progress based on completed stages for now, but we could use completed
             // tasks in the future to make this more accurate
@@ -377,8 +379,10 @@ pub async fn get_job<
         .ok_or_else(|| SchedulerErrorResponse::new(StatusCode::NOT_FOUND))?;
     let stage_plan = format!("{:?}", graph);
     let job = graph.as_ref();
-    let (plain_status, job_status) =
-        format_job_status(&job.status().status, job.end_time() - job.start_time());
+    let (plain_status, job_status) = format_job_status(
+        &job.status().status,
+        job_elapsed_ms(job.start_time(), job.end_time()),
+    );
 
     let num_stages = job.stage_count();
     let completed_stages = job.completed_stages();
@@ -684,6 +688,14 @@ fn task_duration_percentiles(tasks: &[Option<TaskSummary>]) -> Option<Percentile
         p75: percentile_duration(&durations, 75.0),
         max: *durations.last().unwrap(),
     })
+}
+
+/// Returns elapsed wall time in milliseconds for API formatting.
+///
+/// Uses saturating subtraction so inconsistent timestamps (e.g. failed jobs, or
+/// `end_time` still zero while `start_time` is set) do not panic on subtract.
+fn job_elapsed_ms(start_time: u64, end_time: u64) -> u64 {
+    end_time.saturating_sub(start_time)
 }
 
 fn format_job_status(status: &Option<Status>, elapsed_ms: u64) -> (String, String) {
@@ -1000,5 +1012,15 @@ mod tests {
         ];
         let result = get_running_stage_time(&tasks, now);
         assert_eq!(result, "2.00s");
+    }
+
+    #[test]
+    fn test_job_elapsed_ms_normal() {
+        assert_eq!(super::job_elapsed_ms(100, 500), 400);
+    }
+
+    #[test]
+    fn test_job_elapsed_ms_end_before_start_saturates_to_zero() {
+        assert_eq!(super::job_elapsed_ms(500, 100), 0);
     }
 }

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -39,7 +39,6 @@ use datafusion::prelude::SessionConfig;
 use log::{debug, error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec;
 
 // TODO: the AQE planner runs DataFusion's DefaultPhysicalPlanner with a
@@ -1196,10 +1195,7 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
             .map(|l| l.try_into())
             .collect::<ballista_core::error::Result<Vec<_>>>()?;
 
-        self.end_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        self.end_time = timestamp_millis();
 
         self.status = JobStatus {
             job_id: self.job_id.clone(),
@@ -1292,10 +1288,7 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
                 let task_attempt = stage.task_failure_numbers[partition_id];
                 let task_info = crate::state::execution_graph::TaskInfo {
                     task_id,
-                    scheduled_time: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_millis(),
+                    scheduled_time: timestamp_millis() as u128,
                     // Those times will be updated when the task finish
                     launch_time: 0,
                     start_exec_time: 0,

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -1167,6 +1167,9 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
 
     /// fail job with error message
     fn fail_job(&mut self, error: String) {
+        // Same as non-AQE graph: persist end time when the job fails.
+        self.end_time = timestamp_millis();
+
         self.status = JobStatus {
             job_id: self.job_id.clone(),
             job_name: self.job_name.clone(),

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -1167,7 +1167,6 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
 
     /// fail job with error message
     fn fail_job(&mut self, error: String) {
-        // Same as non-AQE graph: persist end time when the job fails.
         self.end_time = timestamp_millis();
 
         self.status = JobStatus {

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1377,10 +1377,7 @@ impl ExecutionGraph for StaticExecutionGraph {
             .map(|l| l.try_into())
             .collect::<Result<Vec<_>>>()?;
 
-        self.end_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        self.end_time = timestamp_millis();
 
         self.status = JobStatus {
             job_id: self.job_id.clone(),
@@ -1791,7 +1788,7 @@ mod test {
         );
         assert!(
             graph.end_time() >= start,
-            "end_time {} should be set and >= start_time {}",
+            "end_time ({}) should be set and >= start_time ({})",
             graph.end_time(),
             start
         );

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1348,8 +1348,6 @@ impl ExecutionGraph for StaticExecutionGraph {
 
     /// fail job with error message
     fn fail_job(&mut self, error: String) {
-        // Match `succeed_job`: record wall-clock end time so job metadata and REST consumers
-        // see a consistent `ended_at` (previously left at 0 while `started_at` was set).
         self.end_time = timestamp_millis();
 
         self.status = JobStatus {
@@ -1775,6 +1773,38 @@ mod test {
         test_coalesce_plan, test_join_plan, test_two_aggregations_plan,
         test_union_all_plan, test_union_plan,
     };
+
+    #[tokio::test]
+    async fn test_fail_job_sets_end_time_and_failed_metadata() -> Result<()> {
+        let mut graph = test_aggregation_plan(4).await;
+        let start = graph.start_time();
+        assert_eq!(graph.end_time(), 0);
+
+        ExecutionGraph::fail_job(&mut graph, "test failure".to_string());
+
+        assert!(
+            matches!(
+                graph.status().status.as_ref(),
+                Some(job_status::Status::Failed(f)) if f.error == "test failure"
+            ),
+            "expected FailedJob status after fail_job"
+        );
+        assert!(
+            graph.end_time() >= start,
+            "end_time {} should be set and >= start_time {}",
+            graph.end_time(),
+            start
+        );
+
+        if let Some(job_status::Status::Failed(failed)) = &graph.status().status {
+            assert_eq!(failed.started_at, start);
+            assert_eq!(failed.ended_at, graph.end_time());
+        } else {
+            panic!("missing FailedJob");
+        }
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_drain_tasks() -> Result<()> {

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1348,6 +1348,10 @@ impl ExecutionGraph for StaticExecutionGraph {
 
     /// fail job with error message
     fn fail_job(&mut self, error: String) {
+        // Match `succeed_job`: record wall-clock end time so job metadata and REST consumers
+        // see a consistent `ended_at` (previously left at 0 while `started_at` was set).
+        self.end_time = timestamp_millis();
+
         self.status = JobStatus {
             job_id: self.job_id.clone(),
             job_name: self.job_name.clone(),


### PR DESCRIPTION
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Closes #1689
 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The REST job list and job-detail handlers computed elapsed time as `end_time - start_time` with `u64`. If `end_time` is before `start_time` (for example `end_time` is still `0` while `start_time` is set, or other inconsistent timestamps on failed jobs), the subtraction underflows and the scheduler API can panic with `attempt to subtract with overflow`. Saturating subtraction matches how we already treat inconsistent timestamps elsewhere in the same module and avoids the panic.
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Add `job_elapsed_ms(start_time, end_time)` using `end_time.saturating_sub(start_time)`.
- Use it in `get_jobs` and `get_job` when calling `format_job_status`.
- Add unit tests for normal duration and `end_time < start_time`.
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, but only in the sense of **bug fix behavior**: the jobs REST API should no longer panic when listing or fetching a job whose stored timestamps are inconsistent; elapsed duration used in status text is clamped to **0 ms** when `end_time < start_time` instead of crashing.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
<!-- No breaking API changes; no `api change` label. -->