### PR TITLE
fix: no executor warning, correct prometheus feature name in TUI

### DIFF
--- a/ballista-cli/src/tui/ui/main/metrics/mod.rs
+++ b/ballista-cli/src/tui/ui/main/metrics/mod.rs
@@ -88,7 +88,7 @@ pub fn render_metrics(f: &mut Frame, area: Rect, app: &App) {
         render_no_metrics(
             f,
             rects[1],
-            "The scheduler is built with 'prometheus_metric' feature disabled.",
+            "The scheduler is built with 'prometheus-metrics' feature disabled.",
         );
     }
 }

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -114,7 +114,7 @@ impl ExecutorManager {
         }
         let alive_executors = self.get_alive_executors();
         if alive_executors.is_empty() {
-            debug!("There's no alive executors for binding tasks");
+            warn!("There's no alive executors for binding tasks");
             return Ok(vec![]);
         }
         self.cluster_state

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -114,7 +114,7 @@ impl ExecutorManager {
         }
         let alive_executors = self.get_alive_executors();
         if alive_executors.is_empty() {
-            warn!("There's no alive executors for binding tasks");
+            warn!("There are no alive executors to bind tasks");
             return Ok(vec![]);
         }
         self.cluster_state


### PR DESCRIPTION
# Which issue does this PR close?

I was looking at testing some stuff locally in distributed mode.
I made : 

```bash
cargo run --bin ballista-scheduler --features prometheus-metrics # first shell
cargo run --bin ballista-cli -- --host localhost --port 50050 # second shell
```

then submit `SELECT 1;` in the cli.

This hangs forever (cannot even close the cli) and nothing appears.
This is because there is no executor, but it's not obvious looking at metrics or terminal output.

 # Rationale for this change

This avoids silent job submission without user feedback. I can also imagine a cluster with all executor not reachable, the task would be submitted but zero warning, and 0 visibility in metrics.

# What changes are included in this PR?

- promote `debug` message to `warn` when no executor (I guess this should never happen and makes the issue visible even running with no extra config)
- fix a typo in the (great!) TUI on prometheus metrics feature name to enable
- ~expose pending task in metrics (metric existed but what never filled)~

- did *not* address the cli hang while waiting for scheduler response (might be a follow up if deemed useful)

# Are there any user-facing changes?

~Existing `pending_tasks_queue_size` is now filled~

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

