### PR TITLE
Make use of Swatinem/rust-cache to make the CI workflows faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,7 @@ CHANGELOG.md
 !target/release/ballista-executor
 !target/release/ballista-cli
 !target/release/tpch
+!target/release-nonlto/ballista-scheduler
+!target/release-nonlto/ballista-executor
+!target/release-nonlto/ballista-cli
+!target/release-nonlto/tpch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -130,6 +130,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
@@ -179,7 +180,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
@@ -220,6 +221,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
@@ -260,7 +262,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
         with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
           workspaces: |
             python -> target
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ concurrency:
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - 'python/**'
   push:
-    tags: ["*-rc*"]
-    branches: ["branch-*"]
+    tags: [ "*-rc*" ]
+    branches: [ "branch-*" ]
     paths:
       - 'python/**'
 
@@ -54,6 +54,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -113,14 +114,14 @@ jobs:
           path: LICENSE.txt
 
   build-python-mac-win:
-    needs: [generate-license]
+    needs: [ generate-license ]
     name: Mac/Win
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
-        os: [macos-latest, windows-latest]
+        python-version: [ "3.10" ]
+        os: [ macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -171,13 +172,14 @@ jobs:
           path: python/target/wheels/*
 
   build-manylinux-x86_64:
-    needs: [generate-license]
+    needs: [ generate-license ]
     name: Manylinux x86_64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
@@ -211,7 +213,7 @@ jobs:
           path: python/target/wheels/*
 
   build-manylinux-aarch64:
-    needs: [generate-license]
+    needs: [ generate-license ]
     name: Manylinux arm64
     runs-on: ubuntu-latest
     steps:
@@ -251,13 +253,14 @@ jobs:
           path: python/target/wheels/*
 
   build-sdist:
-    needs: [generate-license]
+    needs: [ generate-license ]
     name: Source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
+        with:
+          workspaces: |
+            python -> target
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -52,6 +52,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - uses: Swatinem/rust-cache@v2
       - name: Check dependencies
         run: |
           cd dev/msrvcheck

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Check dependencies
         run: |
           cd dev/msrvcheck

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,6 @@ jobs:
           cache-on-failure: "true" # TODO: revert once CI is stable
       - name: Run script
         run: |
-          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista
 
           ./dev/build-ballista-docker.sh
@@ -82,3 +81,4 @@ jobs:
         env:
           DOCKER_USER: ${{ github.actor }}
           DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_FLAG: "release-nonlto"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,12 +42,16 @@ jobs:
           rustup toolchain install stable
           rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
-        with:
-          cache-on-failure: "true" # TODO: revert once CI is stable
       - name: Run script
         run: |
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista
-
+          
+          export RELEASE_FLAG="release-nonlto"
+          export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
+          if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]; then
+            export RELEASE_FLAG="release"
+          fi
+          
           ./dev/build-ballista-docker.sh
 
           docker tag apache/datafusion-ballista-standalone:latest ghcr.io/apache/datafusion-ballista-standalone:latest
@@ -55,7 +59,6 @@ jobs:
           docker tag apache/datafusion-ballista-scheduler:latest ghcr.io/apache/datafusion-ballista-scheduler:latest
 
           # release dockers only when there is a release tag
-          export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]
           then
 
@@ -81,4 +84,4 @@ jobs:
         env:
           DOCKER_USER: ${{ github.actor }}
           DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_FLAG: "release-nonlto"
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: Docker
-on: [pull_request, push]
+on: [ pull_request, push ]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -29,8 +29,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
-      - name: Installs Rust and Cargo
-        run: curl -y --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        with:
+          fetch-depth: 1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         run: |
           sudo apt-get update
@@ -48,7 +51,7 @@ jobs:
           export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]
           then
-            
+          
             docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
 
             echo "publishing docker tag $DOCKER_TAG"
@@ -56,7 +59,7 @@ jobs:
             docker tag apache/datafusion-ballista-standalone:latest ghcr.io/apache/datafusion-ballista-standalone:$DOCKER_TAG
             docker tag apache/datafusion-ballista-executor:latest ghcr.io/apache/datafusion-ballista-executor:$DOCKER_TAG
             docker tag apache/datafusion-ballista-scheduler:latest ghcr.io/apache/datafusion-ballista-scheduler:$DOCKER_TAG
-            
+          
             docker push ghcr.io/apache/datafusion-ballista-standalone:$DOCKER_TAG
             docker push ghcr.io/apache/datafusion-ballista-executor:$DOCKER_TAG
             docker push ghcr.io/apache/datafusion-ballista-scheduler:$DOCKER_TAG

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,12 +46,6 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista
           
-          export RELEASE_FLAG="release-nonlto"
-          export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
-          if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]; then
-            export RELEASE_FLAG="release"
-          fi
-          
           ./dev/build-ballista-docker.sh
 
           docker tag apache/datafusion-ballista-standalone:latest ghcr.io/apache/datafusion-ballista-standalone:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ jobs:
           docker tag apache/datafusion-ballista-scheduler:latest ghcr.io/apache/datafusion-ballista-scheduler:latest
 
           # release dockers only when there is a release tag
+          export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]
           then
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,10 @@ jobs:
     container:
       image: amd64/rust
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y nodejs
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
@@ -36,10 +40,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - uses: Swatinem/rust-cache@v2
-      - name: Install protoc
-        run: |
-          apt-get update
-          apt-get install -y docker-ce
       - name: Run script
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,10 +38,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+        #          sudo apt-get update
+      #          sudo apt-get install -y protobuf-compiler
       - name: Run script
         run: |
+          export PATH=$PATH:$HOME/d/protoc/bin
 
           ./dev/build-ballista-docker.sh
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
   build_docker:
     name: Run Build Docker Script
     runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: Docker
-on: [ pull_request, push ]
+on: [pull_request, push]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -38,8 +38,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         run: |
-        #          sudo apt-get update
-      #          sudo apt-get install -y protobuf-compiler
+          apt-get update
+          apt-get install -y docker-ce
       - name: Run script
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -50,11 +50,11 @@ jobs:
           docker tag apache/datafusion-ballista-executor:latest ghcr.io/apache/datafusion-ballista-executor:latest
           docker tag apache/datafusion-ballista-scheduler:latest ghcr.io/apache/datafusion-ballista-scheduler:latest
 
-          # release dockers only when there is a release tag 
+          # release dockers only when there is a release tag
           export DOCKER_TAG="$(git describe --exact-match --tags $(git log -n1 --pretty='%h') || echo '')"
           if [[ $DOCKER_TAG =~ ^[0-9\.]+(-rc[0-9]+)?$ ]]
           then
-          
+
             docker login ghcr.io -u $DOCKER_USER -p "$DOCKER_PASS"
 
             echo "publishing docker tag $DOCKER_TAG"
@@ -62,7 +62,7 @@ jobs:
             docker tag apache/datafusion-ballista-standalone:latest ghcr.io/apache/datafusion-ballista-standalone:$DOCKER_TAG
             docker tag apache/datafusion-ballista-executor:latest ghcr.io/apache/datafusion-ballista-executor:$DOCKER_TAG
             docker tag apache/datafusion-ballista-scheduler:latest ghcr.io/apache/datafusion-ballista-scheduler:$DOCKER_TAG
-          
+
             docker push ghcr.io/apache/datafusion-ballista-standalone:$DOCKER_TAG
             docker push ghcr.io/apache/datafusion-ballista-executor:$DOCKER_TAG
             docker push ghcr.io/apache/datafusion-ballista-scheduler:$DOCKER_TAG

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: Docker
-on: [pull_request, push]
+on: [ pull_request, push ]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -26,43 +26,27 @@ jobs:
   build_docker:
     name: Run Build Docker Script
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
     steps:
-      - name: Install dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update
-          apt install -y ca-certificates curl nodejs
-          install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          chmod a+r /etc/apt/keyrings/docker.asc
-
-          # Add the repository to Apt sources:
-          tee /etc/apt/sources.list.d/docker.sources <<EOF
-          Types: deb
-          URIs: https://download.docker.com/linux/debian
-          Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
-          Components: stable
-          Architectures: $(dpkg --print-architecture)
-          Signed-By: /etc/apt/keyrings/docker.asc
-          EOF
-
-          apt update
-          apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
+          fetch-tags: true
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-      - uses: Swatinem/rust-cache@v2
+        run: |
+          rustup update stable
+          rustup toolchain install stable
+          rustup default stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
         with:
-          cache-on-failure: "true"
+          cache-on-failure: "true" # TODO: revert once CI is stable
       - name: Run script
         run: |
-          export PATH=$PATH:$HOME/d/protoc/bin
-          git config --global --add safe.directory $PWD
+          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista
 
           ./dev/build-ballista-docker.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,8 +31,25 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y nodejs
+          export DEBIAN_FRONTEND=noninteractive
+          apt update
+          apt install -y ca-certificates curl nodejs
+          install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          chmod a+r /etc/apt/keyrings/docker.asc
+
+          # Add the repository to Apt sources:
+          tee /etc/apt/sources.list.d/docker.sources <<EOF
+          Types: deb
+          URIs: https://download.docker.com/linux/debian
+          Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+          Components: stable
+          Architectures: $(dpkg --print-architecture)
+          Signed-By: /etc/apt/keyrings/docker.asc
+          EOF
+
+          apt update
+          apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,8 +42,6 @@ jobs:
           rustup toolchain install stable
           rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
-        with:
-          cache-on-failure: "true" # TODO: revert once CI is stable
       - name: Run script
         run: |
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,9 +57,13 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
       - name: Run script
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
+          git config --global --add safe.directory $PWD
+          git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista
 
           ./dev/build-ballista-docker.sh
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,8 @@ jobs:
           rustup toolchain install stable
           rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
+        with:
+          cache-on-failure: "true" # TODO: revert once CI is stable
       - name: Run script
         run: |
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,9 +78,6 @@ jobs:
           export ARROW_TEST_DATA=$(pwd)/testing/data
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
           cargo test --profile ci --features=testcontainers
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
 
   # Run `cargo doc` to ensure the rustdoc is clean
   linux-rustdoc:
@@ -118,9 +115,6 @@ jobs:
           export ARROW_TEST_DATA=$(pwd)/testing/data
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
           cargo check --profile ci -p ballista-scheduler -p ballista-executor -p ballista-core -p ballista --no-default-features --locked
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
 
   ballista-test:
     name: test linux balista
@@ -143,9 +137,6 @@ jobs:
           cd ballista
           # Ensure also compiles in standalone mode
           cargo test --profile ci --no-default-features --features standalone --locked
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
 
   windows-test:
     name: windows test
@@ -219,9 +210,6 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run
         run: ci/scripts/rust_fmt.sh
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
 
   clippy:
     name: Clippy
@@ -251,9 +239,6 @@ jobs:
           rustup component add clippy
       - name: Run clippy
         run: ci/scripts/rust_clippy.sh
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
 
   cargo-toml-formatting-checks:
     name: Check Cargo.toml formatting
@@ -281,9 +266,6 @@ jobs:
       - name: Install cargo-tomlfmt
         run: |
           which cargo-tomlfmt || cargo install cargo-tomlfmt
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
       - name: Check Cargo.toml formatting
         run: |
           # if you encounter error, try rerun the command below, finally run 'git diff' to
@@ -295,9 +277,7 @@ jobs:
               echo "cargo tomlfmt found format violations"
               exit 1
           fi
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target"
+
 # Coverage job was failing. https://github.com/apache/arrow-datafusion/issues/590 tracks re-instating it
 
 # coverage:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
         with:
-          submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Prepare cargo build
         run: |
           # Adding `--locked` here to assert that the `Cargo.lock` file is up to
@@ -71,6 +71,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -94,6 +95,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - uses: Swatinem/rust-cache@v2
       - name: Run cargo doc
         run: ci/scripts/rust_docs.sh
 
@@ -109,6 +111,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Try to compile when `--no-default-features` is selected
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -131,6 +134,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Run Ballista tests
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -153,6 +157,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-windows-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
         shell: bash
         run: |
@@ -173,6 +178,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-macos-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
         shell: bash
         run: |
@@ -190,10 +196,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
         with:
-          submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
+      - uses: Swatinem/rust-cache@v2
       - name: Verify that benchmark queries return expected results
         run: |
           cargo test --package ballista-benchmarks --profile release-nonlto --features=ci --locked -- --test-threads=1
@@ -210,6 +216,7 @@ jobs:
           rustup toolchain install stable
           rustup default stable
           rustup component add rustfmt
+      - uses: Swatinem/rust-cache@v2
       - name: Run
         run: ci/scripts/rust_fmt.sh
         env:
@@ -221,8 +228,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64]
-        rust: [stable]
+        arch: [ amd64 ]
+        rust: [ stable ]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -238,6 +245,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
       - name: Install Clippy
         run: |
           rustup component add clippy
@@ -252,8 +260,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64]
-        rust: [stable]
+        arch: [ amd64 ]
+        rust: [ stable ]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -269,6 +277,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
       - name: Install cargo-tomlfmt
         run: |
           which cargo-tomlfmt || cargo install cargo-tomlfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-macos-builder
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
+        with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Prepare cargo build
         run: |
           # Adding `--locked` here to assert that the `Cargo.lock` file is up to
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run tests
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run cargo doc
         run: ci/scripts/rust_docs.sh
 
@@ -111,7 +111,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Try to compile when `--no-default-features` is selected
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run Ballista tests
         run: |
           export PATH=$PATH:$HOME/d/protoc/bin
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-windows-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run tests
         shell: bash
         run: |
@@ -178,7 +178,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-macos-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run tests
         shell: bash
         run: |
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Verify that benchmark queries return expected results
         run: |
           cargo test --package ballista-benchmarks --profile release-nonlto --features=ci --locked -- --test-threads=1
@@ -216,7 +216,7 @@ jobs:
           rustup toolchain install stable
           rustup default stable
           rustup component add rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run
         run: ci/scripts/rust_fmt.sh
         env:
@@ -245,7 +245,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Install Clippy
         run: |
           rustup component add clippy
@@ -277,7 +277,7 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Install cargo-tomlfmt
         run: |
           which cargo-tomlfmt || cargo install cargo-tomlfmt

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -25,8 +25,8 @@ RELEASE_FLAG=${RELEASE_FLAG:=release}
 
 . ./dev/build-set-env.sh
 
-docker build -t "apache/datafusion-ballista-standalone:latest" -f dev/docker/ballista-standalone.Dockerfile .
-docker build -t "apache/datafusion-ballista-scheduler:latest" -f dev/docker/ballista-scheduler.Dockerfile .
-docker build -t "apache/datafusion-ballista-executor:latest" -f dev/docker/ballista-executor.Dockerfile .
-docker build -t "apache/datafusion-ballista-cli:latest" -f dev/docker/ballista-cli.Dockerfile .
-docker build -t "apache/datafusion-ballista-benchmarks:latest" -f dev/docker/ballista-benchmarks.Dockerfile .
+docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-standalone:latest" -f dev/docker/ballista-standalone.Dockerfile .
+docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-scheduler:latest" -f dev/docker/ballista-scheduler.Dockerfile .
+docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-executor:latest" -f dev/docker/ballista-executor.Dockerfile .
+docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-cli:latest" -f dev/docker/ballista-cli.Dockerfile .
+docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-benchmarks:latest" -f dev/docker/ballista-benchmarks.Dockerfile .

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
+set -euo pipefail
 
 RELEASE_FLAG=${RELEASE_FLAG:=release}
 

--- a/dev/build-ballista-docker.sh
+++ b/dev/build-ballista-docker.sh
@@ -28,5 +28,8 @@ RELEASE_FLAG=${RELEASE_FLAG:=release}
 docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-standalone:latest" -f dev/docker/ballista-standalone.Dockerfile .
 docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-scheduler:latest" -f dev/docker/ballista-scheduler.Dockerfile .
 docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-executor:latest" -f dev/docker/ballista-executor.Dockerfile .
-docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-cli:latest" -f dev/docker/ballista-cli.Dockerfile .
-docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-benchmarks:latest" -f dev/docker/ballista-benchmarks.Dockerfile .
+
+if test -z "${CI}"; then
+  docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-cli:latest" -f dev/docker/ballista-cli.Dockerfile .
+  docker build --build-arg RELEASE_FLAG="${RELEASE_FLAG}" -t "apache/datafusion-ballista-benchmarks:latest" -f dev/docker/ballista-benchmarks.Dockerfile .
+fi

--- a/dev/build-ballista-executables.sh
+++ b/dev/build-ballista-executables.sh
@@ -38,6 +38,9 @@ RELEASE_FLAG="${RELEASE_FLAG:=release}"
 cargo build --profile "$RELEASE_FLAG" -p ballista-scheduler  --bin ballista-scheduler
 cargo build --profile "$RELEASE_FLAG" -p ballista-executor   --bin ballista-executor
 
+echo "=== DEBUG === "
+ls -la target/release*/
+
 if test -z "${CI}"; then
   cargo build --profile "$RELEASE_FLAG" -p ballista-cli        --bin ballista-cli
   cargo build --profile "$RELEASE_FLAG" -p ballista-benchmarks --bin tpch

--- a/dev/build-ballista-executables.sh
+++ b/dev/build-ballista-executables.sh
@@ -38,9 +38,6 @@ RELEASE_FLAG="${RELEASE_FLAG:=release}"
 cargo build --profile "$RELEASE_FLAG" -p ballista-scheduler  --bin ballista-scheduler
 cargo build --profile "$RELEASE_FLAG" -p ballista-executor   --bin ballista-executor
 
-echo "=== DEBUG === "
-ls -la target/release*/
-
 if test -z "${CI}"; then
   cargo build --profile "$RELEASE_FLAG" -p ballista-cli        --bin ballista-cli
   cargo build --profile "$RELEASE_FLAG" -p ballista-benchmarks --bin tpch

--- a/dev/build-ballista-executables.sh
+++ b/dev/build-ballista-executables.sh
@@ -37,5 +37,8 @@ RELEASE_FLAG="${RELEASE_FLAG:=release}"
 
 cargo build --profile "$RELEASE_FLAG" -p ballista-scheduler  --bin ballista-scheduler
 cargo build --profile "$RELEASE_FLAG" -p ballista-executor   --bin ballista-executor
-cargo build --profile "$RELEASE_FLAG" -p ballista-cli        --bin ballista-cli
-cargo build --profile "$RELEASE_FLAG" -p ballista-benchmarks --bin tpch
+
+if test -z "${CI}"; then
+  cargo build --profile "$RELEASE_FLAG" -p ballista-cli        --bin ballista-cli
+  cargo build --profile "$RELEASE_FLAG" -p ballista-benchmarks --bin tpch
+fi

--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -17,15 +17,19 @@
 
 FROM ubuntu:24.04
 
+LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
+LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 ARG RELEASE_FLAG=release
 
 ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 
-COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
-COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor
-COPY target/$RELEASE_FLAG/tpch /root/tpch
+COPY target/${RELEASE_FLAG}/ballista-scheduler /root/ballista-scheduler
+COPY target/${RELEASE_FLAG}/ballista-executor /root/ballista-executor
+COPY target/${RELEASE_FLAG}/tpch /root/tpch
 
 COPY benchmarks/run.sh /root/run.sh
 COPY benchmarks/queries/ /root/benchmarks/queries

--- a/dev/docker/ballista-cli.Dockerfile
+++ b/dev/docker/ballista-cli.Dockerfile
@@ -17,13 +17,17 @@
 
 FROM ubuntu:24.04
 
+LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
+LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 ARG RELEASE_FLAG=release
 
 ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 
-COPY target/$RELEASE_FLAG/ballista-cli /root/ballista-cli
+COPY target/${RELEASE_FLAG}/ballista-cli /root/ballista-cli
 
 COPY dev/docker/cli-entrypoint.sh /root/cli-entrypoint.sh
 ENTRYPOINT ["/root/cli-entrypoint.sh"]

--- a/dev/docker/ballista-executor.Dockerfile
+++ b/dev/docker/ballista-executor.Dockerfile
@@ -17,13 +17,17 @@
 
 FROM ubuntu:24.04
 
+LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
+LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 ARG RELEASE_FLAG=release
 
 ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 
-COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor
+COPY target/${RELEASE_FLAG}/ballista-executor /root/ballista-executor
 
 # Expose Ballista Executor gRPC port
 EXPOSE 50051

--- a/dev/docker/ballista-scheduler.Dockerfile
+++ b/dev/docker/ballista-scheduler.Dockerfile
@@ -17,6 +17,10 @@
 
 FROM ubuntu:24.04
 
+LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
+LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 ARG RELEASE_FLAG=release
 
 ENV RELEASE_FLAG=${RELEASE_FLAG}
@@ -24,7 +28,7 @@ ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
+COPY target/${RELEASE_FLAG}/ballista-scheduler /root/ballista-scheduler
 
 # Expose Ballista Scheduler gRPC port
 EXPOSE 50050

--- a/dev/docker/ballista-standalone.Dockerfile
+++ b/dev/docker/ballista-standalone.Dockerfile
@@ -18,7 +18,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
-LABEL org.opencontainers.image.description="Apache Arrow Ballista Distributed SQL Query Engine"
+LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ARG RELEASE_FLAG=release
@@ -30,8 +30,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update && apt-get install -qq -y wget
 
-COPY target/$RELEASE_FLAG/ballista-scheduler /root/ballista-scheduler
-COPY target/$RELEASE_FLAG/ballista-executor /root/ballista-executor
+COPY target/${RELEASE_FLAG}/ballista-scheduler /root/ballista-scheduler
+COPY target/${RELEASE_FLAG}/ballista-executor /root/ballista-executor
 
 RUN chmod a+x /root/ballista-scheduler && \
     chmod a+x /root/ballista-executor


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1674.

# Rationale for this change

Make the CI runs faster

# What changes are included in this PR?

1. Make use of `Swatinem/rust-cache` to make the builds faster
2. Disable the builds of -cli and -benchmarks for Docker CI because no Docker images are pushed for them anyway
3. Remove anything related to Git submodules because such are not used.

# Are there any user-facing changes?

No.