### PR TITLE
Saturate scheduler job elapsed time

### DIFF
--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -936,6 +936,11 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_job_elapsed_saturates_when_end_precedes_start() {
+        assert_eq!(job_elapsed_ms(900, 100), 0);
+    }
+
     // --- get_finished_stage_time ---
 
     #[test]


### PR DESCRIPTION
## Summary
- Saturate scheduler job elapsed time

## Testing
- Not run (publishing focused local fix branch).