### PR TITLE
[TUI] Add support for horizontal scrolling to the job/stage plan popups

### DIFF
--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -206,6 +206,8 @@ impl App {
                     KeyCode::Esc => popup.set_no_details_view(),
                     KeyCode::Up => popup.scroll_up(),
                     KeyCode::Down => popup.scroll_down(),
+                    KeyCode::Left => popup.scroll_left(),
+                    KeyCode::Right => popup.scroll_right(),
                     _ => {}
                 }
             } else if popup.is_no_details_view() {
@@ -247,17 +249,16 @@ impl App {
             match key.code {
                 KeyCode::Up => plans_popup.scroll_up(),
                 KeyCode::Down => plans_popup.scroll_down(),
+                KeyCode::Left => plans_popup.scroll_left(),
+                KeyCode::Right => plans_popup.scroll_right(),
                 KeyCode::Char('s') => {
-                    plans_popup.tab = PlanTab::Stage;
-                    plans_popup.scroll_position = 0;
+                    plans_popup.set_tab(PlanTab::Stage);
                 }
                 KeyCode::Char('p') => {
-                    plans_popup.tab = PlanTab::Physical;
-                    plans_popup.scroll_position = 0;
+                    plans_popup.set_tab(PlanTab::Physical);
                 }
                 KeyCode::Char('l') => {
-                    plans_popup.tab = PlanTab::Logical;
-                    plans_popup.scroll_position = 0;
+                    plans_popup.set_tab(PlanTab::Logical);
                 }
                 KeyCode::Esc => {
                     self.job_plan_popup = None;

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -237,7 +237,8 @@ pub(crate) enum PlanTab {
 pub struct JobPlansPopup {
     pub details: JobDetails,
     pub tab: PlanTab,
-    pub scroll_position: u16,
+    vertical_scroll_position: u16,
+    horizontal_scroll_position: u16,
 }
 
 impl JobPlansPopup {
@@ -245,16 +246,41 @@ impl JobPlansPopup {
         Self {
             details,
             tab,
-            scroll_position: 0,
+            vertical_scroll_position: 0,
+            horizontal_scroll_position: 0,
         }
     }
 
+    pub fn set_tab(&mut self, tab: PlanTab) {
+        self.tab = tab;
+        self.vertical_scroll_position = 0;
+        self.horizontal_scroll_position = 0;
+    }
+
+    pub fn vertical_scroll_position(&self) -> u16 {
+        self.vertical_scroll_position
+    }
+
+    pub fn horizontal_scroll_position(&self) -> u16 {
+        self.horizontal_scroll_position
+    }
+
     pub fn scroll_up(&mut self) {
-        self.scroll_position = self.scroll_position.saturating_sub(1);
+        self.vertical_scroll_position = self.vertical_scroll_position.saturating_sub(1);
     }
 
     pub fn scroll_down(&mut self) {
-        self.scroll_position = self.scroll_position.saturating_add(1);
+        self.vertical_scroll_position = self.vertical_scroll_position.saturating_add(1);
+    }
+
+    pub fn scroll_left(&mut self) {
+        self.horizontal_scroll_position =
+            self.horizontal_scroll_position.saturating_sub(1);
+    }
+
+    pub fn scroll_right(&mut self) {
+        self.horizontal_scroll_position =
+            self.horizontal_scroll_position.saturating_add(1);
     }
 }
 
@@ -674,16 +700,16 @@ mod tests {
     #[test]
     fn job_plans_popup_new_scroll_position_is_zero() {
         let popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
-        assert_eq!(popup.scroll_position, 0);
+        assert_eq!(popup.vertical_scroll_position, 0);
     }
 
     #[test]
     fn job_plans_popup_scroll_down_increments() {
         let mut popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
         popup.scroll_down();
-        assert_eq!(popup.scroll_position, 1);
+        assert_eq!(popup.vertical_scroll_position, 1);
         popup.scroll_down();
-        assert_eq!(popup.scroll_position, 2);
+        assert_eq!(popup.vertical_scroll_position, 2);
     }
 
     #[test]
@@ -692,13 +718,13 @@ mod tests {
         popup.scroll_down();
         popup.scroll_down();
         popup.scroll_up();
-        assert_eq!(popup.scroll_position, 1);
+        assert_eq!(popup.vertical_scroll_position, 1);
     }
 
     #[test]
     fn job_plans_popup_scroll_up_saturates_at_zero() {
         let mut popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
         popup.scroll_up();
-        assert_eq!(popup.scroll_position, 0);
+        assert_eq!(popup.vertical_scroll_position, 0);
     }
 }

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -236,7 +236,7 @@ pub(crate) enum PlanTab {
 #[derive(Clone, Debug)]
 pub struct JobPlansPopup {
     pub details: JobDetails,
-    pub tab: PlanTab,
+    tab: PlanTab,
     vertical_scroll_position: u16,
     horizontal_scroll_position: u16,
 }
@@ -249,6 +249,10 @@ impl JobPlansPopup {
             vertical_scroll_position: 0,
             horizontal_scroll_position: 0,
         }
+    }
+
+    pub fn get_tab(&self) -> &PlanTab {
+        &self.tab
     }
 
     pub fn set_tab(&mut self, tab: PlanTab) {
@@ -286,10 +290,10 @@ impl JobPlansPopup {
 
 #[cfg(test)]
 mod tests {
-    use crate::tui::domain::SortOrder;
     use crate::tui::domain::jobs::{
         Job, JobDetails, JobPlansPopup, JobsData, PlanTab, SortColumn,
     };
+    use crate::tui::domain::SortOrder;
 
     #[expect(clippy::too_many_arguments)]
     fn make_job(
@@ -726,5 +730,29 @@ mod tests {
         let mut popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
         popup.scroll_up();
         assert_eq!(popup.vertical_scroll_position, 0);
+    }
+
+    #[test]
+    fn job_plans_popup_scroll_right_increments() {
+        let mut popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
+        popup.scroll_right();
+        assert_eq!(popup.horizontal_scroll_position, 1);
+    }
+
+    #[test]
+    fn job_plans_popup_scroll_left_saturates_at_zero() {
+        let mut popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
+        popup.scroll_left();
+        assert_eq!(popup.horizontal_scroll_position, 0);
+    }
+
+    #[test]
+    fn job_plans_popup_set_tab_resets_scroll_positions() {
+        let mut popup = JobPlansPopup::new(make_job_details("j1"), PlanTab::Stage);
+        popup.scroll_down();
+        popup.scroll_right();
+        popup.set_tab(PlanTab::Physical);
+        assert_eq!(popup.vertical_scroll_position, 0);
+        assert_eq!(popup.horizontal_scroll_position, 0);
     }
 }

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -290,10 +290,10 @@ impl JobPlansPopup {
 
 #[cfg(test)]
 mod tests {
+    use crate::tui::domain::SortOrder;
     use crate::tui::domain::jobs::{
         Job, JobDetails, JobPlansPopup, JobsData, PlanTab, SortColumn,
     };
-    use crate::tui::domain::SortOrder;
 
     #[expect(clippy::too_many_arguments)]
     fn make_job(

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -77,7 +77,8 @@ pub struct JobStagesPopup {
     pub stages: JobStagesResponse,
     pub table_state: TableState,
     details_view: StageDetailsView,
-    scroll_position: u16,
+    plan_vertical_scroll_position: u16,
+    plan_horizontal_scroll_position: u16,
 }
 
 impl JobStagesPopup {
@@ -87,12 +88,17 @@ impl JobStagesPopup {
             stages,
             table_state: TableState::default(),
             details_view: StageDetailsView::None,
-            scroll_position: 0,
+            plan_vertical_scroll_position: 0,
+            plan_horizontal_scroll_position: 0,
         }
     }
 
-    pub fn plan_scroll_position(&self) -> u16 {
-        self.scroll_position
+    pub fn plan_vertical_scroll_position(&self) -> u16 {
+        self.plan_vertical_scroll_position
+    }
+
+    pub fn plan_horizontal_scroll_position(&self) -> u16 {
+        self.plan_horizontal_scroll_position
     }
 
     pub fn set_tasks_view(&mut self) {
@@ -101,7 +107,8 @@ impl JobStagesPopup {
 
     pub fn set_plan_view(&mut self) {
         self.details_view = StageDetailsView::Plan;
-        self.scroll_position = 0;
+        self.plan_vertical_scroll_position = 0;
+        self.plan_horizontal_scroll_position = 0;
     }
 
     pub fn set_no_details_view(&mut self) {
@@ -137,7 +144,8 @@ impl JobStagesPopup {
                 self.table_state.select(Some(0));
             }
         } else if self.is_plan_view() {
-            self.scroll_position = self.scroll_position.saturating_add(1);
+            self.plan_vertical_scroll_position =
+                self.plan_vertical_scroll_position.saturating_add(1);
         }
     }
 
@@ -158,7 +166,22 @@ impl JobStagesPopup {
                 self.table_state.select(Some(len - 1));
             }
         } else if self.is_plan_view() {
-            self.scroll_position = self.scroll_position.saturating_sub(1);
+            self.plan_vertical_scroll_position =
+                self.plan_vertical_scroll_position.saturating_sub(1);
+        }
+    }
+
+    pub fn scroll_left(&mut self) {
+        if self.is_plan_view() {
+            self.plan_horizontal_scroll_position =
+                self.plan_horizontal_scroll_position.saturating_sub(1);
+        }
+    }
+
+    pub fn scroll_right(&mut self) {
+        if self.is_plan_view() {
+            self.plan_horizontal_scroll_position =
+                self.plan_horizontal_scroll_position.saturating_add(1);
         }
     }
 

--- a/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
@@ -17,10 +17,10 @@
 
 use crate::tui::app::App;
 use crate::tui::domain::jobs::{JobPlansPopup, PlanTab};
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::prelude::{Color, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
-use ratatui::Frame;
 
 pub(crate) fn render_job_plan_popup(f: &mut Frame, app: &App) {
     let Some(job_plans) = &app.job_plan_popup else {

--- a/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
@@ -56,9 +56,10 @@ fn render_plans(f: &mut Frame, area: Rect, job_plans: &JobPlansPopup) {
         .border_style(Style::default().fg(Color::LightCyan))
         .border_type(BorderType::Thick);
 
-    let paragraph = Paragraph::new(plan)
-        .block(block)
-        .scroll((job_plans.scroll_position, 0));
+    let paragraph = Paragraph::new(plan).block(block).scroll((
+        job_plans.vertical_scroll_position(),
+        job_plans.horizontal_scroll_position(),
+    ));
 
     f.render_widget(paragraph, area);
 }

--- a/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
@@ -17,10 +17,10 @@
 
 use crate::tui::app::App;
 use crate::tui::domain::jobs::{JobPlansPopup, PlanTab};
-use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::prelude::{Color, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+use ratatui::Frame;
 
 pub(crate) fn render_job_plan_popup(f: &mut Frame, app: &App) {
     let Some(job_plans) = &app.job_plan_popup else {
@@ -40,7 +40,7 @@ pub(crate) fn render_job_plan_popup(f: &mut Frame, app: &App) {
 
 fn render_plans(f: &mut Frame, area: Rect, job_plans: &JobPlansPopup) {
     let details = &job_plans.details;
-    let tab = &job_plans.tab;
+    let tab = job_plans.get_tab();
 
     let plan = match tab {
         PlanTab::Stage => details.stage_plan.as_deref().unwrap_or("N/A"),

--- a/ballista-cli/src/tui/ui/main/jobs/stage_plan_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_plan_popup.rs
@@ -50,9 +50,10 @@ fn render_plans(f: &mut Frame, area: Rect, app: &App) {
         .border_style(Style::default().fg(Color::LightCyan))
         .border_type(BorderType::Thick);
 
-    let paragraph = Paragraph::new(&*stage.plan)
-        .block(block)
-        .scroll((popup.plan_scroll_position(), 0));
+    let paragraph = Paragraph::new(&*stage.plan).block(block).scroll((
+        popup.plan_vertical_scroll_position(),
+        popup.plan_horizontal_scroll_position(),
+    ));
 
     f.render_widget(paragraph, area);
 }

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -211,6 +211,7 @@ The TUI provides the following views:
 | Key       | Action                     |
 | --------- | -------------------------- |
 | `↑` / `↓` | Scroll up/down             |
+| `←` / `→` | Scroll left/right          |
 | `Esc`     | Return to Job Stages popup |
 
 #### Stage Tasks Popup Keybindings
@@ -234,6 +235,7 @@ The TUI provides the following views:
 | `p`       | Show Physical plan |
 | `l`       | Show Logical plan  |
 | `↑` / `↓` | Scroll up/down     |
+| `←` / `→` | Scroll left/right  |
 | `Esc`     | Close popup        |
 
 #### Executors View Keybindings


### PR DESCRIPTION
# Which issue does this PR close?


Closes #1710 

# Rationale for this change

Some job/stage plans are wider than the popup area and their right part is not visible. 

# What changes are included in this PR?

Add support for scrolling horizontally with Left/Right arrows

# Are there any user-facing changes?

The user can scroll left/right in plan popups in TUI