### PR TITLE
feat: TUI shows running job information

### DIFF
--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -542,10 +542,10 @@ impl App {
         self.jobs_data.selected_job(&self.search_term).is_some()
     }
 
-    pub fn is_selected_job_completed(&self) -> bool {
+    pub fn is_selected_job_completed_or_running(&self) -> bool {
         self.jobs_data
             .selected_job(&self.search_term)
-            .is_some_and(|j| j.status == "Completed")
+            .is_some_and(|j| j.status == "Completed" || j.status == "Running")
     }
 
     pub fn is_selected_job_cancelable(&self) -> bool {
@@ -589,11 +589,11 @@ impl App {
     }
 
     fn open_job_plan_popup(&mut self) {
-        let is_completed = self
+        let in_status_for_popup = self
             .jobs_data
             .selected_job(&self.search_term)
-            .is_some_and(|j| j.status == "Completed");
-        if is_completed && let Some(details) = &self.job_details {
+            .is_some_and(|j| j.status == "Completed" || j.status == "Running");
+        if in_status_for_popup && let Some(details) = &self.job_details {
             self.job_plan_popup =
                 Some(JobPlansPopup::new(details.clone(), PlanTab::Stage));
         }
@@ -789,20 +789,45 @@ mod tests {
         assert!(app.has_more_than_one_job());
     }
 
-    #[test]
-    fn is_selected_job_completed_true_when_completed_job_selected() {
-        let mut app = make_app();
-        app.jobs_data.jobs = vec![make_job("j1", "Completed")];
-        app.jobs_data.table_state.select(Some(0));
-        assert!(app.is_selected_job_completed());
+    // --- open_job_plan_popup tests ---
+
+    fn make_job_details(job_id: &str) -> crate::tui::domain::jobs::JobDetails {
+        crate::tui::domain::jobs::JobDetails {
+            job_id: job_id.to_string(),
+            logical_plan: Some("logical".to_string()),
+            physical_plan: Some("physical".to_string()),
+            stage_plan: Some("stage".to_string()),
+        }
     }
 
     #[test]
-    fn is_selected_job_completed_false_for_running_job() {
+    fn open_job_plan_popup_opens_for_running_job_with_details() {
         let mut app = make_app();
         app.jobs_data.jobs = vec![make_job("j1", "Running")];
         app.jobs_data.table_state.select(Some(0));
-        assert!(!app.is_selected_job_completed());
+        app.job_details = Some(make_job_details("j1"));
+        app.open_job_plan_popup();
+        assert!(app.job_plan_popup.is_some());
+    }
+
+    #[test]
+    fn open_job_plan_popup_opens_for_completed_job_with_details() {
+        let mut app = make_app();
+        app.jobs_data.jobs = vec![make_job("j1", "Completed")];
+        app.jobs_data.table_state.select(Some(0));
+        app.job_details = Some(make_job_details("j1"));
+        app.open_job_plan_popup();
+        assert!(app.job_plan_popup.is_some());
+    }
+
+    #[test]
+    fn open_job_plan_popup_does_not_open_without_details() {
+        let mut app = make_app();
+        app.jobs_data.jobs = vec![make_job("j1", "Running")];
+        app.jobs_data.table_state.select(Some(0));
+        app.job_details = None;
+        app.open_job_plan_popup();
+        assert!(app.job_plan_popup.is_none());
     }
 
     // --- sort_jobs_by toggle tests ---

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -589,11 +589,9 @@ impl App {
     }
 
     fn open_job_plan_popup(&mut self) {
-        let in_status_for_popup = self
-            .jobs_data
-            .selected_job(&self.search_term)
-            .is_some_and(|j| j.status == "Completed" || j.status == "Running");
-        if in_status_for_popup && let Some(details) = &self.job_details {
+        if self.is_selected_job_completed_or_running()
+            && let Some(details) = &self.job_details
+        {
             self.job_plan_popup =
                 Some(JobPlansPopup::new(details.clone(), PlanTab::Stage));
         }
@@ -1081,5 +1079,37 @@ mod tests {
         app.jobs_data.jobs = vec![make_job("j1", "Completed")];
         app.jobs_data.table_state.select(Some(0));
         assert!(!app.is_selected_job_cancelable());
+    }
+
+    #[test]
+    fn is_selected_job_completed_or_running_for_completed() {
+        let mut app = make_app();
+        app.jobs_data.jobs = vec![make_job("j1", "Completed")];
+        app.jobs_data.table_state.select(Some(0));
+        assert!(app.is_selected_job_completed_or_running());
+    }
+
+    #[test]
+    fn is_selected_job_completed_or_running_for_running() {
+        let mut app = make_app();
+        app.jobs_data.jobs = vec![make_job("j1", "Running")];
+        app.jobs_data.table_state.select(Some(0));
+        assert!(app.is_selected_job_completed_or_running());
+    }
+
+    #[test]
+    fn is_selected_job_completed_or_running_for_queued() {
+        let mut app = make_app();
+        app.jobs_data.jobs = vec![make_job("j1", "Queued")];
+        app.jobs_data.table_state.select(Some(0));
+        assert!(!app.is_selected_job_completed_or_running());
+    }
+
+    #[test]
+    fn is_selected_job_completed_or_running_for_failed() {
+        let mut app = make_app();
+        app.jobs_data.jobs = vec![make_job("j1", "Failed")];
+        app.jobs_data.table_state.select(Some(0));
+        assert!(!app.is_selected_job_completed_or_running());
     }
 }

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -38,6 +38,7 @@ pub struct JobStageResponse {
     pub task_duration_percentiles: Option<TaskPercentiles>,
     #[serde(default)]
     pub task_input_percentiles: Option<TaskPercentiles>,
+    #[serde(default)]
     pub tasks: Vec<Option<StageTaskResponse>>,
 }
 

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -29,14 +29,16 @@ pub struct JobStageResponse {
     pub id: String,
     #[serde(rename = "stage_status")]
     pub status: String,
-    #[serde(rename = "stage_plan")]
+    #[serde(rename = "stage_plan", default)]
     pub plan: String,
     pub input_rows: usize,
     pub output_rows: usize,
     pub elapsed_compute: Option<String>,
-    pub task_duration_percentiles: TaskPercentiles,
-    pub task_input_percentiles: TaskPercentiles,
-    pub tasks: Vec<StageTaskResponse>,
+    #[serde(default)]
+    pub task_duration_percentiles: Option<TaskPercentiles>,
+    #[serde(default)]
+    pub task_input_percentiles: Option<TaskPercentiles>,
+    pub tasks: Vec<Option<StageTaskResponse>>,
 }
 
 // TaskSummary
@@ -246,8 +248,8 @@ mod tests {
             input_rows: 0,
             output_rows: 0,
             elapsed_compute: Some("1ns".to_string()),
-            task_duration_percentiles: make_percentiles(),
-            task_input_percentiles: make_percentiles(),
+            task_duration_percentiles: Some(make_percentiles()),
+            task_input_percentiles: Some(make_percentiles()),
             tasks: Vec::new(),
         }
     }

--- a/ballista-cli/src/tui/ui/footer.rs
+++ b/ballista-cli/src/tui/ui/footer.rs
@@ -66,7 +66,7 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                                     .push(Span::from("[c] Cancel job, "));
                             }
 
-                            if app.is_selected_job_completed() {
+                            if app.is_selected_job_completed_or_running() {
                                 current_view_key_bindings
                                     .push(Span::from("[p] View job plans, "));
                             }

--- a/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
@@ -97,23 +97,31 @@ fn build_stage_row(i: usize, stage: &JobStageResponse, app: &App) -> Row<'static
         _ => Color::Gray,
     };
 
-    let p = &stage.task_duration_percentiles;
-    let duration_percentiles = format!(
-        "{}/{}/{}/{}/{}",
-        app.format_duration(p.min),
-        app.format_duration(p.p25),
-        app.format_duration(p.median),
-        app.format_duration(p.p75),
-        app.format_duration(p.max)
+    let duration_percentiles = stage.task_duration_percentiles.as_ref().map_or_else(
+        || "N/A".to_string(),
+        |p| {
+            format!(
+                "{}/{}/{}/{}/{}",
+                app.format_duration(p.min),
+                app.format_duration(p.p25),
+                app.format_duration(p.median),
+                app.format_duration(p.p75),
+                app.format_duration(p.max)
+            )
+        },
     );
-    let p = &stage.task_input_percentiles;
-    let input_percentiles = format!(
-        "{}/{}/{}/{}/{}",
-        app.format_count(p.min.try_into().unwrap_or(0)),
-        app.format_count(p.p25.try_into().unwrap_or(0)),
-        app.format_count(p.median.try_into().unwrap_or(0)),
-        app.format_count(p.p75.try_into().unwrap_or(0)),
-        app.format_count(p.max.try_into().unwrap_or(0))
+    let input_percentiles = stage.task_input_percentiles.as_ref().map_or_else(
+        || "N/A".to_string(),
+        |p| {
+            format!(
+                "{}/{}/{}/{}/{}",
+                app.format_count(p.min.try_into().unwrap_or(0)),
+                app.format_count(p.p25.try_into().unwrap_or(0)),
+                app.format_count(p.median.try_into().unwrap_or(0)),
+                app.format_count(p.p75.try_into().unwrap_or(0)),
+                app.format_count(p.max.try_into().unwrap_or(0))
+            )
+        },
     );
 
     Row::new(vec![

--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -60,6 +60,7 @@ pub(crate) fn render_stage_tasks_popup(f: &mut Frame, app: &App) {
     let rows = stage
         .tasks
         .iter()
+        .flatten()
         .enumerate()
         .map(|(i, task)| build_stage_task_row(i, task, app));
 
@@ -121,20 +122,28 @@ fn build_stage_task_row(i: usize, task: &StageTaskResponse, app: &App) -> Row<'s
         Cell::from(Text::from(task.partition_id.to_string()).right_aligned()),
         Cell::from(Text::from(format_datetime(task.scheduled_time, app)).centered()),
         Cell::from(
-            Text::from(app.format_duration(task.launch_time - task.scheduled_time))
-                .right_aligned(),
+            Text::from(
+                app.format_duration(task.launch_time.saturating_sub(task.scheduled_time)),
+            )
+            .right_aligned(),
         ),
         Cell::from(
-            Text::from(app.format_duration(task.start_exec_time - task.scheduled_time))
-                .right_aligned(),
+            Text::from(app.format_duration(
+                task.start_exec_time.saturating_sub(task.scheduled_time),
+            ))
+            .right_aligned(),
         ),
         Cell::from(
-            Text::from(app.format_duration(task.end_exec_time - task.start_exec_time))
-                .right_aligned(),
+            Text::from(app.format_duration(
+                task.end_exec_time.saturating_sub(task.start_exec_time),
+            ))
+            .right_aligned(),
         ),
         Cell::from(
-            Text::from(app.format_duration(task.finish_time - task.scheduled_time))
-                .right_aligned(),
+            Text::from(
+                app.format_duration(task.finish_time.saturating_sub(task.scheduled_time)),
+            )
+            .right_aligned(),
         ),
     ])
     .style(Style::default().bg(bg))


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

after merging #1703 rest api produces running job information but TUI does not allow drilling down to running job information

<img width="1723" height="355" alt="Screenshot 2026-05-17 at 07 20 12" src="https://github.com/user-attachments/assets/89ef529b-9cd4-4cca-913e-1f2bc8546768" />

# What changes are included in this PR?

change TUI code to allow drilling down to running jobs and stages 
<img width="1712" height="946" alt="Screenshot 2026-05-17 at 08 01 27" src="https://github.com/user-attachments/assets/dd53132e-04f9-4687-8bb4-9bc896331ff8" />

# Are there any user-facing changes?

no