### PR TITLE
feat(aqe): SplitPartitionsRule — file-list sharding for skewed shuffle partitions (v1)

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -101,6 +101,23 @@ pub const BALLISTA_COALESCE_SMALL_PARTITION_FACTOR: &str =
 pub const BALLISTA_COALESCE_MERGED_PARTITION_FACTOR: &str =
     "ballista.planner.coalesce.merged_partition_factor";
 
+/// Configuration key to enable AQE split-skewed-partitions rule.
+/// Disabled by default — opt in for workloads with severe partition skew
+/// downstream of distribution-agnostic operators (Filter/Projection/LocalLimit).
+/// v1 bails on joins and FinalPartitioned aggregates because file-list sharding
+/// breaks hash colocation.
+pub const BALLISTA_SPLIT_ENABLED: &str = "ballista.planner.split.enabled";
+/// Multiplier over the median per-partition byte size at which a partition is
+/// considered skewed enough to split. Mirrors Spark's `skewedPartitionFactor`.
+pub const BALLISTA_SPLIT_SKEW_FACTOR: &str = "ballista.planner.split.skew_factor";
+/// Minimum partition byte size below which the split rule never fires, even
+/// when the skew ratio would otherwise qualify. Prevents pointless splitting
+/// of tiny outliers.
+pub const BALLISTA_SPLIT_MIN_BYTES: &str = "ballista.planner.split.min_split_bytes";
+/// Upper bound on the per-partition split factor. Caps task fan-out to avoid
+/// overwhelming the executor when a single partition is many medians larger.
+pub const BALLISTA_SPLIT_MAX_FACTOR: &str = "ballista.planner.split.max_split_factor";
+
 /// Result type for configuration parsing operations.
 pub type ParseResult<T> = result::Result<T, String>;
 use std::sync::LazyLock;
@@ -219,6 +236,40 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
             "Merged-partition early-flush factor (Spark legacy).".to_string(),
             DataType::Float64,
             Some("1.2".to_string()),
+        ),
+        ConfigEntry::new(
+            BALLISTA_SPLIT_ENABLED.to_string(),
+            "Enables the AQE split-skewed-partitions rule. Disabled by default — \
+             opt in for severe per-partition skew downstream of distribution-agnostic \
+             operators (Filter/Projection/LocalLimit). v1 bails on joins and \
+             FinalPartitioned aggregates."
+                .to_string(),
+            DataType::Boolean,
+            Some(false.to_string()),
+        ),
+        ConfigEntry::new(
+            BALLISTA_SPLIT_SKEW_FACTOR.to_string(),
+            "Multiplier over the median per-partition byte size at which a partition \
+             is considered skewed enough to split. Mirrors Spark's skewedPartitionFactor."
+                .to_string(),
+            DataType::Float64,
+            Some("5.0".to_string()),
+        ),
+        ConfigEntry::new(
+            BALLISTA_SPLIT_MIN_BYTES.to_string(),
+            "Minimum partition byte size below which the split rule never fires, \
+             even when the skew ratio would otherwise qualify."
+                .to_string(),
+            DataType::UInt64,
+            Some((64 * 1024 * 1024_usize).to_string()),
+        ),
+        ConfigEntry::new(
+            BALLISTA_SPLIT_MAX_FACTOR.to_string(),
+            "Upper bound on the per-partition split factor. Caps task fan-out \
+             for very-large outliers."
+                .to_string(),
+            DataType::UInt32,
+            Some(8.to_string()),
         ),
     ];
     entries
@@ -448,6 +499,28 @@ impl BallistaConfig {
     /// Returns the merged-partition early-flush factor (Spark legacy).
     pub fn coalesce_merged_partition_factor(&self) -> f64 {
         self.get_float_setting(BALLISTA_COALESCE_MERGED_PARTITION_FACTOR)
+    }
+
+    /// Returns whether the AQE split-skewed-partitions rule is enabled.
+    pub fn split_enabled(&self) -> bool {
+        self.get_bool_setting(BALLISTA_SPLIT_ENABLED)
+    }
+
+    /// Returns the multiplier over the per-partition byte median at which a
+    /// partition qualifies as skewed (Spark's `skewedPartitionFactor`).
+    pub fn split_skew_factor(&self) -> f64 {
+        self.get_float_setting(BALLISTA_SPLIT_SKEW_FACTOR)
+    }
+
+    /// Returns the minimum partition byte size below which the split rule
+    /// never fires.
+    pub fn split_min_split_bytes(&self) -> u64 {
+        self.get_usize_setting(BALLISTA_SPLIT_MIN_BYTES) as u64
+    }
+
+    /// Returns the upper bound on per-partition split factor.
+    pub fn split_max_split_factor(&self) -> u32 {
+        self.get_usize_setting(BALLISTA_SPLIT_MAX_FACTOR) as u32
     }
 
     /// Should client employ pull or push job tracking strategy

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -31,7 +31,9 @@ use std::path::{Path, PathBuf};
 use datafusion::common::exec_err;
 pub use distributed_explain_analyze::DistributedExplainAnalyzeExec;
 pub use distributed_query::DistributedQueryExec;
-pub use shuffle_reader::{CoalescePlan, PartitionGroup, ShuffleReaderExec};
+pub use shuffle_reader::{
+    CoalescePlan, PartitionGroup, ShuffleReaderExec, SplitPlan, SplitShard,
+};
 pub use shuffle_reader::{stats_for_partition, stats_for_partitions};
 pub use shuffle_writer::DEFAULT_SHUFFLE_CHANNEL_CAPACITY;
 pub use shuffle_writer::ShuffleWriterExec;

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -93,6 +93,44 @@ pub struct PartitionGroup {
     pub upstream_indices: Vec<u32>,
 }
 
+/// Split plan attached to a `ShuffleReaderExec` when `SplitPartitionsRule`
+/// has fired: the inverse of [`CoalescePlan`], one upstream partition fans
+/// out to many output partitions via round-robin file-list assignment.
+/// `K' = shards.len()`, `M = upstream_partition_count`, always `K' >= M`.
+/// Mutually exclusive with `CoalescePlan` on a given reader.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SplitPlan {
+    /// Original upstream partition count (M) before splitting.
+    pub upstream_partition_count: u32,
+    /// Output shards. Length is K' (the post-split partition count).
+    pub shards: Vec<SplitShard>,
+}
+
+/// One output partition's reference back to its upstream M-index.
+/// `split_factor == 1` is a passthrough (whole inner Vec → this shard);
+/// `split_factor > 1` means this shard takes file indices where
+/// `i % split_factor == shard_idx`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SplitShard {
+    /// Index into the upstream `Vec<Vec<PartitionLocation>>` this shard reads.
+    pub upstream_idx: u32,
+    /// Round-robin slot among the `split_factor` shards covering `upstream_idx`.
+    pub shard_idx: u32,
+    /// Number of shards this `upstream_idx` is split into; `1` is passthrough.
+    pub split_factor: u32,
+}
+
+impl SplitShard {
+    /// Round-robin ownership predicate. Encapsulates the
+    /// `i % split_factor == shard_idx` formula so the rule and the adapter
+    /// share one source of truth; also returns `true` for every `file_idx`
+    /// when `split_factor == 1` (passthrough), letting callers use the same
+    /// filter for both cases.
+    pub fn owns_file(&self, file_idx: usize) -> bool {
+        self.split_factor <= 1 || (file_idx as u32) % self.split_factor == self.shard_idx
+    }
+}
+
 /// ShuffleReaderExec reads partitions that have already been materialized by a ShuffleWriterExec
 /// being executed by an executor
 #[derive(Debug, Clone)]
@@ -117,6 +155,11 @@ pub struct ShuffleReaderExec {
     /// is responsible for pre-concatenating the M-shape upstream
     /// `Vec<Vec<PartitionLocation>>` into K-shape before invoking `try_new_coalesced`.
     pub coalesce: Option<CoalescePlan>,
+    /// Optional split metadata. `None` means no split rewrite was applied.
+    /// When `Some`, `partition.len() == split.shards.len()` (K') and the
+    /// adapter has pre-sharded the M-shape upstream locations. Mutually
+    /// exclusive with `coalesce`.
+    pub split: Option<SplitPlan>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     properties: Arc<PlanProperties>,
@@ -147,6 +190,7 @@ impl ShuffleReaderExec {
             broadcast: false,
             upstream_partition_count,
             coalesce: None,
+            split: None,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,    // to be updated at the executor side
@@ -177,6 +221,7 @@ impl ShuffleReaderExec {
             broadcast: true,
             upstream_partition_count,
             coalesce: None,
+            split: None,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,    // to be updated at the executor side
@@ -228,6 +273,44 @@ impl ShuffleReaderExec {
             broadcast: false,
             upstream_partition_count,
             coalesce: Some(coalesce),
+            split: None,
+            metrics: ExecutionPlanMetricsSet::new(),
+            properties,
+            work_dir: None,    // to be updated at the executor side
+            client_pool: None, // to be updated at the executor side
+        })
+    }
+
+    /// Create a new split ShuffleReaderExec. `partition` MUST be the K'-shape,
+    /// pre-sharded `Vec<Vec<PartitionLocation>>` produced by `BallistaAdapter`
+    /// from the leaf Exchange's `SplitPlan`. `partitioning` MUST be
+    /// `Partitioning::UnknownPartitioning(K')` — file-list sharding breaks
+    /// hash co-partitioning, which is why `SplitPartitionsRule` bails on
+    /// join / FinalPartitioned consumers.
+    pub fn try_new_split(
+        stage_id: usize,
+        partition: Vec<Vec<PartitionLocation>>,
+        split: SplitPlan,
+        schema: SchemaRef,
+        partitioning: Partitioning,
+    ) -> Result<Self> {
+        debug_assert_eq!(partition.len(), split.shards.len());
+        debug_assert_eq!(partitioning.partition_count(), split.shards.len());
+        let upstream_partition_count = split.upstream_partition_count as usize;
+        let properties = Arc::new(PlanProperties::new(
+            datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
+            partitioning,
+            datafusion::physical_plan::execution_plan::EmissionType::Incremental,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        ));
+        Ok(Self {
+            stage_id,
+            schema,
+            partition,
+            broadcast: false,
+            upstream_partition_count,
+            coalesce: None,
+            split: Some(split),
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,    // to be updated at the executor side
@@ -244,6 +327,7 @@ impl ShuffleReaderExec {
             broadcast: self.broadcast,
             upstream_partition_count: self.upstream_partition_count,
             coalesce: self.coalesce.clone(),
+            split: self.split.clone(),
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
             work_dir: Some(work_dir),
@@ -259,6 +343,7 @@ impl ShuffleReaderExec {
             broadcast: self.broadcast,
             upstream_partition_count: self.upstream_partition_count,
             coalesce: self.coalesce.clone(),
+            split: self.split.clone(),
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
             work_dir: self.work_dir.clone(),
@@ -293,6 +378,14 @@ impl DisplayAs for ShuffleReaderExec {
                             ", coalesce: {} of {}",
                             c.groups.len(),
                             c.upstream_partition_count,
+                        )?;
+                    }
+                    if let Some(s) = &self.split {
+                        write!(
+                            f,
+                            ", split: {} of {}",
+                            s.shards.len(),
+                            s.upstream_partition_count,
                         )?;
                     }
                     Ok(())
@@ -337,6 +430,7 @@ impl ExecutionPlan for ShuffleReaderExec {
                 broadcast: self.broadcast,
                 upstream_partition_count: self.upstream_partition_count,
                 coalesce: self.coalesce.clone(),
+                split: self.split.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
                 properties: self.properties.clone(),
                 work_dir: self.work_dir.clone(),
@@ -455,12 +549,13 @@ impl ExecutionPlan for ShuffleReaderExec {
                     partition_count
                 );
             }
-            // K-shape (coalesced): self.partition[idx] is the inner Vec holding
-            // the concatenated upstream PartitionLocations for output partition
-            // `idx`. Sum across that inner Vec.
+            // K-shape (coalesced) and K'-shape (split): self.partition[idx] is the
+            // inner Vec holding the per-output-partition PartitionLocations (already
+            // concatenated for coalesce or round-robin-sharded for split). Sum across
+            // that inner Vec.
             // M-shape (legacy): outer = replicas, inner = partition index.
             // Use the existing axis-flipped helper.
-            let stat_for_partition = if self.coalesce.is_some() {
+            let stat_for_partition = if self.coalesce.is_some() || self.split.is_some() {
                 Ok(stats_for_partitions(
                     self.schema.fields().len(),
                     self.partition[idx].iter().map(|loc| loc.partition_stats),

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -21,8 +21,9 @@ use crate::config::{
     BALLISTA_COALESCE_MERGED_PARTITION_FACTOR, BALLISTA_COALESCE_SMALL_PARTITION_FACTOR,
     BALLISTA_COALESCE_TARGET_PARTITION_BYTES, BALLISTA_JOB_NAME,
     BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
-    BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, BALLISTA_STANDALONE_PARALLELISM,
-    BallistaConfig,
+    BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, BALLISTA_SPLIT_ENABLED,
+    BALLISTA_SPLIT_MAX_FACTOR, BALLISTA_SPLIT_MIN_BYTES, BALLISTA_SPLIT_SKEW_FACTOR,
+    BALLISTA_STANDALONE_PARALLELISM, BallistaConfig,
 };
 use crate::planner::BallistaQueryPlanner;
 use crate::serde::protobuf::KeyValuePair;
@@ -267,6 +268,28 @@ pub trait SessionConfigExt {
     fn ballista_coalesce_merged_partition_factor(&self) -> f64;
     /// Sets the merged-partition early-flush factor (Spark legacy).
     fn with_ballista_coalesce_merged_partition_factor(self, factor: f64) -> Self;
+
+    /// Returns whether the AQE split-skewed-partitions rule is enabled.
+    fn ballista_split_enabled(&self) -> bool;
+    /// Sets whether the AQE split-skewed-partitions rule is enabled.
+    fn with_ballista_split_enabled(self, enabled: bool) -> Self;
+
+    /// Returns the multiplier over per-partition byte median at which a partition
+    /// qualifies as skewed (Spark's `skewedPartitionFactor`).
+    fn ballista_split_skew_factor(&self) -> f64;
+    /// Sets the per-partition skew factor.
+    fn with_ballista_split_skew_factor(self, factor: f64) -> Self;
+
+    /// Returns the minimum partition byte size below which the split rule
+    /// never fires.
+    fn ballista_split_min_split_bytes(&self) -> u64;
+    /// Sets the minimum-bytes threshold for splitting.
+    fn with_ballista_split_min_split_bytes(self, bytes: u64) -> Self;
+
+    /// Returns the upper bound on per-partition split factor.
+    fn ballista_split_max_split_factor(&self) -> u32;
+    /// Sets the upper bound on per-partition split factor.
+    fn with_ballista_split_max_split_factor(self, factor: u32) -> Self;
 }
 
 /// [SessionConfigHelperExt] is set of [SessionConfig] extension methods
@@ -680,6 +703,75 @@ impl SessionConfigExt for SessionConfig {
         } else {
             self.with_option_extension(BallistaConfig::default())
                 .set_str(BALLISTA_COALESCE_MERGED_PARTITION_FACTOR, &s)
+        }
+    }
+
+    fn ballista_split_enabled(&self) -> bool {
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.split_enabled())
+            .unwrap_or_else(|| BallistaConfig::default().split_enabled())
+    }
+
+    fn with_ballista_split_enabled(self, enabled: bool) -> Self {
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_bool(BALLISTA_SPLIT_ENABLED, enabled)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_bool(BALLISTA_SPLIT_ENABLED, enabled)
+        }
+    }
+
+    fn ballista_split_skew_factor(&self) -> f64 {
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.split_skew_factor())
+            .unwrap_or_else(|| BallistaConfig::default().split_skew_factor())
+    }
+
+    fn with_ballista_split_skew_factor(self, factor: f64) -> Self {
+        let s = factor.to_string();
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_str(BALLISTA_SPLIT_SKEW_FACTOR, &s)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_str(BALLISTA_SPLIT_SKEW_FACTOR, &s)
+        }
+    }
+
+    fn ballista_split_min_split_bytes(&self) -> u64 {
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.split_min_split_bytes())
+            .unwrap_or_else(|| BallistaConfig::default().split_min_split_bytes())
+    }
+
+    fn with_ballista_split_min_split_bytes(self, bytes: u64) -> Self {
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_usize(BALLISTA_SPLIT_MIN_BYTES, bytes as usize)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_usize(BALLISTA_SPLIT_MIN_BYTES, bytes as usize)
+        }
+    }
+
+    fn ballista_split_max_split_factor(&self) -> u32 {
+        self.options()
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.split_max_split_factor())
+            .unwrap_or_else(|| BallistaConfig::default().split_max_split_factor())
+    }
+
+    fn with_ballista_split_max_split_factor(self, factor: u32) -> Self {
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_usize(BALLISTA_SPLIT_MAX_FACTOR, factor as usize)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_usize(BALLISTA_SPLIT_MAX_FACTOR, factor as usize)
         }
     }
 }

--- a/ballista/scheduler/src/state/aqe/adapter.rs
+++ b/ballista/scheduler/src/state/aqe/adapter.rs
@@ -19,6 +19,7 @@ use crate::planner::create_shuffle_writer_with_config;
 use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
 use crate::state::aqe::planner::AdaptiveStageInfo;
 use ballista_core::execution_plans::ShuffleReaderExec;
+use ballista_core::serde::scheduler::PartitionLocation;
 use datafusion::common::exec_err;
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
@@ -59,8 +60,17 @@ impl BallistaAdapter {
             self.inputs.push(stage_id);
             let partitioning = exchange.properties().partitioning.clone();
 
-            let reader = match exchange.coalesce() {
-                Some(cp) => {
+            let reader = match (exchange.coalesce(), exchange.split()) {
+                (Some(_), Some(_)) => {
+                    // Mutually exclusive by construction — SplitPartitionsRule
+                    // bails when coalesce is already set, and vice-versa. If
+                    // we ever see both, that's a rule bug; surface it loudly.
+                    return exec_err!(
+                        "ExchangeExec has both coalesce and split decisions set; \
+                         these are mutually exclusive"
+                    );
+                }
+                (Some(cp), None) => {
                     // Concatenate M-shape locations into K-shape per CoalescePlan.groups.
                     let k_shape: Vec<Vec<_>> = cp
                         .groups
@@ -89,7 +99,44 @@ impl BallistaAdapter {
                         new_partitioning,
                     )?
                 }
-                None => ShuffleReaderExec::try_new(
+                (None, Some(sp)) => {
+                    // One entry per shard; passthrough shards take the full
+                    // inner Vec, split shards take their round-robin slice
+                    // via `SplitShard::owns_file` (single source of truth
+                    // for the formula, shared with the algorithm module).
+                    let mut k_shape: Vec<Vec<PartitionLocation>> =
+                        Vec::with_capacity(sp.shards.len());
+                    for shard in &sp.shards {
+                        let inner = partitions
+                            .get(shard.upstream_idx as usize)
+                            .ok_or_else(|| {
+                                DataFusionError::Execution(format!(
+                                    "SplitPlan references upstream_idx {} but only {} \
+                                 upstream partitions exist",
+                                    shard.upstream_idx,
+                                    partitions.len(),
+                                ))
+                            })?;
+                        let assigned: Vec<_> = inner
+                            .iter()
+                            .enumerate()
+                            .filter(|(i, _)| shard.owns_file(*i))
+                            .map(|(_, l)| l.clone())
+                            .collect();
+                        k_shape.push(assigned);
+                    }
+                    // Splitting breaks hash co-partitioning by design.
+                    let new_partitioning =
+                        Partitioning::UnknownPartitioning(k_shape.len());
+                    ShuffleReaderExec::try_new_split(
+                        stage_id,
+                        k_shape,
+                        (*sp).clone(),
+                        schema,
+                        new_partitioning,
+                    )?
+                }
+                (None, None) => ShuffleReaderExec::try_new(
                     stage_id,
                     partitions,
                     schema,

--- a/ballista/scheduler/src/state/aqe/execution_plan.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan.rs
@@ -34,7 +34,7 @@
 //!   shuffle metadata.
 
 use ballista_core::execution_plans::{
-    CoalescePlan, stats_for_partition, stats_for_partitions,
+    CoalescePlan, SplitPlan, stats_for_partition, stats_for_partitions,
 };
 use ballista_core::serde::scheduler::PartitionLocation;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -96,6 +96,21 @@ pub struct ExchangeExec {
     /// transform-rebuilt parent chains. Same pattern as `shuffle_partitions`.
     coalesce: Arc<Mutex<Option<Arc<CoalescePlan>>>>,
 
+    /// Per-stage split decision attached to this Exchange by
+    /// `SplitPartitionsRule` before adapter conversion. Mutually exclusive
+    /// with [`Self::coalesce`] — the rule bails if either slot is already set.
+    ///
+    /// `None` means: no split rewrite.
+    /// `Some(sp)` means: the adapter pre-shards the M-shape upstream locations
+    /// into K' = `sp.shards.len()` output partitions (always `K' >= M`) via
+    /// round-robin file-list assignment, and builds the SR with
+    /// `try_new_split(sp)`. Output partitioning becomes `UnknownPartitioning(K')`.
+    ///
+    /// Wrapped in `Arc<Mutex<…>>` for the same reason as `coalesce` —
+    /// `with_new_children` must propagate the slot when the parent chain is
+    /// rebuilt by a transform pass.
+    split: Arc<Mutex<Option<Arc<SplitPlan>>>>,
+
     /// this disables stage from running even it would be suitable to run.
     ///
     /// the main reason for this property this is to allow rules to override
@@ -152,6 +167,7 @@ impl ExchangeExec {
             shuffle_partitions: stage_partitions,
             partitioning,
             coalesce: Arc::new(Mutex::new(None)),
+            split: Arc::new(Mutex::new(None)),
             inactive_stage: false,
         }
     }
@@ -227,6 +243,17 @@ impl ExchangeExec {
     pub fn coalesce(&self) -> Option<Arc<CoalescePlan>> {
         self.coalesce.lock().clone()
     }
+
+    /// Attaches a `SplitPlan`. Mutually exclusive with [`Self::set_coalesce`];
+    /// the rule enforces that invariant. Idempotent overwrite.
+    pub fn set_split(&self, sp: Arc<SplitPlan>) {
+        self.split.lock().replace(sp);
+    }
+
+    /// Returns the attached `SplitPlan`, if `set_split` was called.
+    pub fn split(&self) -> Option<Arc<SplitPlan>> {
+        self.split.lock().clone()
+    }
 }
 
 impl DisplayAs for ExchangeExec {
@@ -256,6 +283,14 @@ impl DisplayAs for ExchangeExec {
                         ", coalesce={} of {}",
                         cp.groups.len(),
                         cp.upstream_partition_count,
+                    )?;
+                }
+                if let Some(sp) = self.split.lock().as_ref() {
+                    write!(
+                        f,
+                        ", split={} of {}",
+                        sp.shards.len(),
+                        sp.upstream_partition_count,
                     )?;
                 }
                 Ok(())
@@ -323,6 +358,8 @@ impl ExecutionPlan for ExchangeExec {
             // Carry the coalesce slot so a transform-rebuilt parent chain
             // doesn't lose the rule's decision.
             new_exec.coalesce = self.coalesce.clone();
+            // Same reason for the split slot.
+            new_exec.split = self.split.clone();
 
             Ok(Arc::new(new_exec))
         } else {

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -57,6 +57,7 @@ pub(crate) mod coalesce;
 pub(crate) mod execution_plan;
 pub mod optimizer_rule;
 pub mod planner;
+pub(crate) mod split;
 #[cfg(test)]
 mod test;
 

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/split_partitions.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/split_partitions.rs
@@ -1,0 +1,290 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! AQE rule that splits skewed shuffle partitions after upstream stages finalize.
+//!
+//! [`SplitPartitionsRule`] runs once per `replan_stages()` pass on a stage
+//! subtree whose root is either an [`ExchangeExec`] (intermediate stage) or
+//! an [`AdaptiveDatafusionExec`] (final stage). The rule mirrors
+//! [`CoalescePartitionsRule`](super::CoalescePartitionsRule) — same per-stage
+//! invocation, same alignment-group leaf walk — but applies the inverse
+//! transform: when one upstream partition is far larger than the median, fan
+//! it out across multiple downstream reader tasks instead of folding small
+//! partitions together.
+//!
+//! # v1 mechanism: file-list sharding
+//!
+//! The reader side already lists multiple `PartitionLocation`s per output
+//! partition (one per upstream map task). Splitting just means handing those
+//! locations to several reader tasks via round-robin assignment. No row-range
+//! reads, no protobuf changes, no executor changes.
+//!
+//! Tradeoff: a partition backed by only one file can't be split this way —
+//! the rule bails on that idx (factor stays at 1). v2 row-range reads lift
+//! this restriction.
+//!
+//! # Why bail on hash/single-partition consumers
+//!
+//! File-list sharding produces `UnknownPartitioning(K')` output. Rows that
+//! used to land in the same hash bucket on the M-side are now scattered
+//! across multiple K'-side partitions (the round-robin assignment is
+//! file-keyed, not row-keyed). That breaks:
+//!
+//! - `HashJoinExec(Partitioned)` and `SortMergeJoinExec` — both legs must
+//!   have matching hash buckets, scattering one side desynchronises the join.
+//! - `AggregateExec(FinalPartitioned)` — assumes each downstream partition
+//!   holds a closed set of group keys. Scattering keys across K' partitions
+//!   makes the final emit duplicate rows per group.
+//! - Any operator with `Distribution::HashPartitioned(_)` or
+//!   `Distribution::SinglePartition` in `required_input_distribution()`.
+//!
+//! Rather than enumerate operator types, the rule walks the stage subtree
+//! and checks `required_input_distribution()` directly. If any node above
+//! the leaves demands hash or single-partition input, the whole stage bails.
+//! This is strictly correct and accommodates new DataFusion operators
+//! without source changes.
+//!
+//! # The alignment group (same invariant as coalesce)
+//!
+//! Even though we bail on joins, multi-leaf non-join stages (e.g. UNION ALL)
+//! still need a *single* split decision applied uniformly to every leaf —
+//! otherwise downstream K' would differ across legs, which the planner
+//! cannot represent. The rule sums byte sizes element-wise across all
+//! leaves (just like coalesce) and attaches the same `SplitPlan` to each.
+//!
+//! # Default off
+//!
+//! `ballista.planner.split.enabled = false` by default. v1 has narrow
+//! real-world applicability (most queries hit a hash/single distribution
+//! requirement on the path and bail), so opt-in keeps the cost-of-being-
+//! enabled at zero for users who don't have the workload it helps.
+
+use std::sync::Arc;
+
+use ballista_core::config::BallistaConfig;
+use ballista_core::execution_plans::SplitPlan;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::{Distribution, ExecutionPlan};
+use log::debug;
+
+use crate::state::aqe::execution_plan::AdaptiveDatafusionExec;
+use crate::state::aqe::execution_plan::ExchangeExec;
+use crate::state::aqe::split::{decide_split_factors, factors_to_shards};
+
+/// AQE rule that attaches a split decision to every leaf `ExchangeExec`
+/// feeding the current stage when one upstream partition is far larger than
+/// the median.
+///
+/// See module docs for design intent.
+#[derive(Debug, Default)]
+pub struct SplitPartitionsRule;
+
+impl PhysicalOptimizerRule for SplitPartitionsRule {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        let bc = config
+            .extensions
+            .get::<BallistaConfig>()
+            .cloned()
+            .unwrap_or_default();
+        if !bc.split_enabled() {
+            return Ok(plan);
+        }
+        let skew_factor = bc.split_skew_factor();
+        let min_split_bytes = bc.split_min_split_bytes();
+        let max_split_factor = bc.split_max_split_factor();
+
+        debug!(
+            "[split-rule] fire: skew_factor={skew_factor} min_split_bytes={min_split_bytes} \
+             max_split_factor={max_split_factor}",
+        );
+
+        // Get the subtree below the root. Two root kinds, same outcome —
+        // same pattern as `CoalescePartitionsRule`.
+        let input = if let Some(ex) = plan.as_any().downcast_ref::<ExchangeExec>() {
+            debug!(
+                "[split-rule] root=ExchangeExec plan_id={} stage_id={:?} stage_resolved={}",
+                ex.plan_id,
+                ex.stage_id(),
+                ex.shuffle_partitions().is_some(),
+            );
+            ex.input().clone()
+        } else if let Some(adp) = plan.as_any().downcast_ref::<AdaptiveDatafusionExec>() {
+            debug!(
+                "[split-rule] root=AdaptiveDatafusionExec stage_id={:?}",
+                adp.stage_id(),
+            );
+            adp.input().clone()
+        } else {
+            debug!(
+                "[split-rule] root is neither ExchangeExec nor AdaptiveDatafusionExec; bail"
+            );
+            return Ok(plan);
+        };
+
+        // Single subtree walk that does two things at once:
+        //   - Distribution-safety check: if any operator demands hash or
+        //     single-partition input, bail (splitting would scatter rows
+        //     that operator needs colocated — catches HashJoinExec
+        //     (Partitioned), SortMergeJoinExec, AggregateExec
+        //     (FinalPartitioned), and any future operator with the same
+        //     requirement).
+        //   - Leaf collection: every `ExchangeExec` becomes a member of
+        //     the alignment group. `Jump` after each hit stops descent
+        //     into the upstream stage's compute.
+        let mut leaves: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
+        let mut unsafe_dist = false;
+        input.apply(|node| {
+            if node.as_any().is::<ExchangeExec>() {
+                leaves.push(node.clone());
+                return Ok(TreeNodeRecursion::Jump);
+            }
+            for dist in node.required_input_distribution() {
+                if matches!(
+                    dist,
+                    Distribution::HashPartitioned(_) | Distribution::SinglePartition
+                ) {
+                    unsafe_dist = true;
+                    return Ok(TreeNodeRecursion::Stop);
+                }
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+        if unsafe_dist {
+            debug!("[split-rule] subtree has hash/single-partition consumer; bail");
+            return Ok(plan);
+        }
+
+        // Helper: downcast each Arc back to &ExchangeExec.
+        fn as_exchange(arc: &Arc<dyn ExecutionPlan>) -> &ExchangeExec {
+            arc.as_any()
+                .downcast_ref::<ExchangeExec>()
+                .expect("filtered to ExchangeExec above")
+        }
+
+        debug!(
+            "[split-rule] collected {} leaf ExchangeExec(s)",
+            leaves.len()
+        );
+
+        // Leaf-scan stage with no upstream Exchanges → nothing to split.
+        if leaves.is_empty() {
+            debug!("[split-rule] no leaves; bail");
+            return Ok(plan);
+        }
+
+        // Conflict / idempotence guard: another rule (coalesce) or a prior
+        // pass already wrote a decision to one of the leaves. Either way,
+        // don't fight it.
+        if leaves.iter().any(|l| {
+            as_exchange(l).coalesce().is_some() || as_exchange(l).split().is_some()
+        }) {
+            debug!("[split-rule] at least one leaf already has coalesce/split set; bail");
+            return Ok(plan);
+        }
+
+        // Alignment-group invariant: all leaves share `M`. Same Q22 guard as
+        // coalesce.
+        let m = as_exchange(&leaves[0])
+            .properties()
+            .partitioning
+            .partition_count();
+        if leaves
+            .iter()
+            .any(|arc| as_exchange(arc).properties().partitioning.partition_count() != m)
+        {
+            debug!("[split-rule] heterogeneous M across leaves; bail");
+            return Ok(plan);
+        }
+
+        // Sum byte sizes element-wise across the alignment group; capture
+        // the first leaf's file-count vector for the v1 single-file guard.
+        // If any leaf is still unresolved, bail — the rule reruns on the
+        // next replan_stages pass anyway.
+        let mut summed = vec![0u64; m];
+        let mut file_counts: Vec<usize> = vec![0; m];
+        for (leaf_ix, arc) in leaves.iter().enumerate() {
+            let ex = as_exchange(arc);
+            let Some(parts) = ex.shuffle_partitions() else {
+                debug!(
+                    "[split-rule] leaf plan_id={} unresolved; bail entire group",
+                    ex.plan_id
+                );
+                return Ok(plan);
+            };
+            for (i, locs) in parts.iter().enumerate() {
+                summed[i] += locs
+                    .iter()
+                    .filter_map(|l| l.partition_stats.num_bytes())
+                    .sum::<u64>();
+                if leaf_ix == 0 {
+                    file_counts[i] = locs.len();
+                }
+            }
+        }
+        debug!(
+            "[split-rule] summed bytes per upstream partition: {summed:?}, \
+             leaf-0 file_counts: {file_counts:?}"
+        );
+
+        let factors = decide_split_factors(
+            &summed,
+            &file_counts,
+            skew_factor,
+            min_split_bytes,
+            max_split_factor,
+        );
+        debug!("[split-rule] decision factors per upstream partition: {factors:?}");
+
+        if factors.iter().all(|&f| f == 1) {
+            debug!("[split-rule] all factors == 1 (no skewed partition qualifies); bail");
+            return Ok(plan);
+        }
+
+        // Attach the same `SplitPlan` to every member of the alignment group.
+        // Sharing the plan (not just the K' value) keeps the per-idx fan-out
+        // identical across leaves — even non-join multi-leaf shapes (UNION)
+        // need this for the downstream K' to be uniform.
+        let sp = Arc::new(SplitPlan {
+            upstream_partition_count: m as u32,
+            shards: factors_to_shards(&factors),
+        });
+        let k_prime = sp.shards.len();
+        for arc in &leaves {
+            let ex = as_exchange(arc);
+            debug!(
+                "[split-rule] set_split(K'={k_prime}) on plan_id={} (M={m})",
+                ex.plan_id,
+            );
+            ex.set_split(sp.clone());
+        }
+        Ok(plan)
+    }
+
+    fn name(&self) -> &str {
+        "SplitPartitionsRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        false
+    }
+}

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -18,7 +18,7 @@ use crate::state::aqe::adapter::BallistaAdapter;
 use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
 use crate::state::aqe::optimizer_rule::{
     CoalescePartitionsRule, DistributedExchangeRule, PropagateEmptyExecRule,
-    WarnOnDuplicateExecRule,
+    SplitPartitionsRule, WarnOnDuplicateExecRule,
 };
 
 use crate::state::execution_stage::StageOutput;
@@ -305,6 +305,14 @@ impl AdaptivePlanner {
                         // that would arise if the rule walked the entire residual
                         // plan in `default_optimizers()`.
                         let plan = CoalescePartitionsRule.optimize(plan, config)?;
+                        // SplitPartitionsRule runs immediately after coalesce so
+                        // it sees post-coalesce stats: if coalesce already folded
+                        // small partitions away, the resulting median is across
+                        // fewer, larger buckets and split is unlikely to fire
+                        // (correct). The rule short-circuits on any leaf that
+                        // already has `coalesce()` set, so the two rules can't
+                        // produce conflicting decisions on the same Exchange.
+                        let plan = SplitPartitionsRule.optimize(plan, config)?;
                         BallistaAdapter::adapt_to_ballista(
                             plan,
                             self.job_name.as_str(),

--- a/ballista/scheduler/src/state/aqe/split/algorithm.rs
+++ b/ballista/scheduler/src/state/aqe/split/algorithm.rs
@@ -1,0 +1,309 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Per-partition split-factor decision and shard expansion.
+//!
+//! `decide_split_factors` mirrors Spark's `OptimizeSkewedJoin` skew-detection
+//! formula: a partition is "skewed" if its byte size exceeds
+//! `skew_factor * median(byte_sizes)` AND exceeds an absolute
+//! `min_split_bytes` floor (so we don't fan-out a few-byte partition just
+//! because the median is zero). For skewed partitions we fan out
+//! `ceil(byte_size / median)`, capped at `max_split_factor` to avoid
+//! overwhelming the executor.
+//!
+//! v1 caveat: file-list sharding can only split a partition whose upstream
+//! `Vec<PartitionLocation>` has length `>= 2`. A single-file partition stays
+//! at factor 1 even when it qualifies on bytes. (Row-range reads would lift
+//! this restriction; that work belongs in v2.)
+//!
+//! Float arithmetic is intentional and matches `coalesce/algorithm.rs` style:
+//! every comparison promotes `u64 → f64` so `skew_factor * median` matches
+//! Spark's reference semantics exactly. Don't pre-compute integer thresholds.
+
+use ballista_core::execution_plans::SplitShard;
+
+/// Decide a split factor per upstream partition.
+///
+/// Returns a `Vec<u32>` of length `summed_bytes.len()` where each entry is
+/// the number of output partitions that upstream idx should fan into.
+/// `1` means passthrough (no split); values `> 1` are bounded by
+/// `max_split_factor`.
+///
+/// Inputs:
+/// - `summed_bytes[i]` — byte size of upstream partition `i` summed across
+///   the alignment group (see `SplitPartitionsRule` docs).
+/// - `file_counts[i]` — number of `PartitionLocation`s backing upstream
+///   partition `i` on leaf 0 of the alignment group. v1 requires
+///   `file_counts[i] >= 2` to actually split — a single-file partition can't
+///   be sharded by file-list assignment.
+/// - `skew_factor` — multiplier over the median (Spark default 5.0).
+/// - `min_split_bytes` — absolute floor; partitions smaller than this are
+///   never split regardless of skew ratio (Spark default 256 MB; ours 64 MB
+///   to match the coalesce target).
+/// - `max_split_factor` — upper bound on per-partition fan-out (Spark default
+///   no explicit cap; we set 8 to match the doc and limit executor pressure).
+///
+/// Edge cases:
+/// - Empty input or `summed_bytes` of all zeros → all factors `1` (median is
+///   0, the multiplicative check short-circuits via the `min_split_bytes` floor).
+/// - `summed_bytes.len() != file_counts.len()` → panics in debug; in release
+///   the shorter slice wins. Callers must enforce equal length.
+pub fn decide_split_factors(
+    summed_bytes: &[u64],
+    file_counts: &[usize],
+    skew_factor: f64,
+    min_split_bytes: u64,
+    max_split_factor: u32,
+) -> Vec<u32> {
+    debug_assert_eq!(
+        summed_bytes.len(),
+        file_counts.len(),
+        "decide_split_factors: summed_bytes and file_counts must agree in length"
+    );
+
+    let median = robust_median(summed_bytes);
+
+    summed_bytes
+        .iter()
+        .zip(file_counts.iter())
+        .map(|(&bytes, &files)| {
+            // v1 file-list sharding can't subdivide a single file.
+            if files <= 1 {
+                return 1u32;
+            }
+            if bytes < min_split_bytes {
+                return 1u32;
+            }
+            let bytes_f = bytes as f64;
+            let median_f = median as f64;
+            if bytes_f < skew_factor * median_f {
+                return 1u32;
+            }
+            // Skew qualified — must split at least 2-ways; cap at max.
+            let raw = if median == 0 {
+                max_split_factor
+            } else {
+                (bytes_f / median_f).ceil() as u32
+            };
+            raw.clamp(2, max_split_factor)
+        })
+        .collect()
+}
+
+/// Expand per-idx split factors into a flat `Vec<SplitShard>`.
+///
+/// Order is `upstream_idx` ascending, then `shard_idx` ascending within each
+/// upstream. For factor `f`, the idx contributes `f` consecutive shards with
+/// `shard_idx` in `0..f`. Factor `1` contributes one passthrough entry with
+/// `shard_idx = 0, split_factor = 1`.
+///
+/// Result length equals `factors.iter().sum::<u32>() as usize` — this is K'.
+pub fn factors_to_shards(factors: &[u32]) -> Vec<SplitShard> {
+    let total: usize = factors.iter().map(|&f| f as usize).sum();
+    let mut shards = Vec::with_capacity(total);
+    for (idx, &f) in factors.iter().enumerate() {
+        // Skipped on factor=0 (which decide_split_factors never produces, but
+        // is defensive against future bugs).
+        for shard_idx in 0..f {
+            shards.push(SplitShard {
+                upstream_idx: idx as u32,
+                shard_idx,
+                split_factor: f,
+            });
+        }
+    }
+    shards
+}
+
+/// Median of a byte-size slice, robust against the single-outlier case the
+/// rule is designed to catch.
+///
+/// Returns 0 for empty input (treated as "no skew" by `decide_split_factors`).
+/// Uses the lower-mid for even-length input — exact-quantile precision isn't
+/// needed; what matters is that one huge value doesn't shift the median up.
+fn robust_median(values: &[u64]) -> u64 {
+    if values.is_empty() {
+        return 0;
+    }
+    let mut sorted: Vec<u64> = values.to_vec();
+    sorted.sort_unstable();
+    sorted[sorted.len() / 2]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Defaults the rule passes in real life. Pulled out so each test below
+    // reads as "this input → this factors vector at the production
+    // configuration", same convention as `coalesce/algorithm.rs`.
+    const SKEW: f64 = 5.0;
+    const MIN_BYTES: u64 = 64 * 1024 * 1024;
+    const MAX_FACTOR: u32 = 8;
+
+    fn factor(summed: &[u64], files: &[usize]) -> Vec<u32> {
+        decide_split_factors(summed, files, SKEW, MIN_BYTES, MAX_FACTOR)
+    }
+
+    #[test]
+    fn no_skew_returns_all_ones() {
+        // Uniform sizes — median equals every entry, ratio is exactly 1 < 5.
+        // Every entry returns factor 1 regardless of file count.
+        let sizes = vec![100 * 1024 * 1024; 8];
+        let files = vec![4; 8];
+        assert_eq!(factor(&sizes, &files), vec![1; 8]);
+    }
+
+    #[test]
+    fn single_outlier_splits_only_that_idx() {
+        // Four partitions: three at 10 MB, one at 2 GB. Median = 10 MB.
+        // 2 GB / 10 MB = 200 (way above max_factor=8) → factor capped at 8.
+        // Files = 8 each so the file-count guard doesn't fire.
+        let sizes = vec![
+            10 * 1024 * 1024,
+            10 * 1024 * 1024,
+            10 * 1024 * 1024,
+            2 * 1024 * 1024 * 1024,
+        ];
+        let files = vec![8; 4];
+        // The three small partitions are below the 64 MB floor → factor 1.
+        // The outlier qualifies on skew ratio and bytes → factor 8 (cap).
+        assert_eq!(factor(&sizes, &files), vec![1, 1, 1, 8]);
+    }
+
+    #[test]
+    fn below_min_bytes_never_splits() {
+        // Huge ratio (1000×) but the largest is 10 MB, below the 64 MB floor.
+        // No split happens — protects us from fanning out trivially small work.
+        let sizes = vec![10 * 1024, 10 * 1024, 10 * 1024 * 1024];
+        let files = vec![4; 3];
+        assert_eq!(factor(&sizes, &files), vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn single_file_cannot_split() {
+        // Outlier qualifies on bytes and ratio, but it's backed by 1 file.
+        // v1 file-list sharding can't subdivide a single file; bail.
+        let sizes = vec![10 * 1024 * 1024, 10 * 1024 * 1024, 2 * 1024 * 1024 * 1024];
+        let files = vec![4, 4, 1]; // outlier has only 1 file
+        assert_eq!(factor(&sizes, &files), vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn max_split_factor_caps_output() {
+        // Five partitions: four at 10 MB, one at 1 GB. Median (lower-mid of
+        // sorted [10MB, 10MB, 10MB, 10MB, 1GB]) = 10 MB. Ratio = 100 — well
+        // above max_factor=4 — so factor clamps to 4. (The small ones stay
+        // at 1: they're below the 64 MB floor.)
+        let sizes = vec![
+            10 * 1024 * 1024,
+            10 * 1024 * 1024,
+            10 * 1024 * 1024,
+            10 * 1024 * 1024,
+            1024 * 1024 * 1024,
+        ];
+        let files = vec![8; 5];
+        let factors = decide_split_factors(&sizes, &files, SKEW, MIN_BYTES, 4);
+        assert_eq!(factors, vec![1, 1, 1, 1, 4]);
+    }
+
+    #[test]
+    fn zero_median_does_not_panic_or_overshoot() {
+        // Three zeros and one large entry — median = 0. Without the
+        // min_split_bytes guard a naive `ceil(bytes / 0)` would be UB; the
+        // guard ensures we exit before that math runs.
+        let sizes = vec![0, 0, 0, 10 * 1024 * 1024 * 1024];
+        let files = vec![4; 4];
+        // The big one qualifies (well above 64 MB and skew=5 × 0 = 0 is trivially
+        // exceeded); factor goes to the max because the divisor is zero.
+        assert_eq!(factor(&sizes, &files), vec![1, 1, 1, 8]);
+    }
+
+    #[test]
+    fn empty_input_returns_empty_factors() {
+        let factors = decide_split_factors(&[], &[], SKEW, MIN_BYTES, MAX_FACTOR);
+        assert!(factors.is_empty());
+    }
+
+    #[test]
+    fn factors_to_shards_passthrough_and_split_mix() {
+        // [1, 1, 3, 1] over upstream idx 0..3 → 6 shards total:
+        // (idx=0, shard=0, factor=1), (idx=1, shard=0, factor=1),
+        // (idx=2, shard=0..2, factor=3) × 3, (idx=3, shard=0, factor=1).
+        let shards = factors_to_shards(&[1, 1, 3, 1]);
+        assert_eq!(shards.len(), 6);
+        assert_eq!(
+            shards[0],
+            SplitShard {
+                upstream_idx: 0,
+                shard_idx: 0,
+                split_factor: 1
+            }
+        );
+        assert_eq!(
+            shards[1],
+            SplitShard {
+                upstream_idx: 1,
+                shard_idx: 0,
+                split_factor: 1
+            }
+        );
+        assert_eq!(
+            shards[2],
+            SplitShard {
+                upstream_idx: 2,
+                shard_idx: 0,
+                split_factor: 3
+            }
+        );
+        assert_eq!(
+            shards[3],
+            SplitShard {
+                upstream_idx: 2,
+                shard_idx: 1,
+                split_factor: 3
+            }
+        );
+        assert_eq!(
+            shards[4],
+            SplitShard {
+                upstream_idx: 2,
+                shard_idx: 2,
+                split_factor: 3
+            }
+        );
+        assert_eq!(
+            shards[5],
+            SplitShard {
+                upstream_idx: 3,
+                shard_idx: 0,
+                split_factor: 1
+            }
+        );
+    }
+
+    #[test]
+    fn factors_to_shards_all_passthrough() {
+        let shards = factors_to_shards(&[1, 1, 1]);
+        assert_eq!(shards.len(), 3);
+        for (i, s) in shards.iter().enumerate() {
+            assert_eq!(s.upstream_idx, i as u32);
+            assert_eq!(s.shard_idx, 0);
+            assert_eq!(s.split_factor, 1);
+        }
+    }
+}

--- a/ballista/scheduler/src/state/aqe/split/mod.rs
+++ b/ballista/scheduler/src/state/aqe/split/mod.rs
@@ -15,14 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod coalesce_partitions;
-pub mod datafusion_patch;
-pub mod distributed_exchange;
-pub mod propagate_empty;
-pub mod split_partitions;
+//! AQE split-skewed-partitions helpers. See [`algorithm`] for details.
 
-pub use coalesce_partitions::*;
-pub use datafusion_patch::*;
-pub use distributed_exchange::*;
-pub use propagate_empty::*;
-pub use split_partitions::*;
+pub(crate) mod algorithm;
+pub(crate) use algorithm::*;

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -26,12 +26,9 @@
 
 use crate::assert_plan;
 use crate::state::aqe::planner::AdaptivePlanner;
-use crate::state::aqe::test::{mock_batch, mock_schema};
+use crate::state::aqe::test::{mock_batch, mock_schema, partitions_with_bytes_and_files};
 use ballista_core::extension::SessionConfigExt;
-use ballista_core::serde::scheduler::{
-    ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
-    PartitionId, PartitionLocation, PartitionStats,
-};
+use ballista_core::serde::scheduler::PartitionLocation;
 use datafusion::datasource::MemTable;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -81,31 +78,9 @@ fn register_partitioned_table(
 fn partitions_with_byte_sizes(
     per_partition_bytes: &[u64],
 ) -> Vec<Vec<PartitionLocation>> {
-    per_partition_bytes
-        .iter()
-        .enumerate()
-        .map(|(idx, &bytes)| {
-            vec![PartitionLocation {
-                map_partition_id: 0,
-                partition_id: PartitionId {
-                    job_id: "".to_string(),
-                    stage_id: 0,
-                    partition_id: idx,
-                },
-                executor_meta: ExecutorMetadata {
-                    id: "".to_string(),
-                    host: "".to_string(),
-                    port: 0,
-                    grpc_port: 0,
-                    specification: ExecutorSpecification::default().with_task_slots(0),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
-                },
-                partition_stats: PartitionStats::new(Some(1), None, Some(bytes)),
-                file_id: None,
-                is_sort_shuffle: false,
-            }]
-        })
-        .collect()
+    let with_files: Vec<(u64, usize)> =
+        per_partition_bytes.iter().map(|&b| (b, 1)).collect();
+    partitions_with_bytes_and_files(&with_files)
 }
 
 /// Happy path: M=8 upstream partitions @ 50 bytes each, target=200.

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -21,6 +21,8 @@ mod alter_stages;
 mod coalesce_rule;
 /// Tests if plan is going to be split to stages correctly
 mod plan_to_stages;
+/// Functional tests for the SplitPartitionsRule (mixed SQL bail + synthetic happy path)
+mod split_rule;
 
 use ballista_core::config::BALLISTA_SHUFFLE_SORT_BASED_ENABLED;
 use ballista_core::extension::SessionConfigExt;
@@ -140,4 +142,57 @@ pub(crate) fn mock_context_sort_shuffle() -> SessionContext {
         .build();
 
     SessionContext::new_with_state(state)
+}
+
+/// Build a `Vec<Vec<PartitionLocation>>` where upstream partition `i`
+/// reports `bytes_and_files[i].0` bytes spread evenly across
+/// `bytes_and_files[i].1` `PartitionLocation` entries (one per upstream
+/// map task).
+///
+/// The two consumers of this helper read different fields:
+/// - the **coalesce** rule sums `num_bytes` across leaves; file count is
+///   irrelevant (use `files = 1`).
+/// - the **split** rule reads both summed `num_bytes` and per-partition
+///   file count (`inner.len()` on leaf 0).
+///
+/// When `files == 1` the entry uses `file_id = None` to match the
+/// coalesce-style "no file metadata" shape; for `files >= 2` each entry
+/// gets a distinct `file_id` and `map_partition_id` so round-robin
+/// assignment in the split adapter has stable ordering.
+pub(crate) fn partitions_with_bytes_and_files(
+    bytes_and_files: &[(u64, usize)],
+) -> Vec<Vec<PartitionLocation>> {
+    bytes_and_files
+        .iter()
+        .enumerate()
+        .map(|(idx, &(bytes, files))| {
+            let per_file = if files == 0 { 0 } else { bytes / files as u64 };
+            (0..files)
+                .map(|file_id| PartitionLocation {
+                    map_partition_id: if files == 1 { 0 } else { file_id },
+                    partition_id: PartitionId {
+                        job_id: "".to_string(),
+                        stage_id: 0,
+                        partition_id: idx,
+                    },
+                    executor_meta: ExecutorMetadata {
+                        id: "".to_string(),
+                        host: "".to_string(),
+                        port: 0,
+                        grpc_port: 0,
+                        specification: ExecutorSpecification::default()
+                            .with_task_slots(0),
+                        os_info: ExecutorOperatingSystemSpecification::default(),
+                    },
+                    partition_stats: PartitionStats::new(Some(1), None, Some(per_file)),
+                    file_id: if files == 1 {
+                        None
+                    } else {
+                        Some(file_id as u64)
+                    },
+                    is_sort_shuffle: false,
+                })
+                .collect()
+        })
+        .collect()
 }

--- a/ballista/scheduler/src/state/aqe/test/split_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/split_rule.rs
@@ -1,0 +1,415 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Functional tests for [`SplitPartitionsRule`].
+//!
+//! Mock helpers (`mock_batch`, `mock_schema`) come from the parent test
+//! module. Byte-size fixtures use the algorithm's production defaults
+//! (skew=5.0, min_split_bytes=64 MiB, max_factor=8) — see
+//! `state/aqe/split/algorithm.rs` tests for unit-level coverage of the
+//! decision function itself.
+
+use crate::assert_plan;
+use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
+use crate::state::aqe::optimizer_rule::SplitPartitionsRule;
+use crate::state::aqe::planner::AdaptivePlanner;
+use crate::state::aqe::test::{mock_batch, mock_schema, partitions_with_bytes_and_files};
+use ballista_core::extension::SessionConfigExt;
+use datafusion::datasource::MemTable;
+use datafusion::datasource::memory::MemorySourceConfig;
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::execution::SessionStateBuilder;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{ExecutionPlan, Partitioning};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use std::sync::Arc;
+
+/// Build a session context with split-rule knobs forced to specific values.
+/// `skew_factor=5.0`, `max_factor=8` are the production defaults; the
+/// `min_split_bytes` floor is set to `1` for tests so we can use small
+/// synthetic byte sizes without hitting the production 64 MiB floor.
+///
+/// `prefer_hash_join`: when `Some(false)`, force the SQL planner to emit
+/// `SortMergeJoinExec` instead of `HashJoinExec(Partitioned)`; `None` keeps
+/// the DataFusion default.
+fn split_context(
+    target_partitions: usize,
+    enabled: bool,
+    prefer_hash_join: Option<bool>,
+) -> SessionContext {
+    let mut config = SessionConfig::new_with_ballista()
+        .with_target_partitions(target_partitions)
+        .with_round_robin_repartition(false)
+        .with_ballista_split_enabled(enabled)
+        .with_ballista_split_skew_factor(5.0)
+        .with_ballista_split_min_split_bytes(1)
+        .with_ballista_split_max_split_factor(8);
+    if let Some(v) = prefer_hash_join {
+        config = config.set_bool("datafusion.optimizer.prefer_hash_join", v);
+    }
+
+    let state = SessionStateBuilder::new()
+        .with_config(config)
+        .with_default_features()
+        .build();
+
+    SessionContext::new_with_state(state)
+}
+
+/// As in `coalesce_rule.rs`: register a MemTable with `n_partitions` rows
+/// so DataFusion's `EnforceDistribution` inserts the hash exchanges needed
+/// for join plans.
+fn register_partitioned_table(
+    ctx: &SessionContext,
+    name: &str,
+    n_partitions: usize,
+) -> datafusion::error::Result<()> {
+    let data = (0..n_partitions)
+        .map(|_| Ok(vec![mock_batch()?]))
+        .collect::<datafusion::error::Result<Vec<_>>>()?;
+    let table = MemTable::try_new(mock_schema(), data)?;
+    ctx.register_table(name, Arc::new(table))?;
+    Ok(())
+}
+
+/// Build a synthetic stage subtree:
+///
+/// ```text
+/// AdaptiveDatafusionExec
+///   ProjectionExec (pass-through, no distribution requirement)
+///     ExchangeExec_leaf (with resolved shuffle_partitions)
+/// ```
+///
+/// ProjectionExec's `required_input_distribution()` is
+/// `UnspecifiedDistribution`, so the safety walk passes — this is the
+/// shape needed to test the rule's slot-attachment path.
+fn build_synthetic_stage(
+    m: usize,
+    bytes_and_files: &[(u64, usize)],
+) -> datafusion::error::Result<(Arc<dyn ExecutionPlan>, Arc<ExchangeExec>)> {
+    debug_assert_eq!(m, bytes_and_files.len());
+
+    let schema = mock_schema();
+    // Tiny in-memory source — content is irrelevant since the leaf is
+    // resolved (the rule doesn't execute, just reads stats).
+    let mem = Arc::new(MemorySourceConfig::try_new(
+        &[vec![mock_batch()?]],
+        schema.clone(),
+        None,
+    )?);
+    let data_source: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(mem));
+
+    let leaf = Arc::new(ExchangeExec::new(
+        data_source,
+        Some(Partitioning::Hash(vec![Arc::new(Column::new("c", 2))], m)),
+        /* plan_id */ 0,
+    ));
+    leaf.resolve_shuffle_partitions(partitions_with_bytes_and_files(bytes_and_files));
+
+    // Project a single column to keep the plan compact in snapshots. This is
+    // a no-op identity-style projection; it exists purely as the "non-hash-
+    // requiring consumer" between the leaf and the root.
+    let projection = Arc::new(ProjectionExec::try_new(
+        vec![(Arc::new(Column::new("a", 0)) as _, "a".to_string())],
+        leaf.clone() as Arc<dyn ExecutionPlan>,
+    )?);
+
+    let root = Arc::new(AdaptiveDatafusionExec::new(
+        /* plan_id */ 1, projection,
+    )) as Arc<dyn ExecutionPlan>;
+
+    Ok((root, leaf))
+}
+
+// ---------- SQL-driven bail tests ----------
+
+/// FinalPartitioned aggregate over a hash exchange: the rule's safety walk
+/// sees `AggregateExec(FinalPartitioned)::required_input_distribution() ==
+/// [HashPartitioned(...)]` and bails. Even with a clearly skewed byte
+/// distribution and split enabled, no `split=` annotation appears on the
+/// leaf Exchange. This is the v1-honest scope check — TPC-H Q2's skew sits
+/// behind a FinalPartitioned aggregate, and v1 cannot help it.
+#[tokio::test]
+async fn bails_on_final_partitioned_aggregate() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, true, None);
+    ctx.register_batch("t", mock_batch()?)?;
+
+    let plan = ctx
+        .sql("select min(a) as c0, c as c2 from t group by c")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let mut planner =
+        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+
+    let _ = planner.runnable_stages()?.unwrap();
+    // Heavy skew on partition 7: 4 KiB vs 1 byte everywhere else. The rule
+    // would split this if the consumer allowed it; FinalPartitioned doesn't.
+    planner.finalise_stage_internal(
+        0,
+        partitions_with_bytes_and_files(&[
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (4096, 4),
+        ]),
+    )?;
+
+    let _ = planner.runnable_stages()?;
+
+    // No `split=` annotation — the safety walk hit AggregateExec
+    // (FinalPartitioned) and bailed.
+    assert_plan!(planner.current_plan(),  @ "
+    AdaptiveDatafusionExec: is_final=true, plan_id=1, stage_id=1, stage_resolved=false
+      ProjectionExec: expr=[min(t.a)@1 as c0, c@0 as c2]
+        AggregateExec: mode=FinalPartitioned, gby=[c@0 as c], aggr=[min(t.a)]
+          ExchangeExec: partitioning=Hash([c@0], 8), plan_id=0, stage_id=0, stage_resolved=true
+            AggregateExec: mode=Partial, gby=[c@1 as c], aggr=[min(t.a)]
+              DataSourceExec: partitions=1, partition_sizes=[1]
+    ");
+
+    Ok(())
+}
+
+/// Partitioned hash join: `HashJoinExec(Partitioned)` requires hash-partitioned
+/// input on both legs. Same safety walk as the aggregate test triggers — the
+/// rule sees a hash distribution requirement and bails on both leg leaves
+/// uniformly. Even though we apply heavy skew to one leg, no `split=` shows
+/// up on either leaf.
+#[tokio::test]
+async fn bails_on_partitioned_hash_join() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, true, None);
+    register_partitioned_table(&ctx, "t1", 8)?;
+    register_partitioned_table(&ctx, "t2", 8)?;
+
+    let plan = ctx
+        .sql("select t1.a, t2.b from t1 join t2 on t1.c = t2.c")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let mut planner =
+        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+
+    let stages = planner.runnable_stages()?.unwrap();
+    assert_eq!(2, stages.len());
+
+    planner.finalise_stage_internal(
+        0,
+        partitions_with_bytes_and_files(&[
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (4096, 4),
+        ]),
+    )?;
+    planner.finalise_stage_internal(1, partitions_with_bytes_and_files(&[(1, 4); 8]))?;
+
+    let _ = planner.runnable_stages()?;
+
+    // Both join legs: `split=` absent (safety walk hit SortMergeJoinExec
+    // /HashJoinExec partitioned requirement).
+    assert_plan!(planner.current_plan(),  @ "
+    AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
+      ProjectionExec: expr=[a@0 as a, b@2 as b]
+        SortMergeJoinExec: join_type=Inner, on=[(c@1, c@1)]
+          SortExec: expr=[c@1 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([c@1], 8), plan_id=0, stage_id=0, stage_resolved=true
+              DataSourceExec: partitions=8, partition_sizes=[1, 1, 1, 1, 1, 1, 1, 1]
+          SortExec: expr=[c@1 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([c@1], 8), plan_id=1, stage_id=1, stage_resolved=true
+              DataSourceExec: partitions=8, partition_sizes=[1, 1, 1, 1, 1, 1, 1, 1]
+    ");
+
+    Ok(())
+}
+
+/// Sort-merge join: same plan shape as the hash-join case when
+/// `prefer_hash_join=false`. SortMergeJoinExec's
+/// `required_input_distribution()` is also `HashPartitioned(...)`, so the
+/// safety walk triggers the same bail.
+#[tokio::test]
+async fn bails_on_sort_merge_join() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, true, Some(false));
+    register_partitioned_table(&ctx, "t1", 8)?;
+    register_partitioned_table(&ctx, "t2", 8)?;
+
+    let plan = ctx
+        .sql("select t1.a, t2.b from t1 join t2 on t1.c = t2.c")
+        .await?
+        .create_physical_plan()
+        .await?;
+    let mut planner =
+        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+
+    let stages = planner.runnable_stages()?.unwrap();
+    assert_eq!(2, stages.len());
+
+    planner.finalise_stage_internal(
+        0,
+        partitions_with_bytes_and_files(&[
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (1, 4),
+            (4096, 4),
+        ]),
+    )?;
+    planner.finalise_stage_internal(1, partitions_with_bytes_and_files(&[(1, 4); 8]))?;
+
+    let _ = planner.runnable_stages()?;
+
+    assert_plan!(planner.current_plan(),  @ "
+    AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
+      ProjectionExec: expr=[a@0 as a, b@2 as b]
+        SortMergeJoinExec: join_type=Inner, on=[(c@1, c@1)]
+          SortExec: expr=[c@1 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([c@1], 8), plan_id=0, stage_id=0, stage_resolved=true
+              DataSourceExec: partitions=8, partition_sizes=[1, 1, 1, 1, 1, 1, 1, 1]
+          SortExec: expr=[c@1 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([c@1], 8), plan_id=1, stage_id=1, stage_resolved=true
+              DataSourceExec: partitions=8, partition_sizes=[1, 1, 1, 1, 1, 1, 1, 1]
+    ");
+
+    Ok(())
+}
+
+/// Disabled rule: even the synthetic safe shape doesn't trigger any split.
+/// The rule returns its input plan verbatim at the first `bc.split_enabled()`
+/// check, so the leaf's split slot stays `None`.
+#[tokio::test]
+async fn skips_when_disabled() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, /* enabled */ false, None);
+    let config = ctx.state().config().options().clone();
+
+    let (root, leaf) = build_synthetic_stage(4, &[(1, 4), (1, 4), (1, 4), (4096, 4)])?;
+
+    let _ = SplitPartitionsRule.optimize(root, &config)?;
+    assert!(
+        leaf.split().is_none(),
+        "leaf should have no SplitPlan when rule is disabled"
+    );
+    Ok(())
+}
+
+// ---------- Synthetic happy-path / decision tests ----------
+
+/// Happy path: one upstream partition is ~4000× larger than the median and
+/// has 4 files. The rule fires; the leaf's split slot holds a SplitPlan with
+/// `K' = 3 passthroughs + 8 split shards = 11` (max_factor cap).
+#[tokio::test]
+async fn attaches_split_when_skewed_partition_has_multiple_files()
+-> datafusion::error::Result<()> {
+    let ctx = split_context(8, true, None);
+    let config = ctx.state().config().options().clone();
+
+    let (root, leaf) = build_synthetic_stage(4, &[(1, 4), (1, 4), (1, 4), (4096, 4)])?;
+
+    let _ = SplitPartitionsRule.optimize(root, &config)?;
+    let sp = leaf.split().expect("rule should have attached a SplitPlan");
+    assert_eq!(sp.upstream_partition_count, 4, "M tracked from leaf");
+    // 3 passthroughs + factor-8 split for the skewed idx = 11 shards.
+    assert_eq!(sp.shards.len(), 11, "K' = 3*1 + 1*8");
+    // Verify the split idx is 3 (the skewed one) with shards 0..8.
+    let split_shards: Vec<_> = sp.shards.iter().filter(|s| s.split_factor > 1).collect();
+    assert_eq!(split_shards.len(), 8);
+    for (i, s) in split_shards.iter().enumerate() {
+        assert_eq!(s.upstream_idx, 3);
+        assert_eq!(s.shard_idx, i as u32);
+        assert_eq!(s.split_factor, 8);
+    }
+    Ok(())
+}
+
+/// Single-file guard: even when the byte distribution would qualify as
+/// skewed, an upstream partition with only one `PartitionLocation` can't be
+/// sharded by file-list assignment in v1. The whole rule returns "no
+/// decision" because every per-idx factor is 1 (the skewed idx is blocked
+/// by `file_counts[i] <= 1`).
+#[tokio::test]
+async fn skips_when_single_file_in_skewed_idx() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, true, None);
+    let config = ctx.state().config().options().clone();
+
+    // partition 3 has 4096 bytes but only 1 file backing it.
+    let (root, leaf) = build_synthetic_stage(4, &[(1, 4), (1, 4), (1, 4), (4096, 1)])?;
+
+    let _ = SplitPartitionsRule.optimize(root, &config)?;
+    assert!(
+        leaf.split().is_none(),
+        "single-file skewed partition cannot be split in v1"
+    );
+    Ok(())
+}
+
+/// Idempotence: a leaf that already has `split()` set is skipped on a
+/// second pass. Same plan, same bytes, two consecutive `optimize` calls —
+/// the slot from the first run is what the second observes, and the rule
+/// short-circuits before recomputing.
+#[tokio::test]
+async fn idempotent_on_second_pass() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, true, None);
+    let config = ctx.state().config().options().clone();
+
+    let (root, leaf) = build_synthetic_stage(4, &[(1, 4), (1, 4), (1, 4), (4096, 4)])?;
+
+    let plan_after_first = SplitPartitionsRule.optimize(root, &config)?;
+    let sp_after_first = leaf.split().expect("first pass should attach SplitPlan");
+    let kprime_first = sp_after_first.shards.len();
+
+    // Second pass should observe the existing slot and bail without
+    // overwriting. We compare Arc identity on the slot contents.
+    let _ = SplitPartitionsRule.optimize(plan_after_first, &config)?;
+    let sp_after_second = leaf.split().expect("second pass should not clear the slot");
+    assert!(
+        Arc::ptr_eq(&sp_after_first, &sp_after_second),
+        "second pass should not overwrite the SplitPlan attached by the first"
+    );
+    assert_eq!(sp_after_second.shards.len(), kprime_first);
+    Ok(())
+}
+
+/// Default-off sanity: when the rule is disabled, optimize returns the
+/// input Arc verbatim (`Arc::ptr_eq` holds). This is the regression check
+/// the verification plan calls "Gate 5".
+#[tokio::test]
+async fn default_off_returns_input_arc_verbatim() -> datafusion::error::Result<()> {
+    let ctx = split_context(8, /* enabled */ false, None);
+    let config = ctx.state().config().options().clone();
+
+    let (root, _leaf) = build_synthetic_stage(4, &[(1, 4), (1, 4), (1, 4), (4096, 4)])?;
+
+    let before = root.clone();
+    let after = SplitPartitionsRule.optimize(root, &config)?;
+    assert!(
+        Arc::ptr_eq(&before, &after),
+        "disabled rule must return the input Arc unchanged"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Adds **`SplitPartitionsRule`** — the inverse of #1684's `CoalescePartitionsRule`. When upstream stats show one shuffle partition is far larger than the median, the rule fans that partition out across multiple reader tasks via round-robin assignment over its file list, instead of folding small partitions together. Same per-stage invocation, same alignment-group leaf walk, same carrier-slot-on-`ExchangeExec` pattern as #1684 — strict architectural mirror.

> **Stacks on #1684.** Until that lands, this PR's diff shows the 5 coalesce commits + 1 split commit. Once #1684 merges I'll rebase and the diff will reduce to the single split commit.

Part of the AQE epic #1359. Motivating bug: #1643 (TPC-H Q2 SF1000, one partition 8670× larger than the median). **v1 does NOT close #1643** — see "v1 scope" below.

## Mechanism — file-list sharding (v1)

The shuffle reader side already lists multiple `PartitionLocation`s per output partition (one per upstream map task). Splitting just means handing those locations to several reader tasks via round-robin assignment by file index. No row-range reads, no protobuf changes, no executor data-path changes — pure scheduler/adapter work.

Tradeoff: a partition backed by only one file can't be split this way. The rule bails on that idx (factor stays at 1). Row-range reads to lift that restriction live in a v2 task doc (linked at the bottom).

## v1 scope — and what it does NOT cover

File-list sharding produces `UnknownPartitioning(K')` output. Rows that used to land in the same hash bucket on the M-side end up scattered across multiple K'-side partitions (the round-robin assignment is file-keyed, not row-keyed). That breaks any downstream operator with a hash or single-partition input requirement:

- `HashJoinExec(Partitioned)` and `SortMergeJoinExec` — both legs must agree on hash buckets.
- `AggregateExec(FinalPartitioned)` — assumes each downstream partition holds a closed set of group keys.
- Any future operator whose `required_input_distribution()` returns `HashPartitioned(_)` or `SinglePartition`.

Rather than enumerate operator types, the rule walks the stage subtree and inspects `required_input_distribution()` directly. If any node above the leaves demands hash or single-partition input, the rule bails the whole stage. Strictly correct, future-proof against new DataFusion operators.

**TPC-H Q2's skew sits behind a `FinalPartitioned` aggregate**, so v1 cannot help it. v1 helps the narrower set of stages where the consumer is distribution-agnostic (`FilterExec`, `ProjectionExec`, `LocalLimitExec`, single-input scans into `UnknownPartitioning` sinks). The infrastructure is the win; v2 (row-range reads + aggregate-aware plan rewriting) is where Q2 lands.

## Surface

Opt-in via a single boolean. **`ballista.planner.split.enabled=false`** is the default — the rule short-circuits, the plan flows through untouched. Users who want the skew-handling turn it on.

| key | default | meaning |
|---|---|---|
| `ballista.planner.split.enabled` | `false` | master gate |
| `ballista.planner.split.skew_factor` | `5.0` | Spark `OptimizeSkewedJoin` default — partition is "skewed" if `bytes > skew_factor × median` |
| `ballista.planner.split.min_split_bytes` | 64 MiB | absolute floor — don't fan-out trivially small partitions |
| `ballista.planner.split.max_split_factor` | `8` | per-partition fan-out cap to limit executor pressure |

## Algorithm

For each per-stage call (mirrors the coalesce rule line-for-line):

1. Bail if disabled.
2. Single subtree walk that does two things: bail if any operator demands `HashPartitioned`/`SinglePartition` input, AND collect every leaf `ExchangeExec` (`Jump` after each hit, same convention as #1684).
3. Conflict guard: bail if any leaf already has `coalesce()` or `split()` set.
4. Alignment-group invariant: every leaf shares M (Q22 guard — same one #1684 added in `fix(coalesce): bail on heterogeneous M`).
5. Sum byte sizes element-wise across the alignment group; capture leaf-0's file-count vector.
6. `decide_split_factors(summed_bytes, file_counts, skew, min_bytes, max_factor)` — three guards (single-file → factor 1; below min-bytes → factor 1; below skew ratio → factor 1) then `ceil(bytes / median)` capped at `max_factor`, floored at 2.
7. If every factor is 1, bail.
8. Build one `SplitPlan` with `shards = factors_to_shards(&factors)` and attach uniformly to every leaf via `set_split` — sharing the plan (not just K') keeps per-idx fan-out identical across leaves, which matters for non-join multi-leaf shapes (UNION).

Sharing the plan across the alignment group is the same invariant #1684 enforces for coalesce — preserves uniform K' downstream.

## Components

| Area | Change |
|---|---|
| **Rule** | `SplitPartitionsRule` in `state/aqe/optimizer_rule/split_partitions.rs`. Unit struct. Invoked per-stage in `AdaptivePlanner::actionable_stages()` right after `CoalescePartitionsRule`. |
| **Carrier** | `ExchangeExec` gains an `Arc<Mutex<Option<Arc<SplitPlan>>>>` slot next to the existing `coalesce` slot, with `set_split` / `split` accessors. `split=K' of M` annotation appears in `DisplayAs` output only when attached. Mutually exclusive with `coalesce` — rule's conflict guard enforces it. |
| **Adapter** | `BallistaAdapter::transform_children` checks `exchange.split()`; on `Some(sp)` it pre-shards the M-shape upstream `Vec<Vec<PartitionLocation>>` into K'-shape via `SplitShard::owns_file(file_idx)` and builds the reader via `ShuffleReaderExec::try_new_split` with `UnknownPartitioning(K')`. |
| **Reader** | `ShuffleReaderExec::try_new_split` constructor + `split: Option<SplitPlan>` field. Threaded through `with_work_dir`, `with_client_pool`, `with_new_children`, `partition_statistics`, `DisplayAs`. `execute()` needs no changes — `self.partition[idx]` already returns the per-output-partition `Vec<PartitionLocation>`, which the adapter has pre-sharded. The reader is oblivious to whether sharding happened. |
| **Algorithm** | Pure-CPU helpers in `state/aqe/split/algorithm.rs` — `decide_split_factors` (median-based skew detection mirroring Spark's `OptimizeSkewedJoin`) + `factors_to_shards` (per-idx factor → flat shard list). |
| **Config** | Four new keys (table above). |

`SplitPlan` is NOT round-tripped through proto in v1 — the rule attaches it on the scheduler side, the adapter consumes it inline, and the resulting `ShuffleReaderExec` ships already-sharded `Vec<Vec<PartitionLocation>>`. A protobuf round-trip would only be needed if the rule outcome had to survive serialization to the executor, which it doesn't.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — workspace tests pass, 0 failures (includes the 7 coalesce regressions from #1684 plus the 8 new split tests).
- [x] `cargo clippy --workspace --all-targets --tests` — 0 warnings.
- [x] `cargo fmt --all` — clean.
- [x] 9 unit tests in `state/aqe/split/algorithm.rs` covering the decision function
- [x] 8 functional tests in `state::aqe::test::split_rule`:
- [ ] **TPC-H SF=100 sanity sweep, 22 queries × 2 join variants, `split.enabled=true`**: deferred to PR validation env. Expected outcome is mostly non-regression — most queries hit a hash or `FinalPartitioned` consumer and the rule bails. If any query *does* fire the rule (a stage ending in `Filter` / `Projection` / `LocalLimit` over a hash exchange), I'll record the K → K' increase in a comment.

## v2 follow-up

The honest scope limitation in v1 (file-list sharding requires ≥2 files per partition; bails on hash/single consumers) is lifted by v2 — row-range reads (`PartitionLocation::row_range: Option<(u64, u64)>`, batch-count IPC reader on the executor) AND aggregate-aware splitting (rewrite `AggregateExec(FinalPartitioned)` into per-shard partial + reshuffle + final). That's the path #1643 will actually land on. Task doc written and cross-linked.
