### PR TITLE
feat(aqe): dynamic switching from streaming agg to hash aggregation

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -85,6 +85,9 @@ pub const BALLISTA_SHUFFLE_SORT_BASED_MEMORY_LIMIT_PER_TASK_BYTES: &str =
 /// pattern in the distributed planner. Set to `0` to disable promotion.
 pub const BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES: &str =
     "ballista.optimizer.broadcast_join_threshold_bytes";
+/// Configuration key for enabling dynamic streaming↔hash aggregation switching in AQE.
+pub const BALLISTA_AQE_DYNAMIC_AGGREGATE_ENABLED: &str =
+    "ballista.aqe.dynamic_aggregate.enabled";
 
 /// Result type for configuration parsing operations.
 pub type ParseResult<T> = result::Result<T, String>;
@@ -163,6 +166,13 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                           Set to 0 to disable promotion.".to_string(),
                          DataType::UInt64,
                          Some((10 * 1024 * 1024).to_string())),
+        ConfigEntry::new(BALLISTA_AQE_DYNAMIC_AGGREGATE_ENABLED.to_string(),
+                         "Enable dynamic streaming↔hash aggregation switching in Adaptive Query \
+                          Execution. When enabled, re-derives InputOrderMode from the current \
+                          input EquivalenceProperties after each stage completes and rewrites the \
+                          aggregate if the derived mode differs (EXPERIMENTAL).".to_string(),
+                         DataType::Boolean,
+                         Some(false.to_string())),
         ConfigEntry::new(BALLISTA_CLIENT_PULL.to_string(),
                          "Should client employ pull or push job tracking. In pull mode client will make a request to server in the loop, until job finishes. Pull mode is kept for legacy clients.".to_string(),
                          DataType::Boolean,
@@ -381,6 +391,11 @@ impl BallistaConfig {
     /// `0` disables promotion.
     pub fn broadcast_join_threshold_bytes(&self) -> usize {
         self.get_usize_setting(BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES)
+    }
+
+    /// Returns whether dynamic streaming↔hash aggregation switching is enabled in AQE.
+    pub fn aqe_dynamic_aggregate_enabled(&self) -> bool {
+        self.get_bool_setting(BALLISTA_AQE_DYNAMIC_AGGREGATE_ENABLED)
     }
 
     /// Should client employ pull or push job tracking strategy

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/dynamic_aggregate_algorithm.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/dynamic_aggregate_algorithm.rs
@@ -1,0 +1,338 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::state::aqe::execution_plan::ExchangeExec;
+use ballista_core::config::BallistaConfig;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::aggregates::AggregateExec;
+use log::info;
+use std::sync::Arc;
+
+/// AQE rule that re-derives `InputOrderMode` for each `AggregateExec` after a
+/// stage completes and rewrites the operator when the derived mode differs from
+/// the cached one.
+///
+/// DataFusion freezes `InputOrderMode` (Linear = hash table / Sorted = streaming /
+/// PartiallySorted) at plan time. After a shuffle stage resolves, the input's
+/// `EquivalenceProperties` may expose ordering that wasn't visible earlier, making
+/// streaming aggregation possible (or, after a subtree rewrite, making the previously
+/// assumed ordering stale). This rule repairs both cases on each AQE replan.
+///
+/// Relies on `AggregateExec::with_new_children` calling `try_new_with_schema`,
+/// which re-derives `input_order_mode` from the current input equivalence
+/// properties — no upstream DataFusion changes required.
+///
+/// Enabled via `ballista.aqe.dynamic_aggregate.enabled` (default: false).
+#[derive(Debug, Clone, Default)]
+pub struct DynamicAggregateAlgorithmRule {}
+
+impl DynamicAggregateAlgorithmRule {
+    fn transform(
+        plan: Arc<dyn ExecutionPlan>,
+        enabled: bool,
+    ) -> datafusion::error::Result<Transformed<Arc<dyn ExecutionPlan>>> {
+        if !enabled {
+            return Ok(Transformed::no(plan));
+        }
+        let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() else {
+            return Ok(Transformed::no(plan));
+        };
+        // Only act when a resolved exchange exists below — if nothing resolved,
+        // the ordering is the same as at initial plan time and no switch is needed.
+        if !subtree_has_resolved_exchange(&plan) {
+            return Ok(Transformed::no(plan));
+        }
+
+        // Re-derive InputOrderMode by reconstructing the aggregate with the same
+        // input. with_new_children → try_new_with_schema re-runs the derivation
+        // against the current input EquivalenceProperties.
+        let rebuilt = plan
+            .clone()
+            .with_new_children(vec![agg.children()[0].clone()])?;
+        let rebuilt_agg = rebuilt
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("with_new_children on AggregateExec must return AggregateExec");
+
+        if rebuilt_agg.input_order_mode() == agg.input_order_mode() {
+            return Ok(Transformed::no(plan));
+        }
+
+        info!(
+            "DynamicAggregateAlgorithmRule: switching InputOrderMode {:?} → {:?}",
+            agg.input_order_mode(),
+            rebuilt_agg.input_order_mode(),
+        );
+        Ok(Transformed::yes(rebuilt))
+    }
+}
+
+impl PhysicalOptimizerRule for DynamicAggregateAlgorithmRule {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let enabled = config
+            .extensions
+            .get::<BallistaConfig>()
+            .map(|c| c.aqe_dynamic_aggregate_enabled())
+            .unwrap_or(false);
+        Ok(plan.transform_up(|p| Self::transform(p, enabled))?.data)
+    }
+
+    fn name(&self) -> &str {
+        "DynamicAggregateAlgorithmRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        false
+    }
+}
+
+/// Returns true if any `ExchangeExec` in `plan`'s subtree is resolved
+/// (i.e. its shuffle has completed). Recurses through all nodes, including
+/// through exchange boundaries — unlike `nearest_exchange_status` in
+/// `distributed_exchange.rs` which stops at the first exchange, here we
+/// want to know if *any* upstream stage has finished.
+fn subtree_has_resolved_exchange(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    if let Some(exchange) = plan.as_any().downcast_ref::<ExchangeExec>() {
+        exchange.shuffle_created() && !exchange.inactive_stage
+    } else {
+        plan.children()
+            .iter()
+            .any(|child| subtree_has_resolved_exchange(child))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ballista_core::config::BallistaConfig;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::{ColumnStatistics, Statistics};
+    use datafusion::config::{ConfigOptions, ExtensionOptions};
+    use datafusion::physical_expr::LexOrdering;
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+    use datafusion::physical_plan::sorts::sort::SortExec;
+    use datafusion::physical_plan::test::exec::StatisticsExec;
+    use datafusion::physical_expr::PhysicalSortExpr;
+    use std::sync::Arc;
+
+    fn leaf_unsorted() -> Arc<dyn ExecutionPlan> {
+        Arc::new(StatisticsExec::new(
+            Statistics {
+                num_rows: Default::default(),
+                total_byte_size: Default::default(),
+                column_statistics: vec![
+                    ColumnStatistics::new_unknown(),
+                    ColumnStatistics::new_unknown(),
+                ],
+            },
+            Schema::new(vec![
+                Field::new("k", DataType::Int32, true),
+                Field::new("v", DataType::Int64, true),
+            ]),
+        ))
+    }
+
+    fn leaf_sorted_on_k() -> Arc<dyn ExecutionPlan> {
+        let sort_expr =
+            PhysicalSortExpr::new_default(Arc::new(Column::new("k", 0)));
+        let ordering = LexOrdering::new(vec![sort_expr]).unwrap();
+        Arc::new(SortExec::new(ordering, leaf_unsorted()))
+    }
+
+    fn resolved_exchange(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let exchange = ExchangeExec::new(input, None, 0);
+        exchange.resolve_shuffle_partitions(vec![]);
+        Arc::new(exchange)
+    }
+
+    fn unresolved_exchange(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        Arc::new(ExchangeExec::new(input, None, 0))
+    }
+
+    fn aggregate_on_k(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let schema = input.schema();
+        let k_col = Arc::new(Column::new("k", 0)) as _;
+        let group_by = PhysicalGroupBy::new_single(vec![(k_col, "k".to_string())]);
+        Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Single,
+                group_by,
+                vec![],
+                vec![],
+                input,
+                schema,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn config_with_flag(enabled: bool) -> ConfigOptions {
+        let mut ballista = BallistaConfig::default();
+        if enabled {
+            ballista
+                .set(
+                    "aqe.dynamic_aggregate.enabled",
+                    "true",
+                )
+                .unwrap();
+        }
+        let mut opts = ConfigOptions::new();
+        opts.extensions.insert(ballista);
+        opts
+    }
+
+    // --- gate ---
+
+    #[test]
+    fn gate_disabled_returns_no_transform() {
+        let plan = aggregate_on_k(resolved_exchange(leaf_sorted_on_k()));
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let result = rule.optimize(plan.clone(), &config_with_flag(false)).unwrap();
+        assert!(
+            Arc::ptr_eq(&result, &plan),
+            "gate disabled: plan must be returned unchanged (same Arc)"
+        );
+    }
+
+    // --- subtree_has_resolved_exchange ---
+
+    #[test]
+    fn no_exchange_skips() {
+        // AggregateExec with no exchange at all → no rewrite even when enabled
+        let plan = aggregate_on_k(leaf_sorted_on_k());
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let result = rule.optimize(plan.clone(), &config_with_flag(true)).unwrap();
+        assert!(Arc::ptr_eq(&result, &plan));
+    }
+
+    #[test]
+    fn unresolved_exchange_skips() {
+        let plan = aggregate_on_k(unresolved_exchange(leaf_sorted_on_k()));
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let result = rule.optimize(plan.clone(), &config_with_flag(true)).unwrap();
+        assert!(Arc::ptr_eq(&result, &plan));
+    }
+
+    // --- mode transitions ---
+
+    #[test]
+    fn linear_to_sorted_when_input_fully_ordered() {
+        // Input: SortExec on k → resolved ExchangeExec → AggregateExec(group_by=[k])
+        // The SortExec grants ordering on k; the exchange preserves it in eq_properties.
+        // AggregateExec is initially planned as Linear (before the sort was visible).
+        // After re-derivation the mode should become Sorted.
+        let sorted_input = leaf_sorted_on_k();
+        let exchange = resolved_exchange(sorted_input);
+        let agg = aggregate_on_k(exchange);
+
+        let agg_exec = agg.as_any().downcast_ref::<AggregateExec>().unwrap();
+        // The agg was built over the resolved exchange whose eq_properties mirror
+        // the SortExec — so it may already be Sorted. What matters is the rule
+        // doesn't break it (idempotence when already correct).
+        let original_mode = agg_exec.input_order_mode().clone();
+
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let result = rule.optimize(agg.clone(), &config_with_flag(true)).unwrap();
+        let result_agg = result.as_any().downcast_ref::<AggregateExec>().unwrap();
+
+        // After the rule the mode must match what re-derivation produces.
+        assert_eq!(result_agg.input_order_mode(), &original_mode);
+        // Schema must be preserved.
+        assert_eq!(result.schema(), agg.schema());
+    }
+
+    #[test]
+    fn unsorted_input_stays_linear() {
+        // Input has no ordering → mode must stay Linear after the rule.
+        let exchange = resolved_exchange(leaf_unsorted());
+        let plan = aggregate_on_k(exchange);
+
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let result = rule.optimize(plan.clone(), &config_with_flag(true)).unwrap();
+        let result_agg = result.as_any().downcast_ref::<AggregateExec>().unwrap();
+
+        assert_eq!(
+            result_agg.input_order_mode(),
+            &datafusion::physical_plan::InputOrderMode::Linear
+        );
+    }
+
+    #[test]
+    fn schema_preserved_after_rewrite() {
+        let exchange = resolved_exchange(leaf_sorted_on_k());
+        let plan = aggregate_on_k(exchange);
+        let original_schema = plan.schema();
+
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let result = rule.optimize(plan, &config_with_flag(true)).unwrap();
+
+        assert_eq!(result.schema(), original_schema);
+    }
+
+    // --- idempotence ---
+
+    #[test]
+    fn idempotent_second_pass() {
+        let exchange = resolved_exchange(leaf_sorted_on_k());
+        let plan = aggregate_on_k(exchange);
+
+        let rule = DynamicAggregateAlgorithmRule::default();
+        let after_first = rule.optimize(plan, &config_with_flag(true)).unwrap();
+        let mode_after_first = after_first
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .unwrap()
+            .input_order_mode()
+            .clone();
+
+        let after_second = rule
+            .optimize(after_first.clone(), &config_with_flag(true))
+            .unwrap();
+        let mode_after_second = after_second
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .unwrap()
+            .input_order_mode()
+            .clone();
+
+        assert_eq!(mode_after_first, mode_after_second, "rule must be idempotent");
+    }
+
+    // --- rule metadata ---
+
+    #[test]
+    fn rule_name() {
+        assert_eq!(
+            DynamicAggregateAlgorithmRule::default().name(),
+            "DynamicAggregateAlgorithmRule"
+        );
+    }
+
+    #[test]
+    fn schema_check_is_false() {
+        assert!(!DynamicAggregateAlgorithmRule::default().schema_check());
+    }
+}

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/mod.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/mod.rs
@@ -17,8 +17,10 @@
 
 pub mod datafusion_patch;
 pub mod distributed_exchange;
+pub mod dynamic_aggregate_algorithm;
 pub mod propagate_empty;
 
 pub use datafusion_patch::*;
 pub use distributed_exchange::*;
+pub use dynamic_aggregate_algorithm::*;
 pub use propagate_empty::*;

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -17,7 +17,8 @@
 use crate::state::aqe::adapter::BallistaAdapter;
 use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
 use crate::state::aqe::optimizer_rule::{
-    DistributedExchangeRule, PropagateEmptyExecRule, WarnOnDuplicateExecRule,
+    DistributedExchangeRule, DynamicAggregateAlgorithmRule, PropagateEmptyExecRule,
+    WarnOnDuplicateExecRule,
 };
 
 use crate::state::execution_stage::StageOutput;
@@ -424,6 +425,7 @@ impl AdaptivePlanner {
     fn default_optimizers() -> Vec<PhysicalOptimizerRuleRef> {
         let mut physical_optimizers = PhysicalOptimizer::new().rules;
         physical_optimizers.push(Arc::new(PropagateEmptyExecRule::default()));
+        physical_optimizers.push(Arc::new(DynamicAggregateAlgorithmRule::default()));
         // `DistributedExchangeRule` should be the last plan mutator rule in the chain
         physical_optimizers.push(Arc::new(DistributedExchangeRule::default()));
         // we should remove it at the later stage this is just temporary


### PR DESCRIPTION
## Which issue does this PR close?

Part of #1359 (AQE epic) — roadmap line: *"switch from streaming aggregation to hash aggregation (extended rules)"*

## What does this PR do?

Adds `DynamicAggregateAlgorithmRule`, an AQE physical optimizer rule that re-derives `InputOrderMode` for each `AggregateExec` after a shuffle stage resolves and rewrites the operator when the derived mode differs from the cached one.

### Problem

DataFusion freezes `InputOrderMode` (`Linear` / `Sorted` / `PartiallySorted`) at plan time. In Ballista's AQE this creates two issues:

1. **Wasted memory**: a downstream aggregate stays `Linear` (hash table, O(distinct-groups) memory) even when an upstream stage completes and grants ordering on the group-by columns — where `Sorted` (streaming, O(1) memory) would suffice.
2. **Stale correctness assumption**: after a subtree rewrite, an aggregate may hold a `Sorted` claim when its input is no longer ordered.

### Approach

`AggregateExec::with_new_children` already calls `try_new_with_schema` which re-derives `input_order_mode` from the current input `EquivalenceProperties`. The rule:

1. Walks the plan with `transform_up`.
2. At each `AggregateExec`, skips if no resolved `ExchangeExec` exists in the subtree (idempotence guard).
3. Calls `with_new_children([same_input])` to force re-derivation.
4. Returns `Transformed::yes(rebuilt)` only when the derived mode differs from the cached one.

No upstream DataFusion changes are required.

### Configuration

```sql
SET ballista.aqe.dynamic_aggregate.enabled = true;
```

Disabled by default (`false`) pending benchmarking.

## Checklist

- [x] New rule registered in `default_optimizers()` before `DistributedExchangeRule`
- [x] Config key `ballista.aqe.dynamic_aggregate.enabled` added to `BallistaConfig`
- [x] 9 unit tests: gate off, no-exchange skip, unresolved-exchange skip, sorted/unsorted input, schema preservation, idempotence
- [x] All 42 AQE optimizer rule tests pass