### PR TITLE
feat: task_manager delegats physical plan creation to execution graph

### DIFF
--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -139,7 +139,6 @@ impl AdaptiveExecutionGraph {
         ctx: &SessionContext,
         logical_plan: &LogicalPlan,
         queued_at: u64,
-        session_config: Arc<SessionConfig>,
     ) -> ballista_core::error::Result<Self> {
         let session_id = ctx.session_id();
 
@@ -151,7 +150,7 @@ impl AdaptiveExecutionGraph {
         //       do we handle it now or just ignore it?
         let physical_plan = handle_explain_plan(job_id, ctx, logical_plan, plan).await?;
         let logical_plan = Some(logical_plan.display_indent().to_string());
-
+        let session_config = Arc::new(ctx.copied_config());
         // TODO: run planner set of optimizers in try_new
         let mut planner = AdaptivePlanner::try_new(
             &session_config,

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -19,6 +19,7 @@ use crate::display::print_stage_metrics;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::scheduler_server::timestamp_millis;
 use crate::state::aqe::planner::AdaptivePlanner;
+use crate::state::distributed_explain::handle_explain_plan;
 use crate::state::execution_graph::{
     ExecutionGraph, ExecutionGraphBox, ExecutionStage, ResolvedStage, RunningTaskInfo,
     StageOutput,
@@ -34,6 +35,8 @@ use ballista_core::serde::protobuf::{
     job_status, task_status,
 };
 use ballista_core::serde::scheduler::{ExecutorMetadata, PartitionLocation};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionConfig;
 use log::{debug, error, info, warn};
@@ -129,20 +132,33 @@ impl AdaptiveExecutionGraph {
     /// This will use the `DistributedPlanner` to break the plan into stages
     /// and build the DAG structure needed for distributed execution.
     #[allow(clippy::too_many_arguments)]
-    pub fn try_new(
+    pub async fn try_new(
         scheduler_id: &str,
         job_id: &str,
         job_name: &str,
-        session_id: &str,
-        plan: Arc<dyn ExecutionPlan>,
+        ctx: &SessionContext,
+        logical_plan: &LogicalPlan,
         queued_at: u64,
         session_config: Arc<SessionConfig>,
-        logical_plan: Option<String>,
     ) -> ballista_core::error::Result<Self> {
-        let mut planner =
-            AdaptivePlanner::try_new(&session_config, plan.clone(), job_name.to_owned())?;
+        let session_id = ctx.session_id();
 
-        //let stages = HashMap::new();
+        // TODO: this is to be changed, we do not run default optimizers comming with the state at this
+        //       point.
+        let plan = ctx.state().create_physical_plan(logical_plan).await?;
+
+        // TODO: explain plan will probably return wrong explanation
+        //       do we handle it now or just ignore it?
+        let physical_plan = handle_explain_plan(job_id, ctx, logical_plan, plan).await?;
+        let logical_plan = Some(logical_plan.display_indent().to_string());
+
+        // TODO: run planner set of optimizers in try_new
+        let mut planner = AdaptivePlanner::try_new(
+            &session_config,
+            physical_plan.clone(),
+            job_name.to_owned(),
+        )?;
+
         let started_at = timestamp_millis();
 
         // initial plans should have at least one stage to run,
@@ -192,7 +208,7 @@ impl AdaptiveExecutionGraph {
             failed_stage_attempts: HashMap::new(),
             session_config,
             logical_plan,
-            physical_plan: plan,
+            physical_plan,
         })
     }
 }

--- a/ballista/scheduler/src/state/distributed_explain.rs
+++ b/ballista/scheduler/src/state/distributed_explain.rs
@@ -27,6 +27,7 @@ use datafusion::logical_expr::{LogicalPlan, PlanType, StringifiedPlan};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::explain::ExplainExec;
 use datafusion::physical_plan::expressions::col;
 use datafusion::physical_plan::expressions::lit;
 use datafusion::physical_plan::placeholder_row::PlaceholderRowExec;
@@ -42,7 +43,7 @@ use crate::{
 
 pub(crate) async fn generate_distributed_explain_plan(
     job_id: &str,
-    session_ctx: Arc<SessionContext>,
+    session_ctx: &SessionContext,
     plan: Arc<LogicalPlan>,
 ) -> Result<String> {
     let session_config = Arc::new(session_ctx.copied_config());
@@ -184,4 +185,26 @@ fn render_stages(stages: HashMap<usize, ExecutionStage>) -> String {
         writeln!(buf, "{:#?}", stage).ok();
     }
     buf
+}
+
+pub(crate) async fn handle_explain_plan(
+    job_id: &str,
+    ctx: &SessionContext,
+    logical_plan: &LogicalPlan,
+    plan: Arc<dyn ExecutionPlan>,
+) -> ballista_core::error::Result<Arc<dyn ExecutionPlan>> {
+    if let LogicalPlan::Explain(explain_plan) = &logical_plan
+        && let Some(explain) = plan.as_any().downcast_ref::<ExplainExec>()
+    {
+        let inner_plan = explain_plan.plan.clone();
+        let plans = explain.stringified_plans();
+
+        let distributed_txt =
+            generate_distributed_explain_plan(job_id, ctx, inner_plan).await?;
+        let (logical_txt, physical_txt) = extract_logical_and_physical_plans(plans);
+
+        construct_distributed_explain_exec(logical_txt, physical_txt, distributed_txt)
+    } else {
+        Ok(plan)
+    }
 }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -15,42 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista_core::JobStatusSubscriber;
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::datasource::listing::{ListingTable, ListingTableUrl};
-use datafusion::datasource::source_as_provider;
-use datafusion::error::DataFusionError;
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
-use std::any::type_name;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Instant;
-
+use crate::cluster::{BallistaCluster, BoundTask, ExecutorSlot};
+use crate::config::SchedulerConfig;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
-
-use crate::state::distributed_explain::{
-    construct_distributed_explain_exec, extract_logical_and_physical_plans,
-    generate_distributed_explain_plan,
-};
+use crate::state::execution_graph::TaskDescription;
 use crate::state::executor_manager::ExecutorManager;
 use crate::state::session_manager::SessionManager;
 use crate::state::task_manager::{TaskLauncher, TaskManager};
-
-use crate::cluster::{BallistaCluster, BoundTask, ExecutorSlot};
-use crate::config::SchedulerConfig;
-use crate::state::execution_graph::TaskDescription;
+use ballista_core::JobStatusSubscriber;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::event_loop::EventSender;
 use ballista_core::serde::BallistaCodec;
 use ballista_core::serde::protobuf::TaskStatus;
+use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::LogicalPlan;
-use datafusion::physical_plan::display::DisplayableExecutionPlan;
-use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use log::{debug, error, info, warn};
 use prost::Message;
+use std::any::type_name;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
 
 mod aqe;
 mod distributed_explain;
@@ -380,120 +366,20 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         job_id: &str,
         job_name: &str,
         session_ctx: Arc<SessionContext>,
-        plan: &LogicalPlan,
+        logical_plan: &LogicalPlan,
         queued_at: u64,
         subscriber: Option<JobStatusSubscriber>,
     ) -> Result<()> {
         let start = Instant::now();
-        let session_config = Arc::new(session_ctx.copied_config());
-        if log::max_level() >= log::Level::Debug {
-            // optimizing the plan here is redundant because the physical planner will do this again
-            // but it is helpful to see what the optimized plan will be
-            let optimized_plan = session_ctx.state().optimize(plan)?;
-            debug!("Optimized plan: {}", optimized_plan.display_indent());
-        }
-
-        let mut explain_inner_logical_plan: Option<Arc<LogicalPlan>> = None;
-        plan.apply(&mut |plan: &LogicalPlan| {
-            if let LogicalPlan::TableScan(scan) = plan {
-                let provider = source_as_provider(&scan.source)?;
-                if let Some(table) = provider.as_any().downcast_ref::<ListingTable>() {
-                    let local_paths: Vec<&ListingTableUrl> = table
-                        .table_paths()
-                        .iter()
-                        .filter(|url| url.as_str().starts_with("file:///"))
-                        .collect();
-                    if !local_paths.is_empty() {
-                        // These are local files rather than remote object stores, so we
-                        // need to check that they are accessible on the scheduler (the client
-                        // may not be on the same host, or the data path may not be correctly
-                        // mounted in the container). There could be thousands of files so we
-                        // just check the first one.
-                        let url = &local_paths[0].as_str();
-                        // the unwraps are safe here because we checked that the url starts with file:///
-                        // we need to check both versions here to support Linux & Windows
-                        ListingTableUrl::parse(url.strip_prefix("file://").unwrap())
-                            .or_else(|_| {
-                                ListingTableUrl::parse(
-                                    url.strip_prefix("file:///").unwrap(),
-                                )
-                            })
-                            .map_err(|e| {
-                                DataFusionError::External(
-                                    format!(
-                                        "logical plan refers to path on local file system \
-                                that is not accessible in the scheduler: {url}: {e:?}"
-                                    )
-                                        .into(),
-                                )
-                            })?;
-                    }
-                }
-            } else if let LogicalPlan::Explain(explain_plan) = plan {
-                explain_inner_logical_plan = Some(explain_plan.plan.clone());
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-
-        let explain_distributed_plan = if let Some(inner_lp) = explain_inner_logical_plan
-        {
-            Some(
-                generate_distributed_explain_plan(job_id, session_ctx.clone(), inner_lp)
-                    .await?,
-            )
-        } else {
-            None
-        };
-        let logical_plan_str = plan.display_indent().to_string();
-
-        let plan = session_ctx.state().create_physical_plan(plan).await?;
-        debug!(
-            "Physical plan: {}",
-            DisplayableExecutionPlan::new(plan.as_ref()).indent(false)
-        );
-
-        let plan = plan.transform_down(&|node: Arc<dyn ExecutionPlan>| {
-            if node.output_partitioning().partition_count() == 0 {
-                let empty: Arc<dyn ExecutionPlan> =
-                    Arc::new(EmptyExec::new(node.schema()));
-                Ok(Transformed::yes(empty))
-            } else if let (Some(explain), Some(explain_distributed_plan)) = (
-                node.as_any()
-                    .downcast_ref::<datafusion::physical_plan::explain::ExplainExec>(),
-                &explain_distributed_plan,
-            ) {
-                let plans = explain.stringified_plans();
-                let (logical_txt, physical_txt) =
-                    extract_logical_and_physical_plans(plans);
-                let distributed_txt = explain_distributed_plan.clone();
-
-                let replaced: Arc<dyn ExecutionPlan> =
-                    construct_distributed_explain_exec(
-                        logical_txt,
-                        physical_txt,
-                        distributed_txt,
-                    )
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
-                Ok(Transformed::yes(replaced))
-            } else {
-                Ok(Transformed::no(node))
-            }
-        })?;
-        debug!(
-            "Transformed physical plan: {}",
-            DisplayableExecutionPlan::new(plan.data.as_ref()).indent(false)
-        );
 
         self.task_manager
             .submit_job(
                 job_id,
                 job_name,
-                &session_ctx.session_id(),
-                plan.data,
+                session_ctx,
+                logical_plan,
                 queued_at,
-                session_config,
                 subscriber,
-                Some(logical_plan_str),
             )
             .await?;
 

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -15,36 +15,34 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::cluster::JobState;
 use crate::config::SchedulerConfig;
 use crate::planner::DefaultDistributedPlanner;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
-
+use crate::state::aqe::AdaptiveExecutionGraph;
+use crate::state::distributed_explain::handle_explain_plan;
 use crate::state::execution_graph::{
     ExecutionGraphBox, RunningTaskInfo, StaticExecutionGraph, TaskDescription,
 };
 use crate::state::executor_manager::ExecutorManager;
-
 use ballista_core::JobStatusSubscriber;
 use ballista_core::error::BallistaError;
 use ballista_core::error::Result;
 use ballista_core::extension::{SessionConfigExt, SessionConfigHelperExt};
-use datafusion::prelude::SessionConfig;
-use rand::distr::Alphanumeric;
-
-use crate::cluster::JobState;
 use ballista_core::serde::BallistaCodec;
 use ballista_core::serde::protobuf::{
     JobStatus, MultiTaskDefinition, TaskDefinition, TaskId, TaskStatus, job_status,
 };
 use ballista_core::serde::scheduler::ExecutorMetadata;
 use dashmap::DashMap;
-
-use crate::state::aqe::AdaptiveExecutionGraph;
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use log::{debug, error, info, trace, warn};
+use rand::distr::Alphanumeric;
 use rand::{RngExt, rng};
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
@@ -278,42 +276,47 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         &self,
         job_id: &str,
         job_name: &str,
-        session_id: &str,
-        plan: Arc<dyn ExecutionPlan>,
+        ctx: Arc<SessionContext>,
+        logical_plan: &LogicalPlan,
         queued_at: u64,
-        session_config: Arc<SessionConfig>,
         subscriber: Option<JobStatusSubscriber>,
-        logical_plan: Option<String>,
     ) -> Result<()> {
         let mut planner = DefaultDistributedPlanner::new();
+        let session_config = Arc::new(ctx.copied_config());
 
         let mut graph = if session_config.ballista_adaptive_query_planner_enabled() {
             debug!("Using adaptive query planner (AQE) for job planning");
             warn!(
                 "Adaptive Query Planning is EXPERIMENTAL, should be used for testing purposes only!"
             );
-            Box::new(AdaptiveExecutionGraph::try_new(
-                &self.scheduler_id,
-                job_id,
-                job_name,
-                session_id,
-                plan,
-                queued_at,
-                session_config,
-                logical_plan,
-            )?) as ExecutionGraphBox
+            Box::new(
+                AdaptiveExecutionGraph::try_new(
+                    &self.scheduler_id,
+                    job_id,
+                    job_name,
+                    &ctx,
+                    logical_plan,
+                    queued_at,
+                    session_config,
+                )
+                .await?,
+            ) as ExecutionGraphBox
         } else {
             debug!("Using static query planner for job planning");
+
+            let plan = ctx.state().create_physical_plan(logical_plan).await?;
+            let plan = handle_explain_plan(job_id, &ctx, logical_plan, plan).await?;
+
             Box::new(StaticExecutionGraph::new(
                 &self.scheduler_id,
                 job_id,
                 job_name,
-                session_id,
+                &ctx.session_id(),
                 plan,
                 queued_at,
                 session_config,
                 &mut planner,
-                logical_plan,
+                Some(logical_plan.display_indent().to_string()),
             )?) as ExecutionGraphBox
         };
 

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -282,8 +282,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         subscriber: Option<JobStatusSubscriber>,
     ) -> Result<()> {
         let mut planner = DefaultDistributedPlanner::new();
-        let session_config = Arc::new(ctx.copied_config());
-
+        let session_state = ctx.state();
+        let session_config = session_state.config();
         let mut graph = if session_config.ballista_adaptive_query_planner_enabled() {
             debug!("Using adaptive query planner (AQE) for job planning");
             warn!(
@@ -297,12 +297,12 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                     &ctx,
                     logical_plan,
                     queued_at,
-                    session_config,
                 )
                 .await?,
             ) as ExecutionGraphBox
         } else {
             debug!("Using static query planner for job planning");
+            let session_config = Arc::new(ctx.copied_config());
 
             let plan = ctx.state().create_physical_plan(logical_plan).await?;
             let plan = handle_explain_plan(job_id, &ctx, logical_plan, plan).await?;


### PR DESCRIPTION

# Which issue does this PR close?


Closes #.

# Rationale for this change

Currently, ballista schedule creates and optimizes physical plan before it is delegated to execution graph for execution. this makes plan change a bit more complicated than it needs to be.

Propagating logical plan to execution graph will give ability to it to transform logical plan (or non optimized physical plan) in any way it needs, simplifying planning rules.

There is a bit of refactoring of existing code, moving some of the code (`EXPLAIN` handling) to its own method.


# What changes are included in this PR?

- change method parameters across few methods around task manager and execution graph creation
- move `EXPLAIN` related code to a function

# Are there any user-facing changes?

yes if users are implementing `execution graph` interface 