### PR TITLE
minor: add tui spacing in task popup

### DIFF
--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -77,6 +77,7 @@ pub(crate) fn render_stage_tasks_popup(f: &mut Frame, app: &App) {
             Constraint::Percentage(9),  // Start latency
             Constraint::Percentage(9),  // Duration
             Constraint::Percentage(9),  // Total Time
+            Constraint::Percentage(1),  // A bit of a space
         ],
     )
     .block(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

adds a bit of spacing in task popup so that total time unit does not get covered with a scroll bar 
# What changes are included in this PR?

# Are there any user-facing changes?
