### PR TITLE
feat(tui): Use separate areas for the table and its associated scrollbar

### DIFF
--- a/ballista-cli/src/tui/ui/main/executors/executors_table.rs
+++ b/ballista-cli/src/tui/ui/main/executors/executors_table.rs
@@ -18,7 +18,7 @@
 use crate::tui::app::App;
 use crate::tui::domain::executors::{Executor, SortColumn};
 use crate::tui::ui::vertical_scrollbar::render_scrollbar;
-use ratatui::layout::Constraint;
+use ratatui::layout::{Constraint, Layout};
 use ratatui::prelude::{Color, Text};
 use ratatui::style::Style;
 use ratatui::widgets::{Cell, HighlightSpacing, Row, Table};
@@ -34,8 +34,13 @@ pub fn render_executors(f: &mut Frame, area: Rect, app: &App) {
     match &app.executors_data.executors {
         executors if !executors.is_empty() => {
             let mut scroll_state = app.executors_data.scrollbar_state;
-            render_executors_table(f, area, app);
-            render_scrollbar(f, area, &mut scroll_state);
+            let rects = Layout::horizontal([
+                Constraint::Min(1),    // Table
+                Constraint::Length(3), // Scrollbar
+            ])
+            .split(area);
+            render_executors_table(f, rects[0], app);
+            render_scrollbar(f, rects[1], &mut scroll_state);
         }
         _no_executors => {
             f.render_widget(no_live_executors(block), area);

--- a/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
@@ -18,7 +18,7 @@
 use crate::tui::app::App;
 use crate::tui::domain::jobs::stages::JobStageResponse;
 use ratatui::Frame;
-use ratatui::layout::Constraint;
+use ratatui::layout::{Constraint, Layout};
 use ratatui::prelude::{Color, Style};
 use ratatui::text::Text;
 use ratatui::widgets::{
@@ -81,8 +81,13 @@ pub(crate) fn render_job_stages_popup(f: &mut Frame, app: &App) {
 
     let mut table_state = popup.table_state;
     let mut scroll_state = popup.scrollbar_state;
-    f.render_stateful_widget(table, area, &mut table_state);
-    crate::tui::ui::vertical_scrollbar::render_scrollbar(f, area, &mut scroll_state);
+    let rects = Layout::horizontal([
+        Constraint::Min(1),    // Table
+        Constraint::Length(3), // Scrollbar
+    ])
+    .split(area);
+    f.render_stateful_widget(table, rects[0], &mut table_state);
+    crate::tui::ui::vertical_scrollbar::render_scrollbar(f, rects[1], &mut scroll_state);
 }
 
 fn build_stage_row(i: usize, stage: &JobStageResponse, app: &App) -> Row<'static> {

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -139,16 +139,21 @@ pub fn render_jobs(f: &mut Frame, area: Rect, app: &App) {
     if !sorted_jobs.is_empty() {
         let mut scroll_state = app.jobs_data.scrollbar_state;
         let mut table_state = app.jobs_data.table_state;
+        let table_area = Layout::horizontal([
+            Constraint::Min(1),    // Table
+            Constraint::Length(3), // Scrollbar
+        ])
+        .split(rects[1]);
         render_jobs_table(
             f,
-            rects[1],
+            table_area[0],
             &sorted_jobs,
             &mut table_state,
             &app.jobs_data.sort_column,
             &app.jobs_data.sort_order,
             app,
         );
-        render_scrollbar(f, rects[1], &mut scroll_state);
+        render_scrollbar(f, table_area[1], &mut scroll_state);
     } else {
         render_no_jobs(f, rects[1]);
     }

--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -18,7 +18,7 @@
 use crate::tui::app::App;
 use crate::tui::domain::jobs::stages::StageTaskResponse;
 use ratatui::Frame;
-use ratatui::layout::Constraint;
+use ratatui::layout::{Constraint, Layout};
 use ratatui::prelude::{Color, Style};
 use ratatui::text::Text;
 use ratatui::widgets::{
@@ -95,8 +95,13 @@ pub(crate) fn render_stage_tasks_popup(f: &mut Frame, app: &App) {
 
     let mut table_state = popup.tasks_table_state;
     let mut scroll_state = popup.tasks_scrollbar_state;
-    f.render_stateful_widget(table, area, &mut table_state);
-    crate::tui::ui::vertical_scrollbar::render_scrollbar(f, area, &mut scroll_state);
+    let rects = Layout::horizontal([
+        Constraint::Min(1),    // Table
+        Constraint::Length(3), // Scrollbar
+    ])
+    .split(area);
+    f.render_stateful_widget(table, rects[0], &mut table_state);
+    crate::tui::ui::vertical_scrollbar::render_scrollbar(f, rects[1], &mut scroll_state);
 }
 
 fn build_stage_task_row(i: usize, task: &StageTaskResponse, app: &App) -> Row<'static> {

--- a/ballista-cli/src/tui/ui/main/metrics/mod.rs
+++ b/ballista-cli/src/tui/ui/main/metrics/mod.rs
@@ -71,7 +71,7 @@ pub fn render_metrics(f: &mut Frame, area: Rect, app: &App) {
     let vertical = Layout::vertical([
         Constraint::Length(3), // Search box
         Constraint::Min(5),    // Table
-        Constraint::Length(4), // Scrollbar
+        Constraint::Length(3), // Scrollbar
     ]);
     let rects = vertical.split(area);
 
@@ -80,8 +80,13 @@ pub fn render_metrics(f: &mut Frame, area: Rect, app: &App) {
     if !filtered_metrics.is_empty() {
         let mut scroll_state = app.metrics_data.scrollbar_state;
         let mut table_state = app.metrics_data.table_state;
-        render_metrics_table(f, rects[1], app, &filtered_metrics, &mut table_state);
-        render_scrollbar(f, rects[1], &mut scroll_state);
+        let table_area = Layout::horizontal([
+            Constraint::Min(1),    // Table
+            Constraint::Length(3), // Scrollbar
+        ])
+        .split(rects[1]);
+        render_metrics_table(f, table_area[0], app, &filtered_metrics, &mut table_state);
+        render_scrollbar(f, table_area[1], &mut scroll_state);
     } else if are_metrics_enabled(app) {
         render_no_metrics(f, rects[1], "No metrics.");
     } else {


### PR DESCRIPTION

# Which issue does this PR close?

Addresses an issue explained at https://github.com/apache/datafusion-ballista/pull/1725#issuecomment-4485893557

# Rationale for this change

Use a separate area for the table and its associated scrollbar.
This way the scrollbar is not rendered over the last column.

# What changes are included in this PR?

Add horizontal area for the table's scrollbar.

# Are there any user-facing changes?

Only UI.
