### PR TITLE
minor: [TUI] Extract a helper method for the table/scrollbar area splitter

### DIFF
--- a/ballista-cli/src/tui/ui/main/executors/executors_table.rs
+++ b/ballista-cli/src/tui/ui/main/executors/executors_table.rs
@@ -17,8 +17,9 @@
 
 use crate::tui::app::App;
 use crate::tui::domain::executors::{Executor, SortColumn};
+use crate::tui::ui::vertical_scrollbar;
 use crate::tui::ui::vertical_scrollbar::render_scrollbar;
-use ratatui::layout::{Constraint, Layout};
+use ratatui::layout::Constraint;
 use ratatui::prelude::{Color, Text};
 use ratatui::style::Style;
 use ratatui::widgets::{Cell, HighlightSpacing, Row, Table};
@@ -34,11 +35,7 @@ pub fn render_executors(f: &mut Frame, area: Rect, app: &App) {
     match &app.executors_data.executors {
         executors if !executors.is_empty() => {
             let mut scroll_state = app.executors_data.scrollbar_state;
-            let rects = Layout::horizontal([
-                Constraint::Min(1),    // Table
-                Constraint::Length(3), // Scrollbar
-            ])
-            .split(area);
+            let rects = vertical_scrollbar::split_area(area);
             render_executors_table(f, rects[0], app);
             render_scrollbar(f, rects[1], &mut scroll_state);
         }

--- a/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
@@ -17,8 +17,9 @@
 
 use crate::tui::app::App;
 use crate::tui::domain::jobs::stages::JobStageResponse;
+use crate::tui::ui::vertical_scrollbar;
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout};
+use ratatui::layout::Constraint;
 use ratatui::prelude::{Color, Style};
 use ratatui::text::Text;
 use ratatui::widgets::{
@@ -81,11 +82,7 @@ pub(crate) fn render_job_stages_popup(f: &mut Frame, app: &App) {
 
     let mut table_state = popup.table_state;
     let mut scroll_state = popup.scrollbar_state;
-    let rects = Layout::horizontal([
-        Constraint::Min(1),    // Table
-        Constraint::Length(3), // Scrollbar
-    ])
-    .split(area);
+    let rects = vertical_scrollbar::split_area(area);
     f.render_stateful_widget(table, rects[0], &mut table_state);
     crate::tui::ui::vertical_scrollbar::render_scrollbar(f, rects[1], &mut scroll_state);
 }

--- a/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_stages_popup.rs
@@ -84,7 +84,7 @@ pub(crate) fn render_job_stages_popup(f: &mut Frame, app: &App) {
     let mut scroll_state = popup.scrollbar_state;
     let rects = vertical_scrollbar::split_area(area);
     f.render_stateful_widget(table, rects[0], &mut table_state);
-    crate::tui::ui::vertical_scrollbar::render_scrollbar(f, rects[1], &mut scroll_state);
+    vertical_scrollbar::render_scrollbar(f, rects[1], &mut scroll_state);
 }
 
 fn build_stage_row(i: usize, stage: &JobStageResponse, app: &App) -> Row<'static> {

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -127,7 +127,6 @@ pub fn render_jobs(f: &mut Frame, area: Rect, app: &App) {
     let rects = Layout::vertical([
         Constraint::Length(3), // Search box
         Constraint::Min(5),    // Table
-        Constraint::Length(4), // Scrollbar padding
     ])
     .split(area);
 

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -34,6 +34,7 @@ use crate::tui::{
     ui::vertical_scrollbar::render_scrollbar,
 };
 
+use crate::tui::ui::vertical_scrollbar;
 use ratatui::style::Color;
 use ratatui::{
     Frame,
@@ -138,11 +139,7 @@ pub fn render_jobs(f: &mut Frame, area: Rect, app: &App) {
     if !sorted_jobs.is_empty() {
         let mut scroll_state = app.jobs_data.scrollbar_state;
         let mut table_state = app.jobs_data.table_state;
-        let table_area = Layout::horizontal([
-            Constraint::Min(1),    // Table
-            Constraint::Length(3), // Scrollbar
-        ])
-        .split(rects[1]);
+        let table_area = vertical_scrollbar::split_area(rects[1]);
         render_jobs_table(
             f,
             table_area[0],

--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -17,8 +17,9 @@
 
 use crate::tui::app::App;
 use crate::tui::domain::jobs::stages::StageTaskResponse;
+use crate::tui::ui::vertical_scrollbar;
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout};
+use ratatui::layout::Constraint;
 use ratatui::prelude::{Color, Style};
 use ratatui::text::Text;
 use ratatui::widgets::{
@@ -95,11 +96,7 @@ pub(crate) fn render_stage_tasks_popup(f: &mut Frame, app: &App) {
 
     let mut table_state = popup.tasks_table_state;
     let mut scroll_state = popup.tasks_scrollbar_state;
-    let rects = Layout::horizontal([
-        Constraint::Min(1),    // Table
-        Constraint::Length(3), // Scrollbar
-    ])
-    .split(area);
+    let rects = vertical_scrollbar::split_area(area);
     f.render_stateful_widget(table, rects[0], &mut table_state);
     crate::tui::ui::vertical_scrollbar::render_scrollbar(f, rects[1], &mut scroll_state);
 }

--- a/ballista-cli/src/tui/ui/main/metrics/mod.rs
+++ b/ballista-cli/src/tui/ui/main/metrics/mod.rs
@@ -68,12 +68,11 @@ pub fn render_metrics(f: &mut Frame, area: Rect, app: &App) {
             .collect()
     };
 
-    let vertical = Layout::vertical([
+    let rects = Layout::vertical([
         Constraint::Length(3), // Search box
         Constraint::Min(5),    // Table
-        Constraint::Length(3), // Scrollbar
-    ]);
-    let rects = vertical.split(area);
+    ])
+    .split(area);
 
     render_search_box(f, rects[0], app);
 

--- a/ballista-cli/src/tui/ui/main/metrics/mod.rs
+++ b/ballista-cli/src/tui/ui/main/metrics/mod.rs
@@ -28,6 +28,7 @@ use crate::tui::{
 };
 use prometheus_parse::HistogramCount;
 
+use crate::tui::ui::vertical_scrollbar;
 use ratatui::style::Color;
 use ratatui::{
     Frame,
@@ -79,11 +80,7 @@ pub fn render_metrics(f: &mut Frame, area: Rect, app: &App) {
     if !filtered_metrics.is_empty() {
         let mut scroll_state = app.metrics_data.scrollbar_state;
         let mut table_state = app.metrics_data.table_state;
-        let table_area = Layout::horizontal([
-            Constraint::Min(1),    // Table
-            Constraint::Length(3), // Scrollbar
-        ])
-        .split(rects[1]);
+        let table_area = vertical_scrollbar::split_area(rects[1]);
         render_metrics_table(f, table_area[0], app, &filtered_metrics, &mut table_state);
         render_scrollbar(f, table_area[1], &mut scroll_state);
     } else if are_metrics_enabled(app) {

--- a/ballista-cli/src/tui/ui/vertical_scrollbar.rs
+++ b/ballista-cli/src/tui/ui/vertical_scrollbar.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
 use std::rc::Rc;
 
@@ -30,10 +30,7 @@ pub(crate) fn render_scrollbar(
             .orientation(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("▲"))
             .end_symbol(Some("▼")),
-        area.inner(Margin {
-            vertical: 1,
-            horizontal: 1,
-        }),
+        area,
         scroll_state,
     );
 }
@@ -44,7 +41,7 @@ pub(crate) fn render_scrollbar(
 pub(crate) fn split_area(area: Rect) -> Rc<[Rect]> {
     Layout::horizontal([
         Constraint::Min(1),    // Table
-        Constraint::Length(3), // Scrollbar
+        Constraint::Length(1), // Scrollbar
     ])
     .split(area)
 }

--- a/ballista-cli/src/tui/ui/vertical_scrollbar.rs
+++ b/ballista-cli/src/tui/ui/vertical_scrollbar.rs
@@ -16,8 +16,9 @@
 // under the License.
 
 use ratatui::Frame;
-use ratatui::layout::{Margin, Rect};
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
+use std::rc::Rc;
 
 pub(crate) fn render_scrollbar(
     frame: &mut Frame,
@@ -35,4 +36,15 @@ pub(crate) fn render_scrollbar(
         }),
         scroll_state,
     );
+}
+
+/// Splits the given area into two parts:
+/// * the first part is the table area
+/// * the second part is the scrollbar area.
+pub(crate) fn split_area(area: Rect) -> Rc<[Rect]> {
+    Layout::horizontal([
+        Constraint::Min(1),    // Table
+        Constraint::Length(3), // Scrollbar
+    ])
+    .split(area)
 }


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up of #1729 

# Rationale for this change

Cleanup and code reuse.

# What changes are included in this PR?

1. Extract a duplicated code for splitting an Area into Table and Scrollbar to a helper method
2. Remove unused Scrollbar area in Jobs and Executors that was not really used.

# Are there any user-facing changes?

Only UI