### PR TITLE
minor: [TUI] Sort the metrics before rendering them

### DIFF
--- a/ballista-cli/src/tui/domain/metrics.rs
+++ b/ballista-cli/src/tui/domain/metrics.rs
@@ -149,7 +149,7 @@ impl FromStr for MetricsResponse {
             };
             metrics.push(metric);
         }
-        // metrics.sort_by(|a, b| a.sample.metric.cmp(&b.sample.metric));
+        metrics.sort_by(|a, b| a.sample.metric.cmp(&b.sample.metric));
 
         Ok(MetricsResponse { metrics })
     }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Each render of the `Metrics` table may "blink" due to the different order of the metrics/rows.

# What changes are included in this PR?

Sort the metrics in the Prometheus response before visualizing them in the Metrics table.

# Are there any user-facing changes?

Only UI
