### PR TITLE
chore: Do not run -cli tests twice

### DIFF
--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -56,3 +56,7 @@ tui-big-text = { version = "0.8.4", optional = true }
 [features]
 default = ["tui"]
 tui = ["dep:chrono", "dep:config", "dep:crossterm", "dep:dotparser", "dep:futures", "dep:percent-encoding", "dep:prometheus-parse", "dep:ratatui", "dep:reqwest", "dep:serde", "dep:serde_json", "dep:tracing-appender", "dep:tui-big-text"]
+
+[[bin]]
+name = "ballista-cli"
+test = false


### PR DESCRIPTION


# Which issue does this PR close?

M/A

# Rationale for this change

Currently all (TUI) unit tests are executed twice: once for lib.rs and a second time for main.rs

# What changes are included in this PR?

Do not test the binary, only the library.

# Are there any user-facing changes?

No.