### PR TITLE
chore(ci): Execute the CI workflows only when this is a push to main or a PR against any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,13 @@ concurrency:
 
 on:
   pull_request:
-    branches: [ "main" ]
     paths:
-      - 'python/**'
+      - "python/**"
   push:
-    tags: [ "*-rc*" ]
-    branches: [ "branch-*" ]
+    tags: ["*-rc*"]
+    branches: ["branch-*"]
     paths:
-      - 'python/**'
+      - "python/**"
 
 jobs:
   test-release:
@@ -69,7 +68,7 @@ jobs:
       - name: Build Python package
         run: |
           cd python
-          uv sync --dev --no-install-package ballista 
+          uv sync --dev --no-install-package ballista
           uv run pytest
 
   build:
@@ -89,13 +88,13 @@ jobs:
       # but do not yet build the rust library
       - name: Install dependencies
         run: |
-          cd python 
+          cd python
           uv sync --dev --no-install-package ballista
 
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
         run: |
-          cd python 
+          cd python
           uv run --no-project ruff check --output-format=github .
           uv run --no-project ruff format --check .
 
@@ -114,14 +113,14 @@ jobs:
           path: LICENSE.txt
 
   build-python-mac-win:
-    needs: [ generate-license ]
+    needs: [generate-license]
     name: Mac/Win
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10" ]
-        os: [ macos-latest, windows-latest ]
+        python-version: ["3.10"]
+        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -178,7 +177,7 @@ jobs:
           path: python/target/wheels/*
 
   build-manylinux-x86_64:
-    needs: [ generate-license ]
+    needs: [generate-license]
     name: Manylinux x86_64
     runs-on: ubuntu-latest
     steps:
@@ -219,7 +218,7 @@ jobs:
           path: python/target/wheels/*
 
   build-manylinux-aarch64:
-    needs: [ generate-license ]
+    needs: [generate-license]
     name: Manylinux arm64
     runs-on: ubuntu-latest
     steps:
@@ -260,7 +259,7 @@ jobs:
           path: python/target/wheels/*
 
   build-sdist:
-    needs: [ generate-license ]
+    needs: [generate-license]
     name: Source distribution
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,11 +20,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
   schedule:
-    - cron: '16 4 * * 1'
+    - cron: "16 4 * * 1"
 
 permissions:
   contents: read
@@ -39,17 +38,17 @@ jobs:
       packages: read
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
-      with:
-        languages: actions
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        with:
+          languages: actions
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
-      with:
-        category: "/language:actions"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        with:
+          category: "/language:actions"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,7 +24,7 @@ concurrency:
 on:
   push:
     branches-ignore:
-      - 'gh-readonly-queue/**'
+      - "gh-readonly-queue/**"
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,7 +16,10 @@
 # under the License.
 
 name: Dev
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -40,8 +43,8 @@ jobs:
     name: Use prettier to check formatting of documents
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v5.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
       - name: Prettier check
@@ -53,5 +56,5 @@ jobs:
             '{ballista,docs}/**/*.md' \
             '!ballista/CHANGELOG.md' \
             README.md \
-            CONTRIBUTING.md 
+            CONTRIBUTING.md
           git diff --exit-code

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,10 @@
 # under the License.
 
 name: Docker
-on: [ pull_request, push ]
+on:
+  pull_request:
+  push:
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -45,7 +48,7 @@ jobs:
       - name: Run script
         run: |
           git config --global --add safe.directory /__w/datafusion-ballista/datafusion-ballista
-          
+
           ./dev/build-ballista-docker.sh
 
           docker tag apache/datafusion-ballista-standalone:latest ghcr.io/apache/datafusion-ballista-standalone:latest
@@ -79,4 +82,3 @@ jobs:
         env:
           DOCKER_USER: ${{ github.actor }}
           DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,8 +17,7 @@
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
     paths:
       - .asf.yaml
       - .github/workflows/docs.yaml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ concurrency:
 
 on:
   push:
+    branches: ["main"]
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -219,8 +220,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
+        arch: [amd64]
+        rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -248,8 +249,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
+        arch: [amd64]
+        rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
       env:

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -26,6 +26,7 @@ concurrency:
 
 on:
   push:
+    branches: ["main"]
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1736

# Rationale for this change

Github Actions execute the same workflows twice - once for the `push` event and a second time for the `pull_request` event because there are no filters for the target branches.

# What changes are included in this PR?

- The `push` event will be triggered only for pushes to the `main` branch
- The `pull_request` event will be triggered for a Pull Request against any branch.  

# Are there any user-facing changes?

No.