### PR TITLE
ci: pin all third-party actions to ASF-allowlisted SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - name: Install Protoc
@@ -80,7 +80,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
 
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
       - name: Generate license file
@@ -128,7 +128,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
@@ -149,7 +149,7 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
 
@@ -183,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
@@ -201,7 +201,7 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
 
@@ -224,7 +224,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
@@ -242,7 +242,7 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@9cfd02964306b527feff5fee75acfd028cce4260 # v6.8.0
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
 
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
@@ -283,7 +283,7 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@9cfd02964306b527feff5fee75acfd028cce4260 # v6.8.0
+      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           enable-cache: true
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

The `Python Release Build` workflow (`.github/workflows/build.yml`) has had `startup_failure` on every trigger since 2026-03-21, including the `53.0.0-rc1` tag push three days ago. The failed runs create zero jobs, so no python wheels were produced for the release candidate, blocking PyPI publish.

ASF Infra enforces that all third-party GitHub Actions must be pinned to a SHA listed in [`apache/infrastructure-actions/approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml). Three classes of references in `build.yml` were not compliant:

| Reference | Lines | Why blocked |
| --- | --- | --- |
| `astral-sh/setup-uv@v7` | 83, 105, 152, 204 | Bare tag, not a SHA |
| `astral-sh/setup-uv@9cfd02964… # v6.8.0` | 245, 286 | SHA not on the allowlist (allowed SHAs are v7.0.0, v7.3.0, v7.3.1, v7.6.0, v8.0.0, v8.1.0) |
| `dtolnay/rust-toolchain@stable` | 55, 131, 186, 227, 268 | Bare tag; only the SHA `29eef336…` is allowlisted |

PR #1516 (Mar 23) was clearly a response to this enforcement turning on, but only pinned a subset of references and missed the ones above.

# What changes are included in this PR?

`.github/workflows/build.yml`:

- Replace 6 occurrences of `astral-sh/setup-uv` (four `@v7` and two `@9cfd02964… # v6.8.0`) with `astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1`, matching the allowlisted reference already present at line 64.
- Replace 5 occurrences of `dtolnay/rust-toolchain@stable` with `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable` (currently the tip of the `stable` ref, so no behavior change).

11 insertions / 11 deletions, single file.

For the two manylinux/sdist jobs this is also a `setup-uv` v6.8.0 → v7.3.1 upgrade. The release-test and ruff jobs already run on v7 with the same `enable-cache: true` input, so the inputs and behavior match the rest of the file.

The workflow itself cannot be exercised in this PR because the broken state means CI for this file's own trigger (`push` to tag, `pull_request` on `python/**`) will not run. Verification will be by cutting a fresh RC after merge and confirming the workflow produces wheels.

# Are there any user-facing changes?

No. CI-only change.