### PR TITLE
ci: pin Windows wheel builder to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-2022]
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -160,14 +160,14 @@ jobs:
           uv run --no-project maturin build --release --strip
 
       - name: List Windows wheels
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: dir python\target\wheels\
         # since the runner is dynamic shellcheck (from actionlint) can't infer this is powershell
         # so we specify it explicitly
         shell: powershell
 
       - name: List Mac wheels
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         run: find python/target/wheels/
 
       - name: Archive wheels


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

\`windows-latest\` just rolled to image \`windows-2025-vs2026\` (Microsoft Windows Server 2025, git 2.54.0). On that image, \`actions/checkout\` writes an auth-header credential file and includes it in the per-repo git config via \`includeIf.gitdir:D:/a/.../.git\`. The new git on Windows handles the forward-slash path in \`includeIf.gitdir\` differently, so the include no longer matches. Git then has no auth-header configured and falls back to prompting for a username for \`https://github.com\` — which fails with \`fatal: Cannot prompt because user interactivity has been disabled\`.

Symptom matrix:

| Trigger | Runner | Result |
| --- | --- | --- |
| Fork PR (e.g. #1749, #1750) on \`windows-latest\` | windows-2025-vs2026 | ❌ \`actions/checkout\` fails on \`git fetch\` |
| Apache push on \`windows-latest\` | windows-2025-vs2026 | ✅ (token-auth path is broader for direct pushes) |
| Fork PR / push on \`macos-latest\` | macos | ✅ |
| Fork PR / push on Linux runners | ubuntu | ✅ |

Only the Windows leg of \`build-python-mac-win\` is affected. With #1749's wheel-job gating in place, this also blocks \`merge-build-artifacts\` and the downstream PyPI publish entirely on any fork PR.

# What changes are included in this PR?

\`.github/workflows/build.yml\`:

- Change the \`build-python-mac-win\` matrix entry \`windows-latest\` to \`windows-2022\`.
- Update the two \`if: matrix.os == 'windows-latest'\` / \`!= 'windows-latest'\` conditions to match.

\`windows-2022\` is still a supported GitHub-hosted runner. This is meant as a temporary pin until \`actions/checkout\` (or git, or the runner image) resolves the \`includeIf.gitdir\` path-matching issue. Once that lands upstream, we can revert to \`windows-latest\`.

# Are there any user-facing changes?

No. CI-only change. The published wheel platform tag (\`win_amd64\`) is the same on both runner versions.