### PR TITLE
feat(aqe): delay join decision & introduce broadcast join in AQE

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -152,7 +152,7 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
         ConfigEntry::new(BALLISTA_ADAPTIVE_PLANNER_ENABLED.to_string(),
                          "Enables Adaptive Query Planning (EXPERIMENTAL)".to_string(),
                          DataType::Boolean,
-                         Some(false.to_string())),
+                         Some(true.to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_SORT_BASED_ENABLED.to_string(),
                          "Enable sort-based shuffle which writes consolidated files with index".to_string(),
                          DataType::Boolean,

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -100,6 +100,10 @@ pub const BALLISTA_COALESCE_SMALL_PARTITION_FACTOR: &str =
 /// Configuration key for the merged-partition early-flush factor (Spark legacy semantics).
 pub const BALLISTA_COALESCE_MERGED_PARTITION_FACTOR: &str =
     "ballista.planner.coalesce.merged_partition_factor";
+/// Configuration key for enabling the AQE dynamic join-selection rule.
+/// When disabled, `SelectJoinRule` is a no-op and `DynamicJoinSelectionExec`
+/// nodes are left in the plan (which will fail at execution — disable only for debugging).
+pub const BALLISTA_ADAPTIVE_JOIN_ENABLED: &str = "ballista.planner.adaptive_join.enabled";
 
 /// Result type for configuration parsing operations.
 pub type ParseResult<T> = result::Result<T, String>;
@@ -219,6 +223,15 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
             "Merged-partition early-flush factor (Spark legacy).".to_string(),
             DataType::Float64,
             Some("1.2".to_string()),
+        ),
+        ConfigEntry::new(
+            BALLISTA_ADAPTIVE_JOIN_ENABLED.to_string(),
+            "Enables the AQE dynamic join-selection rule (SelectJoinRule). \
+             When true (default), DynamicJoinSelectionExec nodes are resolved to \
+             concrete HashJoin or CollectLeft join implementations at runtime. \
+             Disable only for debugging.".to_string(),
+            DataType::Boolean,
+            Some(true.to_string()),
         ),
     ];
     entries
@@ -448,6 +461,11 @@ impl BallistaConfig {
     /// Returns the merged-partition early-flush factor (Spark legacy).
     pub fn coalesce_merged_partition_factor(&self) -> f64 {
         self.get_float_setting(BALLISTA_COALESCE_MERGED_PARTITION_FACTOR)
+    }
+
+    /// Returns whether the AQE dynamic join-selection rule is enabled.
+    pub fn adaptive_join_enabled(&self) -> bool {
+        self.get_bool_setting(BALLISTA_ADAPTIVE_JOIN_ENABLED)
     }
 
     /// Should client employ pull or push job tracking strategy

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -156,7 +156,7 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
         ConfigEntry::new(BALLISTA_ADAPTIVE_PLANNER_ENABLED.to_string(),
                          "Enables Adaptive Query Planning (EXPERIMENTAL)".to_string(),
                          DataType::Boolean,
-                         Some(true.to_string())),
+                         Some(false.to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_SORT_BASED_ENABLED.to_string(),
                          "Enable sort-based shuffle which writes consolidated files with index".to_string(),
                          DataType::Boolean,

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -781,7 +781,7 @@ impl SessionConfigHelperExt for SessionConfig {
             // `SET datafusion.optimizer.prefer_hash_join = true`.
             //
             // See https://github.com/apache/datafusion-ballista/issues/1648
-            .set_bool("datafusion.optimizer.prefer_hash_join", true)
+            .set_bool("datafusion.optimizer.prefer_hash_join", false)
     }
 }
 

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -767,11 +767,11 @@ impl SessionConfigHelperExt for SessionConfig {
             // has been disabled until fixed
             .set_u64(
                 "datafusion.optimizer.hash_join_single_partition_threshold",
-                0,
+                10 * 1024 * 1024,
             )
             .set_u64(
                 "datafusion.optimizer.hash_join_single_partition_threshold_rows",
-                0,
+                100_000,
             )
             //
             // DataFusion's hash join has no spill support, so each parallel
@@ -781,7 +781,7 @@ impl SessionConfigHelperExt for SessionConfig {
             // `SET datafusion.optimizer.prefer_hash_join = true`.
             //
             // See https://github.com/apache/datafusion-ballista/issues/1648
-            .set_bool("datafusion.optimizer.prefer_hash_join", false)
+            .set_bool("datafusion.optimizer.prefer_hash_join", true)
     }
 }
 

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -767,11 +767,11 @@ impl SessionConfigHelperExt for SessionConfig {
             // has been disabled until fixed
             .set_u64(
                 "datafusion.optimizer.hash_join_single_partition_threshold",
-                10 * 1024 * 1024,
+                0,
             )
             .set_u64(
                 "datafusion.optimizer.hash_join_single_partition_threshold_rows",
-                100_000,
+                0,
             )
             //
             // DataFusion's hash join has no spill support, so each parallel

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -693,7 +693,8 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             Ok(())
         } else {
             Err(DataFusionError::Internal(format!(
-                "unsupported plan type: {node:?}"
+                "Unsupported plan node, name: [{}] ",
+                node.name()
             )))
         }
     }

--- a/ballista/scheduler/src/state/aqe/adapter.rs
+++ b/ballista/scheduler/src/state/aqe/adapter.rs
@@ -22,7 +22,7 @@ use ballista_core::execution_plans::ShuffleReaderExec;
 use datafusion::common::exec_err;
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
-use datafusion::physical_plan::Partitioning;
+use datafusion::physical_plan::{ExecutionPlanProperties, Partitioning};
 use datafusion::{
     common::tree_node::{Transformed, TreeNode},
     physical_plan::ExecutionPlan,
@@ -51,6 +51,7 @@ impl BallistaAdapter {
                     "partitions have to be resolved at this point".to_string(),
                 )
             })?;
+
             let stage_id = exchange.stage_id().ok_or_else(|| {
                 DataFusionError::Execution(
                     "stage ID has to be generated at this point".to_string(),
@@ -59,8 +60,8 @@ impl BallistaAdapter {
             self.inputs.push(stage_id);
             let partitioning = exchange.properties().partitioning.clone();
 
-            let reader = match exchange.coalesce() {
-                Some(cp) => {
+            let reader = match (exchange.coalesce(), exchange.broadcast) {
+                (Some(cp), false) => {
                     // Concatenate M-shape locations into K-shape per CoalescePlan.groups.
                     let k_shape: Vec<Vec<_>> = cp
                         .groups
@@ -89,11 +90,17 @@ impl BallistaAdapter {
                         new_partitioning,
                     )?
                 }
-                None => ShuffleReaderExec::try_new(
+                (None, false) => ShuffleReaderExec::try_new(
                     stage_id,
                     partitions,
                     schema,
                     partitioning,
+                )?,
+                (_, true) => ShuffleReaderExec::try_new_broadcast(
+                    stage_id,
+                    exchange.shuffle_partitions_flattened(),
+                    schema,
+                    exchange.input().output_partitioning().partition_count(),
                 )?,
             };
 

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -26,7 +26,7 @@
 
 use datafusion::{
     arrow::compute::SortOptions,
-    common::{JoinType, NullEquality, Result, internal_err},
+    common::{JoinType, NullEquality, Result, exec_err, internal_err},
     physical_expr_common::physical_expr::fmt_sql,
     physical_plan::{
         DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
@@ -108,8 +108,8 @@ impl ExecutionPlan for DynamicJoinSelectionExec {
         _partition: usize,
         _context: std::sync::Arc<datafusion::execution::TaskContext>,
     ) -> datafusion::error::Result<datafusion::execution::SendableRecordBatchStream> {
-        todo!(
-            "this should not be executed, it should have been replaced with optimizer rule"
+        exec_err!(
+            "Operator should not be executed; it should have been replaced by an optimizer rule."
         )
     }
 }

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -301,7 +301,8 @@ impl DynamicJoinSelectionExec {
             self.null_equality,
         )?))
     }
-
+    // this method has been taken from datafusion
+    // join selection optimizer rule
     fn supports_collect_by_thresholds(
         plan: &dyn ExecutionPlan,
         threshold_byte_size: usize,
@@ -353,28 +354,27 @@ impl DynamicJoinSelectionExec {
     }
 
     pub(crate) fn children_resolved(&self) -> bool {
-        fn has_dynamic_join(plan: &Arc<dyn ExecutionPlan>) -> bool {
+        fn has_join_or_unresolved_exchange(plan: &Arc<dyn ExecutionPlan>) -> bool {
+            if let Some(exchange) = plan.as_any().downcast_ref::<ExchangeExec>() {
+                // this should be fine, once we find first resolved
+                // exchange it should not have any unresolved shuffles later
+                // nor dynamic joins
+                return !exchange.shuffle_created();
+            };
+
             plan.as_any()
                 .downcast_ref::<DynamicJoinSelectionExec>()
                 .is_some()
-                || plan.children().iter().any(|c| has_dynamic_join(c))
+                || plan
+                    .children()
+                    .iter()
+                    .any(|c| has_join_or_unresolved_exchange(c))
         }
 
-        fn has_unresolved_exchange(plan: &Arc<dyn ExecutionPlan>) -> bool {
-            if let Some(exchange) = plan.as_any().downcast_ref::<ExchangeExec>()
-                && !exchange.shuffle_created()
-            {
-                true
-            } else {
-                plan.children().iter().any(|c| has_unresolved_exchange(c))
-            }
-        }
-        let left_has_join = has_dynamic_join(&self.left);
-        let right_has_join = has_dynamic_join(&self.right);
-        let left_has_exchange = has_unresolved_exchange(&self.left);
-        let right_has_exchange = has_unresolved_exchange(&self.right);
+        let left_has_join = has_join_or_unresolved_exchange(&self.left);
+        let right_has_join = has_join_or_unresolved_exchange(&self.right);
 
-        !(left_has_join || left_has_exchange || right_has_join || right_has_exchange)
+        !(left_has_join || right_has_join)
     }
 
     pub(crate) fn from_sort_join(
@@ -391,5 +391,147 @@ impl DynamicJoinSelectionExec {
             properties: Arc::clone(merge_join.properties()),
             selection_state: ChildrenState::Unknown,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::aqe::execution_plan::ExchangeExec;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    fn test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]))
+    }
+
+    /// Constructs a minimal `DynamicJoinSelectionExec` around the given children.
+    /// Properties are borrowed from the left child — correct enough for unit tests
+    /// that only exercise `children_resolved`.
+    fn make_dynamic_join(
+        left: Arc<dyn ExecutionPlan>,
+        right: Arc<dyn ExecutionPlan>,
+    ) -> DynamicJoinSelectionExec {
+        DynamicJoinSelectionExec {
+            properties: Arc::clone(left.properties()),
+            left,
+            right,
+            on: vec![],
+            filter: None,
+            join_type: JoinType::Inner,
+            projection: None,
+            null_equality: NullEquality::NullEqualsNothing,
+            selection_state: ChildrenState::Unknown,
+        }
+    }
+
+    // ── 1. Both sides are simple leaf plans ────────────────────────────────────
+
+    #[test]
+    fn children_resolved_returns_true_for_simple_leaves() {
+        let schema = test_schema();
+        let left = Arc::new(EmptyExec::new(schema.clone())) as Arc<dyn ExecutionPlan>;
+        let right = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+
+        let dj = make_dynamic_join(left, right);
+
+        assert!(
+            dj.children_resolved(),
+            "plain EmptyExec children carry no exchange or nested join — must be resolved"
+        );
+    }
+
+    // ── 2 & 3. Unresolved ExchangeExec on each side ────────────────────────────
+
+    #[test]
+    fn children_resolved_returns_false_for_unresolved_left_exchange() {
+        let schema = test_schema();
+        let leaf = Arc::new(EmptyExec::new(schema.clone())) as Arc<dyn ExecutionPlan>;
+        // ExchangeExec::new starts with shuffle_partitions = None → not resolved
+        let unresolved_exchange =
+            Arc::new(ExchangeExec::new(leaf.clone(), None, 0)) as Arc<dyn ExecutionPlan>;
+        let right = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+
+        let dj = make_dynamic_join(unresolved_exchange, right);
+
+        assert!(
+            !dj.children_resolved(),
+            "an unresolved ExchangeExec on the left must block resolution"
+        );
+    }
+
+    #[test]
+    fn children_resolved_returns_false_for_unresolved_right_exchange() {
+        let schema = test_schema();
+        let leaf = Arc::new(EmptyExec::new(schema.clone())) as Arc<dyn ExecutionPlan>;
+        let left = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+        let unresolved_exchange =
+            Arc::new(ExchangeExec::new(leaf, None, 0)) as Arc<dyn ExecutionPlan>;
+
+        let dj = make_dynamic_join(left, unresolved_exchange);
+
+        assert!(
+            !dj.children_resolved(),
+            "an unresolved ExchangeExec on the right must block resolution"
+        );
+    }
+
+    // ── 4. Both ExchangeExecs resolved ────────────────────────────────────────
+
+    #[test]
+    fn children_resolved_returns_true_when_both_exchanges_resolved() {
+        let schema = test_schema();
+        let leaf = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+
+        let left_exchange = ExchangeExec::new(leaf.clone(), None, 0);
+        left_exchange.resolve_shuffle_partitions(vec![]);
+
+        let right_exchange = ExchangeExec::new(leaf, None, 1);
+        right_exchange.resolve_shuffle_partitions(vec![]);
+
+        let dj = make_dynamic_join(
+            Arc::new(left_exchange) as Arc<dyn ExecutionPlan>,
+            Arc::new(right_exchange) as Arc<dyn ExecutionPlan>,
+        );
+
+        assert!(
+            dj.children_resolved(),
+            "exchanges with resolved shuffle partitions must not block resolution"
+        );
+    }
+
+    // ── 5 & 6. Nested DynamicJoinSelectionExec on each side ───────────────────
+
+    #[test]
+    fn children_resolved_returns_false_when_left_child_is_dynamic_join() {
+        let schema = test_schema();
+        let leaf = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+
+        // Inner join whose children are plain leaves — still blocks the outer one
+        let inner = Arc::new(make_dynamic_join(leaf.clone(), leaf.clone()))
+            as Arc<dyn ExecutionPlan>;
+
+        let outer = make_dynamic_join(inner, leaf);
+
+        assert!(
+            !outer.children_resolved(),
+            "a DynamicJoinSelectionExec nested in the left child must block resolution"
+        );
+    }
+
+    #[test]
+    fn children_resolved_returns_false_when_right_child_is_dynamic_join() {
+        let schema = test_schema();
+        let leaf = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+
+        let inner = Arc::new(make_dynamic_join(leaf.clone(), leaf.clone()))
+            as Arc<dyn ExecutionPlan>;
+
+        let outer = make_dynamic_join(leaf, inner);
+
+        assert!(
+            !outer.children_resolved(),
+            "a DynamicJoinSelectionExec nested in the right child must block resolution"
+        );
     }
 }

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -34,8 +34,11 @@ use crate::state::aqe::execution_plan::ExchangeExec;
 /// has children of this join been
 /// repartitioned
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ChildrenState {
+pub enum JoinInputState {
+    /// All inputs has been repartitioned
+    /// which means this join can be resolved
     Repartitioned,
+    /// State on join inputs is unknown
     Unknown,
 }
 
@@ -51,7 +54,7 @@ pub struct DynamicJoinSelectionExec {
     pub projection: Option<Vec<usize>>,
     pub null_equality: NullEquality,
     pub properties: Arc<PlanProperties>,
-    pub selection_state: ChildrenState,
+    pub selection_state: JoinInputState,
     pub null_aware: bool,
 }
 
@@ -143,7 +146,7 @@ impl DisplayAs for DynamicJoinSelectionExec {
                 write!(
                     f,
                     " repartitioned={}",
-                    matches!(self.selection_state, ChildrenState::Repartitioned)
+                    matches!(self.selection_state, JoinInputState::Repartitioned)
                 )?;
 
                 Ok(())
@@ -170,7 +173,7 @@ impl DisplayAs for DynamicJoinSelectionExec {
                 writeln!(
                     f,
                     " repartitioned={}",
-                    matches!(self.selection_state, ChildrenState::Repartitioned)
+                    matches!(self.selection_state, JoinInputState::Repartitioned)
                 )?;
 
                 Ok(())
@@ -227,36 +230,26 @@ impl DynamicJoinSelectionExec {
             PartitionMode::Partitioned
         };
         match (&self.selection_state, partition_mode) {
-            (ChildrenState::Unknown, PartitionMode::CollectLeft) => self
+            (JoinInputState::Unknown, PartitionMode::CollectLeft) => self
                 .to_hash_join(PartitionMode::CollectLeft)
                 .map(JoinSelectionAction::CollectLeft),
-            //
-            //
-            (ChildrenState::Repartitioned, PartitionMode::Partitioned)
+            (JoinInputState::Repartitioned, PartitionMode::Partitioned)
                 if prefer_hash_join =>
             {
                 self.to_hash_join(PartitionMode::Partitioned)
                     .map(JoinSelectionAction::Hash)
             }
-            //
-            //
-            (ChildrenState::Repartitioned, PartitionMode::Partitioned) => {
+            (JoinInputState::Repartitioned, PartitionMode::Partitioned) => {
                 self.to_sort_merge_join().map(JoinSelectionAction::Sort)
             }
-            //
-            //
-            (ChildrenState::Repartitioned, PartitionMode::CollectLeft) => self
+            (JoinInputState::Repartitioned, PartitionMode::CollectLeft) => self
                 .to_hash_join(PartitionMode::CollectLeft)
                 .map(JoinSelectionAction::LateCollectLeft),
-            //(ChildrenState::Repartitioned, PartitionMode::CollectLeft) =>
-            // self
-            //     .to_hash_join(PartitionMode::Partitioned)
-            //     .map(JoinSelectionAction::Hash),
-            (ChildrenState::Unknown, PartitionMode::Partitioned) => Ok(
+            (JoinInputState::Unknown, PartitionMode::Partitioned) => Ok(
                 JoinSelectionAction::Repartition(Arc::new(self.to_partitioned())),
             ),
-            //
-            //
+            // this method calculates partition mode, and at the moment it
+            // can't calculate it as PartitionMode::Auto
             (_, PartitionMode::Auto) => internal_err!("this case should not be possible"),
         }
     }
@@ -326,7 +319,7 @@ impl DynamicJoinSelectionExec {
             projection: self.projection.clone(),
             null_equality: self.null_equality,
             properties: self.properties.clone(),
-            selection_state: ChildrenState::Repartitioned,
+            selection_state: JoinInputState::Repartitioned,
             null_aware: self.null_aware,
         }
     }
@@ -343,12 +336,17 @@ impl DynamicJoinSelectionExec {
             projection: hash_join.projection.as_deref().map(|p| p.to_vec()),
             null_equality: hash_join.null_equality,
             properties: Arc::clone(hash_join.properties()),
-            selection_state: ChildrenState::Unknown,
+            selection_state: JoinInputState::Unknown,
             null_aware: hash_join.null_aware,
         }))
     }
-
-    pub(crate) fn children_resolved(&self) -> bool {
+    /// will return true if all upstream [ExchangeExec] has been resolved
+    /// and all other [DynamicJoinSelectionExec].
+    ///
+    /// Method will short circuit on first resolved [ExchangeExec],
+    /// as there must not be any unresolved [ExchangeExec], in any if
+    /// its children.
+    pub(crate) fn upstream_resolved(&self) -> bool {
         fn has_join_or_unresolved_exchange(plan: &Arc<dyn ExecutionPlan>) -> bool {
             if let Some(exchange) = plan.as_any().downcast_ref::<ExchangeExec>() {
                 // this should be fine, once we find first resolved
@@ -384,7 +382,7 @@ impl DynamicJoinSelectionExec {
             projection: None,
             null_equality: merge_join.null_equality,
             properties: Arc::clone(merge_join.properties()),
-            selection_state: ChildrenState::Unknown,
+            selection_state: JoinInputState::Unknown,
             null_aware: false,
         }))
     }
@@ -417,12 +415,10 @@ mod tests {
             join_type: JoinType::Inner,
             projection: None,
             null_equality: NullEquality::NullEqualsNothing,
-            selection_state: ChildrenState::Unknown,
+            selection_state: JoinInputState::Unknown,
             null_aware: false,
         }
     }
-
-    // ── 1. Both sides are simple leaf plans ────────────────────────────────────
 
     #[test]
     fn children_resolved_returns_true_for_simple_leaves() {
@@ -433,12 +429,10 @@ mod tests {
         let dj = make_dynamic_join(left, right);
 
         assert!(
-            dj.children_resolved(),
+            dj.upstream_resolved(),
             "plain EmptyExec children carry no exchange or nested join — must be resolved"
         );
     }
-
-    // ── 2 & 3. Unresolved ExchangeExec on each side ────────────────────────────
 
     #[test]
     fn children_resolved_returns_false_for_unresolved_left_exchange() {
@@ -452,7 +446,7 @@ mod tests {
         let dj = make_dynamic_join(unresolved_exchange, right);
 
         assert!(
-            !dj.children_resolved(),
+            !dj.upstream_resolved(),
             "an unresolved ExchangeExec on the left must block resolution"
         );
     }
@@ -468,12 +462,10 @@ mod tests {
         let dj = make_dynamic_join(left, unresolved_exchange);
 
         assert!(
-            !dj.children_resolved(),
+            !dj.upstream_resolved(),
             "an unresolved ExchangeExec on the right must block resolution"
         );
     }
-
-    // ── 4. Both ExchangeExecs resolved ────────────────────────────────────────
 
     #[test]
     fn children_resolved_returns_true_when_both_exchanges_resolved() {
@@ -492,12 +484,10 @@ mod tests {
         );
 
         assert!(
-            dj.children_resolved(),
+            dj.upstream_resolved(),
             "exchanges with resolved shuffle partitions must not block resolution"
         );
     }
-
-    // ── 5 & 6. Nested DynamicJoinSelectionExec on each side ───────────────────
 
     #[test]
     fn children_resolved_returns_false_when_left_child_is_dynamic_join() {
@@ -511,7 +501,7 @@ mod tests {
         let outer = make_dynamic_join(inner, leaf);
 
         assert!(
-            !outer.children_resolved(),
+            !outer.upstream_resolved(),
             "a DynamicJoinSelectionExec nested in the left child must block resolution"
         );
     }
@@ -527,7 +517,7 @@ mod tests {
         let outer = make_dynamic_join(leaf, inner);
 
         assert!(
-            !outer.children_resolved(),
+            !outer.upstream_resolved(),
             "a DynamicJoinSelectionExec nested in the right child must block resolution"
         );
     }

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -15,15 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Functional tests for [`CoalescePartitionsRule`]: drive a query through
-//! `AdaptivePlanner`, finalize the upstream stage with synthetic per-partition
-//! byte stats, and snapshot the displayed plan tree so the rule's effect on
-//! the leaf `ExchangeExec` is visible at the `coalesce=K of M` field.
-//!
-//! Each test uses small synthetic byte sizes paired with a small
-//! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
-//! against `split_size_list_by_target_size`.
-
 use datafusion::{
     arrow::compute::SortOptions,
     common::{JoinType, NullEquality, Result, exec_err, internal_err},

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -52,6 +52,7 @@ pub struct DynamicJoinSelectionExec {
     pub null_equality: NullEquality,
     pub properties: Arc<PlanProperties>,
     pub selection_state: ChildrenState,
+    pub null_aware: bool,
 }
 
 impl ExecutionPlan for DynamicJoinSelectionExec {
@@ -91,6 +92,7 @@ impl ExecutionPlan for DynamicJoinSelectionExec {
             null_equality: self.null_equality,
             properties: Arc::clone(&self.properties),
             selection_state: self.selection_state.clone(),
+            null_aware: self.null_aware,
         }))
     }
 
@@ -217,7 +219,7 @@ impl DynamicJoinSelectionExec {
             threshold_collect_left_join_rows,
         ) || Self::supports_collect_by_thresholds(
             self.right.as_ref(),
-            threshold_collect_left_join_rows,
+            threshold_collect_left_join_bytes,
             threshold_collect_left_join_rows,
         ) {
             PartitionMode::CollectLeft
@@ -273,7 +275,7 @@ impl DynamicJoinSelectionExec {
         .with_projection(self.projection.clone())
         .with_partition_mode(partition_mode)
         .with_null_equality(self.null_equality)
-        .with_null_aware(false)
+        .with_null_aware(self.null_aware)
         .build()?;
 
         Ok(Arc::new(hash_join_exec))
@@ -325,6 +327,7 @@ impl DynamicJoinSelectionExec {
             null_equality: self.null_equality,
             properties: self.properties.clone(),
             selection_state: ChildrenState::Repartitioned,
+            null_aware: self.null_aware,
         }
     }
 
@@ -341,6 +344,7 @@ impl DynamicJoinSelectionExec {
             null_equality: hash_join.null_equality,
             properties: Arc::clone(hash_join.properties()),
             selection_state: ChildrenState::Unknown,
+            null_aware: hash_join.null_aware,
         }))
     }
 
@@ -381,6 +385,7 @@ impl DynamicJoinSelectionExec {
             null_equality: merge_join.null_equality,
             properties: Arc::clone(merge_join.properties()),
             selection_state: ChildrenState::Unknown,
+            null_aware: false,
         }))
     }
 }
@@ -413,6 +418,7 @@ mod tests {
             projection: None,
             null_equality: NullEquality::NullEqualsNothing,
             selection_state: ChildrenState::Unknown,
+            null_aware: false,
         }
     }
 

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -1,0 +1,395 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Functional tests for [`CoalescePartitionsRule`]: drive a query through
+//! `AdaptivePlanner`, finalize the upstream stage with synthetic per-partition
+//! byte stats, and snapshot the displayed plan tree so the rule's effect on
+//! the leaf `ExchangeExec` is visible at the `coalesce=K of M` field.
+//!
+//! Each test uses small synthetic byte sizes paired with a small
+//! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
+//! against `split_size_list_by_target_size`.
+
+use datafusion::{
+    arrow::compute::SortOptions,
+    common::{JoinType, NullEquality, Result, internal_err},
+    physical_expr_common::physical_expr::fmt_sql,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
+        joins::{
+            HashJoinExec, HashJoinExecBuilder, JoinOn, PartitionMode, SortMergeJoinExec,
+            utils::JoinFilter,
+        },
+    },
+};
+use std::sync::Arc;
+
+use crate::state::aqe::execution_plan::ExchangeExec;
+
+/// has children of this join been
+/// repartitioned
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChildrenState {
+    Repartitioned,
+    Unknown,
+}
+
+// SortMergeJoinExec::try_new(left, right, on, filter, join_type, sort_options,               null_equality )
+// HashJoinExec::try_new     (left, right, on, filter, join_type, projection, partition_mode, null_equality, null_aware )
+#[derive(Debug)]
+pub struct DynamicJoinSelectionExec {
+    pub left: Arc<dyn ExecutionPlan>,
+    pub right: Arc<dyn ExecutionPlan>,
+    pub on: JoinOn,
+    pub filter: Option<JoinFilter>,
+    pub join_type: JoinType,
+    pub projection: Option<Vec<usize>>,
+    pub null_equality: NullEquality,
+    pub properties: Arc<PlanProperties>,
+    pub selection_state: ChildrenState,
+}
+
+impl ExecutionPlan for DynamicJoinSelectionExec {
+    fn name(&self) -> &str {
+        "DynamicJoinSelectionExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &std::sync::Arc<datafusion::physical_plan::PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&std::sync::Arc<dyn ExecutionPlan>> {
+        vec![&self.left, &self.right]
+    }
+
+    fn with_new_children(
+        self: std::sync::Arc<Self>,
+        children: Vec<std::sync::Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<std::sync::Arc<dyn ExecutionPlan>> {
+        if children.len() != 2 {
+            return internal_err!(
+                "DynamicJoinSelectionExec expects 2 children, got {}",
+                children.len()
+            );
+        }
+        Ok(Arc::new(DynamicJoinSelectionExec {
+            left: Arc::clone(&children[0]),
+            right: Arc::clone(&children[1]),
+            on: self.on.clone(),
+            filter: self.filter.clone(),
+            join_type: self.join_type,
+            projection: self.projection.clone(),
+            null_equality: self.null_equality,
+            properties: Arc::clone(&self.properties),
+            selection_state: self.selection_state.clone(),
+        }))
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: std::sync::Arc<datafusion::execution::TaskContext>,
+    ) -> datafusion::error::Result<datafusion::execution::SendableRecordBatchStream> {
+        todo!(
+            "this should not be executed, it should have been replaced with optimizer rule"
+        )
+    }
+}
+
+impl DisplayAs for DynamicJoinSelectionExec {
+    fn fmt_as(
+        &self,
+        t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                let on = self
+                    .on
+                    .iter()
+                    .map(|(c1, c2)| format!("({c1}, {c2})"))
+                    .collect::<Vec<String>>()
+                    .join(", ");
+                let display_null_equality =
+                    if self.null_equality == NullEquality::NullEqualsNull {
+                        ", NullsEqual: true"
+                    } else {
+                        ""
+                    };
+                write!(
+                    f,
+                    "{}: join_type={:?}, on=[{}]{}{}",
+                    Self::static_name(),
+                    self.join_type,
+                    on,
+                    self.filter.as_ref().map_or_else(
+                        || "".to_string(),
+                        |f| format!(", filter={}", f.expression())
+                    ),
+                    display_null_equality,
+                )?;
+
+                write!(
+                    f,
+                    " repartitioned={}",
+                    matches!(self.selection_state, ChildrenState::Repartitioned)
+                )?;
+
+                Ok(())
+            }
+            DisplayFormatType::TreeRender => {
+                let on = self
+                    .on
+                    .iter()
+                    .map(|(c1, c2)| {
+                        format!("({} = {})", fmt_sql(c1.as_ref()), fmt_sql(c2.as_ref()))
+                    })
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                if self.join_type != JoinType::Inner {
+                    writeln!(f, "join_type={:?}", self.join_type)?;
+                }
+                writeln!(f, "on={on}")?;
+
+                if self.null_equality == NullEquality::NullEqualsNull {
+                    writeln!(f, "NullsEqual: true")?;
+                }
+
+                writeln!(
+                    f,
+                    " repartitioned={}",
+                    matches!(self.selection_state, ChildrenState::Repartitioned)
+                )?;
+
+                Ok(())
+            }
+        }
+    }
+}
+
+pub enum JoinSelectionAction {
+    Repartition(Arc<DynamicJoinSelectionExec>),
+    CollectLeft(Arc<HashJoinExec>),
+    LateCollectLeft(Arc<HashJoinExec>),
+    Hash(Arc<HashJoinExec>),
+    Sort(Arc<SortMergeJoinExec>),
+}
+
+impl DynamicJoinSelectionExec {
+    // this is required, as we do not want to implement
+    // ExecutionPlan::required_input_distribution as other
+    // datafusion planners are going to add repartition
+    pub(crate) fn _required_input_distribution(&self) -> Vec<Distribution> {
+        let (left_expr, right_expr) = self
+            .on
+            .iter()
+            .map(|(l, r)| (Arc::clone(l), Arc::clone(r)))
+            .unzip();
+        vec![
+            Distribution::HashPartitioned(left_expr),
+            Distribution::HashPartitioned(right_expr),
+        ]
+    }
+
+    pub(crate) fn to_actual_join(
+        &self,
+        config: &datafusion::config::ConfigOptions,
+    ) -> Result<JoinSelectionAction> {
+        let prefer_hash_join = config.optimizer.prefer_hash_join;
+        let threshold_collect_left_join_bytes =
+            config.optimizer.hash_join_single_partition_threshold;
+        let threshold_collect_left_join_rows =
+            config.optimizer.hash_join_single_partition_threshold_rows;
+
+        let partition_mode = if Self::supports_collect_by_thresholds(
+            self.left.as_ref(),
+            threshold_collect_left_join_bytes,
+            threshold_collect_left_join_rows,
+        ) || Self::supports_collect_by_thresholds(
+            self.right.as_ref(),
+            threshold_collect_left_join_rows,
+            threshold_collect_left_join_rows,
+        ) {
+            PartitionMode::CollectLeft
+        } else {
+            PartitionMode::Partitioned
+        };
+        match (&self.selection_state, partition_mode) {
+            (ChildrenState::Unknown, PartitionMode::CollectLeft) => self
+                .to_hash_join(PartitionMode::CollectLeft)
+                .map(JoinSelectionAction::CollectLeft),
+            //
+            //
+            (ChildrenState::Repartitioned, PartitionMode::Partitioned)
+                if prefer_hash_join =>
+            {
+                self.to_hash_join(PartitionMode::Partitioned)
+                    .map(JoinSelectionAction::Hash)
+            }
+            //
+            //
+            (ChildrenState::Repartitioned, PartitionMode::Partitioned) => {
+                self.to_sort_merge_join().map(JoinSelectionAction::Sort)
+            }
+            //
+            //
+            (ChildrenState::Repartitioned, PartitionMode::CollectLeft) => self
+                .to_hash_join(PartitionMode::CollectLeft)
+                .map(JoinSelectionAction::LateCollectLeft),
+            //(ChildrenState::Repartitioned, PartitionMode::CollectLeft) =>
+            // self
+            //     .to_hash_join(PartitionMode::Partitioned)
+            //     .map(JoinSelectionAction::Hash),
+            (ChildrenState::Unknown, PartitionMode::Partitioned) => Ok(
+                JoinSelectionAction::Repartition(Arc::new(self.to_partitioned())),
+            ),
+            //
+            //
+            (_, PartitionMode::Auto) => internal_err!("this case should not be possible"),
+        }
+    }
+
+    pub(crate) fn to_hash_join(
+        &self,
+        partition_mode: PartitionMode,
+    ) -> Result<Arc<HashJoinExec>> {
+        let hash_join_exec = HashJoinExecBuilder::new(
+            self.left.clone(),
+            self.right.clone(),
+            self.on.clone(),
+            self.join_type,
+        )
+        .with_filter(self.filter.clone())
+        .with_projection(self.projection.clone())
+        .with_partition_mode(partition_mode)
+        .with_null_equality(self.null_equality)
+        .with_null_aware(false)
+        .build()?;
+
+        Ok(Arc::new(hash_join_exec))
+    }
+
+    pub fn to_sort_merge_join(&self) -> Result<Arc<SortMergeJoinExec>> {
+        //let null_equals_null = self.null_equality == NullEquality::NullEqualsNull;
+        let sort_options = vec![SortOptions::default(); self.on.len()];
+        Ok(Arc::new(SortMergeJoinExec::try_new(
+            Arc::clone(&self.left),
+            Arc::clone(&self.right),
+            self.on.clone(),
+            self.filter.clone(),
+            self.join_type,
+            sort_options,
+            self.null_equality,
+        )?))
+    }
+
+    fn supports_collect_by_thresholds(
+        plan: &dyn ExecutionPlan,
+        threshold_byte_size: usize,
+        threshold_num_rows: usize,
+    ) -> bool {
+        // Currently we do not trust the 0 value from stats, due to stats collection might have bug
+        // TODO check the logic in datasource::get_statistics_with_limit()
+        let Ok(stats) = plan.partition_statistics(None) else {
+            return false;
+        };
+
+        if let Some(byte_size) = stats.total_byte_size.get_value() {
+            *byte_size != 0 && *byte_size < threshold_byte_size
+        } else if let Some(num_rows) = stats.num_rows.get_value() {
+            *num_rows != 0 && *num_rows < threshold_num_rows
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn to_partitioned(&self) -> Self {
+        Self {
+            left: self.left.clone(),
+            right: self.right.clone(),
+            on: self.on.clone(),
+            filter: self.filter.clone(),
+            join_type: self.join_type,
+            projection: self.projection.clone(),
+            null_equality: self.null_equality,
+            properties: self.properties.clone(),
+            selection_state: ChildrenState::Repartitioned,
+        }
+    }
+
+    pub(crate) fn from_hash_join(
+        hash_join: &HashJoinExec,
+    ) -> Result<Arc<DynamicJoinSelectionExec>> {
+        Ok(Arc::new(DynamicJoinSelectionExec {
+            left: Arc::clone(hash_join.left()),
+            right: Arc::clone(hash_join.right()),
+            on: hash_join.on().to_vec(),
+            filter: hash_join.filter().cloned(),
+            join_type: *hash_join.join_type(),
+            projection: hash_join.projection.as_deref().map(|p| p.to_vec()),
+            null_equality: hash_join.null_equality,
+            properties: Arc::clone(hash_join.properties()),
+            selection_state: ChildrenState::Unknown,
+        }))
+    }
+
+    pub(crate) fn children_are_ready(&self) -> bool {
+        fn has_dynamic_join(plan: &Arc<dyn ExecutionPlan>) -> bool {
+            plan.as_any()
+                .downcast_ref::<DynamicJoinSelectionExec>()
+                .is_some()
+                || plan.children().iter().any(|c| has_dynamic_join(c))
+        }
+
+        fn has_unresolved_exchange(plan: &Arc<dyn ExecutionPlan>) -> bool {
+            if let Some(exchange) = plan.as_any().downcast_ref::<ExchangeExec>()
+                && !exchange.shuffle_created()
+            {
+                true
+            } else {
+                plan.children().iter().any(|c| has_unresolved_exchange(c))
+            }
+        }
+        let left_has_join = has_dynamic_join(&self.left);
+        let right_has_join = has_dynamic_join(&self.right);
+        let left_has_exchange = has_unresolved_exchange(&self.left);
+        let right_has_exchange = has_unresolved_exchange(&self.right);
+
+        !(left_has_join || left_has_exchange || right_has_join || right_has_exchange)
+    }
+
+    pub(crate) fn from_sort_join(
+        merge_join: &SortMergeJoinExec,
+    ) -> Result<Arc<DynamicJoinSelectionExec>> {
+        Ok(Arc::new(DynamicJoinSelectionExec {
+            left: Arc::clone(merge_join.left()),
+            right: Arc::clone(merge_join.right()),
+            on: merge_join.on().to_vec(),
+            filter: merge_join.filter().clone(),
+            join_type: merge_join.join_type(),
+            projection: None,
+            null_equality: merge_join.null_equality,
+            properties: Arc::clone(merge_join.properties()),
+            selection_state: ChildrenState::Unknown,
+        }))
+    }
+}

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -18,6 +18,8 @@
 use datafusion::{
     arrow::compute::SortOptions,
     common::{JoinType, NullEquality, Result, exec_err, internal_err},
+    config::ConfigOptions,
+    execution::{SendableRecordBatchStream, TaskContext},
     physical_expr_common::physical_expr::fmt_sql,
     physical_plan::{
         DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
@@ -27,6 +29,7 @@ use datafusion::{
         },
     },
 };
+use log::debug;
 use std::sync::Arc;
 
 use crate::state::aqe::execution_plan::ExchangeExec;
@@ -42,8 +45,6 @@ pub enum JoinInputState {
     Unknown,
 }
 
-// SortMergeJoinExec::try_new(left, right, on, filter, join_type, sort_options,               null_equality )
-// HashJoinExec::try_new     (left, right, on, filter, join_type, projection, partition_mode, null_equality, null_aware )
 #[derive(Debug)]
 pub struct DynamicJoinSelectionExec {
     pub left: Arc<dyn ExecutionPlan>,
@@ -67,18 +68,18 @@ impl ExecutionPlan for DynamicJoinSelectionExec {
         self
     }
 
-    fn properties(&self) -> &std::sync::Arc<datafusion::physical_plan::PlanProperties> {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
-    fn children(&self) -> Vec<&std::sync::Arc<dyn ExecutionPlan>> {
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.left, &self.right]
     }
 
     fn with_new_children(
-        self: std::sync::Arc<Self>,
-        children: Vec<std::sync::Arc<dyn ExecutionPlan>>,
-    ) -> datafusion::error::Result<std::sync::Arc<dyn ExecutionPlan>> {
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() != 2 {
             return internal_err!(
                 "DynamicJoinSelectionExec expects 2 children, got {}",
@@ -102,8 +103,8 @@ impl ExecutionPlan for DynamicJoinSelectionExec {
     fn execute(
         &self,
         _partition: usize,
-        _context: std::sync::Arc<datafusion::execution::TaskContext>,
-    ) -> datafusion::error::Result<datafusion::execution::SendableRecordBatchStream> {
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
         exec_err!(
             "Operator should not be executed; it should have been replaced by an optimizer rule."
         )
@@ -113,7 +114,7 @@ impl ExecutionPlan for DynamicJoinSelectionExec {
 impl DisplayAs for DynamicJoinSelectionExec {
     fn fmt_as(
         &self,
-        t: datafusion::physical_plan::DisplayFormatType,
+        t: DisplayFormatType,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
         match t {
@@ -208,7 +209,7 @@ impl DynamicJoinSelectionExec {
 
     pub(crate) fn to_actual_join(
         &self,
-        config: &datafusion::config::ConfigOptions,
+        config: &ConfigOptions,
     ) -> Result<JoinSelectionAction> {
         let prefer_hash_join = config.optimizer.prefer_hash_join;
         let threshold_collect_left_join_bytes =
@@ -229,6 +230,19 @@ impl DynamicJoinSelectionExec {
         } else {
             PartitionMode::Partitioned
         };
+
+        let stats_left = self.left.partition_statistics(None)?;
+        let stats_right = self.right.partition_statistics(None)?;
+
+        debug!(
+            "to_actual_join: decision: {:?} left: ({:?} | {:?}), right: ({:?} | {:?})",
+            partition_mode,
+            stats_left.num_rows,
+            stats_left.total_byte_size,
+            stats_right.num_rows,
+            stats_right.total_byte_size
+        );
+
         match (&self.selection_state, partition_mode) {
             (JoinInputState::Unknown, PartitionMode::CollectLeft) => self
                 .to_hash_join(PartitionMode::CollectLeft)

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -352,7 +352,7 @@ impl DynamicJoinSelectionExec {
         }))
     }
 
-    pub(crate) fn children_are_ready(&self) -> bool {
+    pub(crate) fn children_resolved(&self) -> bool {
         fn has_dynamic_join(plan: &Arc<dyn ExecutionPlan>) -> bool {
             plan.as_any()
                 .downcast_ref::<DynamicJoinSelectionExec>()

--- a/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/dynamic_join.rs
@@ -242,6 +242,19 @@ impl DynamicJoinSelectionExec {
             (JoinInputState::Repartitioned, PartitionMode::Partitioned) => {
                 self.to_sort_merge_join().map(JoinSelectionAction::Sort)
             }
+            // TODO: not sure about this point
+            // at this point, both inputs has been repartitioned
+            // making it collect left may not make sense, perhaps only
+            // valid strategy at this point is to check if both sides
+            // are small enough to make it single partitioned join.
+            // if single partition join is possibility should we leave it
+            // to coalesce shuffle to make this decision? (if thats the
+            // case we should remove LateCollectLeft )
+            //
+            // would it be better if we try to shuffle build side first
+            // and then if build side is small enough make decision if
+            // this is CollectLeft or Partitioned join. The issue is
+            // we have flip coin chances to pick side which to run first
             (JoinInputState::Repartitioned, PartitionMode::CollectLeft) => self
                 .to_hash_join(PartitionMode::CollectLeft)
                 .map(JoinSelectionAction::LateCollectLeft),

--- a/ballista/scheduler/src/state/aqe/execution_plan/exchange.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/exchange.rs
@@ -103,6 +103,8 @@ impl ExchangeExec {
             plan_id,
             Arc::new(AtomicI64::new(-1)),
             Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(None)),
+            false,
             false,
         )
     }
@@ -118,34 +120,38 @@ impl ExchangeExec {
             plan_id,
             Arc::new(AtomicI64::new(-1)),
             Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(None)),
             true,
+            false,
         )
     }
 
     pub fn to_broadcast(&self, plan_id: usize) -> Self {
-        Self {
-            input: self.input.clone(),
-            properties: self.properties.clone(),
-            partitioning: None,
+        Self::new_with_details(
+            self.input.clone(),
+            None,
             plan_id,
-            stage_id: self.stage_id.clone(),
-            shuffle_partitions: self.shuffle_partitions.clone(),
-            coalesce: self.coalesce.clone(),
-            inactive_stage: self.inactive_stage,
-            broadcast: true,
-        }
+            self.stage_id.clone(),
+            self.shuffle_partitions.clone(),
+            self.coalesce.clone(),
+            true,
+            self.inactive_stage,
+        )
     }
 
     /// Creates a new `ExchangeExec` with explicitly-provided stage ID and
     /// partition storage. Used by the AQE rule infrastructure to construct
     /// exchanges that share atomic state with the enclosing `AdaptivePlanner`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_details(
         input: Arc<dyn ExecutionPlan>,
         partitioning: Option<Partitioning>,
         plan_id: usize,
         stage_id: Arc<AtomicI64>,
         stage_partitions: Arc<Mutex<Option<Vec<Vec<PartitionLocation>>>>>,
+        coalesce: Arc<Mutex<Option<Arc<CoalescePlan>>>>,
         broadcast: bool,
+        inactive_stage: bool,
     ) -> Self {
         let plan_partitioning = match (partitioning.as_ref(), broadcast) {
             (Some(partitioning), false) => partitioning.clone(),
@@ -167,8 +173,8 @@ impl ExchangeExec {
             stage_id,
             shuffle_partitions: stage_partitions,
             partitioning,
-            coalesce: Arc::new(Mutex::new(None)),
-            inactive_stage: false,
+            coalesce,
+            inactive_stage,
             broadcast,
         }
     }
@@ -344,18 +350,18 @@ impl ExecutionPlan for ExchangeExec {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() == 1 {
-            let mut new_exec = Self::new_with_details(
+            let new_exec = Self::new_with_details(
                 children[0].clone(),
                 self.partitioning.clone(),
                 self.plan_id,
                 self.stage_id.clone(),
+                // Carry the coalesce slot so a transform-rebuilt parent chain
+                // doesn't lose the rule's decision.
                 self.shuffle_partitions.clone(),
+                self.coalesce.clone(),
                 self.broadcast,
+                self.inactive_stage,
             );
-            new_exec.inactive_stage = self.inactive_stage;
-            // Carry the coalesce slot so a transform-rebuilt parent chain
-            // doesn't lose the rule's decision.
-            new_exec.coalesce = self.coalesce.clone();
 
             Ok(Arc::new(new_exec))
         } else {

--- a/ballista/scheduler/src/state/aqe/execution_plan/exchange.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/exchange.rs
@@ -81,6 +81,10 @@ pub struct ExchangeExec {
     /// stage execution logic, and to support making more complex
     /// stage run decisions.
     pub(crate) inactive_stage: bool,
+
+    // TODO: make decent description here
+    /// collect left type of thing
+    pub(crate) broadcast: bool,
 }
 
 impl ExchangeExec {
@@ -98,7 +102,37 @@ impl ExchangeExec {
             plan_id,
             Arc::new(AtomicI64::new(-1)),
             Arc::new(Mutex::new(None)),
+            false,
         )
+    }
+    /// new broadcast exchange
+    pub fn new_broadcast(
+        input: Arc<dyn ExecutionPlan>,
+        partitioning: Option<Partitioning>,
+        plan_id: usize,
+    ) -> Self {
+        Self::new_with_details(
+            input,
+            partitioning,
+            plan_id,
+            Arc::new(AtomicI64::new(-1)),
+            Arc::new(Mutex::new(None)),
+            true,
+        )
+    }
+
+    pub fn to_broadcast(&self, plan_id: usize) -> Self {
+        Self {
+            input: self.input.clone(),
+            properties: self.properties.clone(),
+            partitioning: None,
+            plan_id,
+            stage_id: self.stage_id.clone(),
+            shuffle_partitions: self.shuffle_partitions.clone(),
+            coalesce: self.coalesce.clone(),
+            inactive_stage: self.inactive_stage,
+            broadcast: true,
+        }
     }
 
     /// Creates a new `ExchangeExec` with explicitly-provided stage ID and
@@ -110,10 +144,12 @@ impl ExchangeExec {
         plan_id: usize,
         stage_id: Arc<AtomicI64>,
         stage_partitions: Arc<Mutex<Option<Vec<Vec<PartitionLocation>>>>>,
+        broadcast: bool,
     ) -> Self {
-        let plan_partitioning = match partitioning.as_ref() {
-            Some(partitioning) => partitioning.clone(),
-            None => input.output_partitioning().clone(),
+        let plan_partitioning = match (partitioning.as_ref(), broadcast) {
+            (Some(partitioning), false) => partitioning.clone(),
+            (None, false) => input.output_partitioning().clone(),
+            (_, true) => Partitioning::UnknownPartitioning(1),
         };
         let eq_properties = input.properties().eq_properties.clone();
         let properties = Arc::new(PlanProperties::new(
@@ -132,6 +168,7 @@ impl ExchangeExec {
             partitioning,
             coalesce: Arc::new(Mutex::new(None)),
             inactive_stage: false,
+            broadcast,
         }
     }
 
@@ -169,6 +206,14 @@ impl ExchangeExec {
     /// `true` if `shuffle_partitions` contains a value, `false` otherwise.
     pub fn shuffle_partitions(&self) -> Option<Vec<Vec<PartitionLocation>>> {
         self.shuffle_partitions.lock().clone()
+    }
+
+    /// Flattens partition locations into single vector,
+    /// this method is usually used when we want to collect partitions
+    /// to form a broadcast join
+    pub(crate) fn shuffle_partitions_flattened(&self) -> Vec<PartitionLocation> {
+        let partitions = self.shuffle_partitions.lock().clone().unwrap_or_default();
+        partitions.into_iter().flatten().collect()
     }
 
     /// sets the stage id running this exchange
@@ -237,6 +282,9 @@ impl DisplayAs for ExchangeExec {
                         cp.upstream_partition_count,
                     )?;
                 }
+                if self.broadcast {
+                    write!(f, ", broadcast=true",)?
+                }
                 Ok(())
             }
             DisplayFormatType::TreeRender => {
@@ -256,7 +304,11 @@ impl DisplayAs for ExchangeExec {
                         .map(|stage_id| format!("({})", stage_id))
                         .unwrap_or_else(|| "pending".to_string()),
                 )?;
-                writeln!(f, "stage_resolved={}", self.shuffle_created())
+                writeln!(f, "stage_resolved={}", self.shuffle_created())?;
+                if self.broadcast {
+                    writeln!(f, "broadcast=true")?;
+                }
+                Ok(())
             }
         }
     }
@@ -297,6 +349,7 @@ impl ExecutionPlan for ExchangeExec {
                 self.plan_id,
                 self.stage_id.clone(),
                 self.shuffle_partitions.clone(),
+                self.broadcast,
             );
             new_exec.inactive_stage = self.inactive_stage;
             // Carry the coalesce slot so a transform-rebuilt parent chain

--- a/ballista/scheduler/src/state/aqe/execution_plan/exchange.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/exchange.rs
@@ -82,8 +82,9 @@ pub struct ExchangeExec {
     /// stage run decisions.
     pub(crate) inactive_stage: bool,
 
-    // TODO: make decent description here
-    /// collect left type of thing
+    /// Indicates that this exchange is broadcast exchange,
+    /// usually used in broadcast joins.
+    /// CollectLeft HashJoin equivalent in datafusion
     pub(crate) broadcast: bool,
 }
 

--- a/ballista/scheduler/src/state/aqe/execution_plan/mod.rs
+++ b/ballista/scheduler/src/state/aqe/execution_plan/mod.rs
@@ -35,7 +35,9 @@
 //!   shuffle metadata.
 
 mod adaptive;
+mod dynamic_join;
 mod exchange;
 
 pub use adaptive::*;
+pub use dynamic_join::*;
 pub use exchange::*;

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -121,8 +121,6 @@ pub(crate) struct AdaptiveExecutionGraph {
     session_config: Arc<SessionConfig>,
     /// Logical plan as a human-readable string, captured at submission time.
     logical_plan: Option<String>,
-    // /// Physical plan, captured at submission time.
-    //physical_plan: Arc<dyn ExecutionPlan>,
 }
 
 impl AdaptiveExecutionGraph {

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -19,7 +19,6 @@ use crate::display::print_stage_metrics;
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::scheduler_server::timestamp_millis;
 use crate::state::aqe::planner::AdaptivePlanner;
-use crate::state::distributed_explain::handle_explain_plan;
 use crate::state::execution_graph::{
     ExecutionGraph, ExecutionGraphBox, ExecutionStage, ResolvedStage, RunningTaskInfo,
     StageOutput,
@@ -122,8 +121,8 @@ pub(crate) struct AdaptiveExecutionGraph {
     session_config: Arc<SessionConfig>,
     /// Logical plan as a human-readable string, captured at submission time.
     logical_plan: Option<String>,
-    /// Physical plan, captured at submission time.
-    physical_plan: Arc<dyn ExecutionPlan>,
+    // /// Physical plan, captured at submission time.
+    //physical_plan: Arc<dyn ExecutionPlan>,
 }
 
 impl AdaptiveExecutionGraph {
@@ -142,22 +141,37 @@ impl AdaptiveExecutionGraph {
     ) -> ballista_core::error::Result<Self> {
         let session_id = ctx.session_id();
 
-        // TODO: this is to be changed, we do not run default optimizers comming with the state at this
+        // TODO: this is to be changed, we do not run default optimizers coming with the state at this
         //       point.
-        let plan = ctx.state().create_physical_plan(logical_plan).await?;
 
-        // TODO: explain plan will probably return wrong explanation
-        //       do we handle it now or just ignore it?
-        let physical_plan = handle_explain_plan(job_id, ctx, logical_plan, plan).await?;
+        // this state does not have any of the physical optimizers build in by default
+        // //
+        // let state = SessionStateBuilder::new_from_existing(ctx.state())
+        //     .with_physical_optimizer_rules(vec![])
+        //     .build();
+
+        // let plan = state.create_physical_plan(logical_plan).await?;
+
+        // // this is redundant for noe
+        // // let plan = ctx.state().create_physical_plan(logical_plan).await?;
+
+        // // TODO: explain plan will probably return wrong explanation
+        // //       do we handle it now or just ignore it?
+        // let physical_plan = handle_explain_plan(job_id, ctx, logical_plan, plan).await?;
+        // let logical_plan = Some(logical_plan.display_indent().to_string());
+
+        // let mut planner = AdaptivePlanner::try_new(
+        //     &session_config,
+        //     physical_plan.clone(),
+        //     job_name.to_owned(),
+        // )?;
+
+        let mut planner =
+            AdaptivePlanner::try_new(ctx, logical_plan, job_name.to_owned()).await?;
+
         let logical_plan = Some(logical_plan.display_indent().to_string());
-        let session_config = Arc::new(ctx.copied_config());
-        // TODO: run planner set of optimizers in try_new
-        let mut planner = AdaptivePlanner::try_new(
-            &session_config,
-            physical_plan.clone(),
-            job_name.to_owned(),
-        )?;
 
+        let session_config = Arc::new(ctx.copied_config());
         let started_at = timestamp_millis();
 
         // initial plans should have at least one stage to run,
@@ -207,7 +221,7 @@ impl AdaptiveExecutionGraph {
             failed_stage_attempts: HashMap::new(),
             session_config,
             logical_plan,
-            physical_plan,
+            //physical_plan,
         })
     }
 }
@@ -542,7 +556,7 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
     }
 
     fn physical_plan(&self) -> Arc<dyn ExecutionPlan> {
-        self.physical_plan.clone()
+        self.planner.plan.clone()
     }
 
     fn start_time(&self) -> u64 {

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -141,31 +141,6 @@ impl AdaptiveExecutionGraph {
     ) -> ballista_core::error::Result<Self> {
         let session_id = ctx.session_id();
 
-        // TODO: this is to be changed, we do not run default optimizers coming with the state at this
-        //       point.
-
-        // this state does not have any of the physical optimizers build in by default
-        // //
-        // let state = SessionStateBuilder::new_from_existing(ctx.state())
-        //     .with_physical_optimizer_rules(vec![])
-        //     .build();
-
-        // let plan = state.create_physical_plan(logical_plan).await?;
-
-        // // this is redundant for noe
-        // // let plan = ctx.state().create_physical_plan(logical_plan).await?;
-
-        // // TODO: explain plan will probably return wrong explanation
-        // //       do we handle it now or just ignore it?
-        // let physical_plan = handle_explain_plan(job_id, ctx, logical_plan, plan).await?;
-        // let logical_plan = Some(logical_plan.display_indent().to_string());
-
-        // let mut planner = AdaptivePlanner::try_new(
-        //     &session_config,
-        //     physical_plan.clone(),
-        //     job_name.to_owned(),
-        // )?;
-
         let mut planner =
             AdaptivePlanner::try_new(ctx, logical_plan, job_name.to_owned()).await?;
 
@@ -221,7 +196,6 @@ impl AdaptiveExecutionGraph {
             failed_stage_attempts: HashMap::new(),
             session_config,
             logical_plan,
-            //physical_plan,
         })
     }
 }

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/coalesce_partitions.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/coalesce_partitions.rs
@@ -222,6 +222,13 @@ impl PhysicalOptimizerRule for CoalescePartitionsRule {
             return Ok(plan);
         }
 
+        // this is temporary fix until we figure it out how to
+        // make this work with broadcast
+        if leaves.iter().any(|arc| as_exchange(arc).broadcast) {
+            debug!("[coalesce-rule] broadcast leaf present; bail entire group");
+            return Ok(plan);
+        }
+
         // The alignment-group invariant assumes a shared `M`. In every plan
         // shape we currently produce, all leaves of one stage subtree are
         // hash-partitioned by the same target_partitions setting upstream,

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/distributed_exchange.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/distributed_exchange.rs
@@ -37,6 +37,10 @@ pub struct DistributedExchangeRule {
 }
 
 impl DistributedExchangeRule {
+    pub(crate) fn new(plan_id_generator: Arc<AtomicUsize>) -> Self {
+        Self { plan_id_generator }
+    }
+
     pub(crate) fn transform(
         &self,
         execution_plan: Arc<dyn ExecutionPlan>,

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -255,15 +255,6 @@ impl PhysicalOptimizerRule for SelectJoinRule {
                                 Ok(Transformed::yes(exec.data))
                             }
                             JoinSelectionAction::Repartition(dynamic_join) => {
-                                // initial idea to use:
-                                //
-                                // let partition_count = dynamic_join
-                                //     .properties()
-                                //     .output_partitioning()
-                                //     .partition_count();
-                                //
-                                // failed as new exchange nodes will be added due to
-                                // miss match between expected and actual partitioning
                                 let partition_count = config.execution.target_partitions;
                                 let partitioning = dynamic_join
                                     ._required_input_distribution()

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -132,22 +132,29 @@ impl PhysicalOptimizerRule for SelectJoinRule {
         plan: Arc<dyn ExecutionPlan>,
         config: &datafusion::config::ConfigOptions,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let result = plan.transform_up(|node| {
-            if let Some(dynamic_join) =
-                node.as_any().downcast_ref::<DynamicJoinSelectionExec>()
-            {
-                if dynamic_join.children_resolved() {
-                    match dynamic_join.to_actual_join(config)? {
-                        // at this point we know there are two exchanges
-                        JoinSelectionAction::LateCollectLeft(hash_join_exec) => {
-                            if Self::supports_swap_join_order(
-                                hash_join_exec.left.as_ref(),
-                                hash_join_exec.right.as_ref(),
-                            )? {
-                                let left = hash_join_exec.left.clone();
-                                let right = hash_join_exec.right.clone();
+        let bc = config
+            .extensions
+            .get::<BallistaConfig>()
+            .cloned()
+            .unwrap_or_default();
+        if bc.adaptive_join_enabled() {
+            let result = plan.transform_up(|node| {
+                if let Some(dynamic_join) =
+                    node.as_any().downcast_ref::<DynamicJoinSelectionExec>()
+                {
+                    if dynamic_join.children_resolved() {
+                        match dynamic_join.to_actual_join(config)? {
+                            // at this point we know there are two exchanges
+                            // as we added them beforehand
+                            JoinSelectionAction::LateCollectLeft(hash_join_exec) => {
+                                if Self::supports_swap_join_order(
+                                    hash_join_exec.left.as_ref(),
+                                    hash_join_exec.right.as_ref(),
+                                )? {
+                                    let left = hash_join_exec.left.clone();
+                                    let right = hash_join_exec.right.clone();
 
-                                let right = right
+                                    let right = right
                                     .as_any()
                                     .downcast_ref::<ExchangeExec>()
                                     .ok_or(DataFusionError::Execution(
@@ -155,23 +162,23 @@ impl PhysicalOptimizerRule for SelectJoinRule {
                                             .to_owned(),
                                     ))?
                                     .to_broadcast(self.plan_id());
-                                let right = Arc::new(right);
+                                    let right = Arc::new(right);
 
-                                let join = hash_join_exec
-                                    .with_new_children(vec![left, right])?;
+                                    let join = hash_join_exec
+                                        .with_new_children(vec![left, right])?;
 
-                                let join = join
+                                    let join = join
                                     .as_any()
                                     .downcast_ref::<HashJoinExec>()
                                     .ok_or(DataFusionError::Execution(
                                     "HashJoinExec is expected at this point (right)"
                                         .to_owned(),
                                 ))?;
-                                let join =
-                                    join.swap_inputs(PartitionMode::CollectLeft)?;
-                                Ok(Transformed::yes(join))
-                            } else {
-                                let left = hash_join_exec
+                                    let join =
+                                        join.swap_inputs(PartitionMode::CollectLeft)?;
+                                    Ok(Transformed::yes(join))
+                                } else {
+                                    let left = hash_join_exec
                                     .left
                                     .as_any()
                                     .downcast_ref::<ExchangeExec>()
@@ -180,127 +187,150 @@ impl PhysicalOptimizerRule for SelectJoinRule {
                                             .to_owned(),
                                     ))?
                                     .to_broadcast(self.plan_id());
-                                let left = Arc::new(left);
+                                    let left = Arc::new(left);
 
-                                let right = hash_join_exec.right.clone();
+                                    let right = hash_join_exec.right.clone();
 
-                                let join = hash_join_exec
-                                    .with_new_children(vec![left, right])?;
-                                Ok(Transformed::yes(join))
+                                    let join = hash_join_exec
+                                        .with_new_children(vec![left, right])?;
+                                    Ok(Transformed::yes(join))
+                                }
                             }
-                        }
 
-                        JoinSelectionAction::CollectLeft(hash_join_exec) => {
-                            let plan = if Self::supports_swap_join_order(
-                                hash_join_exec.left.as_ref(),
-                                hash_join_exec.right.as_ref(),
-                            )? {
-                                hash_join_exec.swap_inputs(PartitionMode::CollectLeft)?
-                            } else {
-                                hash_join_exec
-                            };
+                            JoinSelectionAction::CollectLeft(hash_join_exec) => {
+                                let plan = if Self::supports_swap_join_order(
+                                    hash_join_exec.left.as_ref(),
+                                    hash_join_exec.right.as_ref(),
+                                )? {
+                                    hash_join_exec
+                                        .swap_inputs(PartitionMode::CollectLeft)?
+                                } else {
+                                    hash_join_exec
+                                };
 
-                            let exec = plan.transform_up(|p| {
-                                if let Some(hash_join) =
-                                    p.as_any().downcast_ref::<HashJoinExec>()
-                                    && matches!(
-                                        hash_join.partition_mode(),
-                                        PartitionMode::CollectLeft
-                                    )
-                                {
-                                    if let Some(data_source) = hash_join
-                                        .left
-                                        .as_any()
-                                        .downcast_ref::<DataSourceExec>(
-                                    ) && let Ok(Some(left)) =
-                                        data_source.repartitioned(1, config)
+                                let exec = plan.transform_up(|p| {
+                                    if let Some(hash_join) =
+                                        p.as_any().downcast_ref::<HashJoinExec>()
+                                        && matches!(
+                                            hash_join.partition_mode(),
+                                            PartitionMode::CollectLeft
+                                        )
                                     {
-                                        let right = hash_join.right.clone();
-                                        let p = p.with_new_children(vec![left, right])?;
-                                        Ok(Transformed::yes(p))
-                                    } else if hash_join
-                                        .left
-                                        .properties()
-                                        .partitioning
-                                        .partition_count()
-                                        > 1
-                                    {
-                                        //if hash_join.left.as_any().downcast_ref::<ExchangeExec>()
-                                        let left = Arc::new(ExchangeExec::new_broadcast(
-                                            hash_join.left.clone(),
-                                            None,
-                                            self.plan_id(),
-                                        ));
-                                        let right = hash_join.right.clone();
-                                        let p = p.with_new_children(vec![left, right])?;
-                                        Ok(Transformed::yes(p))
+                                        if let Some(data_source) = hash_join
+                                            .left
+                                            .as_any()
+                                            .downcast_ref::<DataSourceExec>()
+                                            && let Ok(Some(left)) =
+                                                data_source.repartitioned(1, config)
+                                        {
+                                            let right = hash_join.right.clone();
+                                            let p =
+                                                p.with_new_children(vec![left, right])?;
+                                            Ok(Transformed::yes(p))
+                                        } else if hash_join
+                                            .left
+                                            .properties()
+                                            .partitioning
+                                            .partition_count()
+                                            > 1
+                                        {
+                                            let left = if let Some(exchange) = hash_join
+                                                .left
+                                                .as_any()
+                                                .downcast_ref::<ExchangeExec>()
+                                            {
+                                                Arc::new(
+                                                    exchange.to_broadcast(self.plan_id()),
+                                                )
+                                            } else {
+                                                Arc::new(ExchangeExec::new_broadcast(
+                                                    hash_join.left.clone(),
+                                                    None,
+                                                    self.plan_id(),
+                                                ))
+                                            };
+                                            let right = hash_join.right.clone();
+                                            let p =
+                                                p.with_new_children(vec![left, right])?;
+                                            Ok(Transformed::yes(p))
+                                        } else {
+                                            Ok(Transformed::no(p))
+                                        }
                                     } else {
                                         Ok(Transformed::no(p))
                                     }
+                                })?;
+
+                                Ok(Transformed::yes(exec.data))
+                            }
+                            JoinSelectionAction::Repartition(dynamic_join) => {
+                                // initial idea to use:
+                                //
+                                // let partition_count = dynamic_join
+                                //     .properties()
+                                //     .output_partitioning()
+                                //     .partition_count();
+                                //
+                                // failed as new exchange nodes will be added due to
+                                // miss match between expected and actual partitioning
+                                let partition_count = config.execution.target_partitions;
+                                let partitioning = dynamic_join
+                                    ._required_input_distribution()
+                                    .iter()
+                                    .map(|d| {
+                                        d.clone().create_partitioning(partition_count)
+                                    })
+                                    .collect::<Vec<_>>();
+
+                                let left = dynamic_join.left.clone();
+                                let right = dynamic_join.right.clone();
+
+                                let left = Arc::new(ExchangeExec::new(
+                                    left,
+                                    Some(partitioning[0].clone()),
+                                    self.plan_id(),
+                                ));
+
+                                let right = Arc::new(ExchangeExec::new(
+                                    right,
+                                    Some(partitioning[1].clone()),
+                                    self.plan_id(),
+                                ));
+
+                                let dynamic_join =
+                                    dynamic_join.with_new_children(vec![left, right])?;
+
+                                Ok(Transformed::yes(dynamic_join))
+                            }
+                            JoinSelectionAction::Hash(hash_join_exec) => {
+                                let hash_join_exec = if Self::supports_swap_join_order(
+                                    hash_join_exec.left.as_ref(),
+                                    hash_join_exec.right.as_ref(),
+                                )? {
+                                    hash_join_exec
+                                        .swap_inputs(*hash_join_exec.partition_mode())?
                                 } else {
-                                    Ok(Transformed::no(p))
-                                }
-                            })?;
+                                    hash_join_exec
+                                };
 
-                            Ok(Transformed::yes(exec.data))
+                                Ok(Transformed::yes(hash_join_exec))
+                            }
+                            JoinSelectionAction::Sort(sort_merge_join_exec) => {
+                                Ok(Transformed::yes(sort_merge_join_exec))
+                            }
                         }
-                        JoinSelectionAction::Repartition(dynamic_join) => {
-                            // let partition_count = dynamic_join
-                            //     .properties()
-                            //     .output_partitioning()
-                            //     .partition_count();
-                            let partition_count = config.execution.target_partitions;
-                            let partitioning = dynamic_join
-                                ._required_input_distribution()
-                                .iter()
-                                .map(|d| d.clone().create_partitioning(partition_count))
-                                .collect::<Vec<_>>();
-
-                            let left = dynamic_join.left.clone();
-                            let right = dynamic_join.right.clone();
-
-                            let left = Arc::new(ExchangeExec::new(
-                                left,
-                                Some(partitioning[0].clone()),
-                                self.plan_id(),
-                            ));
-
-                            let right = Arc::new(ExchangeExec::new(
-                                right,
-                                Some(partitioning[1].clone()),
-                                self.plan_id(),
-                            ));
-
-                            let dynamic_join =
-                                dynamic_join.with_new_children(vec![left, right])?;
-
-                            Ok(Transformed::yes(dynamic_join))
-                        }
-                        JoinSelectionAction::Hash(hash_join_exec) => {
-                            let hash_join_exec = if Self::supports_swap_join_order(
-                                hash_join_exec.left.as_ref(),
-                                hash_join_exec.right.as_ref(),
-                            )? {
-                                hash_join_exec
-                                    .swap_inputs(*hash_join_exec.partition_mode())?
-                            } else {
-                                hash_join_exec
-                            };
-
-                            Ok(Transformed::yes(hash_join_exec))
-                        }
-                        JoinSelectionAction::Sort(sort_merge_join_exec) => {
-                            Ok(Transformed::yes(sort_merge_join_exec))
-                        }
+                    } else {
+                        Ok(Transformed::no(node))
                     }
                 } else {
                     Ok(Transformed::no(node))
                 }
-            } else {
-                Ok(Transformed::no(node))
-            }
-        })?;
-        Ok(result.data)
+            })?;
+            Ok(result.data)
+        } else {
+            // disabled using configuration
+            Ok(plan)
+        }
     }
 
     fn name(&self) -> &str {
@@ -596,9 +626,11 @@ mod tests {
     #[tokio::test]
     async fn test_select_join_rule_disabled_via_config() {
         let ctx = make_ctx();
+
         let state = SessionStateBuilder::new()
             .with_physical_optimizer_rules(vec![])
             .build();
+
         let lp = ctx
             .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
             .await
@@ -611,7 +643,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Wrap the plan's joins in DynamicJoinSelectionExec nodes first.
         let dynamic_plan = DelayJoinSelectionRule::default()
             .optimize(plan.clone(), &ConfigOptions::default())
             .unwrap();
@@ -623,15 +654,38 @@ mod tests {
             DataSourceExec: partitions=1, partition_sizes=[1]
         ");
 
+        let resolve_plan = SelectJoinRule::default()
+            .optimize(dynamic_plan.clone(), &ConfigOptions::default())
+            .unwrap();
+
+        assert_plan!(resolve_plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
+        //
         // Build a ConfigOptions with adaptive_join disabled.
+        //
         let mut bc = BallistaConfig::default();
         bc.set("planner.adaptive_join.enabled", "false").unwrap();
-        let mut config = ConfigOptions::default();
-        config.extensions.insert(bc);
+        let mut config_disabled = ConfigOptions::default();
+        config_disabled.extensions.insert(bc);
 
-        // SelectJoinRule must leave the plan untouched when the flag is off.
+        let resolve_plan = SelectJoinRule::default()
+            .optimize(dynamic_plan.clone(), &config_disabled)
+            .unwrap();
+
+        assert_plan!(resolve_plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
         let dynamic_plan = DelayJoinSelectionRule::default()
-            .optimize(plan, &config)
+            .optimize(plan, &config_disabled)
             .unwrap();
 
         assert_plan!(dynamic_plan.as_ref(), @ r"

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -133,7 +133,7 @@ impl PhysicalOptimizerRule for SelectJoinRule {
                 if let Some(dynamic_join) =
                     node.as_any().downcast_ref::<DynamicJoinSelectionExec>()
                 {
-                    if dynamic_join.children_resolved() {
+                    if dynamic_join.upstream_resolved() {
                         match dynamic_join.to_actual_join(config)? {
                             // at this point we know there are two exchanges
                             // as we added them beforehand

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -71,7 +71,7 @@ impl PhysicalOptimizerRule for DelayJoinSelectionRule {
             })?;
             Ok(result.data)
         } else {
-            return Ok(plan);
+            Ok(plan)
         }
     }
 

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -401,7 +401,7 @@ mod tests {
 
         assert_plan!(optimized.as_ref(), @ r"
         ProjectionExec: expr=[id@0 as id, val@2 as val]
-          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
             DataSourceExec: partitions=1, partition_sizes=[1]
             DataSourceExec: partitions=1, partition_sizes=[1]
         ");
@@ -441,7 +441,7 @@ mod tests {
 
         assert_plan!(optimized.as_ref(), @ r"
         ProjectionExec: expr=[id@0 as id, val@2 as val]
-          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
             DataSourceExec: partitions=1, partition_sizes=[1]
             DataSourceExec: partitions=1, partition_sizes=[1]
         ");
@@ -473,7 +473,7 @@ mod tests {
 
         assert_plan!(dynamic_plan.as_ref(), @ r"
         ProjectionExec: expr=[id@0 as id, val@2 as val]
-          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
             DataSourceExec: partitions=1, partition_sizes=[1]
             DataSourceExec: partitions=1, partition_sizes=[1]
         ");
@@ -519,9 +519,9 @@ mod tests {
 
         assert_plan!(dynamic_plan.as_ref(), @ r"
         ProjectionExec: expr=[id@0 as id]
-          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
             ProjectionExec: expr=[id@0 as id]
-              DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+              DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
                 DataSourceExec: partitions=1, partition_sizes=[1]
                 DataSourceExec: partitions=1, partition_sizes=[1]
             DataSourceExec: partitions=1, partition_sizes=[1]

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -124,7 +124,7 @@ impl PhysicalOptimizerRule for SelectJoinRule {
             if let Some(dynamic_join) =
                 node.as_any().downcast_ref::<DynamicJoinSelectionExec>()
             {
-                if dynamic_join.children_are_ready() {
+                if dynamic_join.children_resolved() {
                     match dynamic_join.to_actual_join(config)? {
                         // at this point we know there are two exchanges
                         JoinSelectionAction::LateCollectLeft(hash_join_exec) => {

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -24,6 +24,7 @@
 //! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
 //! against `split_size_list_by_target_size`.
 
+use ballista_core::config::BallistaConfig;
 use datafusion::{
     catalog::memory::DataSourceExec,
     common::tree_node::{Transformed, TreeNode},
@@ -47,20 +48,31 @@ impl PhysicalOptimizerRule for DelayJoinSelectionRule {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &datafusion::config::ConfigOptions,
+        config: &datafusion::config::ConfigOptions,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let result = plan.transform_up(|node| {
-            if let Some(hj) = node.as_any().downcast_ref::<HashJoinExec>() {
-                let dynamic = DynamicJoinSelectionExec::from_hash_join(hj)?;
-                Ok(Transformed::yes(dynamic as Arc<dyn ExecutionPlan>))
-            } else if let Some(smj) = node.as_any().downcast_ref::<SortMergeJoinExec>() {
-                let dynamic = DynamicJoinSelectionExec::from_sort_join(smj)?;
-                Ok(Transformed::yes(dynamic as Arc<dyn ExecutionPlan>))
-            } else {
-                Ok(Transformed::no(node))
-            }
-        })?;
-        Ok(result.data)
+        let bc = config
+            .extensions
+            .get::<BallistaConfig>()
+            .cloned()
+            .unwrap_or_default();
+        if bc.adaptive_join_enabled() {
+            let result = plan.transform_up(|node| {
+                if let Some(hj) = node.as_any().downcast_ref::<HashJoinExec>() {
+                    let dynamic = DynamicJoinSelectionExec::from_hash_join(hj)?;
+                    Ok(Transformed::yes(dynamic as Arc<dyn ExecutionPlan>))
+                } else if let Some(smj) =
+                    node.as_any().downcast_ref::<SortMergeJoinExec>()
+                {
+                    let dynamic = DynamicJoinSelectionExec::from_sort_join(smj)?;
+                    Ok(Transformed::yes(dynamic as Arc<dyn ExecutionPlan>))
+                } else {
+                    Ok(Transformed::no(node))
+                }
+            })?;
+            Ok(result.data)
+        } else {
+            return Ok(plan);
+        }
     }
 
     fn name(&self) -> &str {
@@ -306,12 +318,14 @@ mod tests {
     use std::sync::Arc;
 
     use crate::assert_plan;
+    use ballista_core::config::BallistaConfig;
     use datafusion::{
         arrow::{
             array::{Int32Array, RecordBatch},
             datatypes::{DataType, Field, Schema},
         },
         common::config::ConfigOptions,
+        config::ExtensionOptions,
         datasource::MemTable,
         execution::{
             SessionStateBuilder, config::SessionConfig, context::SessionContext,
@@ -574,5 +588,57 @@ mod tests {
             .unwrap();
 
         assert_plan!(optimized.as_ref(), @ "DataSourceExec: partitions=1, partition_sizes=[1]");
+    }
+
+    /// When `ballista.planner.adaptive_join.enabled = false` the `DelayJoinSelectionRule`
+    /// must be a no-op: a plan containing a `DynamicJoinSelectionExec` node must
+    /// be returned unchanged.
+    #[tokio::test]
+    async fn test_select_join_rule_disabled_via_config() {
+        let ctx = make_ctx();
+        let state = SessionStateBuilder::new()
+            .with_physical_optimizer_rules(vec![])
+            .build();
+        let lp = ctx
+            .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        // Wrap the plan's joins in DynamicJoinSelectionExec nodes first.
+        let dynamic_plan = DelayJoinSelectionRule::default()
+            .optimize(plan.clone(), &ConfigOptions::default())
+            .unwrap();
+
+        assert_plan!(dynamic_plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
+        // Build a ConfigOptions with adaptive_join disabled.
+        let mut bc = BallistaConfig::default();
+        bc.set("planner.adaptive_join.enabled", "false").unwrap();
+        let mut config = ConfigOptions::default();
+        config.extensions.insert(bc);
+
+        // SelectJoinRule must leave the plan untouched when the flag is off.
+        let dynamic_plan = DelayJoinSelectionRule::default()
+            .optimize(plan, &config)
+            .unwrap();
+
+        assert_plan!(dynamic_plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          HashJoinExec: mode=Auto, join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
     }
 }

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -1,0 +1,578 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Functional tests for [`CoalescePartitionsRule`]: drive a query through
+//! `AdaptivePlanner`, finalize the upstream stage with synthetic per-partition
+//! byte stats, and snapshot the displayed plan tree so the rule's effect on
+//! the leaf `ExchangeExec` is visible at the `coalesce=K of M` field.
+//!
+//! Each test uses small synthetic byte sizes paired with a small
+//! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
+//! against `split_size_list_by_target_size`.
+
+use datafusion::{
+    catalog::memory::DataSourceExec,
+    common::tree_node::{Transformed, TreeNode},
+    error::DataFusionError,
+    physical_optimizer::PhysicalOptimizerRule,
+    physical_plan::{
+        ExecutionPlan,
+        joins::{HashJoinExec, PartitionMode, SortMergeJoinExec},
+    },
+};
+use std::sync::{Arc, atomic::AtomicUsize};
+
+use crate::state::aqe::execution_plan::{
+    DynamicJoinSelectionExec, ExchangeExec, JoinSelectionAction,
+};
+
+#[derive(Debug, Default)]
+pub struct DelayJoinSelectionRule {}
+
+impl PhysicalOptimizerRule for DelayJoinSelectionRule {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &datafusion::config::ConfigOptions,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let result = plan.transform_up(|node| {
+            if let Some(hj) = node.as_any().downcast_ref::<HashJoinExec>() {
+                let dynamic = DynamicJoinSelectionExec::from_hash_join(hj)?;
+                Ok(Transformed::yes(dynamic as Arc<dyn ExecutionPlan>))
+            } else if let Some(smj) = node.as_any().downcast_ref::<SortMergeJoinExec>() {
+                let dynamic = DynamicJoinSelectionExec::from_sort_join(smj)?;
+                Ok(Transformed::yes(dynamic as Arc<dyn ExecutionPlan>))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })?;
+        Ok(result.data)
+    }
+
+    fn name(&self) -> &str {
+        "DelayJoinSelectionRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SelectJoinRule {
+    plan_id_generator: Arc<AtomicUsize>,
+}
+
+impl SelectJoinRule {
+    pub(crate) fn new(plan_id_generator: Arc<AtomicUsize>) -> Self {
+        SelectJoinRule { plan_id_generator }
+    }
+
+    fn plan_id(&self) -> usize {
+        self.plan_id_generator
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn supports_swap_join_order(
+        left: &dyn ExecutionPlan,
+        right: &dyn ExecutionPlan,
+    ) -> datafusion::common::Result<bool> {
+        // Get the left and right table's total bytes
+        // If both the left and right tables contain total_byte_size statistics,
+        // use `total_byte_size` to determine `should_swap_join_order`, else use `num_rows`
+        let left_stats = left.partition_statistics(None)?;
+        let right_stats = right.partition_statistics(None)?;
+        // First compare `total_byte_size` of left and right side,
+        // if information in this field is insufficient fallback to the `num_rows`
+        match (
+            left_stats.total_byte_size.get_value(),
+            right_stats.total_byte_size.get_value(),
+        ) {
+            (Some(l), Some(r)) => Ok(l > r),
+            _ => match (
+                left_stats.num_rows.get_value(),
+                right_stats.num_rows.get_value(),
+            ) {
+                (Some(l), Some(r)) => Ok(l > r),
+                _ => Ok(false),
+            },
+        }
+    }
+}
+
+impl PhysicalOptimizerRule for SelectJoinRule {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &datafusion::config::ConfigOptions,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let result = plan.transform_up(|node| {
+            if let Some(dynamic_join) =
+                node.as_any().downcast_ref::<DynamicJoinSelectionExec>()
+            {
+                if dynamic_join.children_are_ready() {
+                    match dynamic_join.to_actual_join(config)? {
+                        // at this point we know there are two exchanges
+                        JoinSelectionAction::LateCollectLeft(hash_join_exec) => {
+                            if Self::supports_swap_join_order(
+                                hash_join_exec.left.as_ref(),
+                                hash_join_exec.right.as_ref(),
+                            )? {
+                                let left = hash_join_exec.left.clone();
+                                let right = hash_join_exec.right.clone();
+
+                                let right = right
+                                    .as_any()
+                                    .downcast_ref::<ExchangeExec>()
+                                    .ok_or(DataFusionError::Execution(
+                                        "ExchangeExec is expected at this point (right)"
+                                            .to_owned(),
+                                    ))?
+                                    .to_broadcast(self.plan_id());
+                                let right = Arc::new(right);
+
+                                let join = hash_join_exec
+                                    .with_new_children(vec![left, right])?;
+
+                                let join = join
+                                    .as_any()
+                                    .downcast_ref::<HashJoinExec>()
+                                    .ok_or(DataFusionError::Execution(
+                                    "HashJoinExec is expected at this point (right)"
+                                        .to_owned(),
+                                ))?;
+                                let join =
+                                    join.swap_inputs(PartitionMode::CollectLeft)?;
+                                Ok(Transformed::yes(join))
+                            } else {
+                                let left = hash_join_exec
+                                    .left
+                                    .as_any()
+                                    .downcast_ref::<ExchangeExec>()
+                                    .ok_or(DataFusionError::Execution(
+                                        "ExchangeExec is expected at this point (left)"
+                                            .to_owned(),
+                                    ))?
+                                    .to_broadcast(self.plan_id());
+                                let left = Arc::new(left);
+
+                                let right = hash_join_exec.right.clone();
+
+                                let join = hash_join_exec
+                                    .with_new_children(vec![left, right])?;
+                                Ok(Transformed::yes(join))
+                            }
+                        }
+
+                        JoinSelectionAction::CollectLeft(hash_join_exec) => {
+                            let plan = if Self::supports_swap_join_order(
+                                hash_join_exec.left.as_ref(),
+                                hash_join_exec.right.as_ref(),
+                            )? {
+                                hash_join_exec.swap_inputs(PartitionMode::CollectLeft)?
+                            } else {
+                                hash_join_exec
+                            };
+
+                            let exec = plan.transform_up(|p| {
+                                if let Some(hash_join) =
+                                    p.as_any().downcast_ref::<HashJoinExec>()
+                                    && matches!(
+                                        hash_join.partition_mode(),
+                                        PartitionMode::CollectLeft
+                                    )
+                                {
+                                    if let Some(data_source) = hash_join
+                                        .left
+                                        .as_any()
+                                        .downcast_ref::<DataSourceExec>(
+                                    ) && let Ok(Some(left)) =
+                                        data_source.repartitioned(1, config)
+                                    {
+                                        let right = hash_join.right.clone();
+                                        let p = p.with_new_children(vec![left, right])?;
+                                        Ok(Transformed::yes(p))
+                                    } else if hash_join
+                                        .left
+                                        .properties()
+                                        .partitioning
+                                        .partition_count()
+                                        > 1
+                                    {
+                                        //if hash_join.left.as_any().downcast_ref::<ExchangeExec>()
+                                        let left = Arc::new(ExchangeExec::new_broadcast(
+                                            hash_join.left.clone(),
+                                            None,
+                                            self.plan_id(),
+                                        ));
+                                        let right = hash_join.right.clone();
+                                        let p = p.with_new_children(vec![left, right])?;
+                                        Ok(Transformed::yes(p))
+                                    } else {
+                                        Ok(Transformed::no(p))
+                                    }
+                                } else {
+                                    Ok(Transformed::no(p))
+                                }
+                            })?;
+
+                            Ok(Transformed::yes(exec.data))
+                        }
+                        JoinSelectionAction::Repartition(dynamic_join) => {
+                            // let partition_count = dynamic_join
+                            //     .properties()
+                            //     .output_partitioning()
+                            //     .partition_count();
+                            let partition_count = config.execution.target_partitions;
+                            let partitioning = dynamic_join
+                                ._required_input_distribution()
+                                .iter()
+                                .map(|d| d.clone().create_partitioning(partition_count))
+                                .collect::<Vec<_>>();
+
+                            let left = dynamic_join.left.clone();
+                            let right = dynamic_join.right.clone();
+
+                            let left = Arc::new(ExchangeExec::new(
+                                left,
+                                Some(partitioning[0].clone()),
+                                self.plan_id(),
+                            ));
+
+                            let right = Arc::new(ExchangeExec::new(
+                                right,
+                                Some(partitioning[1].clone()),
+                                self.plan_id(),
+                            ));
+
+                            let dynamic_join =
+                                dynamic_join.with_new_children(vec![left, right])?;
+
+                            Ok(Transformed::yes(dynamic_join))
+                        }
+                        JoinSelectionAction::Hash(hash_join_exec) => {
+                            let hash_join_exec = if Self::supports_swap_join_order(
+                                hash_join_exec.left.as_ref(),
+                                hash_join_exec.right.as_ref(),
+                            )? {
+                                hash_join_exec
+                                    .swap_inputs(*hash_join_exec.partition_mode())?
+                            } else {
+                                hash_join_exec
+                            };
+
+                            Ok(Transformed::yes(hash_join_exec))
+                        }
+                        JoinSelectionAction::Sort(sort_merge_join_exec) => {
+                            Ok(Transformed::yes(sort_merge_join_exec))
+                        }
+                    }
+                } else {
+                    Ok(Transformed::no(node))
+                }
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })?;
+        Ok(result.data)
+    }
+
+    fn name(&self) -> &str {
+        "SelectJoinRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::assert_plan;
+    use datafusion::{
+        arrow::{
+            array::{Int32Array, RecordBatch},
+            datatypes::{DataType, Field, Schema},
+        },
+        common::config::ConfigOptions,
+        datasource::MemTable,
+        execution::{
+            SessionStateBuilder, config::SessionConfig, context::SessionContext,
+        },
+        physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner},
+    };
+
+    fn make_table(schema: Arc<Schema>) -> Arc<MemTable> {
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+        Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap())
+    }
+
+    fn make_ctx() -> SessionContext {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Int32, false),
+        ]));
+        let ctx = SessionContext::new();
+        ctx.register_table("t1", make_table(Arc::clone(&schema)))
+            .unwrap();
+        ctx.register_table("t2", make_table(schema)).unwrap();
+        ctx
+    }
+
+    fn make_ctx_3tables() -> SessionContext {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Int32, false),
+        ]));
+        let ctx = SessionContext::new();
+        ctx.register_table("t1", make_table(Arc::clone(&schema)))
+            .unwrap();
+        ctx.register_table("t2", make_table(Arc::clone(&schema)))
+            .unwrap();
+        ctx.register_table("t3", make_table(schema)).unwrap();
+        ctx
+    }
+
+    #[tokio::test]
+    async fn test_hash_join_replaced_with_dynamic() {
+        let ctx = make_ctx();
+        let state = SessionStateBuilder::new()
+            .with_physical_optimizer_rules(vec![])
+            .build();
+        let lp = ctx
+            .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        assert_plan!(plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          HashJoinExec: mode=Auto, join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
+        let optimized = DelayJoinSelectionRule::default()
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap();
+
+        assert_plan!(optimized.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_sort_merge_join_replaced_with_dynamic() {
+        let ctx = make_ctx();
+        let config =
+            SessionConfig::new().set_bool("datafusion.optimizer.prefer_hash_join", false);
+        let state = SessionStateBuilder::new()
+            .with_config(config)
+            .with_physical_optimizer_rules(vec![])
+            .build();
+
+        let lp = ctx
+            .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        assert_plan!(plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          SortMergeJoinExec: join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
+        let optimized = DelayJoinSelectionRule::default()
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap();
+
+        assert_plan!(optimized.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_replaces_dynamic_with_sort_merge_join() {
+        let ctx = make_ctx();
+        let config =
+            SessionConfig::new().set_bool("datafusion.optimizer.prefer_hash_join", false);
+        let state = SessionStateBuilder::new()
+            .with_config(config.clone())
+            .with_physical_optimizer_rules(vec![])
+            .build();
+        let lp = ctx
+            .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        let dynamic_plan = DelayJoinSelectionRule::default()
+            .optimize(plan, config.options())
+            .unwrap();
+
+        assert_plan!(dynamic_plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
+        let resolved = SelectJoinRule::default()
+            .optimize(dynamic_plan, config.options())
+            .unwrap();
+
+        assert_plan!(resolved.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id, val@2 as val]
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_nested_dynamic_joins() {
+        let ctx = make_ctx_3tables();
+        let config =
+            SessionConfig::new().set_bool("datafusion.optimizer.prefer_hash_join", false);
+
+        let state = SessionStateBuilder::new()
+            .with_physical_optimizer_rules(vec![])
+            .with_config(config.clone())
+            .build();
+
+        let lp = ctx
+            .sql("SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t1.id = t3.id")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        let dynamic_plan = DelayJoinSelectionRule::default()
+            .optimize(plan, config.options())
+            .unwrap();
+
+        assert_plan!(dynamic_plan.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id]
+          DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+            ProjectionExec: expr=[id@0 as id]
+              DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)]
+                DataSourceExec: partitions=1, partition_sizes=[1]
+                DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+
+        let resolved = SelectJoinRule::default()
+            .optimize(dynamic_plan, config.options())
+            .unwrap();
+
+        assert_plan!(resolved.as_ref(), @ r"
+        ProjectionExec: expr=[id@0 as id]
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
+            ProjectionExec: expr=[id@0 as id]
+              HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
+                DataSourceExec: partitions=1, partition_sizes=[1]
+                DataSourceExec: partitions=1, partition_sizes=[1]
+            DataSourceExec: partitions=1, partition_sizes=[1]
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_non_join_plan_untouched() {
+        let ctx = make_ctx();
+        let state = SessionStateBuilder::new()
+            .with_physical_optimizer_rules(vec![])
+            .build();
+        let lp = ctx
+            .sql("SELECT id FROM t1")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        let resolved = SelectJoinRule::default()
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap();
+
+        assert_plan!(resolved.as_ref(), @ "DataSourceExec: partitions=1, partition_sizes=[1]");
+    }
+
+    #[tokio::test]
+    async fn test_non_join_plan_untouched() {
+        let ctx = make_ctx();
+        let state = SessionStateBuilder::new()
+            .with_physical_optimizer_rules(vec![])
+            .build();
+        let lp = ctx
+            .sql("SELECT id FROM t1")
+            .await
+            .unwrap()
+            .into_optimized_plan()
+            .unwrap();
+        let plan = DefaultPhysicalPlanner::default()
+            .create_physical_plan(&lp, &state)
+            .await
+            .unwrap();
+
+        let optimized = DelayJoinSelectionRule::default()
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap();
+
+        assert_plan!(optimized.as_ref(), @ "DataSourceExec: partitions=1, partition_sizes=[1]");
+    }
+}

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -15,15 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Functional tests for [`CoalescePartitionsRule`]: drive a query through
-//! `AdaptivePlanner`, finalize the upstream stage with synthetic per-partition
-//! byte stats, and snapshot the displayed plan tree so the rule's effect on
-//! the leaf `ExchangeExec` is visible at the `coalesce=K of M` field.
-//!
-//! Each test uses small synthetic byte sizes paired with a small
-//! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
-//! against `split_size_list_by_target_size`.
-
 use ballista_core::config::BallistaConfig;
 use datafusion::{
     catalog::memory::DataSourceExec,

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/mod.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/mod.rs
@@ -18,9 +18,11 @@
 pub mod coalesce_partitions;
 pub mod datafusion_patch;
 pub mod distributed_exchange;
+pub mod join_selection;
 pub mod propagate_empty;
 
 pub use coalesce_partitions::*;
 pub use datafusion_patch::*;
 pub use distributed_exchange::*;
+pub use join_selection::*;
 pub use propagate_empty::*;

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -40,7 +40,10 @@ macro_rules! is_empty_exec {
 
 macro_rules! empty_exec {
     ($e:expr) => {
-        Ok(Transformed::yes(Arc::new(EmptyExec::new($e.schema()))))
+        Ok(Transformed::yes(Arc::new(
+            EmptyExec::new($e.schema())
+                .with_partitions($e.properties().output_partitioning().partition_count()),
+        )))
     };
 }
 

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -25,11 +25,14 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::aggregates::AggregateExec;
 #[allow(deprecated)]
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::joins::HashJoinExec;
 use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use std::sync::Arc;
 
 macro_rules! is_empty_exec {
@@ -88,6 +91,20 @@ impl PropagateEmptyExecRule {
             && is_empty_exec!(aggregation.input())
         {
             empty_exec!(aggregation)
+        } else if let Some(repartition) = plan.as_any().downcast_ref::<RepartitionExec>()
+            && is_empty_exec!(repartition.input())
+        {
+            empty_exec!(repartition)
+        } else if let Some(coalesce_partition) =
+            plan.as_any().downcast_ref::<CoalescePartitionsExec>()
+            && is_empty_exec!(coalesce_partition.input())
+        {
+            empty_exec!(coalesce_partition)
+        } else if let Some(sort_preserving_merge) =
+            plan.as_any().downcast_ref::<SortPreservingMergeExec>()
+            && is_empty_exec!(sort_preserving_merge.input())
+        {
+            empty_exec!(sort_preserving_merge)
         } else if let Some(hash_join) = plan.as_any().downcast_ref::<HashJoinExec>()
             // TODO: - we need other joins, this one is used for testing cancellation
             && hash_join.join_type == Inner

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -495,6 +495,8 @@ impl AdaptivePlanner {
         // add default set
         physical_optimizers.extend(PhysicalOptimizer::new().rules);
 
+        // FIXME: we need to be able to disable rule,
+        //        i found it breaking TPCH SF10
         physical_optimizers.push(Arc::new(PropagateEmptyExecRule::default()));
 
         // `DistributedExchangeRule` should be the last plan mutator rule in the chain

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -17,16 +17,19 @@
 use crate::state::aqe::adapter::BallistaAdapter;
 use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
 use crate::state::aqe::optimizer_rule::{
-    CoalescePartitionsRule, DistributedExchangeRule, PropagateEmptyExecRule,
-    WarnOnDuplicateExecRule,
+    CoalescePartitionsRule, DelayJoinSelectionRule, DistributedExchangeRule,
+    PropagateEmptyExecRule, SelectJoinRule, WarnOnDuplicateExecRule,
 };
 
+use crate::state::distributed_explain::handle_explain_plan;
 use crate::state::execution_stage::StageOutput;
 use ballista_core::execution_plans::ShuffleWriter;
 use ballista_core::serde::scheduler::PartitionLocation;
 use datafusion::common;
 use datafusion::common::{HashMap, exec_err};
+use datafusion::execution::context::SessionContext;
 use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_optimizer::optimizer::PhysicalOptimizer;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties, displayable};
@@ -36,6 +39,7 @@ use log::debug;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 use tokio::time::Instant;
 
 type PhysicalOptimizerRuleRef =
@@ -52,13 +56,16 @@ pub struct AdaptivePlanner {
     /// Generates the next stage ID.
     /// Stage IDs are incremental and unique for each job.
     stage_id_generator: usize,
+    /// plan id generator
+    #[allow(dead_code)] // TODO: keep it for now until we refactor it
+    pub plan_id_generator: Arc<AtomicUsize>,
     /// The session state needed for optimizer calls.
     /// This also freezes the session configuration for a given job.
     session_state: SessionState,
     /// Physical planner used for this job
     physical_planner: Arc<DefaultPhysicalPlanner>,
     /// physical plan representing given job
-    plan: Arc<dyn ExecutionPlan>,
+    pub(crate) plan: Arc<dyn ExecutionPlan>,
     /// caches current runnable stages
     runnable_stage_cache: HashMap<usize, Arc<dyn ExecutionPlan>>,
     /// job name
@@ -90,6 +97,7 @@ impl AdaptivePlanner {
     pub fn try_new_with_optimizers(
         session_config: &SessionConfig,
         plan: Arc<dyn ExecutionPlan>,
+        plan_id_generator: Arc<AtomicUsize>,
         job_name: String,
         physical_optimizer_rules: Vec<PhysicalOptimizerRuleRef>,
     ) -> common::Result<Self> {
@@ -99,7 +107,8 @@ impl AdaptivePlanner {
         let plan = planner.optimize_physical_plan(plan, &session_state, |_, _| {})?;
 
         Ok(Self {
-            stage_id_generator: 0,
+            stage_id_generator: 0, // FIXME: compatibility issue with static where stages start from 1
+            plan_id_generator,
             session_state,
             physical_planner: planner.into(),
             plan,
@@ -118,16 +127,54 @@ impl AdaptivePlanner {
     ///
     /// # Returns
     /// A new instance of `AdaptivePlanner` or an error if the initialization fails.
-    pub fn try_new(
+    #[cfg(test)]
+    pub fn try_from_plan(
         session_config: &SessionConfig,
         plan: Arc<dyn ExecutionPlan>,
         job_name: String,
     ) -> common::Result<Self> {
+        let plan_id_generator = Arc::new(AtomicUsize::new(0));
         Self::try_new_with_optimizers(
             session_config,
             plan,
+            plan_id_generator.clone(),
             job_name,
-            Self::default_optimizers(),
+            Self::default_optimizers(plan_id_generator),
+        )
+    }
+
+    /// Creates a new `AdaptivePlanner` with default physical optimizer rules.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The session context
+    /// * `logical_plan` - The logical plan for the job.
+    /// * `job_name` - The name of the job.
+    ///
+    /// # Returns
+    /// A new instance of `AdaptivePlanner` or an error if the initialization fails.
+    pub async fn try_new(
+        ctx: &SessionContext,
+        logical_plan: &LogicalPlan,
+        job_name: String,
+    ) -> common::Result<Self> {
+        let state = SessionStateBuilder::new_from_existing(ctx.state())
+            .with_physical_optimizer_rules(vec![Arc::new(
+                DelayJoinSelectionRule::default(),
+            )])
+            .build();
+
+        let plan = state.create_physical_plan(logical_plan).await?;
+        let plan = handle_explain_plan(&job_name, ctx, logical_plan, plan)
+            .await
+            .unwrap(); // FIXME
+        let plan_id_generator = Arc::new(AtomicUsize::new(0));
+        Self::try_new_with_optimizers(
+            ctx.state().config(),
+            plan,
+            plan_id_generator.clone(),
+            job_name,
+            Self::default_optimizers(plan_id_generator),
         )
     }
     /// Cancels a stage by its ID.
@@ -210,14 +257,18 @@ impl AdaptivePlanner {
         &mut self,
         stage_id: usize,
     ) -> common::Result<Vec<Vec<PartitionLocation>>> {
-        let output_partition_count = self
-            .runnable_stage_cache
-            .get(&stage_id)
-            .ok_or(datafusion::error::DataFusionError::Execution(
+        let stage = self.runnable_stage_cache.get(&stage_id).ok_or(
+            datafusion::error::DataFusionError::Execution(
                 "Can't find active cache resolve".into(),
-            ))?
-            .output_partitioning()
-            .partition_count();
+            ),
+        )?;
+        let is_broadcast = stage
+            .as_any()
+            .downcast_ref::<ExchangeExec>()
+            .map(|e| e.broadcast)
+            .unwrap_or(false);
+
+        let output_partition_count = stage.output_partitioning().partition_count();
 
         let stage_output = self
             .runnable_stage_output
@@ -225,7 +276,7 @@ impl AdaptivePlanner {
             .ok_or(datafusion::error::DataFusionError::Execution(
                 "Can't find active stage to update resolve".into(),
             ))?
-            .partition_locations(output_partition_count);
+            .partition_locations(output_partition_count, is_broadcast);
 
         self.finalise_stage_internal(stage_id, stage_output.clone())?;
 
@@ -428,11 +479,22 @@ impl AdaptivePlanner {
     ///
     /// # Returns
     /// A vector of default physical optimizer rules.
-    fn default_optimizers() -> Vec<PhysicalOptimizerRuleRef> {
-        let mut physical_optimizers = PhysicalOptimizer::new().rules;
+    fn default_optimizers(
+        plan_id_generator: Arc<AtomicUsize>,
+    ) -> Vec<PhysicalOptimizerRuleRef> {
+        let mut physical_optimizers: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> =
+            vec![];
+        // select actual join implementation based on current runtime information
+        physical_optimizers
+            .push(Arc::new(SelectJoinRule::new(plan_id_generator.clone())));
+        // add default set
+        physical_optimizers.extend(PhysicalOptimizer::new().rules);
+
         physical_optimizers.push(Arc::new(PropagateEmptyExecRule::default()));
+
         // `DistributedExchangeRule` should be the last plan mutator rule in the chain
-        physical_optimizers.push(Arc::new(DistributedExchangeRule::default()));
+        physical_optimizers
+            .push(Arc::new(DistributedExchangeRule::new(plan_id_generator)));
         // we should remove it at the later stage this is just temporary
         // to detect possible duplicate execs.
         // rule does not mutate plan hance it can go after `DistributedExchangeRule`

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -489,15 +489,15 @@ impl AdaptivePlanner {
     ) -> Vec<PhysicalOptimizerRuleRef> {
         let mut physical_optimizers: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> =
             vec![];
+
+        // changing plan before other built in optimizers kick in
+        physical_optimizers.push(Arc::new(PropagateEmptyExecRule::default()));
+
         // select actual join implementation based on current runtime information
         physical_optimizers
             .push(Arc::new(SelectJoinRule::new(plan_id_generator.clone())));
         // add default set
         physical_optimizers.extend(PhysicalOptimizer::new().rules);
-
-        // FIXME: we need to be able to disable rule,
-        //        i found it breaking TPCH SF10
-        physical_optimizers.push(Arc::new(PropagateEmptyExecRule::default()));
 
         // `DistributedExchangeRule` should be the last plan mutator rule in the chain
         physical_optimizers

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -27,6 +27,7 @@ use ballista_core::execution_plans::ShuffleWriter;
 use ballista_core::serde::scheduler::PartitionLocation;
 use datafusion::common;
 use datafusion::common::{HashMap, exec_err};
+use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::{SessionState, SessionStateBuilder};
 use datafusion::logical_expr::LogicalPlan;
@@ -56,9 +57,6 @@ pub struct AdaptivePlanner {
     /// Generates the next stage ID.
     /// Stage IDs are incremental and unique for each job.
     stage_id_generator: usize,
-    /// plan id generator
-    #[allow(dead_code)] // TODO: keep it for now until we refactor it
-    pub plan_id_generator: Arc<AtomicUsize>,
     /// The session state needed for optimizer calls.
     /// This also freezes the session configuration for a given job.
     session_state: SessionState,
@@ -97,7 +95,6 @@ impl AdaptivePlanner {
     pub fn try_new_with_optimizers(
         session_config: &SessionConfig,
         plan: Arc<dyn ExecutionPlan>,
-        plan_id_generator: Arc<AtomicUsize>,
         job_name: String,
         physical_optimizer_rules: Vec<PhysicalOptimizerRuleRef>,
     ) -> common::Result<Self> {
@@ -108,7 +105,6 @@ impl AdaptivePlanner {
 
         Ok(Self {
             stage_id_generator: 0, // FIXME: compatibility issue with static where stages start from 1
-            plan_id_generator,
             session_state,
             physical_planner: planner.into(),
             plan,
@@ -137,7 +133,6 @@ impl AdaptivePlanner {
         Self::try_new_with_optimizers(
             session_config,
             plan,
-            plan_id_generator.clone(),
             job_name,
             Self::default_optimizers(plan_id_generator),
         )
@@ -158,23 +153,25 @@ impl AdaptivePlanner {
         logical_plan: &LogicalPlan,
         job_name: String,
     ) -> common::Result<Self> {
-        let state = SessionStateBuilder::new_from_existing(ctx.state())
-            .with_physical_optimizer_rules(vec![Arc::new(
-                DelayJoinSelectionRule::default(),
-            )])
-            .build();
+        // session state with very limited set of optimizers.
+        // this optimizer set will be executed only once, before
+        // running standard set of optimizers, which will
+        // after each stage.
+        let state = Self::create_session_state(
+            ctx.state().config(),
+            Self::plan_preparation_optimizers(),
+        );
 
         let plan = state.create_physical_plan(logical_plan).await?;
         let plan = handle_explain_plan(&job_name, ctx, logical_plan, plan)
             .await
-            .unwrap(); // FIXME
-        let plan_id_generator = Arc::new(AtomicUsize::new(0));
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+
         Self::try_new_with_optimizers(
             ctx.state().config(),
             plan,
-            plan_id_generator.clone(),
             job_name,
-            Self::default_optimizers(plan_id_generator),
+            Self::default_optimizers(Arc::new(AtomicUsize::new(0))),
         )
     }
     /// Cancels a stage by its ID.
@@ -513,6 +510,13 @@ impl AdaptivePlanner {
 
         physical_optimizers
     }
+
+    /// set of rules which will be executed ONCE before
+    /// running standard set of physical optimizers
+    fn plan_preparation_optimizers() -> Vec<PhysicalOptimizerRuleRef> {
+        vec![Arc::new(DelayJoinSelectionRule::default())]
+    }
+
     /// Creates a session state with the given configuration and optimizer rules.
     ///
     /// # Arguments

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -269,17 +269,22 @@ impl AdaptivePlanner {
             .unwrap_or(false);
 
         let output_partition_count = stage.output_partitioning().partition_count();
-
-        let stage_output = self
-            .runnable_stage_output
-            .remove(&stage_id)
-            .ok_or(datafusion::error::DataFusionError::Execution(
-                "Can't find active stage to update resolve".into(),
-            ))?
-            .partition_locations(output_partition_count, is_broadcast);
-
+        let stage_output = if is_broadcast {
+            self.runnable_stage_output
+                .remove(&stage_id)
+                .ok_or(datafusion::error::DataFusionError::Execution(
+                    "Can't find active stage to resolve".into(),
+                ))?
+                .partition_locations_broadcast()
+        } else {
+            self.runnable_stage_output
+                .remove(&stage_id)
+                .ok_or(datafusion::error::DataFusionError::Execution(
+                    "Can't find active stage to resolve".into(),
+                ))?
+                .partition_locations(output_partition_count)
+        };
         self.finalise_stage_internal(stage_id, stage_output.clone())?;
-
         Ok(stage_output)
     }
 

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -54,8 +54,11 @@ async fn should_propagate_empty_stage() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(1, stages.len());
@@ -114,8 +117,11 @@ async fn should_propagate_empty_stage_and_remove() -> datafusion::error::Result<
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -180,8 +186,11 @@ async fn should_support_join_re_ordering() -> datafusion::error::Result<()> {
         MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
     ");
 
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), join, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        join,
+        "test_job".to_string(),
+    )?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
@@ -277,8 +286,11 @@ async fn should_support_cross_join() -> datafusion::error::Result<()> {
       MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(8192), [(Col[0]:)]]
     ");
 
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), join, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        join,
+        "test_job".to_string(),
+    )?;
 
     //
     // plan after AQE, note the join has already been re-ordered
@@ -380,8 +392,11 @@ async fn should_cancel_the_stage() -> datafusion::error::Result<()> {
         .create_physical_plan()
         .await?;
 
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), join, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        join,
+        "test_job".to_string(),
+    )?;
 
     let (stages, cancellable) = planner.actionable_stages()?;
     assert_eq!(2, stages.unwrap().len());

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -152,17 +152,17 @@ async fn should_propagate_empty_stage_and_remove() -> datafusion::error::Result<
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(1, stages.len());
     assert_plan!(stages.first().unwrap().plan.as_ref(),  @ r"
-    SortShuffleWriterExec: partitioning=Hash([c0@0], 2)
+    ShuffleWriterExec: partitioning: None
       EmptyExec
     ");
     planner.finalise_stage_internal(1, mock_partitions_with_statistics_no_data())?;
 
     let stages = planner.runnable_stages()?;
     assert_plan!(planner.current_plan(),  @ r"
-    AdaptiveDatafusionExec: is_final=true, plan_id=1, stage_id=2, stage_resolved=false
+    AdaptiveDatafusionExec: is_final=true, plan_id=1, stage_id=1, stage_resolved=true
       EmptyExec
     ");
-    assert!(stages.is_some());
+    assert!(stages.is_none());
 
     Ok(())
 }

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -46,7 +46,16 @@ fn coalesce_context(target_partitions: usize, enabled: bool) -> SessionContext {
         .with_target_partitions(target_partitions)
         .with_round_robin_repartition(false)
         .with_ballista_coalesce_enabled(enabled)
-        .with_ballista_coalesce_target_partition_bytes(200);
+        .with_ballista_coalesce_target_partition_bytes(200)
+        .set_bool("datafusion.optimizer.prefer_hash_join", false)
+        .set_u64(
+            "datafusion.optimizer.hash_join_single_partition_threshold",
+            0,
+        )
+        .set_u64(
+            "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+            0,
+        );
 
     let state = SessionStateBuilder::new()
         .with_config(config)

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -126,12 +126,15 @@ async fn should_attach_coalesce_when_partitions_pack_below_m()
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     // Before any stage finalizes the leaves are unresolved, so the rule
     // no-ops: `coalesce=none`.
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
       ProjectionExec: expr=[min(t.a)@1 as c0, c@0 as c2]
         AggregateExec: mode=FinalPartitioned, gby=[c@0 as c], aggr=[min(t.a)]
@@ -151,7 +154,7 @@ async fn should_attach_coalesce_when_partitions_pack_below_m()
     // `CoalescePlan` to plan_id=0.
     let _ = planner.runnable_stages()?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=true, plan_id=1, stage_id=1, stage_resolved=false
       ProjectionExec: expr=[min(t.a)@1 as c0, c@0 as c2]
         AggregateExec: mode=FinalPartitioned, gby=[c@0 as c], aggr=[min(t.a)]
@@ -176,13 +179,16 @@ async fn should_skip_coalesce_when_rule_disabled() -> datafusion::error::Result<
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let _ = planner.runnable_stages()?.unwrap();
     planner.finalise_stage_internal(0, partitions_with_byte_sizes(&[50; 8]))?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
       ProjectionExec: expr=[min(t.a)@1 as c0, c@0 as c2]
         AggregateExec: mode=FinalPartitioned, gby=[c@0 as c], aggr=[min(t.a)]
@@ -210,13 +216,16 @@ async fn should_skip_coalesce_when_partitions_are_full() -> datafusion::error::R
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let _ = planner.runnable_stages()?.unwrap();
     planner.finalise_stage_internal(0, partitions_with_byte_sizes(&[300; 8]))?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
       ProjectionExec: expr=[min(t.a)@1 as c0, c@0 as c2]
         AggregateExec: mode=FinalPartitioned, gby=[c@0 as c], aggr=[min(t.a)]
@@ -246,8 +255,11 @@ async fn should_attach_coalesce_to_both_sides_of_hash_join()
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(2, stages.len());
@@ -259,7 +271,7 @@ async fn should_attach_coalesce_to_both_sides_of_hash_join()
     // attaches the shared `CoalescePlan` to both leaf Exchanges.
     let _ = planner.runnable_stages()?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
       ProjectionExec: expr=[a@0 as a, b@2 as b]
         SortMergeJoinExec: join_type=Inner, on=[(c@1, c@1)]
@@ -296,8 +308,11 @@ async fn should_attach_coalesce_to_all_three_legs_of_two_hash_joins()
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(3, stages.len());
@@ -310,7 +325,7 @@ async fn should_attach_coalesce_to_all_three_legs_of_two_hash_joins()
     // attaches the same `CoalescePlan` to all three leaf Exchanges.
     let _ = planner.runnable_stages()?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=true, plan_id=3, stage_id=3, stage_resolved=false
       ProjectionExec: expr=[a@0 as a, b@2 as b, c@3 as c]
         SortMergeJoinExec: join_type=Inner, on=[(c@1, c@0)]
@@ -358,8 +373,11 @@ async fn should_attach_coalesce_to_both_sides_of_sort_merge_join()
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(2, stages.len());
@@ -370,7 +388,7 @@ async fn should_attach_coalesce_to_both_sides_of_sort_merge_join()
     // Surface the join stage so `CoalescePartitionsRule` fires per-stage.
     let _ = planner.runnable_stages()?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
       ProjectionExec: expr=[a@0 as a, b@2 as b]
         SortMergeJoinExec: join_type=Inner, on=[(c@1, c@1)]
@@ -402,8 +420,11 @@ async fn shuffle_reader_uses_coalesced_k_when_rule_fires() -> datafusion::error:
         .await?
         .create_physical_plan()
         .await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     // Stage 0 is the upstream shuffle writer, partitioning by `c` into M=8.
     let stages = planner.runnable_stages()?.unwrap();

--- a/ballista/scheduler/src/state/aqe/test/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/test/join_selection.rs
@@ -94,14 +94,6 @@ fn make_ctx_without_collect_left(prefer_hash_join: bool) -> SessionContext {
             "datafusion.optimizer.hash_join_single_partition_threshold_rows",
             0,
         )
-        .set_u64(
-            "datafusion.optimizer.hash_join_single_partition_threshold",
-            0,
-        )
-        .set_u64(
-            "datafusion.optimizer.hash_join_single_partition_threshold_rows",
-            0,
-        )
         .with_target_partitions(4)
         .with_round_robin_repartition(false);
     let state = SessionStateBuilder::new_with_default_features()

--- a/ballista/scheduler/src/state/aqe/test/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/test/join_selection.rs
@@ -1,0 +1,419 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Functional tests for [`CoalescePartitionsRule`]: drive a query through
+//! `AdaptivePlanner`, finalize the upstream stage with synthetic per-partition
+//! byte stats, and snapshot the displayed plan tree so the rule's effect on
+//! the leaf `ExchangeExec` is visible at the `coalesce=K of M` field.
+//!
+//! Each test uses small synthetic byte sizes paired with a small
+//! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
+//! against `split_size_list_by_target_size`.
+
+use crate::{
+    assert_plan,
+    state::aqe::{planner::AdaptivePlanner, test::mock_partitions_with_statistics},
+};
+use datafusion::{
+    arrow::{
+        array::{Int32Array, RecordBatch},
+        datatypes::{DataType, Field, Schema},
+    },
+    datasource::MemTable,
+    execution::{SessionStateBuilder, config::SessionConfig, context::SessionContext},
+};
+use std::sync::Arc;
+
+fn make_table(schema: Arc<Schema>) -> Arc<MemTable> {
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0])),
+            Arc::new(Int32Array::from(vec![
+                10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
+            ])),
+        ],
+    )
+    .unwrap();
+
+    Arc::new(
+        MemTable::try_new(
+            schema,
+            vec![
+                vec![batch.clone()],
+                vec![batch.clone()],
+                vec![batch.clone()],
+                vec![batch],
+            ],
+        )
+        .unwrap(),
+    )
+}
+
+fn make_ctx(prefer_hash_join: bool) -> SessionContext {
+    let config = SessionConfig::new()
+        // .set_u64(
+        //     "datafusion.optimizer.hash_join_single_partition_threshold",
+        //     0,
+        // )
+        // .set_u64(
+        //     "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+        //     0,
+        // )
+        .set_bool("datafusion.optimizer.prefer_hash_join", prefer_hash_join)
+        .with_target_partitions(4)
+        .with_round_robin_repartition(false);
+    let state = SessionStateBuilder::new_with_default_features()
+        .with_config(config)
+        .build();
+    SessionContext::new_with_state(state)
+}
+
+fn make_ctx_without_collect_left(prefer_hash_join: bool) -> SessionContext {
+    let config = SessionConfig::new()
+        .set_bool("datafusion.optimizer.prefer_hash_join", prefer_hash_join)
+        .set_u64(
+            "datafusion.optimizer.hash_join_single_partition_threshold",
+            0,
+        )
+        .set_u64(
+            "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+            0,
+        )
+        .set_u64(
+            "datafusion.optimizer.hash_join_single_partition_threshold",
+            0,
+        )
+        .set_u64(
+            "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+            0,
+        )
+        .with_target_partitions(4)
+        .with_round_robin_repartition(false);
+    let state = SessionStateBuilder::new_with_default_features()
+        .with_config(config)
+        .build();
+    SessionContext::new_with_state(state)
+}
+
+fn register_2tables(ctx: &SessionContext) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]));
+    ctx.register_table("t1", make_table(Arc::clone(&schema)))
+        .unwrap();
+    ctx.register_table("t2", make_table(schema)).unwrap();
+}
+
+fn register_3tables(ctx: &SessionContext) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]));
+
+    ctx.register_table("t1", make_table(Arc::clone(&schema)))
+        .unwrap();
+    ctx.register_table("t2", make_table(Arc::clone(&schema)))
+        .unwrap();
+    ctx.register_table("t3", make_table(schema)).unwrap();
+}
+
+#[tokio::test]
+async fn test_hash_join_two_tables_coalesce() -> datafusion::common::Result<()> {
+    let ctx = make_ctx(true);
+    register_2tables(&ctx);
+
+    let lp = ctx
+        .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+        .await
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
+
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_string()).await?;
+    let plan = planner.current_plan();
+    // TODO: we could probably push datasource to read single partition
+    assert_plan!(plan, @ r"
+        AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0, val@2]
+            ExchangeExec: partitioning=None, plan_id=0, stage_id=pending, stage_resolved=false, broadcast=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+        ");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_hash_join_two_tables_repartition() -> datafusion::common::Result<()> {
+    let ctx = make_ctx_without_collect_left(true);
+    register_2tables(&ctx);
+
+    let lp = ctx
+        .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+        .await
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
+
+    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_string()).await?;
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id, val@2 as val]
+        DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=true
+          ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=pending, stage_resolved=false
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=pending, stage_resolved=false
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    let (stages, cancellable) = planner.actionable_stages()?;
+    let stages = stages.unwrap();
+    assert_eq!(2, stages.len());
+    assert_eq!(0, cancellable.len());
+
+    planner.finalise_stage_internal(0, mock_partitions_with_statistics())?;
+    planner.finalise_stage_internal(1, mock_partitions_with_statistics())?;
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
+      HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, id@0)], projection=[id@0, val@2]
+        ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=0, stage_resolved=true
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+        ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=1, stage_resolved=true
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    let (stages, cancellable) = planner.actionable_stages()?;
+    let stages = stages.unwrap();
+    assert_eq!(1, stages.len());
+    assert_eq!(0, cancellable.len());
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
+      HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@0, id@0)], projection=[id@0, val@2]
+        ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=0, stage_resolved=true
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+        ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=1, stage_resolved=true
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sort_merge_join_two_tables_repartition() -> datafusion::common::Result<()> {
+    let ctx = make_ctx_without_collect_left(false);
+    register_2tables(&ctx);
+
+    let lp = ctx
+        .sql("SELECT t1.id, t2.val FROM t1 JOIN t2 ON t1.id = t2.id")
+        .await
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
+
+    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_string()).await?;
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id, val@2 as val]
+        DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=true
+          ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=pending, stage_resolved=false
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=pending, stage_resolved=false
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    let (stages, cancellable) = planner.actionable_stages()?;
+    let stages = stages.unwrap();
+    assert_eq!(2, stages.len());
+    assert_eq!(0, cancellable.len());
+
+    planner.finalise_stage_internal(0, mock_partitions_with_statistics())?;
+    planner.finalise_stage_internal(1, mock_partitions_with_statistics())?;
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id, val@2 as val]
+        SortMergeJoinExec: join_type=Inner, on=[(id@0, id@0)]
+          SortExec: expr=[id@0 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=0, stage_resolved=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          SortExec: expr=[id@0 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=1, stage_resolved=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    let (stages, cancellable) = planner.actionable_stages()?;
+    let stages = stages.unwrap();
+    assert_eq!(1, stages.len());
+    assert_eq!(0, cancellable.len());
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id, val@2 as val]
+        SortMergeJoinExec: join_type=Inner, on=[(id@0, id@0)]
+          SortExec: expr=[id@0 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=0, stage_resolved=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          SortExec: expr=[id@0 ASC], preserve_partitioning=[true]
+            ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=1, stage_resolved=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_hash_join_three_tables_collect_left() -> datafusion::common::Result<()> {
+    let ctx = make_ctx(true);
+    register_3tables(&ctx);
+
+    let lp = ctx
+        .sql("SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t1.id = t3.id")
+        .await
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
+    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_string()).await?;
+    let plan = planner.current_plan();
+
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id]
+        DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
+            ExchangeExec: partitioning=None, plan_id=0, stage_id=pending, stage_resolved=false, broadcast=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    let (stages, cancellable) = planner.actionable_stages()?;
+    let stages = stages.unwrap();
+    assert_eq!(1, stages.len());
+    assert_eq!(0, cancellable.len());
+
+    let plan = planner.current_plan();
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id]
+        DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
+            ExchangeExec: partitioning=None, plan_id=0, stage_id=0, stage_resolved=false, broadcast=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    let stage = stages.first().unwrap();
+
+    // plan for first stage
+    assert_plan!(stage.plan.as_ref(), @ r"
+    ShuffleWriterExec: partitioning: None
+      DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    planner.finalise_stage_internal(0, mock_partitions_with_statistics())?;
+
+    let (stages, cancellable) = planner.actionable_stages()?;
+    let stages = stages.unwrap();
+    assert_eq!(1, stages.len());
+    assert_eq!(0, cancellable.len());
+
+    assert_plan!(planner.current_plan(),  @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
+      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
+        ExchangeExec: partitioning=None, plan_id=2, stage_id=1, stage_resolved=false, broadcast=true
+          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
+            ExchangeExec: partitioning=None, plan_id=0, stage_id=0, stage_resolved=true, broadcast=true
+              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+            DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+        DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_hash_join_three_tables_repartition() -> datafusion::common::Result<()> {
+    let ctx = make_ctx_without_collect_left(true);
+    register_3tables(&ctx);
+
+    let lp = ctx
+        .sql("SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t1.id = t3.id")
+        .await
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_string()).await?;
+    let plan = planner.current_plan();
+
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id]
+        DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
+          ProjectionExec: expr=[id@0 as id]
+            DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=true
+              ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=pending, stage_resolved=false
+                DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+              ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=pending, stage_resolved=false
+                DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sort_merge_join_three_tables_repartition() -> datafusion::common::Result<()>
+{
+    let ctx = make_ctx_without_collect_left(false);
+    register_3tables(&ctx);
+
+    let lp = ctx
+        .sql("SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t1.id = t3.id")
+        .await
+        .unwrap()
+        .into_optimized_plan()
+        .unwrap();
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_string()).await?;
+    let plan = planner.current_plan();
+
+    assert_plan!(plan, @ r"
+    AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
+      ProjectionExec: expr=[id@0 as id]
+        DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=false
+          ProjectionExec: expr=[id@0 as id]
+            DynamicJoinSelectionExec: join_type=Inner, on=[(id@0, id@0)] repartitioned=true
+              ExchangeExec: partitioning=Hash([id@0], 4), plan_id=0, stage_id=pending, stage_resolved=false
+                DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+              ExchangeExec: partitioning=Hash([id@0], 4), plan_id=1, stage_id=pending, stage_resolved=false
+                DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+    ");
+
+    Ok(())
+}

--- a/ballista/scheduler/src/state/aqe/test/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/test/join_selection.rs
@@ -15,15 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Functional tests for [`CoalescePartitionsRule`]: drive a query through
-//! `AdaptivePlanner`, finalize the upstream stage with synthetic per-partition
-//! byte stats, and snapshot the displayed plan tree so the rule's effect on
-//! the leaf `ExchangeExec` is visible at the `coalesce=K of M` field.
-//!
-//! Each test uses small synthetic byte sizes paired with a small
-//! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
-//! against `split_size_list_by_target_size`.
-
 use crate::{
     assert_plan,
     state::aqe::{planner::AdaptivePlanner, test::mock_partitions_with_statistics},

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -19,6 +19,8 @@
 mod alter_stages;
 /// Functional tests for the CoalescePartitionsRule end-to-end through the planner
 mod coalesce_rule;
+/// covers join selection tests
+mod join_selection;
 /// Tests if plan is going to be split to stages correctly
 mod plan_to_stages;
 

--- a/ballista/scheduler/src/state/aqe/test/plan_to_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/plan_to_stages.rs
@@ -40,8 +40,11 @@ async fn should_add_exchanges() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -66,8 +69,11 @@ async fn should_split_plan_into_runnable_stages_internal() -> datafusion::error:
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -115,8 +121,11 @@ async fn should_split_plan_into_stages() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -171,8 +180,11 @@ async fn should_create_initial_plan() -> datafusion::error::Result<()> {
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     // plan has only two exchanges after initial planning
     // other stages will be added as stages get resolved
@@ -218,8 +230,11 @@ async fn should_split_stages_resolve_right_branch() -> datafusion::error::Result
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let runnable_stages = planner.identify_runnable_stages()?.unwrap();
     assert_eq!(2, runnable_stages.len());
@@ -285,8 +300,11 @@ async fn should_split_stages_resolve_left_branch() -> datafusion::error::Result<
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let runnable_stages = planner.identify_runnable_stages()?.unwrap();
     assert_eq!(2, runnable_stages.len());
@@ -357,8 +375,11 @@ async fn should_split_stages_resolve_both() -> datafusion::error::Result<()> {
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let runnable_stages = planner.identify_runnable_stages()?.unwrap();
     assert_eq!(2, runnable_stages.len());
@@ -414,7 +435,7 @@ async fn should_ignore_inactive_stages() -> datafusion::error::Result<()> {
     let exchange_exec = Arc::new(exchange_exec);
     let ctx = mock_context();
 
-    let mut planner = AdaptivePlanner::try_new(
+    let mut planner = AdaptivePlanner::try_from_plan(
         ctx.state().config(),
         exchange_exec,
         "test_job".to_string(),
@@ -443,8 +464,11 @@ async fn should_use_sort_shuffle_when_enabled() -> datafusion::error::Result<()>
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(1, stages.len());
@@ -470,8 +494,11 @@ async fn should_use_sort_shuffle_by_default() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner =
-        AdaptivePlanner::try_new(ctx.state().config(), plan, "test_job".to_string())?;
+    let mut planner = AdaptivePlanner::try_from_plan(
+        ctx.state().config(),
+        plan,
+        "test_job".to_string(),
+    )?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(1, stages.len());

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -1058,22 +1058,28 @@ impl StageOutput {
     }
     /// returns vector of partition locations
     /// which is compatible with ShuffleReader vector format
+    ///
+    /// `output_partition_count` is the number of expected
+    ///  output partition number
     pub fn partition_locations(
         mut self,
-        output_partitions: usize,
-        is_broadcast: bool,
+        output_partition_count: usize,
     ) -> Vec<Vec<PartitionLocation>> {
-        if is_broadcast {
-            self.partition_locations.into_values().collect()
-        } else {
-            let mut partition_locations = Vec::new();
-            for i in 0..output_partitions {
-                let p = self.partition_locations.remove(&i).unwrap_or_default();
-                partition_locations.push(p);
-            }
-
-            partition_locations
+        let mut partition_locations = Vec::new();
+        for i in 0..output_partition_count {
+            let p = self.partition_locations.remove(&i).unwrap_or_default();
+            partition_locations.push(p);
         }
+
+        partition_locations
+    }
+
+    /// returns vector of partition locations
+    /// which is compatible with ShuffleReader vector format
+    /// supporting broadcast shuffle read.
+    /// All partitions are merged into one
+    pub fn partition_locations_broadcast(self) -> Vec<Vec<PartitionLocation>> {
+        self.partition_locations.into_values().collect()
     }
 }
 

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -1061,14 +1061,19 @@ impl StageOutput {
     pub fn partition_locations(
         mut self,
         output_partitions: usize,
+        is_broadcast: bool,
     ) -> Vec<Vec<PartitionLocation>> {
-        let mut partition_locations = Vec::new();
-        for i in 0..output_partitions {
-            let p = self.partition_locations.remove(&i).unwrap_or_default();
-            partition_locations.push(p);
-        }
+        if is_broadcast {
+            self.partition_locations.into_values().collect()
+        } else {
+            let mut partition_locations = Vec::new();
+            for i in 0..output_partitions {
+                let p = self.partition_locations.remove(&i).unwrap_or_default();
+                partition_locations.push(p);
+            }
 
-        partition_locations
+            partition_locations
+        }
     }
 }
 


### PR DESCRIPTION
## Overview

This commit implements **dynamic join strategy selection** in Ballista's Adaptive Query Execution (AQE) pipeline. Instead of choosing a join strategy at planning time (when data sizes are unknown), the plan now inserts a placeholder `DynamicJoinSelectionExec` node that defers the decision until runtime statistics are available.


```text 
Before (planning time)
  HashJoinExec / SortMergeJoinExec
      ↑ chosen by DataFusion optimizer (no runtime stats)

After (AQE flow)
  Step 1 – plan creation:
    DelayJoinSelectionRule → DynamicJoinSelectionExec  (placeholder)

  Step 2 – stage completes, stats available:
    SelectJoinRule → CollectLeft | LateCollectLeft | Hash | Sort | Repartition
                          ↑ decided using actual byte / row counts
```

The change means Ballista can now **broadcast small tables** or **swap join sides** based on real data sizes observed during execution, not just estimates from the logical plan.

Introduced planner rules consider few configuration values to decide join type:

- `datafusion.optimizer.hash_join_single_partition_threshold_rows`, to select broadcast join or not
- `datafusion.optimizer.hash_join_single_partition_threshold`, to select broadcast join or not
- `datafusion.optimizer.prefer_hash_join` to select actual preferred join implementation

with dynamic join selection some TPCH jobs have less stages created 

<img width="1697" height="634" alt="Screenshot 2026-05-23 at 20 51 03" src="https://github.com/user-attachments/assets/bc9ff52b-3ec2-4879-a223-8ef13b99d379" />

compared to static scheduling 

<img width="1707" height="630" alt="Screenshot 2026-05-23 at 20 55 20" src="https://github.com/user-attachments/assets/dfb037ee-e3b7-4bfe-a077-e97832f7c4d3" />


## TODO 

- [x] **broadcast join gives bad results for  `TPCH` 2, 13, 16**
- [x] configuration to disable rule `ballista.planner.adaptive_join.enabled`
- [x] test with `sort join`
- [ ] decision should we stick with `ballista.optimizer.broadcast_join_threshold_bytes` or go with datafusion configuration values
- [ ] more testing 
- [x] `TPCDS` `Q72` test https://github.com/apache/datafusion/issues/17494
- [x] code clean up 

## Context 

this PR is part of #1359 

## Testing

currently relevant configuration values are not set, to this feature for testing configure : 

```
ballista.planner.adaptive.enabled=true
datafusion.optimizer.hash_join_single_partition_threshold=10485760
datafusion.optimizer.hash_join_single_partition_threshold_rows=100_000
```
