### PR TITLE
ci: produce real aarch64 wheel and upload sdist artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [generate-license, build, test-release]
     name: Manylinux arm64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -307,6 +307,12 @@ jobs:
             echo "Directory is clean"
           fi
         shell: bash
+
+      - name: Archive sdist
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-sdist
+          path: python/dist/*.tar.gz
 
   merge-build-artifacts:
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Two latent bugs in the python release wheel pipeline that caused today's \`53.0.0-rc1-pypitest-1\` run to produce an incomplete merged \`dist\` artifact (3 wheels of an expected 4, plus no sdist).

**1. \`build-manylinux-aarch64\` does not actually build aarch64.** The job is named \"Manylinux arm64\" but runs on \`ubuntu-latest\` (x86_64) and calls \`maturin build\` with no \`--target\` flag. So it produces an x86_64 wheel whose filename is identical to the one from \`build-manylinux-x86_64\`. When \`actions/upload-artifact/merge\` combines the per-platform \`dist-*\` artifacts into the merged \`dist\`, it deduplicates the two identical wheels — only one survives. Sizes from the pypitest-1 run line this up exactly: per-platform artifacts total ~204 MB; merged \`dist\` is 152 MB ≈ all components minus one ~52 MB manylinux wheel.

**2. \`build-sdist\` never uploads its sdist.** The job runs \`maturin build --release --sdist --out dist\`, which writes to \`python/dist/\`, but there is no \`actions/upload-artifact\` step. So the sdist never becomes a workflow artifact at all, neither standalone nor merged.

# What changes are included in this PR?

\`.github/workflows/build.yml\`:

- Switch \`build-manylinux-aarch64\` from \`runs-on: ubuntu-latest\` to \`runs-on: ubuntu-24.04-arm\` (GitHub-hosted arm64 runner, GA since early 2025). Maturin will now detect arm64 and emit a \`*-manylinux_*_aarch64.whl\` wheel with a distinct filename. The merge job has nothing to deduplicate against the x86_64 wheel.
- Add an \`actions/upload-artifact\` step to \`build-sdist\` that uploads \`python/dist/*.tar.gz\` as the \`dist-sdist\` artifact. \`dist-sdist\` matches the existing \`pattern: dist-*\` filter in \`merge-build-artifacts\`, so the sdist will appear in the merged \`dist\` automatically.

# Are there any user-facing changes?

No code changes. CI artifact set change: the merged \`dist\` artifact will now contain four wheels (manylinux x86_64, manylinux aarch64, macOS arm64, Windows amd64) and one sdist, matching what \`dev/release/README.md\` documents as the expected platform set.

Note: \`test-release\` (pytest) failures in PR CI here are pre-existing on \`main\` (broken \`ctx.tables()\` test from #1513). Fix is in #1750.