### PR TITLE
ci: only run Python Release Build on RC tags and matching PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,12 +297,17 @@ jobs:
 
       - name: Assert sdist build does not generate wheels
         run: |
-          if [ "$(ls -A target/wheels)" ]; then
-            echo "Error: Sdist build generated wheels"
+          cd python
+          # `--out dist` causes maturin to place artifacts under python/dist/.
+          # Older maturin versions also wrote to the default python/target/wheels/,
+          # so check both locations.
+          found=$(find dist target/wheels -name '*.whl' 2>/dev/null || true)
+          if [ -n "$found" ]; then
+            echo "Error: Sdist build generated wheels:"
+            echo "$found"
             exit 1
-          else
-            echo "Directory is clean"
           fi
+          echo "No wheels generated (expected)."
         shell: bash
 
       - name: Archive sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,6 @@ on:
       - "python/**"
   push:
     tags: ["*-rc*"]
-    branches: ["branch-*"]
-    paths:
-      - "python/**"
 
 jobs:
   test-release:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Two small fixes to the Python Release Build workflow.

**1. Triggers.** The current `on:` block has two problems. It runs the wheel pipeline on every push to a release branch (`push: branches: ["branch-*"]`) — heavy, and a release-branch push isn't the canonical event for cutting artifacts; the RC tag is. It also gates tag pushes on a `paths: ["python/**"]` filter scoped to the whole `push:` block, so an RC tag push only triggers if the tagged commit changed `python/**`. `53.0.0-rc1` happened to trigger only because GitHub's `paths` filter on tag pushes compares against the previous tag (which had python/** changes since the prior release). Relying on that is fragile.

**2. Sdist assertion was always vacuous.** `build-sdist`'s assertion step ran `ls -A target/wheels` from the default workdir. Because each `run:` step starts with cwd reset to the workspace root, the `cd python` from the previous step did not carry over and `target/wheels` resolved to `<repo>/target/wheels`, which doesn't exist. `ls -A` returned empty and the assertion always printed "Directory is clean" regardless of what maturin actually produced.

# What changes are included in this PR?

`.github/workflows/build.yml`:

- Drop `branches:` and `paths:` from the `push:` block, leaving only `tags: ["*-rc*"]`. The pull-request trigger is unchanged.
- Rewrite the sdist assertion to `cd python` and `find dist target/wheels -name '*.whl'`, covering both the current `--out dist` location and the older default `target/wheels/`.

Resulting trigger semantics:

| Event | Fires? |
| --- | --- |
| PR touching `python/**` | ✅ (build + test-release only; wheel jobs skip on PR per #1749) |
| PR not touching `python/**` | ❌ |
| Push of any `*-rc*` tag | ✅ always, regardless of paths |
| Push to `branch-*` | ❌ |
| Push to `main` | ❌ |

# Are there any user-facing changes?

No code changes. CI-only. Release managers should be aware: cutting an RC is now the sole trigger for producing release artifacts on the apache repo, and it always rebuilds regardless of what the RC commit touched.