### PR TITLE
ci: gate TPC-H workflow on rust-only path allow list

### DIFF
--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -29,9 +29,7 @@ on:
     branches: ["main"]
     paths:
       - "ballista/**"
-      - "ballista-cli/**"
       - "benchmarks/**"
-      - "examples/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -40,9 +38,7 @@ on:
   pull_request:
     paths:
       - "ballista/**"
-      - "ballista-cli/**"
       - "benchmarks/**"
-      - "examples/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -27,17 +27,27 @@ concurrency:
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
+    paths:
+      - "ballista/**"
+      - "ballista-cli/**"
+      - "benchmarks/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/tpch.yml"
+      - ".github/actions/setup-builder/**"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
+    paths:
+      - "ballista/**"
+      - "ballista-cli/**"
+      - "benchmarks/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/tpch.yml"
+      - ".github/actions/setup-builder/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Which issue does this PR close?

Part of apache/datafusion#22455.

# Rationale for this change

The TPC-H workflow currently uses a `paths-ignore` deny list that only excludes a few obvious doc paths, so it still runs for changes that cannot affect the benchmark (e.g. Python bindings, other workflows, dev tooling). An allow list makes the trigger intent explicit and avoids wasted CI minutes on irrelevant changes.

# What changes are included in this PR?

Switches the `push` and `pull_request` triggers in `.github/workflows/tpch.yml` from `paths-ignore` to `paths`. The allow list is scoped to what the workflow actually builds and runs:

- `ballista/**` — scheduler, executor, core, client (built as `ballista-scheduler` and `ballista-executor`)
- `benchmarks/**` — `ballista-benchmarks` and the `tpch` driver
- Root manifests: `Cargo.toml`, `Cargo.lock`
- Pinned toolchain: `rust-toolchain.toml`
- The workflow file itself and the shared `setup-builder` action it consumes

The Python crate (`python/`, excluded from the workspace), `ballista-cli/`, `examples/`, docs, other workflows, and dev tooling no longer trigger the run.

# Are there any user-facing changes?

No.