### PR TITLE
ci: gate Docker workflow on rust-only path allow list

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,28 @@
 name: Docker
 on:
   pull_request:
+    paths:
+      - "ballista/**"
+      - "ballista-cli/**"
+      - "benchmarks/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "dev/docker/**"
+      - "dev/build-ballista-docker.sh"
+      - ".github/workflows/docker.yml"
   push:
     branches: ["main"]
+    paths:
+      - "ballista/**"
+      - "ballista-cli/**"
+      - "benchmarks/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "dev/docker/**"
+      - "dev/build-ballista-docker.sh"
+      - ".github/workflows/docker.yml"
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}


### PR DESCRIPTION
# Which issue does this PR close?

Part of apache/datafusion#22455.

# Rationale for this change

The Docker workflow currently has no path filtering, so every push and PR triggers a full Rust build and rebuild of all three Ballista docker images, even for changes that cannot affect the image contents (docs, Python bindings, other workflows, dev tooling). This is one of the heavier workflows in the repo and burns CI minutes for nothing on those PRs.

# What changes are included in this PR?

Adds a `paths` allow list to both the `push` and `pull_request` triggers in `.github/workflows/docker.yml`, scoped to what the build actually consumes:

- `ballista/**`, `ballista-cli/**`, `benchmarks/**` — the workspace crates baked into the images
- Root manifests: `Cargo.toml`, `Cargo.lock`
- Pinned toolchain: `rust-toolchain.toml`
- `dev/docker/**` — Dockerfiles and entrypoint scripts
- `dev/build-ballista-docker.sh` — the build driver
- `.github/workflows/docker.yml` — the workflow itself

# Are there any user-facing changes?

No.