### PR TITLE
ci: gate Rust workflow on workspace path allow list and rename to Ballista Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Rust
+name: Ballista Rust
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -24,17 +24,35 @@ concurrency:
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
+    paths:
+      - "ballista/**"
+      - "ballista-cli/**"
+      - "benchmarks/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "ci/scripts/**"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-macos-builder/**"
+      - ".github/actions/setup-windows-builder/**"
+      - ".github/actions/setup-rust-runtime/**"
+      - ".github/workflows/rust.yml"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
+    paths:
+      - "ballista/**"
+      - "ballista-cli/**"
+      - "benchmarks/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "ci/scripts/**"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-macos-builder/**"
+      - ".github/actions/setup-windows-builder/**"
+      - ".github/actions/setup-rust-runtime/**"
+      - ".github/workflows/rust.yml"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:


### PR DESCRIPTION
# Which issue does this PR close?

Part of apache/datafusion#22455.

# Rationale for this change

`rust.yml` is the heaviest CI workflow in the repo: full Linux/macOS/Windows test matrix plus clippy, rustdoc, fmt, benchmark verification, and Cargo.toml format checks. It currently uses a `paths-ignore` deny list that only excludes docs and Markdown, so changes to the `python/` crate (which is excluded from the Cargo workspace) still trigger the whole matrix even though they cannot affect any of these jobs.

Additionally, the workflow is named just `Rust`, which is indistinguishable from the core DataFusion `Rust` workflow when looking at the ASF GitHub runner usage dashboards.

# What changes are included in this PR?

1. Switch `push` and `pull_request` triggers from `paths-ignore` to a `paths` allow list scoped to what the workflow actually consumes:
   - Workspace crates: `ballista/**`, `ballista-cli/**`, `benchmarks/**`, `examples/**`
   - Root manifests: `Cargo.toml`, `Cargo.lock`
   - Pinned toolchain: `rust-toolchain.toml`
   - `ci/scripts/**` — used by the lint, clippy, rustdoc, and tomlfmt jobs
   - Reusable setup actions: `setup-builder`, `setup-macos-builder`, `setup-windows-builder`, `setup-rust-runtime`
   - The workflow file itself
2. Rename the workflow from `Rust` to `Ballista Rust` so it is distinguishable from the core DataFusion Rust workflow in shared ASF runner-usage charts.

# Are there any user-facing changes?

The workflow's display name in GitHub Actions UIs and required-check lists changes from `Rust` to `Ballista Rust`. Branch protection rules that reference the old name by string will need to be updated.