### PR TITLE
ci: gate CodeQL workflow on .github path changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,11 @@ name: "CodeQL"
 on:
   push:
     branches: ["main"]
+    paths:
+      - ".github/**"
   pull_request:
+    paths:
+      - ".github/**"
   schedule:
     - cron: "16 4 * * 1"
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of apache/datafusion#22455.

# Rationale for this change

The CodeQL workflow is configured with `languages: actions`, so it only scans the GitHub Actions workflow files under `.github/`. It currently fires on every push and PR regardless of what changed, which means it re-analyzes the same set of workflow files for unrelated Rust, doc, or Python changes. The weekly schedule already guarantees baseline coverage even when nothing in `.github/` has been touched.

# What changes are included in this PR?

Adds `paths: .github/**` to the `push` and `pull_request` triggers in `.github/workflows/codeql.yml`. The weekly `schedule` trigger is unchanged.

# Are there any user-facing changes?

No.