### PR TITLE
ci: use maturin sdist subcommand to avoid building a wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,7 @@ jobs:
         run: |
           cd python
           uv sync --dev --no-install-package ballista
-          uv run --no-project maturin build --release --sdist --out dist --strip
+          uv run --no-project maturin sdist --out dist
 
       - name: Assert sdist build does not generate wheels
         run: |


### PR DESCRIPTION
# Which issue does this PR close?

<!-- no issue filed -->

Closes #.

# Rationale for this change

The Python Release Build's "Source distribution" job runs `maturin build --release --sdist --out dist --strip`. The `maturin build` subcommand produces a wheel even when `--sdist` is passed, so the job ends up emitting both a wheel and the sdist. This trips the "Assert sdist build does not generate wheels" step that was added in #1753, e.g. https://github.com/apache/datafusion-ballista/actions/runs/26345525629/job/77555535891:

```
Error: Sdist build generated wheels:
dist/ballista-52.0.0-cp310-abi3-manylinux_2_39_x86_64.whl
```

(The assertion previously looked in `target/wheels` rather than `python/dist`, so the same misbuild silently slipped through.)

# What changes are included in this PR?

Switch the sdist job's build command to the dedicated `maturin sdist --out dist` subcommand, which only produces a `.tar.gz`. The `--release` and `--strip` flags only apply to wheel builds and are dropped.

# Are there any user-facing changes?

No.