### PR TITLE
chore(ci): Execute the "Dependencies" workflow on push to main and for PRs

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,8 +23,7 @@ concurrency:
 
 on:
   push:
-    branches-ignore:
-      - "gh-readonly-queue/**"
+    branches: [ "main" ]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up of #1738 
https://github.com/apache/datafusion-ballista/pull/1738#discussion_r3271711643

# Rationale for this change

The "Dependencies" workflow still runs twice - once for `pull_request` and another time for a `push` to a branch that is not `gh-readonly-queue/**`.
E.g. https://github.com/apache/datafusion-ballista/pull/1773/checks

# What changes are included in this PR?

The CI workflow will now run for `pull_request` against any branch and `push` to `main`. Like many of the other workflows

# Are there any user-facing changes?

No