### PR TITLE
feat: add `/api/job/{job_id}/config` endpoint to retrieve session configuration

### DIFF
--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -938,7 +938,7 @@ pub async fn get_job_config<
         .task_manager
         .get_job_config(&job_id)
         .await
-        .map(Json)
+        .map(|e| Json(e.to_props()))
         .map_err(|_| SchedulerErrorResponse::new(StatusCode::NOT_FOUND))
 }
 

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -926,6 +926,22 @@ pub async fn get_scheduler_metrics<
     }
 }
 
+pub async fn get_job_config<
+    T: AsLogicalPlan + Clone + Send + Sync + 'static,
+    U: AsExecutionPlan + Send + Sync + 'static,
+>(
+    State(data_server): State<Arc<SchedulerServer<T, U>>>,
+    Path(job_id): Path<String>,
+) -> Result<impl IntoResponse, SchedulerErrorResponse> {
+    data_server
+        .state
+        .task_manager
+        .get_job_config(&job_id)
+        .await
+        .map(Json)
+        .map_err(|_| SchedulerErrorResponse::new(StatusCode::NOT_FOUND))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ballista/scheduler/src/api/routes.rs
+++ b/ballista/scheduler/src/api/routes.rs
@@ -38,6 +38,10 @@ pub fn get_routes<
             get(handlers::get_job::<T, U>).patch(handlers::cancel_job::<T, U>),
         )
         .route(
+            "/api/job/{job_id}/config",
+            get(handlers::get_job_config::<T, U>),
+        )
+        .route(
             "/api/job/{job_id}/stages",
             get(handlers::get_query_stages::<T, U>),
         )

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -529,6 +529,10 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
         self.session_id.as_str()
     }
 
+    fn session_config(&self) -> Arc<SessionConfig> {
+        self.session_config.clone()
+    }
+
     fn status(&self) -> &JobStatus {
         &self.status
     }

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -109,7 +109,10 @@ pub trait ExecutionGraph: Debug {
     /// Returns the session ID associated with this job.
     fn session_id(&self) -> &str;
 
-    /// Returns the current job status.
+    /// Returns the session config associated with this job.
+    fn session_config(&self) -> Arc<SessionConfig>;
+
+    /// Returns the current status of the job.
     fn status(&self) -> &JobStatus;
 
     /// Returns the logical plan as a string, if captured at submission time.
@@ -641,6 +644,10 @@ impl ExecutionGraph for StaticExecutionGraph {
 
     fn session_id(&self) -> &str {
         self.session_id.as_str()
+    }
+
+    fn session_config(&self) -> Arc<SessionConfig> {
+        self.session_config.clone()
     }
 
     fn status(&self) -> &JobStatus {

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -35,6 +35,7 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::scheduler::ExecutorMetadata;
 use dashmap::DashMap;
+use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
@@ -441,13 +442,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     }
 
     /// Get the session configuration for a job.
-    pub async fn get_job_config(&self, job_id: &str) -> Result<HashMap<String, String>> {
+    pub async fn get_job_config(&self, job_id: &str) -> Result<Arc<SessionConfig>> {
         let graph = self
             .get_job_execution_graph(job_id)
             .await?
             .ok_or_else(|| BallistaError::General(format!("Job {job_id} not found")))?;
 
-        Ok(graph.session_config().to_props())
+        Ok(graph.session_config())
     }
 
     /// Update given task statuses in the respective job and return a tuple containing:

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -440,6 +440,16 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         }
     }
 
+    /// Get the session configuration for a job.
+    pub async fn get_job_config(&self, job_id: &str) -> Result<HashMap<String, String>> {
+        let graph = self
+            .get_job_execution_graph(job_id)
+            .await?
+            .ok_or_else(|| BallistaError::General(format!("Job {job_id} not found")))?;
+
+        Ok(graph.session_config().to_props())
+    }
+
     /// Update given task statuses in the respective job and return a tuple containing:
     /// 1. A list of QueryStageSchedulerEvent to publish.
     /// 2. A list of reservations that can now be offered.

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -32,5 +32,6 @@ The scheduler also provides a REST API that allows jobs to be monitored.
 | /api/job/{job_id}/dot                | GET    | Produce a query plan in DOT (graphviz) format.                    |
 | /api/job/:job_id/dot_svg             | GET    | Produce a query plan in SVG format. (`graphviz-support` required) |
 | /api/job/{job_id}                    | PATCH  | Cancel a currently running job                                    |
+| /api/job/{job_id}/config             | GET    | Get session configuration for a job.                             |
 | /api/job/:job_id/stage/:stage_id/dot | GET    | Produces stage plan in DOT (graphviz) format                      |
 | /api/metrics                         | GET    | Return current scheduler metric set                               |

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -25,13 +25,13 @@ The scheduler also provides a REST API that allows jobs to be monitored.
 
 > This is optional scheduler feature which should be enabled with the `rest-api` feature.
 
-| API                                  | Method | Description                                                       |
-| ------------------------------------ | ------ | ----------------------------------------------------------------- |
-| /api/jobs                            | GET    | Get a list of jobs that have been submitted to the cluster.       |
-| /api/job/{job_id}                    | GET    | Get a summary of a submitted job.                                 |
-| /api/job/{job_id}/dot                | GET    | Produce a query plan in DOT (graphviz) format.                    |
-| /api/job/{job_id}/dot_svg             | GET    | Produce a query plan in SVG format. (`graphviz-support` required) |
-| /api/job/{job_id}                    | PATCH  | Cancel a currently running job                                    |
-| /api/job/{job_id}/config             | GET    | Get session configuration for a job.                             |
+| API                                    | Method | Description                                                       |
+| -------------------------------------- | ------ | ----------------------------------------------------------------- |
+| /api/jobs                              | GET    | Get a list of jobs that have been submitted to the cluster.       |
+| /api/job/{job_id}                      | GET    | Get a summary of a submitted job.                                 |
+| /api/job/{job_id}/dot                  | GET    | Produce a query plan in DOT (graphviz) format.                    |
+| /api/job/{job_id}/dot_svg              | GET    | Produce a query plan in SVG format. (`graphviz-support` required) |
+| /api/job/{job_id}                      | PATCH  | Cancel a currently running job                                    |
+| /api/job/{job_id}/config               | GET    | Get session configuration for a job.                              |
 | /api/job/{job_id}/stage/{stage_id}/dot | GET    | Produces stage plan in DOT (graphviz) format                      |
-| /api/metrics                         | GET    | Return current scheduler metric set                               |
+| /api/metrics                           | GET    | Return current scheduler metric set                               |

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -30,8 +30,8 @@ The scheduler also provides a REST API that allows jobs to be monitored.
 | /api/jobs                            | GET    | Get a list of jobs that have been submitted to the cluster.       |
 | /api/job/{job_id}                    | GET    | Get a summary of a submitted job.                                 |
 | /api/job/{job_id}/dot                | GET    | Produce a query plan in DOT (graphviz) format.                    |
-| /api/job/:job_id/dot_svg             | GET    | Produce a query plan in SVG format. (`graphviz-support` required) |
+| /api/job/{job_id}/dot_svg             | GET    | Produce a query plan in SVG format. (`graphviz-support` required) |
 | /api/job/{job_id}                    | PATCH  | Cancel a currently running job                                    |
 | /api/job/{job_id}/config             | GET    | Get session configuration for a job.                             |
-| /api/job/:job_id/stage/:stage_id/dot | GET    | Produces stage plan in DOT (graphviz) format                      |
+| /api/job/{job_id}/stage/{stage_id}/dot | GET    | Produces stage plan in DOT (graphviz) format                      |
 | /api/metrics                         | GET    | Return current scheduler metric set                               |


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-ballista/issues/1783.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Being able to debug configuration for any already executed job.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `/api/job/{job_id}/config` endpoint in REST API

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Documentation is updated

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Possible follow-up : add this to TUI to allow inspecting the config
