### PR TITLE
fix: handle task execution errors and panics in executor

### DIFF
--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -20,6 +20,7 @@
 use crate::execution_engine::DefaultExecutionEngine;
 use crate::execution_engine::ExecutionEngine;
 use crate::execution_engine::QueryStageExecutor;
+use crate::execution_loop::any_to_string;
 use crate::metrics::ExecutorMetricsCollector;
 use crate::metrics::LoggingMetricsCollector;
 use ballista_core::ConfigProducer;
@@ -30,10 +31,13 @@ use ballista_core::serde::protobuf;
 use ballista_core::serde::protobuf::ExecutorRegistration;
 use ballista_core::serde::scheduler::PartitionId;
 use dashmap::DashMap;
+use datafusion::error::DataFusionError;
 use datafusion::execution::context::TaskContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::SessionConfig;
+use futures::FutureExt;
 use futures::future::AbortHandle;
+use log::error;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -197,7 +201,19 @@ impl Executor {
         self.abort_handles
             .insert((task_id, partition.clone()), abort_handle);
 
-        let partitions = task.await??;
+        let partitions = match std::panic::AssertUnwindSafe(task).catch_unwind().await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => {
+                let error_msg = "Task has been aborted!";
+                error!("{}", error_msg);
+                Err(DataFusionError::Internal(error_msg.to_string()))
+            }
+            Err(p) => {
+                let error_msg = format!("Task panicked: {}", any_to_string(&p));
+                error!("{}", error_msg);
+                Err(DataFusionError::Internal(error_msg))
+            }
+        };
 
         self.abort_handles.remove(&(task_id, partition.clone()));
 
@@ -208,7 +224,7 @@ impl Executor {
             query_stage_exec,
         );
 
-        Ok(partitions)
+        partitions.map_err(|e| BallistaError::DataFusionError(Box::new(e)))
     }
 
     /// Cancels a running task by aborting its execution.

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -31,13 +31,13 @@ use ballista_core::serde::protobuf;
 use ballista_core::serde::protobuf::ExecutorRegistration;
 use ballista_core::serde::scheduler::PartitionId;
 use dashmap::DashMap;
-use datafusion::error::DataFusionError;
 use datafusion::execution::context::TaskContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::SessionConfig;
 use futures::FutureExt;
 use futures::future::AbortHandle;
 use log::error;
+use log::warn;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -202,16 +202,17 @@ impl Executor {
             .insert((task_id, partition.clone()), abort_handle);
 
         let partitions = match std::panic::AssertUnwindSafe(task).catch_unwind().await {
-            Ok(Ok(result)) => result,
+            Ok(Ok(result)) => {
+                result.map_err(|e| BallistaError::DataFusionError(Box::new(e)))
+            }
             Ok(Err(_)) => {
-                let error_msg = "Task has been aborted!";
-                error!("{}", error_msg);
-                Err(DataFusionError::Internal(error_msg.to_string()))
+                warn!("Task has been aborted!");
+                Err(BallistaError::Cancelled)
             }
             Err(p) => {
-                let error_msg = format!("Task panicked: {}", any_to_string(&p));
-                error!("{}", error_msg);
-                Err(DataFusionError::Internal(error_msg))
+                let error_msg = format!("{:#?}", any_to_string(&p));
+                error!("{error_msg}");
+                Err(BallistaError::Internal(error_msg))
             }
         };
 
@@ -224,7 +225,7 @@ impl Executor {
             query_stage_exec,
         );
 
-        partitions.map_err(|e| BallistaError::DataFusionError(Box::new(e)))
+        partitions
     }
 
     /// Cancels a running task by aborting its execution.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

The executor previously used `??` to propagate task errors, which did not handle panics occurring inside task futures. A panicking task would unwind past the executor and potentially crash the process or leave state inconsistent. This change wraps task execution in `catch_unwind` so both errors and panics are caught and converted into proper `DataFusionError` values.

# What changes are included in this PR?

- Wraps task future execution in `std::panic::AssertUnwindSafe(...).catch_unwind().await` in `executor.rs`
- Maps task abort (`Ok(Err(_))`) to a `DataFusionError::Internal` with a clear "Task has been aborted!" message
- Maps task panics (`Err(p)`) to a `DataFusionError::Internal` with the panic payload stringified via the existing `any_to_string` helper from `execution_loop`
- Logs an error for both cases before returning
- Converts the resulting `DataFusionError` to `BallistaError` at the call site via `map_err`

# Are there any user-facing changes?

No user-facing changes. The executor is now more resilient — panics inside tasks are caught and reported as errors rather than propagating uncontrolled, which improves stability of the executor process.