### PR TITLE
Scheduler client reuse

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -56,6 +56,11 @@ pub const BALLISTA_CLIENT_GRPC_TCP_KEEPALIVE_SECONDS: &str =
 /// Configuration key for HTTP/2 keep-alive interval for gRPC clients in seconds.
 pub const BALLISTA_CLIENT_GRPC_HTTP2_KEEPALIVE_INTERVAL_SECONDS: &str =
     "ballista.client.grpc_http2_keepalive_interval_seconds";
+/// Configuration key for the idle timeout, in seconds, after which the
+/// client-side cached scheduler `Channel` is closed and the next query
+/// will reconnect.
+pub const BALLISTA_CLIENT_SCHEDULER_CHANNEL_IDLE_TIMEOUT_SECONDS: &str =
+    "ballista.client.scheduler_channel_idle_timeout_seconds";
 /// Should client employ pull or push job tracking strategy
 pub const BALLISTA_CLIENT_PULL: &str = "ballista.client.pull";
 /// Should client use tls connection
@@ -147,6 +152,12 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          Some((3600).to_string())),
         ConfigEntry::new(BALLISTA_CLIENT_GRPC_HTTP2_KEEPALIVE_INTERVAL_SECONDS.to_string(),
                          "HTTP/2 keep-alive interval for gRPC client in seconds".to_string(),
+                         DataType::UInt64,
+                         Some((300).to_string())),
+        ConfigEntry::new(BALLISTA_CLIENT_SCHEDULER_CHANNEL_IDLE_TIMEOUT_SECONDS.to_string(),
+                         "Idle timeout in seconds for the client-side cached scheduler gRPC channel. After \
+                          this many seconds with no query activity, the underlying TCP connection is closed \
+                          and the next query reconnects.".to_string(),
                          DataType::UInt64,
                          Some((300).to_string())),
         ConfigEntry::new(BALLISTA_ADAPTIVE_PLANNER_ENABLED.to_string(),
@@ -364,6 +375,14 @@ impl BallistaConfig {
     /// Returns the HTTP/2 keep-alive interval for gRPC clients in seconds.
     pub fn grpc_client_http2_keepalive_interval_seconds(&self) -> usize {
         self.get_usize_setting(BALLISTA_CLIENT_GRPC_HTTP2_KEEPALIVE_INTERVAL_SECONDS)
+    }
+
+    /// Returns the idle timeout for the client-side cached scheduler
+    /// `Channel`, in seconds. When the cached channel goes unused for
+    /// this many seconds, the underlying TCP connection is closed and
+    /// the next query reconnects.
+    pub fn scheduler_channel_idle_timeout_seconds(&self) -> usize {
+        self.get_usize_setting(BALLISTA_CLIENT_SCHEDULER_CHANNEL_IDLE_TIMEOUT_SECONDS)
     }
 
     /// Returns the maximum message size for gRPC clients in bytes.

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -18,6 +18,7 @@
 use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
 use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
+use crate::scheduler_client::SchedulerChannelCache;
 use crate::serde::protobuf::get_job_status_result::FlightProxy;
 use crate::serde::protobuf::{
     ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult, KeyValuePair,
@@ -85,10 +86,19 @@ pub struct DistributedQueryExec<T: 'static + AsLogicalPlan> {
     metrics: ExecutionPlanMetricsSet,
     /// The scheduler job id after the query has been accepted.
     job_id: Arc<Mutex<Option<String>>>,
+    /// Shared cache for the scheduler `Channel`. Cloned in from the
+    /// `BallistaQueryPlanner` so all queries on the same session share one
+    /// HTTP/2 connection to the scheduler.
+    scheduler_channel_cache: SchedulerChannelCache,
 }
 
 impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
     /// Creates a new distributed query execution plan.
+    ///
+    /// Builds a fresh [`SchedulerChannelCache`] with the default idle
+    /// timeout. In production the planner constructs the cache and
+    /// shares it across queries via [`with_extension`](Self::with_extension);
+    /// this constructor is convenient for tests and single-query callers.
     pub fn new(
         scheduler_url: String,
         config: BallistaConfig,
@@ -108,6 +118,7 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
             job_id: Arc::new(Mutex::new(None)),
+            scheduler_channel_cache: SchedulerChannelCache::with_default_timeout(),
         }
     }
 
@@ -118,6 +129,7 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         plan: LogicalPlan,
         extension_codec: Arc<dyn LogicalExtensionCodec>,
         session_id: String,
+        scheduler_channel_cache: SchedulerChannelCache,
     ) -> Self {
         let properties = Arc::new(Self::compute_properties(
             plan.schema().as_arrow().clone().into(),
@@ -132,12 +144,19 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
             job_id: Arc::new(Mutex::new(None)),
+            scheduler_channel_cache,
         }
     }
 
     /// Returns the scheduler job id after the query has been accepted.
     pub fn job_id(&self) -> Option<String> {
         self.job_id.lock().clone()
+    }
+
+    /// Returns the cache used by this exec to share a scheduler `Channel`
+    /// with sibling execs on the same session.
+    pub fn scheduler_channel_cache(&self) -> &SchedulerChannelCache {
+        &self.scheduler_channel_cache
     }
 
     fn compute_properties(schema: SchemaRef) -> PlanProperties {
@@ -208,6 +227,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
             )),
             metrics: ExecutionPlanMetricsSet::new(),
             job_id: Arc::clone(&self.job_id),
+            scheduler_channel_cache: self.scheduler_channel_cache.clone(),
         }))
     }
 
@@ -272,6 +292,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                     Arc::clone(&self.job_id),
                     partition,
                     session_config,
+                    self.scheduler_channel_cache.clone(),
                 )
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),
             )
@@ -300,6 +321,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedQueryExec<T> {
                     Arc::clone(&self.job_id),
                     partition,
                     session_config,
+                    self.scheduler_channel_cache.clone(),
                 )
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),
             )
@@ -339,6 +361,7 @@ async fn execute_query_pull(
     job_id_handle: Arc<Mutex<Option<String>>>,
     partition: usize,
     session_config: SessionConfig,
+    scheduler_channel_cache: SchedulerChannelCache,
 ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
     let customize_endpoint =
@@ -350,34 +373,28 @@ async fn execute_query_pull(
     // Capture query submission time for total_query_time_ms
     let query_start_time = std::time::Instant::now();
 
-    info!("Connecting to Ballista scheduler at {scheduler_url}");
-    // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
-    let mut endpoint =
-        create_grpc_client_endpoint(scheduler_url.clone(), Some(&grpc_config))
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-
-    if let Some(ref customize) = customize_endpoint {
-        endpoint = customize
-            .configure_endpoint(endpoint)
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-    }
-
-    let connection = endpoint
-        .connect()
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-
-    let mut scheduler = SchedulerGrpcClient::with_interceptor(
-        connection,
-        grpc_interceptor.as_ref().clone(),
+    let channel = build_scheduler_channel(
+        &scheduler_channel_cache,
+        &scheduler_url,
+        &grpc_config,
+        customize_endpoint.clone(),
     )
-    .max_encoding_message_size(max_message_size)
-    .max_decoding_message_size(max_message_size);
+    .await?;
+
+    let mut scheduler =
+        SchedulerGrpcClient::with_interceptor(channel, grpc_interceptor.as_ref().clone())
+            .max_encoding_message_size(max_message_size)
+            .max_decoding_message_size(max_message_size);
 
     let query_result = scheduler
         .execute_query(query)
         .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+        .map_err(|status| {
+            if crate::scheduler_client::is_transport_error(&status) {
+                scheduler_channel_cache.invalidate();
+            }
+            DataFusionError::Execution(format!("{status:?}"))
+        })?
         .into_inner();
 
     let query_result = match query_result.result.unwrap() {
@@ -407,7 +424,12 @@ async fn execute_query_pull(
                 job_id: job_id.clone(),
             })
             .await
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+            .map_err(|status| {
+                if crate::scheduler_client::is_transport_error(&status) {
+                    scheduler_channel_cache.invalidate();
+                }
+                DataFusionError::Execution(format!("{status:?}"))
+            })?
             .into_inner();
         let status = status.and_then(|s| s.status);
         let wait_future = tokio::time::sleep(Duration::from_millis(50));
@@ -512,6 +534,7 @@ async fn execute_query_push(
     job_id_handle: Arc<Mutex<Option<String>>>,
     partition: usize,
     session_config: SessionConfig,
+    scheduler_channel_cache: SchedulerChannelCache,
 ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send> {
     let grpc_interceptor = session_config.ballista_grpc_interceptor();
     let customize_endpoint =
@@ -523,34 +546,28 @@ async fn execute_query_push(
     // Capture query submission time for total_query_time_ms
     let query_start_time = std::time::Instant::now();
 
-    info!("Connecting to Ballista scheduler at {scheduler_url}");
-    // TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again
-    let mut endpoint =
-        create_grpc_client_endpoint(scheduler_url.clone(), Some(&grpc_config))
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-
-    if let Some(ref customize) = customize_endpoint {
-        endpoint = customize
-            .configure_endpoint(endpoint)
-            .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-    }
-
-    let connection = endpoint
-        .connect()
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-
-    let mut scheduler = SchedulerGrpcClient::with_interceptor(
-        connection,
-        grpc_interceptor.as_ref().clone(),
+    let channel = build_scheduler_channel(
+        &scheduler_channel_cache,
+        &scheduler_url,
+        &grpc_config,
+        customize_endpoint.clone(),
     )
-    .max_encoding_message_size(max_message_size)
-    .max_decoding_message_size(max_message_size);
+    .await?;
+
+    let mut scheduler =
+        SchedulerGrpcClient::with_interceptor(channel, grpc_interceptor.as_ref().clone())
+            .max_encoding_message_size(max_message_size)
+            .max_decoding_message_size(max_message_size);
 
     let mut query_status_stream = scheduler
         .execute_query_push(query)
         .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
+        .map_err(|status| {
+            if crate::scheduler_client::is_transport_error(&status) {
+                scheduler_channel_cache.invalidate();
+            }
+            DataFusionError::Execution(format!("{status:?}"))
+        })?
         .into_inner();
 
     let mut prev_status: Option<job_status::Status> = None;
@@ -562,7 +579,12 @@ async fn execute_query_push(
             .ok_or(DataFusionError::Execution(
                 "Stream closed without job completing".to_string(),
             ))?
-            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+            .map_err(|status| {
+                if crate::scheduler_client::is_transport_error(&status) {
+                    scheduler_channel_cache.invalidate();
+                }
+                DataFusionError::Execution(status.to_string())
+            })?;
 
         let GetJobStatusResult {
             status,
@@ -663,6 +685,38 @@ async fn execute_query_push(
             }
         };
     }
+}
+
+/// Returns a `Channel` to the scheduler, building one through `cache` if
+/// none is currently cached. The build closure logs "Connecting to ..."
+/// so the message fires once per actual connect (not per query).
+async fn build_scheduler_channel(
+    cache: &SchedulerChannelCache,
+    scheduler_url: &str,
+    grpc_config: &GrpcClientConfig,
+    customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+) -> Result<tonic::transport::Channel> {
+    let scheduler_url = scheduler_url.to_string();
+    let grpc_config = grpc_config.clone();
+    cache
+        .get_or_init(|| async move {
+            info!("Connecting to Ballista scheduler at {scheduler_url}");
+            let mut endpoint =
+                create_grpc_client_endpoint(scheduler_url, Some(&grpc_config))
+                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+
+            if let Some(ref customize) = customize_endpoint {
+                endpoint = customize
+                    .configure_endpoint(endpoint)
+                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            }
+
+            endpoint
+                .connect()
+                .await
+                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))
+        })
+        .await
 }
 
 fn get_client_host_port(

--- a/ballista/core/src/lib.rs
+++ b/ballista/core/src/lib.rs
@@ -54,6 +54,9 @@ pub mod object_store;
 pub mod planner;
 /// Runtime registry for codec and function registration.
 pub mod registry;
+/// Scheduler `Channel` cache used by the client to reuse the gRPC
+/// connection across queries on the same session.
+pub mod scheduler_client;
 /// Serialization and deserialization for Ballista messages and plans.
 pub mod serde;
 /// General utility functions for Ballista operations.

--- a/ballista/core/src/planner.rs
+++ b/ballista/core/src/planner.rs
@@ -17,6 +17,7 @@
 
 use crate::config::BallistaConfig;
 use crate::execution_plans::{DistributedExplainAnalyzeExec, DistributedQueryExec};
+use crate::scheduler_client::SchedulerChannelCache;
 use crate::serde::BallistaLogicalExtensionCodec;
 
 use async_trait::async_trait;
@@ -31,6 +32,7 @@ use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion_proto::logical_plan::{AsLogicalPlan, LogicalExtensionCodec};
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// [BallistaQueryPlanner] planner takes logical plan
 /// and executes it remotely on on scheduler.
@@ -43,6 +45,11 @@ pub struct BallistaQueryPlanner<T: AsLogicalPlan> {
     config: BallistaConfig,
     extension_codec: Arc<dyn LogicalExtensionCodec>,
     local_planner: DefaultPhysicalPlanner,
+    /// Shared cache for the scheduler gRPC `Channel`. Constructed once
+    /// per planner (≈ once per `SessionContext`) and cloned into each
+    /// `DistributedQueryExec` so all queries on a session share one
+    /// HTTP/2 connection.
+    scheduler_channel_cache: SchedulerChannelCache,
     _plan_type: PhantomData<T>,
 }
 
@@ -60,11 +67,13 @@ impl<T: AsLogicalPlan> std::fmt::Debug for BallistaQueryPlanner<T> {
 impl<T: 'static + AsLogicalPlan> BallistaQueryPlanner<T> {
     /// Creates a new Ballista query planner with the specified scheduler URL and configuration.
     pub fn new(scheduler_url: String, config: BallistaConfig) -> Self {
+        let scheduler_channel_cache = scheduler_channel_cache_from_config(&config);
         Self {
             scheduler_url,
             config,
             extension_codec: Arc::new(BallistaLogicalExtensionCodec::default()),
             local_planner: DefaultPhysicalPlanner::default(),
+            scheduler_channel_cache,
             _plan_type: PhantomData,
         }
     }
@@ -75,12 +84,14 @@ impl<T: 'static + AsLogicalPlan> BallistaQueryPlanner<T> {
         config: BallistaConfig,
         extension_codec: Arc<dyn LogicalExtensionCodec>,
     ) -> Self {
+        let scheduler_channel_cache = scheduler_channel_cache_from_config(&config);
         Self {
             scheduler_url,
             config,
             extension_codec,
             local_planner: DefaultPhysicalPlanner::default(),
             _plan_type: PhantomData,
+            scheduler_channel_cache,
         }
     }
 
@@ -91,14 +102,22 @@ impl<T: 'static + AsLogicalPlan> BallistaQueryPlanner<T> {
         extension_codec: Arc<dyn LogicalExtensionCodec>,
         local_planner: DefaultPhysicalPlanner,
     ) -> Self {
+        let scheduler_channel_cache = scheduler_channel_cache_from_config(&config);
         Self {
             scheduler_url,
             config,
             extension_codec,
             _plan_type: PhantomData,
             local_planner,
+            scheduler_channel_cache,
         }
     }
+}
+
+fn scheduler_channel_cache_from_config(config: &BallistaConfig) -> SchedulerChannelCache {
+    SchedulerChannelCache::new(Duration::from_secs(
+        config.scheduler_channel_idle_timeout_seconds() as u64,
+    ))
 }
 
 #[async_trait]
@@ -140,6 +159,7 @@ impl<T: 'static + AsLogicalPlan> QueryPlanner for BallistaQueryPlanner<T> {
                             inner_plan,
                             self.extension_codec.clone(),
                             session_state.session_id().to_string(),
+                            self.scheduler_channel_cache.clone(),
                         ));
 
                     Ok(Arc::new(DistributedExplainAnalyzeExec::new(
@@ -158,6 +178,7 @@ impl<T: 'static + AsLogicalPlan> QueryPlanner for BallistaQueryPlanner<T> {
                         logical_plan.clone(),
                         self.extension_codec.clone(),
                         session_state.session_id().to_string(),
+                        self.scheduler_channel_cache.clone(),
                     )))
                 }
             }
@@ -316,6 +337,50 @@ mod test {
                 .as_any()
                 .downcast_ref::<DistributedQueryExec<LogicalPlanNode>>()
                 .is_some()
+        );
+        Ok(())
+    }
+
+    /// Verifies that the planner's `SchedulerChannelCache` is **shared**
+    /// across every `DistributedQueryExec` it builds. This is the
+    /// invariant that makes connection reuse work end-to-end: if two
+    /// consecutive `create_physical_plan` calls produced execs with
+    /// distinct caches, each query would open its own scheduler
+    /// connection and the feature would be silently broken.
+    #[tokio::test]
+    async fn planner_shares_scheduler_channel_cache_across_queries() -> Result<()> {
+        let ctx = context();
+        ctx.sql("CREATE TABLE tt (c0 INT)").await?.show().await?;
+        let planner = BallistaQueryPlanner::<LogicalPlanNode>::new(
+            "http://localhost:50050".to_string(),
+            BallistaConfig::default(),
+        );
+
+        let df1 = ctx.sql("SELECT * FROM tt").await?;
+        let df2 = ctx.sql("SELECT c0 FROM tt").await?;
+
+        let plan1 = planner
+            .create_physical_plan(df1.logical_plan(), &ctx.state())
+            .await?;
+        let plan2 = planner
+            .create_physical_plan(df2.logical_plan(), &ctx.state())
+            .await?;
+
+        let exec1 = plan1
+            .as_any()
+            .downcast_ref::<DistributedQueryExec<LogicalPlanNode>>()
+            .expect("plan1 should be a DistributedQueryExec");
+        let exec2 = plan2
+            .as_any()
+            .downcast_ref::<DistributedQueryExec<LogicalPlanNode>>()
+            .expect("plan2 should be a DistributedQueryExec");
+
+        assert!(
+            exec1
+                .scheduler_channel_cache()
+                .shares_inner_with(exec2.scheduler_channel_cache()),
+            "two queries on the same planner must share one cache so they \
+             reuse a single scheduler gRPC connection"
         );
         Ok(())
     }

--- a/ballista/core/src/scheduler_client.rs
+++ b/ballista/core/src/scheduler_client.rs
@@ -1,0 +1,481 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Lazily-initialized, idle-evicting cache for a scheduler [`tonic::transport::Channel`].
+//!
+//! [`SchedulerChannelCache`] holds at most one `Channel` per cache instance.
+//! It is intended to be embedded in a long-lived owner (e.g. a query planner
+//! that lives for the lifetime of a `SessionContext`) and cloned cheaply into
+//! per-query execution nodes.
+//!
+//! # Lifecycle
+//!
+//! * **Lazy init.** The first call to [`SchedulerChannelCache::get_or_init`]
+//!   runs the supplied build closure to produce a `Channel`. Concurrent
+//!   first-callers do *not* race: an internal [`tokio::sync::OnceCell`]
+//!   guarantees exactly one `build()` invocation; the rest suspend and
+//!   wake when the result is ready.
+//! * **Idle eviction.** A background tokio task ticks every
+//!   `idle_timeout / 3` (minimum 15 s). If the cached `Channel` has not
+//!   been observed by [`get_or_init`](SchedulerChannelCache::get_or_init)
+//!   for `idle_timeout`, the task swaps in a fresh empty cell so the
+//!   underlying TCP connection drops.
+//! * **Failure invalidation.** Callers may call
+//!   [`invalidate`](SchedulerChannelCache::invalidate) on transport-level
+//!   RPC errors to force the next acquire to reconnect. Use the
+//!   [`is_transport_error`] helper to recognise such errors.
+//!
+//! # `tonic::transport::Channel` semantics
+//!
+//! A `Channel` wraps an HTTP/2 connection. Cloning a `Channel` is cheap and
+//! shares the underlying connection — concurrent RPCs from cloned channels
+//! multiplex over HTTP/2 streams without serialising. We therefore cache
+//! one `Channel` and hand out clones.
+
+use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use tokio::sync::OnceCell;
+use tonic::transport::Channel;
+
+/// Default idle timeout for [`SchedulerChannelCache::with_default_timeout`].
+pub const DEFAULT_SCHEDULER_CHANNEL_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Lazily-initialized, idle-evicting, single-flight cache for a scheduler
+/// [`tonic::transport::Channel`].
+///
+/// See the module-level docs for the lifecycle.
+#[derive(Clone)]
+pub struct SchedulerChannelCache {
+    inner: Arc<Inner>,
+    idle_timeout: Duration,
+}
+
+impl std::fmt::Debug for SchedulerChannelCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchedulerChannelCache")
+            .field("idle_timeout", &self.idle_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+struct Inner {
+    state: Mutex<Slot>,
+}
+
+struct Slot {
+    /// Current init cell. Cloned out under the lock and used outside it.
+    /// Eviction or [`SchedulerChannelCache::invalidate`] swaps this with a
+    /// fresh empty `OnceCell::new()`. Callers already awaiting the old cell
+    /// continue to receive whatever the in-flight build produced — only
+    /// future callers (and future builds) use the new cell.
+    cell: Arc<OnceCell<Channel>>,
+    /// Last time a caller observed this slot. Drives idle eviction.
+    last_used: Instant,
+}
+
+impl SchedulerChannelCache {
+    /// Creates a cache with the specified idle timeout and starts the
+    /// background eviction task.
+    pub fn new(idle_timeout: Duration) -> Self {
+        let initial_slot = Slot {
+            cell: Arc::new(OnceCell::new()),
+            last_used: Instant::now(),
+        };
+        let inner = Arc::new(Inner {
+            state: Mutex::new(initial_slot),
+        });
+
+        Self::spawn_eviction_task(Arc::downgrade(&inner), idle_timeout);
+
+        Self {
+            inner,
+            idle_timeout,
+        }
+    }
+
+    /// Convenience constructor using
+    /// [`DEFAULT_SCHEDULER_CHANNEL_IDLE_TIMEOUT`].
+    pub fn with_default_timeout() -> Self {
+        Self::new(DEFAULT_SCHEDULER_CHANNEL_IDLE_TIMEOUT)
+    }
+
+    /// Returns a `Channel`, building one if the cache is empty.
+    ///
+    /// Concurrent first-callers do not race to connect — exactly one
+    /// `build()` future runs and the rest await its result.
+    pub async fn get_or_init<F, Fut, E>(&self, build: F) -> Result<Channel, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Channel, E>>,
+    {
+        // 1. Take a snapshot of the current cell under the lock.
+        //    Stale-and-initialized → swap in a fresh empty cell.
+        //    Stale-but-uninitialized (build is in flight) → keep waiting,
+        //    do not orphan the in-flight builder.
+        //    Always refresh last_used so active traffic keeps the cell warm.
+        let cell = {
+            let mut guard = self.inner.state.lock();
+            let stale = guard.cell.initialized()
+                && guard.last_used.elapsed() >= self.idle_timeout;
+            if stale {
+                guard.cell = Arc::new(OnceCell::new());
+            }
+            guard.last_used = Instant::now();
+            Arc::clone(&guard.cell)
+        }; // parking_lot::Mutex guard dropped before .await below.
+
+        // 2. Single-flight init. Across N concurrent callers holding clones
+        //    of the same OnceCell, exactly one runs `build()`; the rest
+        //    suspend and wake when the result is ready.
+        let channel = cell.get_or_try_init(build).await?;
+        Ok(channel.clone())
+    }
+
+    /// Drops the cached channel so the next [`get_or_init`] call reconnects.
+    /// Call on transport-level RPC errors (see [`is_transport_error`]).
+    ///
+    /// Callers that already hold a clone of the previous cell continue to
+    /// receive whatever its in-flight build produced. Only future callers
+    /// see the fresh, empty cell and trigger a new build.
+    ///
+    /// [`get_or_init`]: Self::get_or_init
+    pub fn invalidate(&self) {
+        let mut guard = self.inner.state.lock();
+        guard.cell = Arc::new(OnceCell::new());
+        guard.last_used = Instant::now();
+    }
+
+    fn spawn_eviction_task(weak: Weak<Inner>, idle_timeout: Duration) {
+        // No empirical evidence behind 15 — chosen to match the executor's
+        // DefaultBallistaClientPool. We can revisit if needed.
+        let check_interval = Duration::from_secs((idle_timeout.as_secs() / 3).max(15));
+
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            log::debug!(
+                "SchedulerChannelCache: no current tokio runtime; \
+                 skipping background idle-eviction task"
+            );
+            return;
+        };
+
+        handle.spawn(async move {
+            let mut ticker = tokio::time::interval(check_interval);
+            loop {
+                ticker.tick().await;
+                match weak.upgrade() {
+                    None => break, // cache dropped → exit task
+                    Some(inner) => {
+                        let mut guard = inner.state.lock();
+                        // Only evict an *initialized* cell that's gone idle.
+                        // An uninitialized cell means a build is in flight —
+                        // leave it alone so we don't orphan the builder.
+                        let stale = guard.cell.initialized()
+                            && guard.last_used.elapsed() >= idle_timeout;
+                        if stale {
+                            guard.cell = Arc::new(OnceCell::new());
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /// Test-only: returns true iff the slot's cell currently holds a
+    /// populated `Channel`.
+    #[cfg(test)]
+    pub(crate) fn is_initialized(&self) -> bool {
+        self.inner.state.lock().cell.initialized()
+    }
+
+    /// Returns `true` iff `self` and `other` are clones of the same
+    /// cache (i.e. they share the same underlying state and would see
+    /// each other's writes). Intended for tests that want to verify
+    /// the cache is being plumbed through correctly.
+    pub fn shares_inner_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+/// Returns `true` if `status` looks like a transport-level failure
+/// (i.e. the underlying connection is broken). Callers should
+/// [`SchedulerChannelCache::invalidate`] on these so the next request
+/// reconnects.
+///
+/// We treat both `Unavailable` and `Unknown` as transport errors because
+/// tonic surfaces some `hyper`/`h2` failures via `Code::Unknown`.
+pub fn is_transport_error(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unavailable | tonic::Code::Unknown
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+    use tonic::transport::Endpoint;
+
+    /// Build a `Channel` value without any network I/O. The channel is
+    /// valid as a Rust value — we can cache, clone, and drop it — but no
+    /// real RPC will succeed on it. That is fine for unit tests of the
+    /// cache primitive itself.
+    fn fake_channel() -> Channel {
+        Endpoint::from_static("http://127.0.0.1:1").connect_lazy()
+    }
+
+    #[tokio::test]
+    async fn fresh_cache_is_uninitialized() {
+        let cache = SchedulerChannelCache::new(Duration::from_secs(60));
+        assert!(!cache.is_initialized());
+    }
+
+    #[tokio::test]
+    async fn get_or_init_caches_first_call() {
+        let cache = SchedulerChannelCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let calls_a = Arc::clone(&calls);
+        cache
+            .get_or_init(|| async move {
+                calls_a.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(fake_channel())
+            })
+            .await
+            .unwrap();
+
+        let calls_b = Arc::clone(&calls);
+        cache
+            .get_or_init(|| async move {
+                calls_b.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(fake_channel())
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cache.is_initialized());
+    }
+
+    #[tokio::test]
+    async fn single_flight_under_concurrent_callers() {
+        let cache = SchedulerChannelCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+        // Hold the build until we explicitly release it so all callers
+        // pile up on the same OnceCell.
+        let release = Arc::new(Notify::new());
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let cache = cache.clone();
+            let calls = Arc::clone(&calls);
+            let release = Arc::clone(&release);
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_init(|| async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        release.notified().await;
+                        Ok::<_, std::io::Error>(fake_channel())
+                    })
+                    .await
+                    .unwrap();
+            }));
+        }
+
+        // Give all tasks a chance to enter get_or_try_init before releasing.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        release.notify_waiters();
+
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cache.is_initialized());
+    }
+
+    #[tokio::test]
+    async fn build_failure_does_not_poison() {
+        let cache = SchedulerChannelCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        // First wave: all builders fail.
+        //
+        // tokio::sync::OnceCell::get_or_try_init does NOT broadcast errors:
+        // on failure it releases the init permit and the next waiter
+        // becomes the active builder. This is desirable — a transient
+        // failure (broken connection that comes back, scheduler that
+        // restarts mid-init) gives the next caller a fresh attempt
+        // without poisoning the cell. So `calls` may be anywhere from
+        // 1 (callers funneled sequentially) up to N (each waiter ran
+        // its own attempt). What we care about for non-poisoning is
+        // that the cell stays uninitialized and the next caller
+        // succeeds.
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let cache = cache.clone();
+            let calls = Arc::clone(&calls);
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_init(|| async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Err::<Channel, _>(std::io::Error::other("boom"))
+                    })
+                    .await
+            }));
+        }
+        for h in handles {
+            assert!(h.await.unwrap().is_err());
+        }
+        let after_failures = calls.load(Ordering::SeqCst);
+        assert!(after_failures >= 1, "at least one builder must have run");
+        assert!(after_failures <= 4, "at most one builder per waiter");
+        assert!(!cache.is_initialized());
+
+        // Second wave: succeeds, proving no poisoning.
+        let calls_b = Arc::clone(&calls);
+        cache
+            .get_or_init(|| async move {
+                calls_b.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(fake_channel())
+            })
+            .await
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), after_failures + 1);
+        assert!(cache.is_initialized());
+    }
+
+    #[tokio::test]
+    async fn invalidate_swaps_in_fresh_cell() {
+        let cache = SchedulerChannelCache::new(Duration::from_secs(60));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..2 {
+            let calls = Arc::clone(&calls);
+            cache
+                .get_or_init(|| async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, std::io::Error>(fake_channel())
+                })
+                .await
+                .unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cache.is_initialized());
+
+        cache.invalidate();
+        assert!(!cache.is_initialized());
+
+        let calls_after = Arc::clone(&calls);
+        cache
+            .get_or_init(|| async move {
+                calls_after.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::io::Error>(fake_channel())
+            })
+            .await
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn idle_eviction_drops_initialized_cell() {
+        let idle = Duration::from_millis(100);
+        let cache = SchedulerChannelCache::new(idle);
+
+        cache
+            .get_or_init(|| async { Ok::<_, std::io::Error>(fake_channel()) })
+            .await
+            .unwrap();
+        assert!(cache.is_initialized());
+
+        // Wait long enough for at least one eviction tick after expiry.
+        // check_interval = max(idle/3, 15s) = 15s in unit-test world, so
+        // we drive eviction manually instead.
+        // Helper: simulate a tick by replicating the eviction logic.
+        tokio::time::sleep(idle + Duration::from_millis(50)).await;
+        manually_evict_if_stale(&cache, idle);
+        assert!(!cache.is_initialized());
+    }
+
+    #[tokio::test]
+    async fn idle_eviction_does_not_swap_in_flight_cell() {
+        let idle = Duration::from_millis(100);
+        let cache = SchedulerChannelCache::new(idle);
+        let release = Arc::new(Notify::new());
+        let release_for_task = Arc::clone(&release);
+
+        let cache_for_task = cache.clone();
+        let handle = tokio::spawn(async move {
+            cache_for_task
+                .get_or_init(|| async move {
+                    release_for_task.notified().await;
+                    Ok::<_, std::io::Error>(fake_channel())
+                })
+                .await
+                .unwrap();
+        });
+
+        // Let the task enter get_or_try_init, then sleep past the idle
+        // threshold while the build is still pending.
+        tokio::time::sleep(idle + Duration::from_millis(50)).await;
+        manually_evict_if_stale(&cache, idle);
+
+        // Cell pointer must NOT have been swapped — the in-flight build
+        // is still on the original cell.
+        assert!(!cache.is_initialized()); // not initialized YET, but cell unchanged
+
+        release.notify_waiters();
+        handle.await.unwrap();
+        assert!(cache.is_initialized()); // build completed on the original cell
+    }
+
+    #[tokio::test]
+    async fn dropping_cache_drops_inner() {
+        let cache = SchedulerChannelCache::new(Duration::from_secs(60));
+        // Test lives inside the module, so we can downgrade Arc<Inner>
+        // directly without exposing a public accessor.
+        let weak = Arc::downgrade(&cache.inner);
+        assert!(weak.upgrade().is_some());
+        drop(cache);
+        assert!(
+            weak.upgrade().is_none(),
+            "Inner must drop when no strong refs remain — eviction task \
+             must hold only a Weak"
+        );
+    }
+
+    #[test]
+    fn is_transport_error_matches_unavailable_and_unknown() {
+        assert!(is_transport_error(&tonic::Status::unavailable("x")));
+        assert!(is_transport_error(&tonic::Status::unknown("x")));
+        assert!(!is_transport_error(&tonic::Status::invalid_argument("x")));
+        assert!(!is_transport_error(&tonic::Status::not_found("x")));
+        assert!(!is_transport_error(&tonic::Status::permission_denied("x")));
+    }
+
+    /// Replicates the eviction task's per-tick logic so unit tests don't
+    /// have to wait for the real check interval (which is at least 15 s).
+    fn manually_evict_if_stale(cache: &SchedulerChannelCache, idle_timeout: Duration) {
+        let mut guard = cache.inner.state.lock();
+        let stale = guard.cell.initialized() && guard.last_used.elapsed() >= idle_timeout;
+        if stale {
+            guard.cell = Arc::new(OnceCell::new());
+        }
+    }
+}


### PR DESCRIPTION
 # Which issue does this PR close?

# Rationale for this change

  Today every query against a Ballista cluster opens a brand-new TCP+TLS+HTTP/2 connection to the scheduler, runs
  `execute_query` plus a polling loop of `get_job_status`, and discards the connection. Even when the same
  `SessionContext` runs many queries against one scheduler URL, the handshake is paid on every query.

  `tonic::transport::Channel` is `Clone` and HTTP/2 multiplexes concurrent RPCs over one connection by design — so
  the per-query reconnect is throwing away exactly the thing meant to be shared. For interactive REPLs and JDBC
  sessions, this is a constant per-query latency floor (and worse on TLS-enabled deployments).

  Two `TODO reuse the scheduler to avoid connecting to the Ballista scheduler again and again` markers flag this in
   the source today:

  - `ballista/core/src/execution_plans/distributed_query.rs:354` (`execute_query_pull`)
  - `ballista/core/src/execution_plans/distributed_query.rs:527` (`execute_query_push`)

  # What changes are included in this PR?

  Adds a per-planner, lazily-initialized, idle-evicting, single-flight `SchedulerChannelCache` that holds one
  `tonic::transport::Channel` per `BallistaQueryPlanner`. The cache is constructed once per planner (≈ once per
  `SessionContext`) and cloned into every `DistributedQueryExec` it builds, so all queries on a session share one
  HTTP/2 connection.

  # Are these changes tested?

  Yes:

  - 9 unit tests on `SchedulerChannelCache`: lazy init, single-flight under 16 concurrent callers, 
  build-failure-doesn't-poison, `invalidate()` swap semantics, idle eviction with and without an in-flight build, 
  drop-of-cache exits the eviction task (proving the eviction task holds only a `Weak`), and the 
  `is_transport_error` predicate.
  - 1 unit test in `BallistaQueryPlanner` asserting that two `create_physical_plan` calls produce exec nodes whose 
  caches share the same `Arc<Inner>` — the invariant that makes the feature actually work end-to-end.
  - All pre-existing `ballista-core` tests pass unchanged (108 / 108 lib tests green).

  # Are there any user-facing changes?

  One new config option:

  - `ballista.client.scheduler_channel_idle_timeout_seconds` — idle timeout in seconds for the client-side cached 
  scheduler gRPC channel. After this many seconds with no query activity, the underlying TCP connection is closed 
  and the next query reconnects. Default `300`.