### PR TITLE
chore(ci): Use MacOS Github hosted runners for the small CI checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - ".github/**"
   pull_request:
@@ -35,7 +35,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,13 +39,10 @@ on:
 jobs:
   depcheck:
     name: msrv dependency check
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6.0.2
         with:
-          submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,7 +18,7 @@
 name: Dev
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
 
 concurrency:
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   rat:
     name: Release Audit Tool (RAT)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -41,7 +41,7 @@ jobs:
 
   prettier:
     name: Use prettier to check formatting of documents
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   process:
     name: Process
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Assign GitHub labels
         if: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - .asf.yaml
       - .github/workflows/docs.yaml
@@ -28,7 +28,7 @@ name: Deploy DataFusion Ballista site
 jobs:
   build-docs:
     name: Build docs
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout docs sources
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,6 +247,8 @@ jobs:
           rustup toolchain install stable
           rustup default stable
           rustup component add clippy
+      - name: Install protoc
+        run: brew install protobuf
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run clippy
         run: ci/scripts/rust_clippy.sh
@@ -266,7 +268,6 @@ jobs:
         run: |
           rustup toolchain install stable
           rustup default stable
-          rustup component add clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Install cargo-tomlfmt
         uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "ballista/**"
       - "ballista-cli/**"
@@ -136,7 +136,7 @@ jobs:
           cargo check --profile ci -p ballista-scheduler -p ballista-executor -p ballista-core -p ballista --no-default-features --locked
 
   ballista-test:
-    name: test linux balista
+    name: test linux ballista
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -219,9 +219,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Setup toolchain
@@ -235,26 +233,19 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
+    runs-on: macos-latest
+    env:
+      # Disable full debug symbol generation to speed up CI build and keep memory down
+      # "1" means line tables only, which is useful for panic tracebacks.
+      RUSTFLAGS: "-C debuginfo=1"
     steps:
       - uses: actions/checkout@v6.0.2
         with:
-          submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Install Clippy
         run: |
@@ -264,30 +255,25 @@ jobs:
 
   cargo-toml-formatting-checks:
     name: Check Cargo.toml formatting
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
+    runs-on: macos-latest
+    env:
+      # Disable full debug symbol generation to speed up CI build and keep memory down
+      # "1" means line tables only, which is useful for panic tracebacks.
+      RUSTFLAGS: "-C debuginfo=1"
     steps:
       - uses: actions/checkout@v6.0.2
         with:
-          submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Install cargo-tomlfmt
-        run: |
-          which cargo-tomlfmt || cargo install cargo-tomlfmt
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        with:
+          tool: cargo-tomlfmt@0.2.1
+
       - name: Check Cargo.toml formatting
         run: |
           # if you encounter error, try rerun the command below, finally run 'git diff' to

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,13 +243,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
-      - name: Install Clippy
         run: |
+          rustup toolchain install stable
+          rustup default stable
           rustup component add clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run clippy
         run: ci/scripts/rust_clippy.sh
 
@@ -265,9 +263,10 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup component add clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Install cargo-tomlfmt
         uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1


### PR DESCRIPTION

# Which issue does this PR close?

N/A

# Rationale for this change

The Ubuntu ones are in shortage

# What changes are included in this PR?

Change some of the CI jobs to use `macos-latest` instead of `ubuntu-latest`

# Are there any user-facing changes?

No
