### PR TITLE
chore(docker): Use yellow_tripdata_2022-01.parquet from nightlies.apache.org

### DIFF
--- a/dev/docker/ballista-standalone.Dockerfile
+++ b/dev/docker/ballista-standalone.Dockerfile
@@ -36,12 +36,6 @@ COPY target/${RELEASE_FLAG}/ballista-executor /root/ballista-executor
 RUN chmod a+x /root/ballista-scheduler && \
     chmod a+x /root/ballista-executor
 
-# populate some sample data for ListingSchemaProvider
-RUN mkdir -p /data && \
-    wget -q https://nightlies.apache.org/datafusion/ballista/yellow_tripdata_2022-01.parquet -P /data/
-ENV DATAFUSION_CATALOG_LOCATION=/data
-ENV DATAFUSION_CATALOG_TYPE=csv
-
 # Expose Ballista Scheduler gRPC port
 EXPOSE 50050
 

--- a/dev/docker/ballista-standalone.Dockerfile
+++ b/dev/docker/ballista-standalone.Dockerfile
@@ -38,7 +38,7 @@ RUN chmod a+x /root/ballista-scheduler && \
 
 # populate some sample data for ListingSchemaProvider
 RUN mkdir -p /data && \
-    wget -q https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet -P /data/
+    wget -q https://nightlies.apache.org/datafusion/ballista/yellow_tripdata_2022-01.parquet -P /data/
 ENV DATAFUSION_CATALOG_LOCATION=/data
 ENV DATAFUSION_CATALOG_TYPE=csv
 


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

# Rationale for this change

Trying to solve this error:
```
ballista-standalone.Dockerfile:40
--------------------
  39 |     # populate some sample data for ListingSchemaProvider
  40 | >>> RUN mkdir -p /data && \
  41 | >>>     wget -q https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet -P /data/
  42 |     ENV DATAFUSION_CATALOG_LOCATION=/data
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c mkdir -p /data &&     wget -q https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet -P /data/" did not complete successfully: exit code: 8
```

https://github.com/apache/datafusion-ballista/pull/1816#issuecomment-4619391141


# What changes are included in this PR?

Copied https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet to https://nightlies.apache.org/datafusion/ballista/yellow_tripdata_2022-01.parquet and updated ballista-standalone.Dockerfile to use it

# Are there any user-facing changes?

No