### PR TITLE
feat(scheduler): Use command line options for CORS origins/methods instead of env vars

### DIFF
--- a/ballista/scheduler/src/api/routes.rs
+++ b/ballista/scheduler/src/api/routes.rs
@@ -91,8 +91,8 @@ fn allowed_origins(config: Arc<SchedulerConfig>) -> AllowOrigin {
     };
 
     match config.cors_allowed_origins.trim() {
-        origins if origins.is_empty() => AllowOrigin::list(default_origins()),
-        origins if origins == "*" => AllowOrigin::any(),
+        "" => AllowOrigin::list(default_origins()),
+        "*" => AllowOrigin::any(),
         origins => {
             let mut header_values = Vec::new();
             for origin in origins.split(',') {
@@ -128,8 +128,8 @@ fn allowed_methods(config: Arc<SchedulerConfig>) -> AllowMethods {
     };
 
     match config.cors_allowed_methods.trim() {
-        methods if methods.is_empty() => AllowMethods::list(default_methods()),
-        methods if methods == "*" => AllowMethods::any(),
+        "" => AllowMethods::list(default_methods()),
+        "*" => AllowMethods::any(),
         methods => {
             let mut allowed_methods = Vec::new();
             for method in methods.split(',') {

--- a/ballista/scheduler/src/api/routes.rs
+++ b/ballista/scheduler/src/api/routes.rs
@@ -70,6 +70,19 @@ pub fn get_routes<
 }
 
 fn cors(config: Arc<SchedulerConfig>) -> CorsLayer {
+    let allowed_origins = allowed_origins(config.clone());
+    let allowed_methods = allowed_methods(config.clone());
+
+    tracing::debug!("CORS allowed origins: {allowed_origins:?}");
+    tracing::debug!("CORS allowed methods: {allowed_methods:?}");
+
+    CorsLayer::new()
+        .allow_origin(allowed_origins)
+        .allow_methods(allowed_methods)
+        .allow_headers(AllowHeaders::any())
+}
+
+fn allowed_origins(config: Arc<SchedulerConfig>) -> AllowOrigin {
     let default_origins = || {
         vec![
             HeaderValue::from_static("http://localhost:8080"),
@@ -77,7 +90,7 @@ fn cors(config: Arc<SchedulerConfig>) -> CorsLayer {
         ]
     };
 
-    let allowed_origins = match config.cors_allowed_origins.trim() {
+    match config.cors_allowed_origins.trim() {
         origins if origins.is_empty() => AllowOrigin::list(default_origins()),
         origins if origins == "*" => AllowOrigin::any(),
         origins => {
@@ -92,8 +105,10 @@ fn cors(config: Arc<SchedulerConfig>) -> CorsLayer {
             }
             AllowOrigin::list(header_values)
         }
-    };
+    }
+}
 
+fn allowed_methods(config: Arc<SchedulerConfig>) -> AllowMethods {
     let default_methods = || {
         vec![
             http::Method::GET,
@@ -102,7 +117,7 @@ fn cors(config: Arc<SchedulerConfig>) -> CorsLayer {
         ]
     };
 
-    let allowed_methods = match config.cors_allowed_methods.trim() {
+    match config.cors_allowed_methods.trim() {
         methods if methods.is_empty() || methods == "*" => AllowMethods::any(),
         methods => {
             let mut allowed_methods = methods
@@ -116,10 +131,5 @@ fn cors(config: Arc<SchedulerConfig>) -> CorsLayer {
             }
             AllowMethods::list(allowed_methods)
         }
-    };
-
-    CorsLayer::new()
-        .allow_origin(allowed_origins)
-        .allow_methods(allowed_methods)
-        .allow_headers(AllowHeaders::any())
+    }
 }

--- a/ballista/scheduler/src/api/routes.rs
+++ b/ballista/scheduler/src/api/routes.rs
@@ -65,7 +65,7 @@ pub fn get_routes<
     );
 
     router
-        .layer(cors(scheduler_server.clone().state.config.clone()))
+        .layer(cors(scheduler_server.state.config.clone()))
         .with_state(scheduler_server)
 }
 
@@ -94,12 +94,22 @@ fn allowed_origins(config: Arc<SchedulerConfig>) -> AllowOrigin {
         origins if origins.is_empty() => AllowOrigin::list(default_origins()),
         origins if origins == "*" => AllowOrigin::any(),
         origins => {
-            let mut header_values = origins
-                .split(',')
-                .filter(|method| !method.trim().is_empty())
-                .map(|origin| origin.trim().parse().ok())
-                .collect::<Option<Vec<_>>>()
-                .unwrap_or_else(default_origins);
+            let mut header_values = Vec::new();
+            for origin in origins.split(',') {
+                let origin = origin.trim();
+                if !origin.is_empty() {
+                    match origin.parse::<HeaderValue>() {
+                        Ok(val) => header_values.push(val),
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to parse CORS allowed origin '{}': {}",
+                                origin,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
             if header_values.is_empty() {
                 header_values = default_origins();
             }
@@ -118,14 +128,23 @@ fn allowed_methods(config: Arc<SchedulerConfig>) -> AllowMethods {
     };
 
     match config.cors_allowed_methods.trim() {
-        methods if methods.is_empty() || methods == "*" => AllowMethods::any(),
+        methods if methods.is_empty() => AllowMethods::list(default_methods()),
+        methods if methods == "*" => AllowMethods::any(),
         methods => {
-            let mut allowed_methods = methods
-                .split(',')
-                .filter(|method| !method.trim().is_empty())
-                .map(|method| method.trim().parse().ok())
-                .collect::<Option<Vec<_>>>()
-                .unwrap_or_else(default_methods);
+            let mut allowed_methods = Vec::new();
+            for method in methods.split(',') {
+                let method = method.trim();
+                if !method.is_empty() {
+                    match method.parse::<http::Method>() {
+                        Ok(val) => allowed_methods.push(val),
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to parse CORS allowed method '{method}': {e}"
+                            );
+                        }
+                    }
+                }
+            }
             if allowed_methods.is_empty() {
                 allowed_methods = default_methods();
             }

--- a/ballista/scheduler/src/api/routes.rs
+++ b/ballista/scheduler/src/api/routes.rs
@@ -11,12 +11,14 @@
 // limitations under the License.
 
 use crate::api::handlers;
+use crate::config::SchedulerConfig;
 use crate::scheduler_server::SchedulerServer;
 use axum::{Router, routing::get};
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
+use http::HeaderValue;
 use std::sync::Arc;
-use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
+use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
 
 /// All routes configured for rest-api.
 pub fn get_routes<
@@ -62,32 +64,62 @@ pub fn get_routes<
         get(handlers::get_job_svg_graph::<T, U>),
     );
 
-    router.with_state(scheduler_server).layer(cors())
+    router
+        .layer(cors(scheduler_server.clone().state.config.clone()))
+        .with_state(scheduler_server)
 }
 
-fn cors() -> CorsLayer {
-    let allowed_origins = std::env::var("BALLISTA_CORS_ALLOWED_ORIGINS")
-        .ok()
-        .and_then(|origins| {
-            origins
+fn cors(config: Arc<SchedulerConfig>) -> CorsLayer {
+    let default_origins = || {
+        vec![
+            HeaderValue::from_static("http://localhost:8080"),
+            HeaderValue::from_static("https://nightlies.apache.org"),
+        ]
+    };
+
+    let allowed_origins = match config.cors_allowed_origins.trim() {
+        origins if origins.is_empty() => AllowOrigin::list(default_origins()),
+        origins if origins == "*" => AllowOrigin::any(),
+        origins => {
+            let mut header_values = origins
                 .split(',')
+                .filter(|method| !method.trim().is_empty())
                 .map(|origin| origin.trim().parse().ok())
                 .collect::<Option<Vec<_>>>()
-        })
-        .unwrap_or_else(|| vec!["http://localhost:8080".parse().unwrap()]);
+                .unwrap_or_else(default_origins);
+            if header_values.is_empty() {
+                header_values = default_origins();
+            }
+            AllowOrigin::list(header_values)
+        }
+    };
 
-    let allowed_methods = std::env::var("BALLISTA_CORS_ALLOWED_METHODS")
-        .ok()
-        .and_then(|methods| {
-            methods
+    let default_methods = || {
+        vec![
+            http::Method::GET,
+            http::Method::OPTIONS,
+            http::Method::PATCH,
+        ]
+    };
+
+    let allowed_methods = match config.cors_allowed_methods.trim() {
+        methods if methods.is_empty() || methods == "*" => AllowMethods::any(),
+        methods => {
+            let mut allowed_methods = methods
                 .split(',')
+                .filter(|method| !method.trim().is_empty())
                 .map(|method| method.trim().parse().ok())
                 .collect::<Option<Vec<_>>>()
-        })
-        .unwrap_or_else(|| vec![http::Method::GET, http::Method::PATCH]);
+                .unwrap_or_else(default_methods);
+            if allowed_methods.is_empty() {
+                allowed_methods = default_methods();
+            }
+            AllowMethods::list(allowed_methods)
+        }
+    };
 
     CorsLayer::new()
-        .allow_origin(AllowOrigin::list(allowed_origins))
+        .allow_origin(allowed_origins)
         .allow_methods(allowed_methods)
         .allow_headers(AllowHeaders::any())
 }

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -195,6 +195,22 @@ pub struct Config {
         help = "Should the REST API be disabled"
     )]
     pub disable_rest_api: bool,
+    #[cfg(feature = "rest-api")]
+    /// Comma-separated list of allowed origins for CORS
+    #[arg(
+        long,
+        default_value_t = String::default(),
+        help = "Comma-separated list of allowed origins for CORS. By default, http://localhost:8080 and https://nightlies.apache.org are allowed."
+    )]
+    pub cors_allowed_origins: String,
+    #[cfg(feature = "rest-api")]
+    /// Comma-separated list of allowed methods for CORS
+    #[arg(
+        long,
+        default_value_t = String::default(),
+        help = "Comma-separated list of allowed methods for CORS. By default, GET, PATCH, and OPTIONS are allowed."
+    )]
+    pub cors_allowed_methods: String,
 }
 
 /// Configurations for the ballista scheduler of scheduling jobs and tasks
@@ -256,6 +272,12 @@ pub struct SchedulerConfig {
     #[cfg(feature = "rest-api")]
     /// Should the rest api be disabled
     pub disable_rest_api: bool,
+    #[cfg(feature = "rest-api")]
+    /// Comma-separated list of allowed origins for CORS
+    pub cors_allowed_origins: String,
+    #[cfg(feature = "rest-api")]
+    /// Comma-separated list of allowed methods for CORS
+    pub cors_allowed_methods: String,
 }
 
 impl Default for SchedulerConfig {
@@ -288,6 +310,10 @@ impl Default for SchedulerConfig {
             stage_max_failures: 4,
             #[cfg(feature = "rest-api")]
             disable_rest_api: false,
+            #[cfg(feature = "rest-api")]
+            cors_allowed_origins: String::default(),
+            #[cfg(feature = "rest-api")]
+            cors_allowed_methods: String::default(),
         }
     }
 }
@@ -516,6 +542,10 @@ impl TryFrom<Config> for SchedulerConfig {
             stage_max_failures: opt.stage_max_failures,
             #[cfg(feature = "rest-api")]
             disable_rest_api: opt.disable_rest_api,
+            #[cfg(feature = "rest-api")]
+            cors_allowed_origins: opt.cors_allowed_origins,
+            #[cfg(feature = "rest-api")]
+            cors_allowed_methods: opt.cors_allowed_methods,
         };
 
         Ok(config)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1804

# Rationale for this change

Use command line options instead of environment variables for consistency.


# What changes are included in this PR?


Add http://localhost:8080 (local dev) and
https://nightlies.apache.org (convenience deployment) to the allowed origins

# Are there any user-facing changes?

The scheduler binary now has two more options:
* `--cors-allowed-origins "..."` (`*` allows any, `""` uses the defaults, anything else sets custom ones)
* `--cors-allowed-methods "..."` (`*` allows all methods, `""` uses the defaults - GET, OPTIONS, PATCH, anything else sets custom ones)