### PR TITLE
feat(TUI): enable various plan rendering formats

### DIFF
--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -249,8 +249,6 @@ impl App {
                     _ => {}
                 }
             } else if popup.is_plan_view() {
-                use crate::tui::domain::jobs::stages::StagePlanTab;
-
                 // Collect job_id + tab to fetch while popup is still borrowed,
                 // then drop the borrow before the async call.
                 let fetch = match key.code {
@@ -287,7 +285,7 @@ impl App {
                 };
 
                 if let Some((job_id, tab)) = fetch
-                    && let Err(e) = load_stage_plan(self, &job_id, tab).await
+                    && let Err(e) = load_stage_plan(self, &job_id, &tab).await
                 {
                     tracing::error!("Failed to load stage plan: {e:?}");
                 }
@@ -988,8 +986,6 @@ impl App {
                     _ => {}
                 }
             } else if popup.is_plan_view() {
-                use crate::tui::domain::jobs::stages::StagePlanTab;
-
                 let fetch = match key.code {
                     KeyCode::Char('d') => popup
                         .set_tab(StagePlanTab::Default)

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -53,6 +53,7 @@ use crate::tui::http_client::HttpClient;
 use crate::tui::ui::{
     load_executor_details_popup, load_executors_data, load_job_details, load_job_dot,
     load_job_stages_popup, load_jobs_data, load_metrics_data,
+    load_stage_plan,
 };
 
 const INVALID_DATE: &str = "Invalid date";
@@ -221,13 +222,32 @@ impl App {
                     _ => {}
                 }
             } else if popup.is_plan_view() {
-                match key.code {
-                    KeyCode::Esc => popup.set_no_details_view(),
-                    KeyCode::Up => popup.scroll_up(),
-                    KeyCode::Down => popup.scroll_down(),
-                    KeyCode::Left => popup.scroll_left(),
-                    KeyCode::Right => popup.scroll_right(),
-                    _ => {}
+                use crate::tui::domain::jobs::stages::StagePlanTab;
+
+                // Collect job_id + tab to fetch while popup is still borrowed,
+                // then drop the borrow before the async call.
+                let fetch = match key.code {
+                    KeyCode::Char('d') => popup
+                        .set_tab(StagePlanTab::Default)
+                        .map(|tab| (popup.job_id.clone(), tab)),
+                    KeyCode::Char('t') => popup
+                        .set_tab(StagePlanTab::Tree)
+                        .map(|tab| (popup.job_id.clone(), tab)),
+                    KeyCode::Char('m') => popup
+                        .set_tab(StagePlanTab::Metrics)
+                        .map(|tab| (popup.job_id.clone(), tab)),
+                    KeyCode::Esc => { popup.set_no_details_view(); None }
+                    KeyCode::Up => { popup.scroll_up();    None }
+                    KeyCode::Down => { popup.scroll_down();  None }
+                    KeyCode::Left => { popup.scroll_left();  None }
+                    KeyCode::Right => { popup.scroll_right(); None }
+                    _ => None,
+                };
+
+                if let Some((job_id, tab)) = fetch {
+                    if let Err(e) = load_stage_plan(self, &job_id, tab).await {
+                        tracing::error!("Failed to load stage plan: {e:?}");
+                    }
                 }
             } else if popup.is_no_details_view() {
                 match key.code {
@@ -796,6 +816,11 @@ impl App {
             }
             UiData::JobStagesData(job_id, stages) => {
                 self.job_stages_popup = Some(JobStagesPopup::new(job_id, stages));
+            }
+            UiData::JobStagesPlanData(_job_id, tab, stages) => {
+                if let Some(popup) = &mut self.job_stages_popup {
+                    popup.cache_plan_response(tab, stages);
+                }
             }
             UiData::ExecutorDetails(executor) => {
                 self.executor_details_popup = Some(ExecutorDetailsPopup::new(executor));

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -32,7 +32,7 @@ use crate::tui::{
         jobs::{
             CancelJobResult, JobConfigPopup, JobDetails, JobPlansPopup, JobsData,
             PhysicalFormat, PlanTab, SortColumn as JobsSortColumn,
-            stages::{JobStagesPopup, StagesGraph},
+            stages::{JobStagesPopup, StagePlanTab, StagesGraph},
         },
         metrics::MetricsData,
         metrics::SortColumn as MetricsSortColumn,
@@ -366,7 +366,7 @@ impl App {
             if let Some(job_id) = fetch_tree {
                 match self
                     .http_client
-                    .get_job_details(&job_id, Some("tree"))
+                    .get_job_details(&job_id, StagePlanTab::Tree)
                     .await
                 {
                     Ok(details) => {

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -258,10 +258,10 @@ impl App {
                     _ => None,
                 };
 
-                if let Some((job_id, tab)) = fetch {
-                    if let Err(e) = load_stage_plan(self, &job_id, tab).await {
-                        tracing::error!("Failed to load stage plan: {e:?}");
-                    }
+                if let Some((job_id, tab)) = fetch
+                    && let Err(e) = load_stage_plan(self, &job_id, tab).await
+                {
+                    tracing::error!("Failed to load stage plan: {e:?}");
                 }
             } else if popup.is_no_details_view() {
                 match key.code {

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -52,8 +52,7 @@ use crate::tui::http_client::HttpClient;
 #[cfg(not(feature = "web"))]
 use crate::tui::ui::{
     load_executor_details_popup, load_executors_data, load_job_details, load_job_dot,
-    load_job_stages_popup, load_jobs_data, load_metrics_data,
-    load_stage_plan,
+    load_job_stages_popup, load_jobs_data, load_metrics_data, load_stage_plan,
 };
 
 const INVALID_DATE: &str = "Invalid date";
@@ -236,11 +235,26 @@ impl App {
                     KeyCode::Char('m') => popup
                         .set_tab(StagePlanTab::Metrics)
                         .map(|tab| (popup.job_id.clone(), tab)),
-                    KeyCode::Esc => { popup.set_no_details_view(); None }
-                    KeyCode::Up => { popup.scroll_up();    None }
-                    KeyCode::Down => { popup.scroll_down();  None }
-                    KeyCode::Left => { popup.scroll_left();  None }
-                    KeyCode::Right => { popup.scroll_right(); None }
+                    KeyCode::Esc => {
+                        popup.set_no_details_view();
+                        None
+                    }
+                    KeyCode::Up => {
+                        popup.scroll_up();
+                        None
+                    }
+                    KeyCode::Down => {
+                        popup.scroll_down();
+                        None
+                    }
+                    KeyCode::Left => {
+                        popup.scroll_left();
+                        None
+                    }
+                    KeyCode::Right => {
+                        popup.scroll_right();
+                        None
+                    }
                     _ => None,
                 };
 

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -18,6 +18,8 @@
 #[cfg(not(feature = "web"))]
 use crate::tui::TuiError;
 use crate::tui::TuiResult;
+#[cfg(feature = "web")]
+use crate::tui::domain::jobs::stages::StagePlanTab;
 use crate::tui::event::Event;
 #[cfg(feature = "web")]
 use crate::tui::event::web::Sender;
@@ -28,8 +30,8 @@ use crate::tui::{
             ExecutorDetailsPopup, ExecutorsData, SortColumn as ExecutorsSortColumn,
         },
         jobs::{
-            CancelJobResult, JobDetails, JobPlansPopup, JobsData, PlanTab,
-            SortColumn as JobsSortColumn,
+            CancelJobResult, JobDetails, JobPlansPopup, JobsData, PhysicalFormat,
+            PlanTab, SortColumn as JobsSortColumn,
             stages::{JobStagesPopup, StagesGraph},
         },
         metrics::MetricsData,
@@ -299,25 +301,55 @@ impl App {
         }
 
         if let Some(ref mut plans_popup) = self.job_plan_popup {
-            match key.code {
-                KeyCode::Up => plans_popup.scroll_up(),
-                KeyCode::Down => plans_popup.scroll_down(),
-                KeyCode::Left => plans_popup.scroll_left(),
-                KeyCode::Right => plans_popup.scroll_right(),
-                KeyCode::Char('s') => {
-                    plans_popup.set_tab(PlanTab::Stage);
+            let fetch_tree = if key.code == KeyCode::Char('t')
+                && plans_popup.get_tab() == &PlanTab::Physical
+            {
+                plans_popup
+                    .set_physical_format(PhysicalFormat::Tree)
+                    .map(|_| plans_popup.details.job_id.clone())
+            } else {
+                match key.code {
+                    KeyCode::Up => {
+                        plans_popup.scroll_up();
+                    }
+                    KeyCode::Down => {
+                        plans_popup.scroll_down();
+                    }
+                    KeyCode::Left => {
+                        plans_popup.scroll_left();
+                    }
+                    KeyCode::Right => {
+                        plans_popup.scroll_right();
+                    }
+                    KeyCode::Char('s') => plans_popup.set_tab(PlanTab::Stage),
+                    KeyCode::Char('p') => plans_popup.set_tab(PlanTab::Physical),
+                    KeyCode::Char('l') => plans_popup.set_tab(PlanTab::Logical),
+                    KeyCode::Char('d') if plans_popup.get_tab() == &PlanTab::Physical => {
+                        plans_popup.set_physical_format(PhysicalFormat::Default);
+                    }
+                    KeyCode::Esc => {
+                        self.job_plan_popup = None;
+                    }
+                    _ => {}
                 }
-                KeyCode::Char('p') => {
-                    plans_popup.set_tab(PlanTab::Physical);
+                None
+            };
+
+            if let Some(job_id) = fetch_tree {
+                match self
+                    .http_client
+                    .get_job_details(&job_id, Some("tree"))
+                    .await
+                {
+                    Ok(details) => {
+                        if let Some(p) = &mut self.job_plan_popup {
+                            p.details.physical_plan_tree = details.physical_plan;
+                        }
+                    }
+                    Err(e) => tracing::error!("Failed to load tree physical plan: {e:?}"),
                 }
-                KeyCode::Char('l') => {
-                    plans_popup.set_tab(PlanTab::Logical);
-                }
-                KeyCode::Esc => {
-                    self.job_plan_popup = None;
-                }
-                _ => {}
             }
+
             return Ok(());
         }
 
@@ -823,7 +855,13 @@ impl App {
                 };
             }
             UiData::JobDetails(details) => {
-                self.job_details = Some(details);
+                if details.physical_plan_tree.is_some() {
+                    if let Some(popup) = &mut self.job_plan_popup {
+                        popup.details.physical_plan_tree = details.physical_plan_tree;
+                    }
+                } else {
+                    self.job_details = Some(details);
+                }
             }
             UiData::JobStagesGraph(graph) => {
                 self.job_dot_popup = Some(graph);
@@ -831,7 +869,7 @@ impl App {
             UiData::JobStagesData(job_id, stages) => {
                 self.job_stages_popup = Some(JobStagesPopup::new(job_id, stages));
             }
-            UiData::JobStagesPlanData(_job_id, tab, stages) => {
+            UiData::JobStagesPlanData(tab, stages) => {
                 if let Some(popup) = &mut self.job_stages_popup {
                     popup.cache_plan_response(tab, stages);
                 }
@@ -880,14 +918,43 @@ impl App {
                     _ => {}
                 }
             } else if popup.is_plan_view() {
-                match key.code {
-                    KeyCode::Esc => popup.set_no_details_view(),
-                    KeyCode::Up => popup.scroll_up(),
-                    KeyCode::Down => popup.scroll_down(),
-                    KeyCode::Left => popup.scroll_left(),
-                    KeyCode::Right => popup.scroll_right(),
-                    _ => {}
-                }
+                use crate::tui::domain::jobs::stages::StagePlanTab;
+
+                let fetch = match key.code {
+                    KeyCode::Char('d') => popup
+                        .set_tab(StagePlanTab::Default)
+                        .map(|tab| (popup.job_id.clone(), tab)),
+                    KeyCode::Char('t') => popup
+                        .set_tab(StagePlanTab::Tree)
+                        .map(|tab| (popup.job_id.clone(), tab)),
+                    KeyCode::Char('m') => popup
+                        .set_tab(StagePlanTab::Metrics)
+                        .map(|tab| (popup.job_id.clone(), tab)),
+                    KeyCode::Esc => {
+                        popup.set_no_details_view();
+                        None
+                    }
+                    KeyCode::Up => {
+                        popup.scroll_up();
+                        None
+                    }
+                    KeyCode::Down => {
+                        popup.scroll_down();
+                        None
+                    }
+                    KeyCode::Left => {
+                        popup.scroll_left();
+                        None
+                    }
+                    KeyCode::Right => {
+                        popup.scroll_right();
+                        None
+                    }
+                    _ => None,
+                };
+
+                return fetch
+                    .map(|(job_id, tab)| WebKeyAsyncAction::LoadStagePlan(job_id, tab));
             } else if popup.is_no_details_view() {
                 match key.code {
                     KeyCode::Up => popup.scroll_up(),
@@ -918,18 +985,39 @@ impl App {
         }
 
         if let Some(ref mut plans_popup) = self.job_plan_popup {
-            match key.code {
-                KeyCode::Up => plans_popup.scroll_up(),
-                KeyCode::Down => plans_popup.scroll_down(),
-                KeyCode::Left => plans_popup.scroll_left(),
-                KeyCode::Right => plans_popup.scroll_right(),
-                KeyCode::Char('s') => plans_popup.set_tab(PlanTab::Stage),
-                KeyCode::Char('p') => plans_popup.set_tab(PlanTab::Physical),
-                KeyCode::Char('l') => plans_popup.set_tab(PlanTab::Logical),
-                KeyCode::Esc => self.job_plan_popup = None,
-                _ => {}
-            }
-            return None;
+            let fetch_tree = if key.code == KeyCode::Char('t')
+                && plans_popup.get_tab() == &PlanTab::Physical
+            {
+                plans_popup
+                    .set_physical_format(PhysicalFormat::Tree)
+                    .map(|_| plans_popup.details.job_id.clone())
+            } else {
+                match key.code {
+                    KeyCode::Up => {
+                        plans_popup.scroll_up();
+                    }
+                    KeyCode::Down => {
+                        plans_popup.scroll_down();
+                    }
+                    KeyCode::Left => {
+                        plans_popup.scroll_left();
+                    }
+                    KeyCode::Right => {
+                        plans_popup.scroll_right();
+                    }
+                    KeyCode::Char('s') => plans_popup.set_tab(PlanTab::Stage),
+                    KeyCode::Char('p') => plans_popup.set_tab(PlanTab::Physical),
+                    KeyCode::Char('l') => plans_popup.set_tab(PlanTab::Logical),
+                    KeyCode::Char('d') if plans_popup.get_tab() == &PlanTab::Physical => {
+                        plans_popup.set_physical_format(PhysicalFormat::Default);
+                    }
+                    KeyCode::Esc => self.job_plan_popup = None,
+                    _ => {}
+                }
+                None
+            };
+
+            return fetch_tree.map(WebKeyAsyncAction::LoadJobPlanTree);
         }
 
         if let Some(ref mut executor_popup) = self.executor_details_popup {
@@ -1123,6 +1211,8 @@ pub enum WebKeyAsyncAction {
     CancelJob(String),
     UpdateJobDetails(Option<String>),
     ReloadView,
+    LoadJobPlanTree(String),
+    LoadStagePlan(String, StagePlanTab),
 }
 
 #[cfg(test)]
@@ -1238,6 +1328,7 @@ mod tests {
             job_id: job_id.to_string(),
             logical_plan: Some("logical".to_string()),
             physical_plan: Some("physical".to_string()),
+            physical_plan_tree: Some("tree".to_string()),
             stage_plan: Some("stage".to_string()),
         }
     }

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -364,7 +364,7 @@ impl App {
             if let Some(job_id) = fetch_tree {
                 match self
                     .http_client
-                    .get_job_details(&job_id, StagePlanTab::Tree)
+                    .get_job_details(&job_id, &StagePlanTab::Tree)
                     .await
                 {
                     Ok(details) => {

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -18,8 +18,6 @@
 #[cfg(not(feature = "web"))]
 use crate::tui::TuiError;
 use crate::tui::TuiResult;
-#[cfg(feature = "web")]
-use crate::tui::domain::jobs::stages::StagePlanTab;
 use crate::tui::event::Event;
 #[cfg(feature = "web")]
 use crate::tui::event::web::Sender;

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -30,8 +30,8 @@ use crate::tui::{
             ExecutorDetailsPopup, ExecutorsData, SortColumn as ExecutorsSortColumn,
         },
         jobs::{
-            CancelJobResult, JobConfigPopup, JobDetails, JobPlansPopup, JobsData, PhysicalFormat,
-            PlanTab, SortColumn as JobsSortColumn,
+            CancelJobResult, JobConfigPopup, JobDetails, JobPlansPopup, JobsData,
+            PhysicalFormat, PlanTab, SortColumn as JobsSortColumn,
             stages::{JobStagesPopup, StagesGraph},
         },
         metrics::MetricsData,
@@ -53,8 +53,9 @@ use tokio::sync::mpsc::Sender;
 use crate::tui::http_client::HttpClient;
 #[cfg(not(feature = "web"))]
 use crate::tui::ui::{
-    load_executor_details_popup, load_executors_data, load_job_config_popup, load_job_details, load_job_dot,
-    load_job_stages_popup, load_jobs_data, load_metrics_data, load_stage_plan,
+    load_executor_details_popup, load_executors_data, load_job_config_popup,
+    load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data,
+    load_metrics_data, load_stage_plan,
 };
 
 const INVALID_DATE: &str = "Invalid date";

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -219,11 +219,18 @@ pub enum CancelJobResult {
     Failure { job_id: String, error: String },
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum PhysicalFormat {
+    Default,
+    Tree,
+}
+
 #[derive(Clone, Debug)]
 pub struct JobDetails {
     pub job_id: String,
     pub logical_plan: Option<String>,
     pub physical_plan: Option<String>,
+    pub physical_plan_tree: Option<String>,
     pub stage_plan: Option<String>,
 }
 
@@ -238,6 +245,7 @@ pub(crate) enum PlanTab {
 pub struct JobPlansPopup {
     pub details: JobDetails,
     tab: PlanTab,
+    physical_format: PhysicalFormat,
     vertical_scroll_position: u16,
     horizontal_scroll_position: u16,
 }
@@ -247,6 +255,7 @@ impl JobPlansPopup {
         Self {
             details,
             tab,
+            physical_format: PhysicalFormat::Default,
             vertical_scroll_position: 0,
             horizontal_scroll_position: 0,
         }
@@ -254,6 +263,24 @@ impl JobPlansPopup {
 
     pub fn get_tab(&self) -> &PlanTab {
         &self.tab
+    }
+
+    pub fn get_physical_format(&self) -> &PhysicalFormat {
+        &self.physical_format
+    }
+
+    /// Returns Some(()) if a fetch is needed (tree not cached yet), None if already available.
+    pub fn set_physical_format(&mut self, fmt: PhysicalFormat) -> Option<()> {
+        self.physical_format = fmt;
+        self.vertical_scroll_position = 0;
+        self.horizontal_scroll_position = 0;
+        if self.physical_format == PhysicalFormat::Tree
+            && self.details.physical_plan_tree.is_none()
+        {
+            Some(())
+        } else {
+            None
+        }
     }
 
     pub fn set_tab(&mut self, tab: PlanTab) {
@@ -696,6 +723,7 @@ mod tests {
     fn make_job_details(id: &str) -> JobDetails {
         JobDetails {
             job_id: id.to_string(),
+            physical_plan_tree: None,
             logical_plan: None,
             physical_plan: None,
             stage_plan: None,

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+#![allow(unfulfilled_lint_expectations)]
 use ratatui::widgets::{ScrollbarState, TableState};
 use serde::Deserialize;
 
@@ -81,6 +81,7 @@ pub enum StageDetailsView {
     Plan(StagePlanTab),
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum StagePlanTab {
     Default,
@@ -104,13 +105,14 @@ pub struct JobStagesPopup {
 
 impl JobStagesPopup {
     pub fn new(job_id: String, stages: JobStagesResponse) -> Self {
-        let mut cache = PlanCache::default();
-        cache.default = Some(stages.clone());
         Self {
             job_id,
             scrollbar_state: ScrollbarState::new(stages.stages.len()),
+            plan_cache: PlanCache {
+                default: Some(stages.clone()),
+                ..Default::default()
+            },
             stages,
-            plan_cache: cache,
             table_state: TableState::default(),
             tasks_table_state: TableState::default(),
             tasks_scrollbar_state: ScrollbarState::new(0),
@@ -134,6 +136,7 @@ impl JobStagesPopup {
         }
     }
 
+    #[allow(dead_code)]
     pub fn cached_response(&self, tab: &StagePlanTab) -> Option<JobStagesResponse> {
         match tab {
             StagePlanTab::Default => self.plan_cache.default.clone(),
@@ -185,6 +188,7 @@ impl JobStagesPopup {
         matches!(self.details_view, StageDetailsView::Plan(_))
     }
 
+    #[allow(dead_code)]
     pub fn set_tab(&mut self, tab: StagePlanTab) -> Option<StagePlanTab> {
         self.details_view = StageDetailsView::Plan(tab.clone());
         self.plan_vertical_scroll_position = 0;

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -81,7 +81,6 @@ pub enum StageDetailsView {
     Plan(StagePlanTab),
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum StagePlanTab {
     Default,

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#![allow(unfulfilled_lint_expectations)]
+
 use ratatui::widgets::{ScrollbarState, TableState};
 use serde::Deserialize;
 
@@ -87,6 +87,16 @@ pub enum StagePlanTab {
     Default,
     Tree,
     Metrics,
+}
+
+impl StagePlanTab {
+    pub fn as_query_param(&self) -> &'static str {
+        match self {
+            StagePlanTab::Default => "",
+            StagePlanTab::Tree => "plan_format=tree",
+            StagePlanTab::Metrics => "plan_format=metrics",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -185,7 +195,6 @@ impl JobStagesPopup {
         matches!(self.details_view, StageDetailsView::Plan(_))
     }
 
-    #[allow(dead_code)]
     pub fn set_tab(&mut self, tab: StagePlanTab) -> Option<StagePlanTab> {
         self.details_view = StageDetailsView::Plan(tab.clone());
         self.plan_vertical_scroll_position = 0;

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -17,6 +17,7 @@
 
 use ratatui::widgets::{ScrollbarState, TableState};
 use serde::Deserialize;
+use std::fmt::Display;
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct JobStagesResponse {
@@ -95,6 +96,17 @@ impl StagePlanTab {
             StagePlanTab::Tree => "plan_format=tree",
             StagePlanTab::Metrics => "plan_format=metrics",
         }
+    }
+}
+
+impl Display for StagePlanTab {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            StagePlanTab::Default => "default".to_string(),
+            StagePlanTab::Tree => "tree".to_string(),
+            StagePlanTab::Metrics => "metrics".to_string(),
+        };
+        write!(f, "{}", str)
     }
 }
 

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -123,25 +123,22 @@ impl JobStagesPopup {
     }
 
     pub fn cache_plan_response(&mut self, fmt: StagePlanTab, resp: JobStagesResponse) {
-        match fmt {
-            StagePlanTab::Default => self.plan_cache.default = Some(resp.clone()),
-            StagePlanTab::Tree => self.plan_cache.tree = Some(resp.clone()),
-            StagePlanTab::Metrics => self.plan_cache.metrics = Some(resp.clone()),
-        }
-        // If we're currently on that tab, update the live stages too so the
-        // selection / scroll state is preserved.
         let active_fmt = self.active_plan_format();
-        if active_fmt == Some(fmt) {
-            self.stages = resp;
+        if active_fmt.as_ref() == Some(&fmt) {
+            self.stages = resp.clone();
+        }
+        match fmt {
+            StagePlanTab::Default => self.plan_cache.default = Some(resp),
+            StagePlanTab::Tree => self.plan_cache.tree = Some(resp),
+            StagePlanTab::Metrics => self.plan_cache.metrics = Some(resp),
         }
     }
 
-    #[allow(dead_code)]
-    pub fn cached_response(&self, tab: &StagePlanTab) -> Option<JobStagesResponse> {
+    pub fn cached_response(&self, tab: &StagePlanTab) -> Option<&JobStagesResponse> {
         match tab {
-            StagePlanTab::Default => self.plan_cache.default.clone(),
-            StagePlanTab::Tree => self.plan_cache.tree.clone(),
-            StagePlanTab::Metrics => self.plan_cache.metrics.clone(),
+            StagePlanTab::Default => self.plan_cache.default.as_ref(),
+            StagePlanTab::Tree => self.plan_cache.tree.as_ref(),
+            StagePlanTab::Metrics => self.plan_cache.metrics.as_ref(),
         }
     }
 
@@ -195,7 +192,7 @@ impl JobStagesPopup {
         self.plan_horizontal_scroll_position = 0;
 
         if let Some(cached) = self.cached_response(&tab) {
-            self.stages = cached;
+            self.stages = cached.clone();
             None
         } else {
             Some(tab)

--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -67,17 +67,32 @@ pub struct TaskPercentiles {
     pub p75: u64,
 }
 
+#[derive(Debug, Default)]
+pub struct PlanCache {
+    pub default: Option<JobStagesResponse>,
+    pub tree: Option<JobStagesResponse>,
+    pub metrics: Option<JobStagesResponse>,
+}
+
 #[derive(Debug, PartialEq)]
 pub enum StageDetailsView {
     None,
     Tasks,
-    Plan,
+    Plan(StagePlanTab),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StagePlanTab {
+    Default,
+    Tree,
+    Metrics,
 }
 
 #[derive(Debug)]
 pub struct JobStagesPopup {
     pub job_id: String,
     pub stages: JobStagesResponse,
+    pub plan_cache: PlanCache,
     pub table_state: TableState,
     pub scrollbar_state: ScrollbarState,
     pub tasks_table_state: TableState,
@@ -89,16 +104,48 @@ pub struct JobStagesPopup {
 
 impl JobStagesPopup {
     pub fn new(job_id: String, stages: JobStagesResponse) -> Self {
+        let mut cache = PlanCache::default();
+        cache.default = Some(stages.clone());
         Self {
             job_id,
             scrollbar_state: ScrollbarState::new(stages.stages.len()),
             stages,
+            plan_cache: cache,
             table_state: TableState::default(),
             tasks_table_state: TableState::default(),
             tasks_scrollbar_state: ScrollbarState::new(0),
             details_view: StageDetailsView::None,
             plan_vertical_scroll_position: 0,
             plan_horizontal_scroll_position: 0,
+        }
+    }
+
+    pub fn cache_plan_response(&mut self, fmt: StagePlanTab, resp: JobStagesResponse) {
+        match fmt {
+            StagePlanTab::Default => self.plan_cache.default = Some(resp.clone()),
+            StagePlanTab::Tree => self.plan_cache.tree = Some(resp.clone()),
+            StagePlanTab::Metrics => self.plan_cache.metrics = Some(resp.clone()),
+        }
+        // If we're currently on that tab, update the live stages too so the
+        // selection / scroll state is preserved.
+        let active_fmt = self.active_plan_format();
+        if active_fmt == Some(fmt) {
+            self.stages = resp;
+        }
+    }
+
+    pub fn cached_response(&self, tab: &StagePlanTab) -> Option<JobStagesResponse> {
+        match tab {
+            StagePlanTab::Default => self.plan_cache.default.clone(),
+            StagePlanTab::Tree => self.plan_cache.tree.clone(),
+            StagePlanTab::Metrics => self.plan_cache.metrics.clone(),
+        }
+    }
+
+    pub fn active_plan_format(&self) -> Option<StagePlanTab> {
+        match &self.details_view {
+            StageDetailsView::Plan(tab) => Some(tab.clone()),
+            _ => None,
         }
     }
 
@@ -117,7 +164,7 @@ impl JobStagesPopup {
     }
 
     pub fn set_plan_view(&mut self) {
-        self.details_view = StageDetailsView::Plan;
+        self.details_view = StageDetailsView::Plan(StagePlanTab::Default);
         self.plan_vertical_scroll_position = 0;
         self.plan_horizontal_scroll_position = 0;
     }
@@ -135,7 +182,20 @@ impl JobStagesPopup {
     }
 
     pub fn is_plan_view(&self) -> bool {
-        self.details_view == StageDetailsView::Plan
+        matches!(self.details_view, StageDetailsView::Plan(_))
+    }
+
+    pub fn set_tab(&mut self, tab: StagePlanTab) -> Option<StagePlanTab> {
+        self.details_view = StageDetailsView::Plan(tab.clone());
+        self.plan_vertical_scroll_position = 0;
+        self.plan_horizontal_scroll_position = 0;
+
+        if let Some(cached) = self.cached_response(&tab) {
+            self.stages = cached;
+            None
+        } else {
+            Some(tab)
+        }
     }
 
     pub fn scroll_down(&mut self) {

--- a/ballista-cli/src/tui/event.rs
+++ b/ballista-cli/src/tui/event.rs
@@ -39,7 +39,7 @@ pub enum UiData {
     JobStagesGraph(StagesGraph),
     JobStagesData(String, JobStagesResponse),
     #[allow(dead_code)]
-    JobStagesPlanData(String, StagePlanTab, JobStagesResponse),
+    JobStagesPlanData(StagePlanTab, JobStagesResponse),
     ExecutorDetails(Executor),
     CancelJobResult(CancelJobResult),
 }

--- a/ballista-cli/src/tui/event.rs
+++ b/ballista-cli/src/tui/event.rs
@@ -38,6 +38,7 @@ pub enum UiData {
     JobDetails(JobDetails),
     JobStagesGraph(StagesGraph),
     JobStagesData(String, JobStagesResponse),
+    #[allow(dead_code)]
     JobStagesPlanData(String, StagePlanTab, JobStagesResponse),
     ExecutorDetails(Executor),
     CancelJobResult(CancelJobResult),

--- a/ballista-cli/src/tui/event.rs
+++ b/ballista-cli/src/tui/event.rs
@@ -20,7 +20,7 @@ use crate::tui::domain::{
     executors::Executor,
     jobs::{
         CancelJobResult, Job, JobDetails,
-        stages::{JobStagesResponse, StagesGraph},
+        stages::{JobStagesResponse, StagePlanTab, StagesGraph},
     },
     metrics::Metric,
 };
@@ -38,6 +38,7 @@ pub enum UiData {
     JobDetails(JobDetails),
     JobStagesGraph(StagesGraph),
     JobStagesData(String, JobStagesResponse),
+    JobStagesPlanData(String, StagePlanTab, JobStagesResponse),
     ExecutorDetails(Executor),
     CancelJobResult(CancelJobResult),
 }

--- a/ballista-cli/src/tui/event.rs
+++ b/ballista-cli/src/tui/event.rs
@@ -39,7 +39,6 @@ pub enum UiData {
     JobConfig(JobConfigPopup),
     JobStagesGraph(StagesGraph),
     JobStagesData(String, JobStagesResponse),
-    #[allow(dead_code)]
     JobStagesPlanData(StagePlanTab, JobStagesResponse),
     ExecutorDetails(Executor),
     CancelJobResult(CancelJobResult),

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -21,6 +21,7 @@ use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
+use crate::tui::domain::jobs::stages::StagePlanTab;
 use crate::tui::{
     TuiResult,
     domain::{
@@ -109,7 +110,7 @@ impl HttpClient {
     pub async fn get_job_details(
         &self,
         job_id: &str,
-        plan_format: Option<&str>,
+        plan_format: StagePlanTab,
     ) -> TuiResult<JobDetails> {
         #[derive(serde::Deserialize, Debug)]
         struct JobDetailResponse {
@@ -119,12 +120,9 @@ impl HttpClient {
         }
 
         let url = self.url(&format!(
-            "job/{}{}",
+            "job/{}?{}",
             self.url_encode(job_id),
-            match plan_format {
-                Some(fmt) => format!("?plan_format={fmt}"),
-                None => String::new(),
-            }
+            plan_format.as_query_param(),
         ));
         let resp = self.json::<JobDetailResponse>(&url).await?;
         Ok(JobDetails {

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -126,14 +126,22 @@ impl HttpClient {
         self.text(&url).await
     }
 
-    pub async fn get_job_stages(&self, job_id: &str) -> TuiResult<JobStagesResponse> {
+    pub async fn get_job_stages(
+        &self,
+        job_id: &str,
+        plan_format: Option<&str>,
+    ) -> TuiResult<JobStagesResponse> {
+        let fmt = plan_format.unwrap_or_else(|| {
+            if self.config.job.stage.plan.tree { "tree" } else { "" }
+        });
+
         let url = self.url(&format!(
             "job/{}/stages{}",
             self.url_encode(job_id),
-            if self.config.job.stage.plan.tree {
-                "?plan_format=tree"
+            if fmt.is_empty() {
+                String::new()
             } else {
-                ""
+                format!("?plan_format={fmt}")
             }
         ));
         self.json::<JobStagesResponse>(&url).await

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -132,7 +132,11 @@ impl HttpClient {
         plan_format: Option<&str>,
     ) -> TuiResult<JobStagesResponse> {
         let fmt = plan_format.unwrap_or_else(|| {
-            if self.config.job.stage.plan.tree { "tree" } else { "" }
+            if self.config.job.stage.plan.tree {
+                "tree"
+            } else {
+                ""
+            }
         });
 
         let url = self.url(&format!(

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -103,7 +103,11 @@ impl HttpClient {
             })
     }
 
-    pub async fn get_job_details(&self, job_id: &str) -> TuiResult<JobDetails> {
+    pub async fn get_job_details(
+        &self,
+        job_id: &str,
+        plan_format: Option<&str>,
+    ) -> TuiResult<JobDetails> {
         #[derive(serde::Deserialize, Debug)]
         struct JobDetailResponse {
             logical_plan: Option<String>,
@@ -111,12 +115,20 @@ impl HttpClient {
             stage_plan: Option<String>,
         }
 
-        let url = self.url(&format!("job/{}", self.url_encode(job_id)));
+        let url = self.url(&format!(
+            "job/{}{}",
+            self.url_encode(job_id),
+            match plan_format {
+                Some(fmt) => format!("?plan_format={fmt}"),
+                None => String::new(),
+            }
+        ));
         let resp = self.json::<JobDetailResponse>(&url).await?;
         Ok(JobDetails {
             job_id: job_id.to_string(),
             logical_plan: resp.logical_plan,
             physical_plan: resp.physical_plan,
+            physical_plan_tree: None,
             stage_plan: resp.stage_plan,
         })
     }
@@ -131,22 +143,13 @@ impl HttpClient {
         job_id: &str,
         plan_format: Option<&str>,
     ) -> TuiResult<JobStagesResponse> {
-        let fmt = plan_format.unwrap_or({
-            if self.config.job.stage.plan.tree {
-                "tree"
-            } else {
-                ""
-            }
-        });
-
         let url = self.url(&format!(
             "job/{}/stages{}",
             self.url_encode(job_id),
-            if fmt.is_empty() {
-                String::new()
-            } else {
-                format!("?plan_format={fmt}")
-            }
+            match plan_format {
+                Some(fmt) => format!("?plan_format={}", fmt),
+                None => String::new(),
+            },
         ));
         self.json::<JobStagesResponse>(&url).await
     }

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -110,7 +110,7 @@ impl HttpClient {
     pub async fn get_job_details(
         &self,
         job_id: &str,
-        plan_format: StagePlanTab,
+        plan_format: &StagePlanTab,
     ) -> TuiResult<JobDetails> {
         #[derive(serde::Deserialize, Debug)]
         struct JobDetailResponse {
@@ -142,15 +142,12 @@ impl HttpClient {
     pub async fn get_job_stages(
         &self,
         job_id: &str,
-        plan_format: Option<&str>,
+        plan_format: &StagePlanTab,
     ) -> TuiResult<JobStagesResponse> {
         let url = self.url(&format!(
-            "job/{}/stages{}",
+            "job/{}/stages?{}",
             self.url_encode(job_id),
-            match plan_format {
-                Some(fmt) => format!("?plan_format={}", fmt),
-                None => String::new(),
-            },
+            plan_format.as_query_param(),
         ));
         self.json::<JobStagesResponse>(&url).await
     }

--- a/ballista-cli/src/tui/http_client.rs
+++ b/ballista-cli/src/tui/http_client.rs
@@ -131,7 +131,7 @@ impl HttpClient {
         job_id: &str,
         plan_format: Option<&str>,
     ) -> TuiResult<JobStagesResponse> {
-        let fmt = plan_format.unwrap_or_else(|| {
+        let fmt = plan_format.unwrap_or({
             if self.config.job.stage.plan.tree {
                 "tree"
             } else {

--- a/ballista-cli/src/tui/infrastructure/config.rs
+++ b/ballista-cli/src/tui/infrastructure/config.rs
@@ -31,24 +31,6 @@ pub struct HttpSettings {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct JobSettings {
-    /// The job stages' settings
-    pub stage: JobStageSettings,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct JobStageSettings {
-    /// The job plan's settings
-    pub plan: JobPlanSettings,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct JobPlanSettings {
-    /// Whether to render the plan as a tree.
-    pub tree: bool,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct Settings {
     pub scheduler: SchedulerSettings,
     #[cfg(not(target_arch = "wasm32"))]
@@ -57,8 +39,6 @@ pub struct Settings {
     pub data_reload_interval_ms: u64,
     /// How often to refresh the UI. In millis.
     pub repaint_interval_ms: u64,
-
-    pub job: JobSettings,
 }
 
 const DEFAULT_CONFIG: &str = r#"

--- a/ballista-cli/src/tui/mod.rs
+++ b/ballista-cli/src/tui/mod.rs
@@ -292,7 +292,10 @@ pub(crate) mod web {
 
         match action {
             WebKeyAsyncAction::LoadJobStages(id) => {
-                match http_client.get_job_stages(&id, None).await {
+                match http_client
+                    .get_job_stages(&id, &StagePlanTab::Default)
+                    .await
+                {
                     Ok(mut stages) => {
                         stages
                             .stages
@@ -352,7 +355,7 @@ pub(crate) mod web {
             WebKeyAsyncAction::UpdateJobDetails(job_id) => {
                 if let Some(id) = job_id {
                     match http_client
-                        .get_job_details(&id, StagePlanTab::Default)
+                        .get_job_details(&id, &StagePlanTab::Default)
                         .await
                     {
                         Ok(details) => {
@@ -367,7 +370,7 @@ pub(crate) mod web {
                 }
             }
             WebKeyAsyncAction::LoadJobPlanTree(id) => {
-                match http_client.get_job_details(&id, StagePlanTab::Tree).await {
+                match http_client.get_job_details(&id, &StagePlanTab::Tree).await {
                     Ok(mut details) => {
                         details.physical_plan_tree = details.physical_plan.take();
                         send_data(UiData::JobDetails(details), tx).await;
@@ -378,13 +381,7 @@ pub(crate) mod web {
                 }
             }
             WebKeyAsyncAction::LoadStagePlan(job_id, tab) => {
-                use crate::tui::domain::jobs::stages::StagePlanTab;
-                let fmt = match tab {
-                    StagePlanTab::Default => Some(""),
-                    StagePlanTab::Tree => Some("tree"),
-                    StagePlanTab::Metrics => Some("metrics"),
-                };
-                match http_client.get_job_stages(&job_id, fmt).await {
+                match http_client.get_job_stages(&job_id, &tab).await {
                     Ok(mut stages) => {
                         stages
                             .stages

--- a/ballista-cli/src/tui/mod.rs
+++ b/ballista-cli/src/tui/mod.rs
@@ -109,6 +109,7 @@ mod _tui {
 
 #[cfg(feature = "web")]
 pub(crate) mod web {
+    use crate::tui::domain::jobs::stages::StagePlanTab;
     use crate::tui::{
         TuiResult,
         app::{App, WebKeyAsyncAction},
@@ -350,7 +351,10 @@ pub(crate) mod web {
             }
             WebKeyAsyncAction::UpdateJobDetails(job_id) => {
                 if let Some(id) = job_id {
-                    match http_client.get_job_details(&id, None).await {
+                    match http_client
+                        .get_job_details(&id, StagePlanTab::Default)
+                        .await
+                    {
                         Ok(details) => {
                             send_data(UiData::JobDetails(details), tx).await;
                         }
@@ -363,7 +367,7 @@ pub(crate) mod web {
                 }
             }
             WebKeyAsyncAction::LoadJobPlanTree(id) => {
-                match http_client.get_job_details(&id, Some("tree")).await {
+                match http_client.get_job_details(&id, StagePlanTab::Tree).await {
                     Ok(mut details) => {
                         details.physical_plan_tree = details.physical_plan.take();
                         send_data(UiData::JobDetails(details), tx).await;

--- a/ballista-cli/src/tui/mod.rs
+++ b/ballista-cli/src/tui/mod.rs
@@ -332,7 +332,7 @@ pub(crate) mod web {
             }
             WebKeyAsyncAction::UpdateJobDetails(job_id) => {
                 if let Some(id) = job_id {
-                    match http_client.get_job_details(&id).await {
+                    match http_client.get_job_details(&id, None).await {
                         Ok(details) => {
                             send_data(UiData::JobDetails(details), tx).await;
                         }
@@ -341,6 +341,36 @@ pub(crate) mod web {
                                 "Failed to load job details for '{id}': {e:?}"
                             )
                         }
+                    }
+                }
+            }
+            WebKeyAsyncAction::LoadJobPlanTree(id) => {
+                match http_client.get_job_details(&id, Some("tree")).await {
+                    Ok(mut details) => {
+                        details.physical_plan_tree = details.physical_plan.take();
+                        send_data(UiData::JobDetails(details), tx).await;
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to load tree plan for '{id}': {e:?}")
+                    }
+                }
+            }
+            WebKeyAsyncAction::LoadStagePlan(job_id, tab) => {
+                use crate::tui::domain::jobs::stages::StagePlanTab;
+                let fmt = match tab {
+                    StagePlanTab::Default => Some(""),
+                    StagePlanTab::Tree => Some("tree"),
+                    StagePlanTab::Metrics => Some("metrics"),
+                };
+                match http_client.get_job_stages(&job_id, fmt).await {
+                    Ok(mut stages) => {
+                        stages
+                            .stages
+                            .sort_by_key(|s| s.id.parse::<u64>().unwrap_or(u64::MAX));
+                        send_data(UiData::JobStagesPlanData(tab, stages), tx).await;
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to load stage plan for '{job_id}': {e:?}")
                     }
                 }
             }

--- a/ballista-cli/src/tui/mod.rs
+++ b/ballista-cli/src/tui/mod.rs
@@ -291,7 +291,7 @@ pub(crate) mod web {
 
         match action {
             WebKeyAsyncAction::LoadJobStages(id) => {
-                match http_client.get_job_stages(&id).await {
+                match http_client.get_job_stages(&id, None).await {
                     Ok(mut stages) => {
                         stages
                             .stages

--- a/ballista-cli/src/tui/ui/footer.rs
+++ b/ballista-cli/src/tui/ui/footer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::tui::app::App;
+use crate::tui::domain::jobs::PlanTab;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::Style;
@@ -44,6 +45,13 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                     current_view_key_bindings.push(Span::from("[↑↓←→] Scroll, "));
                     current_view_key_bindings.push(Span::from("[s] Stage plan, "));
                     current_view_key_bindings.push(Span::from("[p] Physical plan, "));
+                    if let Some(popup) = app.job_plan_popup.as_ref()
+                        && popup.get_tab() == &PlanTab::Physical
+                    {
+                        current_view_key_bindings
+                            .push(Span::from("[d] Default format, "));
+                        current_view_key_bindings.push(Span::from("[t] Tree format, "));
+                    }
                     current_view_key_bindings.push(Span::from("[l] Logical plan, "));
                     current_view_key_bindings.push(Span::from("[Esc] Close popup, "));
                 } else if app.is_job_config_popup_open() {

--- a/ballista-cli/src/tui/ui/footer.rs
+++ b/ballista-cli/src/tui/ui/footer.rs
@@ -81,6 +81,12 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                             current_view_key_bindings
                                 .push(Span::from("[↑↓] Scroll up/down, "));
                             current_view_key_bindings
+                                .push(Span::from("[d] Default format, "));
+                            current_view_key_bindings
+                                .push(Span::from("[t] Tree format, "));
+                            current_view_key_bindings
+                                .push(Span::from("[m] Show metrics, "));
+                            current_view_key_bindings
                                 .push(Span::from("[Esc] Close popup, "));
                         } else if app.is_job_stage_tasks_popup_open() {
                             current_view_key_bindings

--- a/ballista-cli/src/tui/ui/footer.rs
+++ b/ballista-cli/src/tui/ui/footer.rs
@@ -38,24 +38,26 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
 
             if app.is_jobs_view() {
                 if app.job_dot_popup.is_some() {
-                    current_view_key_bindings.push(Span::from("[↑↓] Scroll up/down, "));
+                    current_view_key_bindings.push(Span::from("[↑↓←→] Scroll, "));
                     current_view_key_bindings.push(Span::from("[Esc] Close popup, "));
                 } else if app.job_plan_popup.is_some() {
-                    current_view_key_bindings.push(Span::from("[↑↓] Scroll up/down, "));
+                    current_view_key_bindings.push(Span::from("[↑↓←→] Scroll, "));
                     current_view_key_bindings.push(Span::from("[s] Stage plan, "));
                     current_view_key_bindings.push(Span::from("[p] Physical plan, "));
                     current_view_key_bindings.push(Span::from("[l] Logical plan, "));
                     current_view_key_bindings.push(Span::from("[Esc] Close popup, "));
                 } else {
-                    if app.has_more_than_one_job() {
-                        current_view_key_bindings.push(Span::from("[↑↓] Navigate, "));
-                        current_view_key_bindings.push(Span::from("[/] Search jobs, "));
-                        current_view_key_bindings.push(Span::from(
-                            "[1,2,3] Sort by first/second/third/... column, ",
-                        ));
-                    }
                     if app.has_selected_job() {
                         if !app.is_job_stages_popup_open() {
+                            if app.has_more_than_one_job() {
+                                current_view_key_bindings
+                                    .push(Span::from("[↑↓] Navigate, "));
+                                current_view_key_bindings
+                                    .push(Span::from("[/] Search jobs, "));
+                                current_view_key_bindings.push(Span::from(
+                                    "[1,2,3] Sort by first/second/third/... column, ",
+                                ));
+                            }
                             current_view_key_bindings
                                 .push(Span::from("[Enter] View stages, "));
                             current_view_key_bindings
@@ -78,8 +80,7 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                             current_view_key_bindings
                                 .push(Span::from("[Esc] Close popup, "));
                         } else if app.is_job_stage_plan_popup_open() {
-                            current_view_key_bindings
-                                .push(Span::from("[↑↓] Scroll up/down, "));
+                            current_view_key_bindings.push(Span::from("[↑↓←→] Scroll, "));
                             current_view_key_bindings
                                 .push(Span::from("[d] Default format, "));
                             current_view_key_bindings
@@ -89,9 +90,16 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                             current_view_key_bindings
                                 .push(Span::from("[Esc] Close popup, "));
                         } else if app.is_job_stage_tasks_popup_open() {
+                            current_view_key_bindings.push(Span::from("[↑↓] Navigate, "));
                             current_view_key_bindings
                                 .push(Span::from("[Esc] Close popup, "));
                         }
+                    } else if app.has_more_than_one_job() {
+                        current_view_key_bindings.push(Span::from("[↑↓] Navigate, "));
+                        current_view_key_bindings.push(Span::from("[/] Search jobs, "));
+                        current_view_key_bindings.push(Span::from(
+                            "[1,2,3] Sort by first/second/third/... column, ",
+                        ));
                     }
                 }
                 if !current_view_key_bindings.is_empty() {

--- a/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/job_plan_popup.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::tui::app::App;
-use crate::tui::domain::jobs::{JobPlansPopup, PlanTab};
+use crate::tui::domain::jobs::{JobPlansPopup, PhysicalFormat, PlanTab};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::prelude::{Color, Style};
@@ -42,13 +42,28 @@ fn render_plans(f: &mut Frame, area: Rect, job_plans: &JobPlansPopup) {
     let details = &job_plans.details;
     let tab = job_plans.get_tab();
 
-    let plan = match tab {
-        PlanTab::Stage => details.stage_plan.as_deref().unwrap_or("N/A"),
-        PlanTab::Physical => details.physical_plan.as_deref().unwrap_or("N/A"),
-        PlanTab::Logical => details.logical_plan.as_deref().unwrap_or("N/A"),
+    let (plan, physical_fmt) = match tab {
+        PlanTab::Stage => (details.stage_plan.as_deref().unwrap_or("N/A"), ""),
+        PlanTab::Logical => (details.logical_plan.as_deref().unwrap_or("N/A"), ""),
+        PlanTab::Physical => match job_plans.get_physical_format() {
+            PhysicalFormat::Default => (
+                details.physical_plan.as_deref().unwrap_or("N/A"),
+                "(press t to switch to tree format) ",
+            ),
+            PhysicalFormat::Tree => (
+                details
+                    .physical_plan_tree
+                    .as_deref()
+                    .unwrap_or("Loading..."),
+                "(press d to switch to default format) ",
+            ),
+        },
     };
 
-    let title = format!(" {:?} plan for job '{}' ", tab, details.job_id);
+    let title = format!(
+        " {:?} plan for job '{}' {}",
+        tab, details.job_id, physical_fmt
+    );
 
     let block = Block::default()
         .title(title)

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -131,23 +131,15 @@ pub async fn load_job_stages_popup(app: &App, job_id: &str) -> TuiResult<()> {
 pub async fn load_stage_plan(
     app: &App,
     job_id: &str,
-    tab: crate::tui::domain::jobs::stages::StagePlanTab,
+    tab: &StagePlanTab,
 ) -> TuiResult<()> {
-    use crate::tui::domain::jobs::stages::StagePlanTab;
-
-    let fmt = match tab {
-        StagePlanTab::Default => Some(""),
-        StagePlanTab::Tree => Some("tree"),
-        StagePlanTab::Metrics => Some("metrics"),
-    };
-
     let mut stages = app
         .http_client
-        .get_job_stages(job_id, &tab)
+        .get_job_stages(job_id, tab)
         .await
-        .inspect(|s| tracing::trace!("Loaded {fmt:?} plan for job '{job_id}': {s:?}"))
+        .inspect(|s| tracing::trace!("Loaded the {tab:?} plan for job '{job_id}': {s:?}"))
         .inspect_err(|e| {
-            tracing::error!("Failed to load {fmt:?} plan for job '{job_id}': {e:?}")
+            tracing::error!("Failed to load the {tab:?} plan for job '{job_id}': {e:?}")
         })?;
 
     stages
@@ -155,7 +147,7 @@ pub async fn load_stage_plan(
         .sort_by_key(|s| s.id.parse::<u64>().unwrap_or(u64::MAX));
 
     app.send_event(Event::DataLoaded {
-        data: UiData::JobStagesPlanData(tab, stages),
+        data: UiData::JobStagesPlanData(tab.clone(), stages),
     })
     .await
 }

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -81,11 +81,12 @@ pub async fn load_job_dot(app: &App, job_id: &str) -> TuiResult<()> {
     }
 }
 
+/// Loading whole job's stages to render the popup window
 #[cfg(not(feature = "web"))]
 pub async fn load_job_stages_popup(app: &App, job_id: &str) -> TuiResult<()> {
     let mut stages = app
         .http_client
-        .get_job_stages(job_id)
+        .get_job_stages(job_id, None)
         .await
         .inspect(|stages| tracing::trace!("Loaded stages for job '{job_id}': {stages:?}"))
         .inspect_err(|e| {
@@ -98,6 +99,40 @@ pub async fn load_job_stages_popup(app: &App, job_id: &str) -> TuiResult<()> {
 
     app.send_event(Event::DataLoaded {
         data: UiData::JobStagesData(job_id.to_owned(), stages),
+    })
+    .await
+}
+
+/// Loading stage's plan to render the popup window
+#[cfg(not(feature = "web"))]
+pub async fn load_stage_plan(
+    app: &App,
+    job_id: &str,
+    tab: crate::tui::domain::jobs::stages::StagePlanTab,
+) -> TuiResult<()> {
+    use crate::tui::domain::jobs::stages::StagePlanTab;
+
+    let fmt = match tab {
+        StagePlanTab::Default => None,
+        StagePlanTab::Tree => Some("tree"),
+        StagePlanTab::Metrics => Some("metrics"),
+    };
+
+    let mut stages = app
+        .http_client
+        .get_job_stages(job_id, fmt)
+        .await
+        .inspect(|s| tracing::trace!("Loaded {fmt:?} plan for job '{job_id}': {s:?}"))
+        .inspect_err(|e| {
+            tracing::error!("Failed to load {fmt:?} plan for job '{job_id}': {e:?}")
+        })?;
+
+    stages
+        .stages
+        .sort_by_key(|s| s.id.parse::<u64>().unwrap_or(u64::MAX));
+
+    app.send_event(Event::DataLoaded {
+        data: UiData::JobStagesPlanData(job_id.to_owned(), tab, stages),
     })
     .await
 }

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -109,7 +109,7 @@ pub async fn load_job_config_popup(app: &App, job_id: &str) -> TuiResult<()> {
 pub async fn load_job_stages_popup(app: &App, job_id: &str) -> TuiResult<()> {
     let mut stages = app
         .http_client
-        .get_job_stages(job_id, None)
+        .get_job_stages(job_id, &StagePlanTab::Default)
         .await
         .inspect(|stages| tracing::trace!("Loaded stages for job '{job_id}': {stages:?}"))
         .inspect_err(|e| {
@@ -143,7 +143,7 @@ pub async fn load_stage_plan(
 
     let mut stages = app
         .http_client
-        .get_job_stages(job_id, fmt)
+        .get_job_stages(job_id, &tab)
         .await
         .inspect(|s| tracing::trace!("Loaded {fmt:?} plan for job '{job_id}': {s:?}"))
         .inspect_err(|e| {
@@ -164,7 +164,7 @@ pub async fn load_stage_plan(
 pub async fn load_job_details(app: &App, job_id: &str) -> TuiResult<()> {
     let details = match app
         .http_client
-        .get_job_details(job_id, StagePlanTab::Default)
+        .get_job_details(job_id, &StagePlanTab::Default)
         .await
     {
         Ok(d) => d,

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -113,7 +113,7 @@ pub async fn load_stage_plan(
     use crate::tui::domain::jobs::stages::StagePlanTab;
 
     let fmt = match tab {
-        StagePlanTab::Default => None,
+        StagePlanTab::Default => Some(""),
         StagePlanTab::Tree => Some("tree"),
         StagePlanTab::Metrics => Some("metrics"),
     };
@@ -132,14 +132,14 @@ pub async fn load_stage_plan(
         .sort_by_key(|s| s.id.parse::<u64>().unwrap_or(u64::MAX));
 
     app.send_event(Event::DataLoaded {
-        data: UiData::JobStagesPlanData(job_id.to_owned(), tab, stages),
+        data: UiData::JobStagesPlanData(tab, stages),
     })
     .await
 }
 
 #[cfg(not(feature = "web"))]
 pub async fn load_job_details(app: &App, job_id: &str) -> TuiResult<()> {
-    let details = match app.http_client.get_job_details(job_id).await {
+    let details = match app.http_client.get_job_details(job_id, None).await {
         Ok(d) => d,
         Err(e) => {
             tracing::error!("Failed to load job details for {job_id}: {e:?}");

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -26,7 +26,7 @@ pub mod stage_tasks_popup;
 #[cfg(not(feature = "web"))]
 use crate::tui::{
     TuiResult,
-    domain::jobs::{JobConfigEntry, JobConfigPopup},
+    domain::jobs::{JobConfigEntry, JobConfigPopup, stages::StagePlanTab},
     event::{Event, UiData},
 };
 use crate::tui::{
@@ -83,7 +83,7 @@ pub async fn load_job_dot(app: &App, job_id: &str) -> TuiResult<()> {
     }
 }
 
-/// Loading whole job's stages to render the popup window
+/// Loading the whole job's stages to render the popup window
 #[cfg(not(feature = "web"))]
 pub async fn load_job_config_popup(app: &App, job_id: &str) -> TuiResult<()> {
     let config = match app.http_client.get_job_config(job_id).await {
@@ -162,7 +162,11 @@ pub async fn load_stage_plan(
 
 #[cfg(not(feature = "web"))]
 pub async fn load_job_details(app: &App, job_id: &str) -> TuiResult<()> {
-    let details = match app.http_client.get_job_details(job_id, None).await {
+    let details = match app
+        .http_client
+        .get_job_details(job_id, StagePlanTab::Default)
+        .await
+    {
         Ok(d) => d,
         Err(e) => {
             tracing::error!("Failed to load job details for {job_id}: {e:?}");

--- a/ballista-cli/src/tui/ui/main/mod.rs
+++ b/ballista-cli/src/tui/ui/main/mod.rs
@@ -23,7 +23,10 @@ pub use executors::{executor_details_popup, render_executors};
 #[cfg(not(feature = "web"))]
 pub use executors::{load_executor_details_popup, load_executors_data};
 #[cfg(not(feature = "web"))]
-pub use jobs::{load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data, load_stage_plan};
+pub use jobs::{
+    load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data,
+    load_stage_plan,
+};
 
 #[cfg(feature = "web")]
 pub(crate) use jobs::dot_parser;

--- a/ballista-cli/src/tui/ui/main/mod.rs
+++ b/ballista-cli/src/tui/ui/main/mod.rs
@@ -24,8 +24,8 @@ pub use executors::{executor_details_popup, render_executors};
 pub use executors::{load_executor_details_popup, load_executors_data};
 #[cfg(not(feature = "web"))]
 pub use jobs::{
-    load_job_config_popup, load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data,
-    load_stage_plan,
+    load_job_config_popup, load_job_details, load_job_dot, load_job_stages_popup,
+    load_jobs_data, load_stage_plan,
 };
 
 #[cfg(feature = "web")]

--- a/ballista-cli/src/tui/ui/main/mod.rs
+++ b/ballista-cli/src/tui/ui/main/mod.rs
@@ -23,7 +23,7 @@ pub use executors::{executor_details_popup, render_executors};
 #[cfg(not(feature = "web"))]
 pub use executors::{load_executor_details_popup, load_executors_data};
 #[cfg(not(feature = "web"))]
-pub use jobs::{load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data};
+pub use jobs::{load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data, load_stage_plan};
 
 #[cfg(feature = "web")]
 pub(crate) use jobs::dot_parser;

--- a/ballista-cli/src/tui/ui/mod.rs
+++ b/ballista-cli/src/tui/ui/mod.rs
@@ -36,7 +36,7 @@ pub use main::{
 #[cfg(not(feature = "web"))]
 pub use main::{
     load_executor_details_popup, load_executors_data, load_job_details, load_job_dot,
-    load_job_stages_popup, load_jobs_data, load_metrics_data,
+    load_job_stages_popup, load_jobs_data, load_metrics_data, load_stage_plan,
 };
 
 use ratatui::{

--- a/ballista-cli/src/tui/ui/mod.rs
+++ b/ballista-cli/src/tui/ui/mod.rs
@@ -36,8 +36,9 @@ pub use main::{
 };
 #[cfg(not(feature = "web"))]
 pub use main::{
-    load_executor_details_popup, load_executors_data, load_job_config_popup, load_job_details, load_job_dot,
-    load_job_stages_popup, load_jobs_data, load_metrics_data, load_stage_plan,
+    load_executor_details_popup, load_executors_data, load_job_config_popup,
+    load_job_details, load_job_dot, load_job_stages_popup, load_jobs_data,
+    load_metrics_data, load_stage_plan,
 };
 
 use ratatui::{

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -287,12 +287,8 @@ The TUI reads its configuration from a YAML file located at the platform-specifi
 Create the file manually if it does not exist. The following settings are available:
 
 ```yaml
-tick_interval_ms: 2000
-
-job:
-  stage:
-    plan:
-      tree: false
+data_reload_interval_ms: 2000
+repaint_interval_ms: 50
 
 scheduler:
   url: http://localhost:50050
@@ -301,8 +297,8 @@ http:
   timeout: 2000
 ```
 
-- `tick_interval_ms`: How often the TUI refreshes data from the scheduler (milliseconds).
-- `job.stage.plan.tree`: Whether to show the stage execution plan as a tree.
+- `data_reload_interval_ms`: How often the TUI refreshes data from the scheduler (milliseconds).
+- `repaint_interval_ms`: How often the TUI repaints the screen (milliseconds).
 - `scheduler.url`: The Ballista scheduler HTTP endpoint.
 - `http.timeout`: HTTP request timeout in milliseconds.
 


### PR DESCRIPTION
# Which issue does this PR close?

Adresses #1807

 # Rationale for this change
`Scheduler`'s REST API interface now supports different styles of plan's rendering for stages. Beforehand, in the Ballista's TUI we could only render the "default" looking plan.

# What changes are included in this PR?
Switching between different formatting styles for stage's plan.

# Are there any user-facing changes?
Yes. 
Now we have three possible variants of stage's plan formatting:
1. Default (which is enabled by default when pressing `p` in the job's Stages section. Also we can switch back to it by pressing `d`
2. Tree-format - by pressing `t`
3. Metrics - by pressing `m`

## Here is the demonstration:
https://github.com/user-attachments/assets/50b9844a-65c9-4a9b-b6c9-ba1c7cfea81a

