### PR TITLE
chore(ci): Fix the Rust installer for MacOS in dependencies.yml

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: ./.github/actions/setup-macos-builder
         with:
           rust-version: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,12 +243,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Rust toolchain
-        run: |
-          rustup toolchain install stable
-          rustup default stable
-          rustup component add clippy
-      - name: Install protoc
-        run: brew install protobuf
+        uses: ./.github/actions/setup-macos-builder
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run clippy
         run: ci/scripts/rust_clippy.sh


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up of #1810

# Rationale for this change

Fix broken Rust toolchain install 
See https://github.com/apache/datafusion-ballista/actions/runs/27115921485/job/80022693049?pr=1831
```
Prepare all required actions
Getting action download info
Run ./.github/actions/setup-builder
Run apt-get update
/Users/runner/work/_temp/99deeb48-b5a1-4c48-9b41-bd5480b91512.sh: line 1: apt-get: command not found
```

# What changes are included in this PR?

Use the macos installer action

# Are there any user-facing changes?

No