### PR TITLE
chore(ci): Fix the name of a CI job dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs:
-      - build-python-mac-win
+      - build-python-mac
       - build-manylinux-x86_64
       - build-manylinux-aarch64
       - build-sdist


### PR DESCRIPTION
# Which issue does this PR close?


Follow-up of #1801 

# Rationale for this change

https://github.com/apache/datafusion-ballista/actions/runs/27124402420
```
[Invalid workflow file: .github/workflows/build.yml#L1](https://github.com/apache/datafusion-ballista/actions/runs/27124402420/workflow)
(Line: 316, Col: 9): Job 'merge-build-artifacts' depends on unknown job 'build-python-mac-win'.
```

# What changes are included in this PR?

Update the name of a CI job dependency

# Are there any user-facing changes?

No