### PR TITLE
chore(ci): Download macos aarch64 build of protoc

### DIFF
--- a/.github/actions/setup-macos-builder/action.yaml
+++ b/.github/actions/setup-macos-builder/action.yaml
@@ -27,11 +27,13 @@ runs:
   steps:
     - name: Install protobuf compiler
       shell: bash
+      env:
+        PROTOBUF_VERSION: 29.1
       run: |
         mkdir -p $HOME/d/protoc
         cd $HOME/d/protoc
-        export PROTO_ZIP="protoc-29.1-osx-x86_64.zip"
-        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v29.1/$PROTO_ZIP
+        export PROTO_ZIP="protoc-${PROTOBUF_VERSION}-osx-aarch_64.zip"
+        curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/${PROTO_ZIP}
         unzip $PROTO_ZIP
         echo "$HOME/d/protoc/bin" >> $GITHUB_PATH
         export PATH=$PATH:$HOME/d/protoc/bin


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

The MacOS build sometimes fail with:

https://github.com/apache/datafusion-ballista/actions/runs/27124743045/job/80050283764
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:07 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:08 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
100    92  100    92    0     0      8      0  0:00:11  0:00:11 --:--:--    19
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
Archive:  protoc-29.1-osx-x86_64.zip
unzip:  cannot find zipfile directory in one of protoc-29.1-osx-x86_64.zip or
        protoc-29.1-osx-x86_64.zip.zip, and cannot find protoc-29.1-osx-x86_64.zip.ZIP, period.
```

# What changes are included in this PR?

Download the aarch64 build of protoc (for MacOS M series).

# Are there any user-facing changes?

No.
