### PR TITLE
chore(github): Enable "Update branch" button for PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,8 +39,8 @@ github:
     rebase: false
   features:
     issues: true
-# publishes the content of the `asf-site` branch to
-# https://datafusion.apache.org/ballista/
+  # publishes the content of the `asf-site` branch to
+  # https://datafusion.apache.org/ballista/
   rulesets:
     - name: "Default Branch Protection"
       type: branch
@@ -49,11 +49,17 @@ github:
           - "~DEFAULT_BRANCH"
           - "release/*"
           - "rel/*"
-        excludes: []
+        excludes: [ ]
       bypass_teams:
         - root
       restrict_deletion: true
       restrict_force_push: true
+  pull_requests:
+    # enable updating head branches of pull requests
+    allow_update_branch: true
+    allow_auto_merge: true
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
 publish:
   whoami: asf-site
   subdir: ballista


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Also allow "Auto Merge" and "Delete branch on merge" functionalities

Same as for DataFusion - https://github.com/apache/datafusion/blob/c83a981b5564485965dba8b63fb2d46ea5a24e5a/.asf.yaml#L106C3-L111C30

It will enable us to update contributors' PRs without bothering them to do it. 
E.g. https://github.com/apache/datafusion-ballista/pull/1824 CI checks currently fail due to unrelated problem that is already fixed. 

# What changes are included in this PR?

Update .asf.yaml

# Are there any user-facing changes?

No
