### PR TITLE
chore(ci): Run `cargo check` and `cargo doc` CI jobs on MacOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,19 +59,17 @@ on:
 
 jobs:
   # Check crate compiles and base cargo check passes
-  linux-build-lib:
-    name: linux build test
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+  build-lib:
+    name: cargo check
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        uses: ./.github/actions/setup-macos-builder
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
-      - name: Prepare cargo build
+      - name: cargo check
         run: |
           # Adding `--locked` here to assert that the `Cargo.lock` file is up to
           # date with the manifest. When this fails, please make sure to commit
@@ -99,18 +97,14 @@ jobs:
           cargo test --profile ci --features=testcontainers
 
   # Run `cargo doc` to ensure the rustdoc is clean
-  linux-rustdoc:
+  rustdoc:
     name: cargo doc
-    needs: linux-build-lib
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    needs: build-lib
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6.0.3
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
+        uses: ./.github/actions/setup-macos-builder
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run cargo doc
         run: ci/scripts/rust_docs.sh
@@ -168,9 +162,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-macos-builder
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
-        with:
-          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: false
       - name: Run tests
         shell: bash
         run: |


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up of #1810

# Rationale for this change

`cargo doc` CI job is the slowest one now because it depends on `cargo check` and both need an Ubuntu runner and the Ubuntu runners are overloaded
Use macos-latest runner for these jobs to run them sooner.

# What changes are included in this PR?

Change from `ubuntu-latest` to `macos-latest` for `cargo check` and `cargo doc` CI jobs

# Are there any user-facing changes?

No.
