### PR TITLE
refactor: make use of `async_trait::async_trait` consistent across project

### DIFF
--- a/ballista/core/src/client_pool.rs
+++ b/ballista/core/src/client_pool.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 // ---------------------------------------------------------------------------
 
 /// Manages a pool of reusable [BallistaClient] connections.
-#[async_trait]
+#[async_trait::async_trait]
 pub trait BallistaClientPool: Send + Sync + Debug {
     /// Acquire an idle client for `(host, port, config)`, or create a new one if the
     /// pool is empty for that key. The returned [PooledClient] returns itself

--- a/ballista/core/src/client_pool.rs
+++ b/ballista/core/src/client_pool.rs
@@ -21,7 +21,6 @@ use crate::client::BallistaClient;
 use crate::error::Result;
 use crate::extension::BallistaConfigGrpcEndpoint;
 use crate::utils::GrpcClientConfig;
-use async_trait::async_trait;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;

--- a/ballista/core/src/event_loop.rs
+++ b/ballista/core/src/event_loop.rs
@@ -20,7 +20,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use async_trait::async_trait;
 use log::{error, info};
 use tokio::sync::mpsc;
 

--- a/ballista/core/src/event_loop.rs
+++ b/ballista/core/src/event_loop.rs
@@ -27,7 +27,7 @@ use tokio::sync::mpsc;
 use crate::error::{BallistaError, Result};
 
 /// Trait defining actions to be performed in response to events in an event loop.
-#[async_trait]
+#[async_trait::async_trait]
 pub trait EventAction<E>: Send + Sync {
     /// Called when the event loop starts.
     fn on_start(&self);

--- a/ballista/core/src/planner.rs
+++ b/ballista/core/src/planner.rs
@@ -19,7 +19,6 @@ use crate::config::BallistaConfig;
 use crate::execution_plans::{DistributedExplainAnalyzeExec, DistributedQueryExec};
 use crate::serde::BallistaLogicalExtensionCodec;
 
-use async_trait::async_trait;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
 use datafusion::error::DataFusionError;

--- a/ballista/core/src/planner.rs
+++ b/ballista/core/src/planner.rs
@@ -101,7 +101,7 @@ impl<T: 'static + AsLogicalPlan> BallistaQueryPlanner<T> {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl<T: 'static + AsLogicalPlan> QueryPlanner for BallistaQueryPlanner<T> {
     async fn create_physical_plan(
         &self,

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1695,7 +1695,7 @@ pub mod scheduler_grpc_server {
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SchedulerGrpcServer.
-    #[async_trait]
+    #[async_trait::async_trait]
     pub trait SchedulerGrpc: std::marker::Send + std::marker::Sync + 'static {
         /// Executors must poll the scheduler for heartbeat and to receive tasks
         async fn poll_work(
@@ -2733,7 +2733,7 @@ pub mod executor_grpc_server {
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ExecutorGrpcServer.
-    #[async_trait]
+    #[async_trait::async_trait]
     pub trait ExecutorGrpc: std::marker::Send + std::marker::Sync + 'static {
         async fn launch_task(
             &self,

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -1695,7 +1695,7 @@ pub mod scheduler_grpc_server {
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with SchedulerGrpcServer.
-    #[async_trait::async_trait]
+    #[async_trait]
     pub trait SchedulerGrpc: std::marker::Send + std::marker::Sync + 'static {
         /// Executors must poll the scheduler for heartbeat and to receive tasks
         async fn poll_work(
@@ -2733,7 +2733,7 @@ pub mod executor_grpc_server {
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ExecutorGrpcServer.
-    #[async_trait::async_trait]
+    #[async_trait]
     pub trait ExecutorGrpc: std::marker::Send + std::marker::Sync + 'static {
         async fn launch_task(
             &self,

--- a/ballista/executor/src/client_pool.rs
+++ b/ballista/executor/src/client_pool.rs
@@ -146,7 +146,7 @@ fn evict(idle: &IdleMap, timeout: Duration) {
     });
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl BallistaClientPool for DefaultBallistaClientPool {
     async fn acquire(
         &self,

--- a/ballista/executor/src/client_pool.rs
+++ b/ballista/executor/src/client_pool.rs
@@ -29,7 +29,6 @@
 //! A optional background tokio task evicts idle connections that have not been used
 //! within the configured `idle_timeout`.
 
-use async_trait::async_trait;
 use ballista_core::client::BallistaClient;
 use ballista_core::client_pool::{BallistaClientPool, PooledClient};
 use ballista_core::error::Result;

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -64,7 +64,7 @@ pub trait ExecutionEngine: Sync + Send {
 /// and can be executed as one unit with each partition running in parallel.
 /// The output of each partition is re-partitioned and written to disk in
 /// Arrow IPC format. Subsequent stages read these results via ShuffleReaderExec.
-#[async_trait]
+#[async_trait::async_trait]
 pub trait QueryStageExecutor: Sync + Send + Debug + Display {
     /// Executes a single partition of this query stage.
     ///
@@ -230,7 +230,7 @@ impl Display for DefaultQueryStageExec {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl QueryStageExecutor for DefaultQueryStageExec {
     async fn execute_query_stage(
         &self,

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -21,7 +21,6 @@
 //! query stages in a distributed setting. The execution engine is responsible
 //! for creating query stage executors from physical plans.
 
-use async_trait::async_trait;
 use ballista_core::client_pool::BallistaClientPool;
 use ballista_core::execution_plans::sort_shuffle::SortShuffleWriterExec;
 use ballista_core::execution_plans::{ShuffleReaderExec, ShuffleWriterExec};

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -20,7 +20,6 @@ use crate::cluster::{
     JobStatus, TaskDistributionPolicy, bind_task_bias, bind_task_round_robin,
 };
 use crate::state::execution_graph::ExecutionGraphBox;
-use async_trait::async_trait;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::protobuf::{
     AvailableTaskSlots, ExecutorHeartbeat, ExecutorStatus, FailedJob, QueuedJob,

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -63,7 +63,7 @@ pub struct InMemoryClusterState {
     cluster_event_sender: ClusterEventSender<ClusterStateEvent>,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl ClusterState for InMemoryClusterState {
     async fn bind_schedulable_tasks(
         &self,
@@ -320,7 +320,7 @@ impl ExtendedJobStatus {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl JobState for InMemoryJobState {
     async fn submit_job(
         &self,

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -154,7 +154,7 @@ pub type ExecutorSlot = (String, u32);
 /// Trait for maintaining a globally consistent view of cluster resources.
 ///
 /// Implementations track executor registration, heartbeats, and available task slots.
-#[tonic::async_trait]
+#[async_trait::async_trait]
 pub trait ClusterState: Send + Sync + 'static {
     /// Initializes the cluster state backend.
     ///
@@ -277,7 +277,7 @@ pub type JobStateEventStream = Pin<Box<dyn Stream<Item = JobStateEvent> + Send>>
 /// Trait for persisting state related to executing jobs.
 ///
 /// Implementations handle job lifecycle, execution graphs, and session management.
-#[tonic::async_trait]
+#[async_trait::async_trait]
 pub trait JobState: Send + Sync {
     /// Accepts a job into the scheduler's queue.
     ///

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use ballista_core::serde::protobuf::{FailedJob, JobStatus};
 use log::{error, info, trace, warn};
 

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -65,7 +65,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> QueryStageSchedul
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
     EventAction<QueryStageSchedulerEvent> for QueryStageScheduler<T, U>
 {

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -25,7 +25,6 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 
 use crate::config::SchedulerConfig;
 use crate::metrics::SchedulerMetricsCollector;

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -25,7 +25,6 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-
 use crate::config::SchedulerConfig;
 use crate::metrics::SchedulerMetricsCollector;
 use crate::planner::DefaultDistributedPlanner;

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -80,7 +80,7 @@ const TEST_SCHEDULER_NAME: &str = "localhost:50050";
 #[derive(Debug)]
 pub struct ExplodingTableProvider;
 
-#[async_trait]
+#[async_trait::async_trait]
 impl TableProvider for ExplodingTableProvider {
     fn as_any(&self) -> &dyn Any {
         self
@@ -346,7 +346,7 @@ impl VirtualExecutor {
 #[derive(Default)]
 pub struct BlackholeTaskLauncher {}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl TaskLauncher for BlackholeTaskLauncher {
     async fn launch_tasks(
         &self,

--- a/docs/source/user-guide/extensions-example.md
+++ b/docs/source/user-guide/extensions-example.md
@@ -347,7 +347,7 @@ transformation is performed using implementing `ExtensionPlanner` trait:
 #[derive(Debug, Clone, Default)]
 pub struct CustomPlannerExtension {}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl ExtensionPlanner for CustomPlannerExtension {
     async fn plan_extension(
         &self,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1847 

 # Rationale for this change
Inconsistent usage of `#[tonic::async_trait]`, `#[async_trait]` and `#[async_trait::async_trait]` leads to unnecessary cognitive load on developer.

# What changes are included in this PR?
- Changed all `#[async_trait]` into `#[async_trait::async_trait]` and removed the `use async_trait::async_trait;` statements.
- Changed two occurences of `#[tonic::async_trait]` to `#[async_trait::async_trait]` on trait definitions that are not gRPC related.

# Are there any user-facing changes?
No.
