### PR TITLE
feat: decouple partition location from executor metadata

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -104,6 +104,7 @@ message ShuffleReaderExecNode {
 message ShuffleReaderPartition {
   // each partition of a shuffle read can read data from multiple locations
   repeated PartitionLocation location = 1;
+  map<string, ExecutorMetadata> executor_map = 2;
 }
 
 // CoalescePartitionsRule output: groups upstream partitions into coalesced output partitions.
@@ -272,7 +273,7 @@ message PartitionLocation {
   uint32 map_partition_id = 1;
   // partition_id of the shuffle, a composition of(job_id + map_stage_id + partition_id).
   PartitionId partition_id = 2;
-  ExecutorMetadata executor_meta = 3;
+  string executor_id = 3;
   PartitionStats partition_stats = 4;
   optional uint64 file_id = 6;
   bool is_sort_shuffle = 7;
@@ -367,8 +368,8 @@ message ExecutorMetadata {
   string host = 2;
   uint32 port = 3;
   uint32 grpc_port = 4;
-  ExecutorSpecification specification = 5;
-  ExecutorOperatingSystemSpecification os_info = 6;
+  optional ExecutorSpecification specification = 5;
+  optional ExecutorOperatingSystemSpecification os_info = 6;
 }
 
 
@@ -726,9 +727,10 @@ message GetJobMetricsResult {
 
 message SuccessfulJob {
   repeated PartitionLocation partition_location = 1;
-  uint64 queued_at = 2;
-  uint64 started_at = 3;
-  uint64 ended_at = 4;
+  map<string, ExecutorMetadata> executor_map = 2;
+  uint64 queued_at = 3;
+  uint64 started_at = 4;
+  uint64 ended_at = 5;
 }
 
 message QueuedJob {

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -103,8 +103,7 @@ message ShuffleReaderExecNode {
 
 message ShuffleReaderPartition {
   // each partition of a shuffle read can read data from multiple locations
-  repeated PartitionLocation location = 1;
-  map<string, ExecutorMetadata> executor_map = 2;
+  repeated PartitionLocationExt locations = 1;
 }
 
 // CoalescePartitionsRule output: groups upstream partitions into coalesced output partitions.
@@ -283,6 +282,12 @@ message PartitionLocation {
   reserved "path";
 }
 
+// Holding both partition info and executor metadata for connection
+message PartitionLocationExt {
+  repeated PartitionLocation location = 1;
+  map<string, ExecutorConnection> executor_map = 2;
+}
+
 // Unique identifier for a materialized partition of data
 message PartitionId {
   string job_id = 1;
@@ -360,6 +365,12 @@ message OperatorMetric {
     NamedRatio ratio = 14;
     uint64 output_batches = 15;
   }
+}
+
+message ExecutorConnection {
+  string host = 2;
+  uint32 port = 3;
+  uint32 grpc_port = 4;
 }
 
 // Used by scheduler
@@ -726,11 +737,10 @@ message GetJobMetricsResult {
 }
 
 message SuccessfulJob {
-  repeated PartitionLocation partition_location = 1;
-  map<string, ExecutorMetadata> executor_map = 2;
-  uint64 queued_at = 3;
-  uint64 started_at = 4;
-  uint64 ended_at = 5;
+  PartitionLocationExt locations = 1;
+  uint64 queued_at = 2;
+  uint64 started_at = 3;
+  uint64 ended_at = 4;
 }
 
 message QueuedJob {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -20,12 +20,12 @@ use crate::client::BallistaClient;
 use crate::config::BallistaConfig;
 use crate::extension::{BallistaConfigGrpcEndpoint, SessionConfigExt};
 use crate::serde::protobuf::get_job_status_result::FlightProxy;
+use crate::serde::protobuf::{self, SuccessfulJob};
 use crate::serde::protobuf::{
     ExecuteQueryParams, GetJobStatusParams, GetJobStatusResult, KeyValuePair,
     PartitionLocation, execute_query_params::Query, execute_query_result, job_status,
     scheduler_grpc_client::SchedulerGrpcClient,
 };
-use crate::serde::protobuf::{ExecutorMetadata, SuccessfulJob};
 use crate::utils::{GrpcClientConfig, create_grpc_client_endpoint};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::error::ArrowError;
@@ -526,15 +526,18 @@ async fn execute_query_pull(
                 queued_at,
                 started_at,
                 ended_at,
-                partition_location,
-                executor_map,
+                locations,
                 ..
             })) => {
                 // Calculate job execution time (server-side execution)
                 let job_execution_ms = ended_at.saturating_sub(started_at);
                 let duration = Duration::from_millis(job_execution_ms);
-                let executor_map = Arc::new(executor_map);
-
+                let locations = locations.ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "SuccessfulJob missing locations".to_string(),
+                    )
+                })?;
+                let executor_connection = Arc::new(locations.executor_map);
                 info!("Job {job_id} finished executing in {duration:?} ");
 
                 // Calculate scheduling time (server-side queue time)
@@ -562,10 +565,11 @@ async fn execute_query_pull(
                 // happens lazily when the stream is consumed, not during execute_query.
                 // This could be added in a future enhancement by wrapping the stream.
 
-                let streams = partition_location.into_iter().map(move |partition| {
+                let streams = locations.location.into_iter().map(move |partition| {
+                    let executor_connection = executor_connection.clone();
                     let f = fetch_partition(
                         partition,
-                        executor_map.clone(),
+                        executor_connection,
                         max_message_size,
                         true,
                         scheduler_url.clone(),
@@ -695,14 +699,18 @@ async fn execute_query_push(
                 queued_at,
                 started_at,
                 ended_at,
-                partition_location,
-                executor_map,
+                locations,
                 ..
             })) => {
                 // Calculate job execution time (server-side execution)
                 let job_execution_ms = ended_at.saturating_sub(started_at);
                 let duration = Duration::from_millis(job_execution_ms);
-                let executor_map = Arc::new(executor_map);
+                let locations = locations.ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "SuccessfulJob missing locations".to_string(),
+                    )
+                })?;
+                let executor_connection = Arc::new(locations.executor_map);
 
                 info!("Job {job_id} finished executing in {duration:?} ");
 
@@ -731,10 +739,11 @@ async fn execute_query_push(
                 // happens lazily when the stream is consumed, not during execute_query.
                 // This could be added in a future enhancement by wrapping the stream.
 
-                let streams = partition_location.into_iter().map(move |partition| {
+                let streams = locations.location.into_iter().map(move |partition| {
+                    let executor_connection = executor_connection.clone();
                     let f = fetch_partition(
                         partition,
-                        executor_map.clone(),
+                        executor_connection,
                         max_message_size,
                         true,
                         scheduler_url.clone(),
@@ -756,7 +765,8 @@ async fn execute_query_push(
 }
 
 fn get_client_host_port(
-    executor_metadata: &ExecutorMetadata,
+    executor_host: &str,
+    executor_port: u16,
     scheduler_url: &str,
     flight_proxy: &Option<FlightProxy>,
 ) -> Result<(String, u16)> {
@@ -790,19 +800,16 @@ fn get_client_host_port(
         Some(FlightProxy::Local(false)) | None => {
             debug!(
                 "Fetching results from executor: {}:{}",
-                executor_metadata.host, executor_metadata.port
+                executor_host, executor_port,
             );
-            Ok((
-                executor_metadata.host.clone(),
-                executor_metadata.port as u16,
-            ))
+            Ok((executor_host.to_string(), executor_port))
         }
     }
 }
 #[allow(clippy::too_many_arguments)]
 async fn fetch_partition(
     location: PartitionLocation,
-    executor_map: Arc<HashMap<String, ExecutorMetadata>>,
+    executor_conn_map: Arc<HashMap<String, protobuf::ExecutorConnection>>,
     max_message_size: usize,
     flight_transport: bool,
     scheduler_url: String,
@@ -812,21 +819,24 @@ async fn fetch_partition(
     io_retries_times: u8,
     io_retry_wait_time_ms: u64,
 ) -> Result<SendableRecordBatchStream> {
-    let metadata = executor_map.get(&location.executor_id).ok_or_else(|| {
-        DataFusionError::Internal(format!(
-            "Executor {} not found in map",
-            location.executor_id
-        ))
-    })?;
+    let executor_conn =
+        executor_conn_map
+            .get(&location.executor_id)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "Executor {} not found in map",
+                    location.executor_id
+                ))
+            })?;
 
     let partition_id = location.partition_id.ok_or_else(|| {
         DataFusionError::Internal("Received empty partition id".to_owned())
     })?;
-    let host = metadata.host.as_str();
-    let port = metadata.port as u16;
+    let host = executor_conn.host.as_str();
+    let port = executor_conn.port as u16;
 
     let (client_host, client_port) =
-        get_client_host_port(metadata, &scheduler_url, &flight_proxy)?;
+        get_client_host_port(host, port, &scheduler_url, &flight_proxy)?;
 
     let mut ballista_client = BallistaClient::try_new(
         client_host.as_str(),
@@ -843,7 +853,7 @@ async fn fetch_partition(
     .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
     ballista_client
         .fetch_partition_proxied(
-            &metadata.id,
+            &location.executor_id,
             &partition_id.into(),
             location.file_id,
             location.is_sort_shuffle,
@@ -862,8 +872,8 @@ mod test {
     use crate::execution_plans::distributed_query::{
         DistributedQueryExec, get_client_host_port,
     };
-    use crate::serde::protobuf::ExecutorMetadata;
     use crate::serde::protobuf::get_job_status_result::FlightProxy;
+    use crate::serde::scheduler::ExecutorConnection;
     use datafusion::logical_expr::LogicalPlan;
     use datafusion::physical_plan::ExecutionPlan;
     use datafusion_proto::protobuf::LogicalPlanNode;
@@ -875,36 +885,36 @@ mod test {
         let scheduler_port: u16 = 5000;
 
         let scheduler_url = format!("http://{scheduler_host}:{scheduler_port}");
-        let executor = ExecutorMetadata {
-            id: "test".to_string(),
+        let executor = ExecutorConnection {
             host: "executor".to_string(),
             port: 12345,
             grpc_port: 1,
-            specification: None,
-            os_info: None,
         };
 
         // no flight proxy -> client should fetch results from executor
         assert_eq!(
-            get_client_host_port(&executor, &scheduler_url, &None).unwrap(),
-            (executor.host.clone(), executor.port as u16)
+            get_client_host_port(&executor.host, executor.port, &scheduler_url, &None)
+                .unwrap(),
+            (executor.host.clone(), executor.port)
         );
 
         // same, no flight proxy
         assert_eq!(
             get_client_host_port(
-                &executor,
+                &executor.host,
+                executor.port,
                 &scheduler_url,
                 &Some(FlightProxy::Local(false))
             )
             .unwrap(),
-            (executor.host.clone(), executor.port as u16)
+            (executor.host.clone(), executor.port)
         );
 
         // embedded flight proxy on scheduler
         assert_eq!(
             get_client_host_port(
-                &executor,
+                &executor.host,
+                executor.port,
                 &scheduler_url,
                 &Some(FlightProxy::Local(true))
             )
@@ -915,7 +925,8 @@ mod test {
         // external proxy
         assert_eq!(
             get_client_host_port(
-                &executor,
+                &executor.host,
+                executor.port,
                 &scheduler_url,
                 &Some(FlightProxy::External("proxy:1234".to_string()))
             )

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -50,6 +50,7 @@ use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
 use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
 use log::{debug, error, info};
 use parking_lot::Mutex;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -526,11 +527,13 @@ async fn execute_query_pull(
                 started_at,
                 ended_at,
                 partition_location,
+                executor_map,
                 ..
             })) => {
                 // Calculate job execution time (server-side execution)
                 let job_execution_ms = ended_at.saturating_sub(started_at);
                 let duration = Duration::from_millis(job_execution_ms);
+                let executor_map = Arc::new(executor_map);
 
                 info!("Job {job_id} finished executing in {duration:?} ");
 
@@ -562,6 +565,7 @@ async fn execute_query_pull(
                 let streams = partition_location.into_iter().map(move |partition| {
                     let f = fetch_partition(
                         partition,
+                        executor_map.clone(),
                         max_message_size,
                         true,
                         scheduler_url.clone(),
@@ -692,11 +696,13 @@ async fn execute_query_push(
                 started_at,
                 ended_at,
                 partition_location,
+                executor_map,
                 ..
             })) => {
                 // Calculate job execution time (server-side execution)
                 let job_execution_ms = ended_at.saturating_sub(started_at);
                 let duration = Duration::from_millis(job_execution_ms);
+                let executor_map = Arc::new(executor_map);
 
                 info!("Job {job_id} finished executing in {duration:?} ");
 
@@ -728,6 +734,7 @@ async fn execute_query_push(
                 let streams = partition_location.into_iter().map(move |partition| {
                     let f = fetch_partition(
                         partition,
+                        executor_map.clone(),
                         max_message_size,
                         true,
                         scheduler_url.clone(),
@@ -795,6 +802,7 @@ fn get_client_host_port(
 #[allow(clippy::too_many_arguments)]
 async fn fetch_partition(
     location: PartitionLocation,
+    executor_map: Arc<HashMap<String, ExecutorMetadata>>,
     max_message_size: usize,
     flight_transport: bool,
     scheduler_url: String,
@@ -804,8 +812,11 @@ async fn fetch_partition(
     io_retries_times: u8,
     io_retry_wait_time_ms: u64,
 ) -> Result<SendableRecordBatchStream> {
-    let metadata = location.executor_meta.ok_or_else(|| {
-        DataFusionError::Internal("Received empty executor metadata".to_owned())
+    let metadata = executor_map.get(&location.executor_id).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "Executor {} not found in map",
+            location.executor_id
+        ))
     })?;
 
     let partition_id = location.partition_id.ok_or_else(|| {
@@ -815,7 +826,7 @@ async fn fetch_partition(
     let port = metadata.port as u16;
 
     let (client_host, client_port) =
-        get_client_host_port(&metadata, &scheduler_url, &flight_proxy)?;
+        get_client_host_port(metadata, &scheduler_url, &flight_proxy)?;
 
     let mut ballista_client = BallistaClient::try_new(
         client_host.as_str(),

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -1322,7 +1322,7 @@ mod tests {
                     },
                     executor_meta: Arc::new(ExecutorMetadata {
                         id: "executor_1".to_string(),
-                        host: "executor_1".to_string(),
+                        host: "localhost".to_string(),
                         port: 7070,
                         grpc_port: 8080,
                         specification: ExecutorSpecification::default()
@@ -1441,7 +1441,7 @@ mod tests {
                 },
                 executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
+                    host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
@@ -1492,7 +1492,7 @@ mod tests {
                 },
                 executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
+                    host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
@@ -1544,7 +1544,7 @@ mod tests {
                 },
                 executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
+                    host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
@@ -1596,7 +1596,7 @@ mod tests {
                 },
                 executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
+                    host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
@@ -1966,7 +1966,7 @@ mod tests {
                 },
                 executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
+                    host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
@@ -2202,7 +2202,7 @@ mod tests {
                 },
                 executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
+                    host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -851,7 +851,7 @@ fn send_fetch_partitions(
         let read_metrics = read_metrics.clone();
 
         spawned_tasks.push(SpawnedTask::spawn(async move {
-            let addr = p.executor_meta.id.clone();
+            let addr = p.executor_id.clone();
             let size = block_size(&p, default_block_size);
 
             // Time spent blocked acquiring the three governor permits (#1951).
@@ -980,6 +980,7 @@ async fn fetch_partition_buffered(
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
     client_pool: Option<Arc<dyn BallistaClientPool>>,
 ) -> result::Result<(SchemaRef, Vec<RecordBatch>), BallistaError> {
+    let executor_id = &location.executor_id;
     let stream = fetch_partition_remote(
         location,
         config,
@@ -989,11 +990,10 @@ async fn fetch_partition_buffered(
     )
     .await?;
     let schema = stream.schema();
-    let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
     let batches = stream.try_collect::<Vec<_>>().await.map_err(|e| {
         BallistaError::FetchFailed(
-            metadata.id.clone(),
+            executor_id.to_string(),
             partition_id.stage_id,
             partition_id.partition_id,
             e.to_string(),
@@ -1654,14 +1654,12 @@ mod tests {
                 stage_id: input_stage_id,
                 partition_id: 0,
             },
-            executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
-                    host: "executor_1".to_string(),
-                    port: 7070,
-                    grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
-                }),
+            executor_id: String::from("id"),
+            executor_connection: Arc::new(ExecutorConnection {
+                host: "localhost".to_string(),
+                port: 50050,
+                grpc_port: 50052,
+            }),
             partition_stats: Default::default(),
             file_id: None,
             is_sort_shuffle: false,

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -1320,7 +1320,7 @@ mod tests {
                         stage_id,
                         partition_id: i,
                     },
-                    executor_meta: ExecutorMetadata {
+                    executor_meta: Arc::new(ExecutorMetadata {
                         id: "executor_1".to_string(),
                         host: "executor_1".to_string(),
                         port: 7070,
@@ -1328,7 +1328,7 @@ mod tests {
                         specification: ExecutorSpecification::default()
                             .with_task_slots(1),
                         os_info: ExecutorOperatingSystemSpecification::default(),
-                    },
+                    }),
                     partition_stats: PartitionStats {
                         num_rows: Some(rows),
                         num_batches: None,
@@ -1439,14 +1439,14 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: ExecutorMetadata {
+                executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: PartitionStats {
                     num_rows: Some(1),
                     num_batches: None,
@@ -1490,14 +1490,14 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: ExecutorMetadata {
+                executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: PartitionStats {
                     num_rows: Some(1),
                     num_batches: None,
@@ -1542,14 +1542,14 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: ExecutorMetadata {
+                executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: PartitionStats {
                     num_rows: Some(1),
                     num_batches: None,
@@ -1594,14 +1594,14 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: ExecutorMetadata {
+                executor_meta: Arc::new(ExecutorMetadata {
                     id: "executor_1".to_string(),
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
                     specification: ExecutorSpecification::default().with_task_slots(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: Default::default(),
                 file_id: None,
                 is_sort_shuffle: false,
@@ -1668,14 +1668,14 @@ mod tests {
                 stage_id: input_stage_id,
                 partition_id: 0,
             },
-            executor_meta: ExecutorMetadata {
-                id: "executor_1".to_string(),
-                host: "executor_1".to_string(),
-                port: 7070,
-                grpc_port: 8080,
-                specification: ExecutorSpecification::default().with_task_slots(1),
-                os_info: ExecutorOperatingSystemSpecification::default(),
-            },
+            executor_meta: Arc::new(ExecutorMetadata {
+                    id: "executor_1".to_string(),
+                    host: "executor_1".to_string(),
+                    port: 7070,
+                    grpc_port: 8080,
+                    specification: ExecutorSpecification::default().with_task_slots(1),
+                    os_info: ExecutorOperatingSystemSpecification::default(),
+                }),
             partition_stats: Default::default(),
             file_id: None,
             is_sort_shuffle: false,
@@ -1964,14 +1964,14 @@ mod tests {
                     stage_id: 1,
                     partition_id,
                 },
-                executor_meta: ExecutorMetadata {
-                    id: format!("exec{partition_id}"),
-                    host: "localhost".to_string(),
-                    port: 50051,
-                    grpc_port: 50052,
-                    specification: ExecutorSpecification::default().with_task_slots(12),
+                executor_meta: Arc::new(ExecutorMetadata {
+                    id: "executor_1".to_string(),
+                    host: "executor_1".to_string(),
+                    port: 7070,
+                    grpc_port: 8080,
+                    specification: ExecutorSpecification::default().with_task_slots(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: Default::default(),
                 file_id,
                 is_sort_shuffle: false,
@@ -2200,14 +2200,14 @@ mod tests {
                     stage_id: 7,
                     partition_id,
                 },
-                executor_meta: ExecutorMetadata {
-                    id: format!("exec-{partition_id}"),
-                    host: "localhost".to_string(),
-                    port: 50051,
-                    grpc_port: 50052,
-                    specification: ExecutorSpecification::default(),
+                executor_meta: Arc::new(ExecutorMetadata {
+                    id: "executor_1".to_string(),
+                    host: "executor_1".to_string(),
+                    port: 7070,
+                    grpc_port: 8080,
+                    specification: ExecutorSpecification::default().with_task_slots(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: PartitionStats::new(Some(100), Some(1), Some(1024)),
                 file_id: None,
                 is_sort_shuffle: false,

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -377,7 +377,7 @@ impl ExecutionPlan for ShuffleReaderExec {
         let mut partition_locations = HashMap::new();
         for p in &self.partition[partition] {
             partition_locations
-                .entry(p.executor_meta.id.clone())
+                .entry(p.executor_id.clone())
                 .or_insert_with(Vec::new)
                 .push(p.clone());
         }
@@ -1045,12 +1045,12 @@ async fn fetch_partition_remote(
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
     client_pool: Option<Arc<dyn BallistaClientPool>>,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
-    let metadata = &location.executor_meta;
+    let executor_id = &location.executor_id;
     let partition_id = &location.partition_id;
     let file_id = location.file_id;
     let is_sort_shuffle = location.is_sort_shuffle;
-    let host = metadata.host.as_str();
-    let port = metadata.port;
+    let host = &location.executor_connection.host;
+    let port = location.executor_connection.port;
 
     if let Some(pool) = client_pool {
         let mut pooled = pool
@@ -1058,7 +1058,7 @@ async fn fetch_partition_remote(
             .await
             .map_err(|error| match error {
                 BallistaError::GrpcConnectionError(msg) => BallistaError::FetchFailed(
-                    metadata.id.clone(),
+                    executor_id.to_string(),
                     partition_id.stage_id,
                     partition_id.partition_id,
                     msg,
@@ -1068,7 +1068,7 @@ async fn fetch_partition_remote(
 
         let result = pooled
             .fetch_partition(
-                &metadata.id,
+                executor_id,
                 partition_id,
                 file_id,
                 is_sort_shuffle,
@@ -1088,7 +1088,7 @@ async fn fetch_partition_remote(
                 .map_err(|error| match error {
                     BallistaError::GrpcConnectionError(msg) => {
                         BallistaError::FetchFailed(
-                            metadata.id.clone(),
+                            executor_id.to_string(),
                             partition_id.stage_id,
                             partition_id.partition_id,
                             msg,
@@ -1099,7 +1099,7 @@ async fn fetch_partition_remote(
 
         ballista_client
             .fetch_partition(
-                &metadata.id,
+                executor_id,
                 partition_id,
                 file_id,
                 is_sort_shuffle,
@@ -1115,7 +1115,7 @@ fn fetch_partition_local(
     sort_shuffle_enabled: bool,
 ) -> result::Result<SendableRecordBatchStream, BallistaError> {
     let path = &location.path(work_dir)?;
-    let metadata = &location.executor_meta;
+    let executor_id = &location.executor_id;
     let partition_id = &location.partition_id;
     let data_path = std::path::Path::new(path);
 
@@ -1139,7 +1139,7 @@ fn fetch_partition_local(
         )
         .map_err(|e| {
             BallistaError::FetchFailed(
-                metadata.id.clone(),
+                executor_id.to_string(),
                 partition_id.stage_id,
                 partition_id.partition_id,
                 e.to_string(),
@@ -1151,7 +1151,7 @@ fn fetch_partition_local(
     let reader = fetch_partition_local_inner(path).map_err(|e| {
         // return BallistaError::FetchFailed may let scheduler retry this task.
         BallistaError::FetchFailed(
-            metadata.id.clone(),
+            executor_id.to_string(),
             partition_id.stage_id,
             partition_id.partition_id,
             e.to_string(),
@@ -1278,10 +1278,7 @@ impl RecordBatchStream for CoalescedShuffleReaderStream {
 mod tests {
     use super::*;
     use crate::execution_plans::{ShuffleWriterExec, create_shuffle_path};
-    use crate::serde::scheduler::{
-        ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
-        PartitionId,
-    };
+    use crate::serde::scheduler::{ExecutorConnection, PartitionId};
     use crate::utils;
     use datafusion::arrow::array::{Int32Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -1320,14 +1317,11 @@ mod tests {
                         stage_id,
                         partition_id: i,
                     },
-                    executor_meta: Arc::new(ExecutorMetadata {
-                        id: "executor_1".to_string(),
+                    executor_id: "executor_1".to_string(),
+                    executor_connection: Arc::new(ExecutorConnection {
                         host: "localhost".to_string(),
                         port: 7070,
                         grpc_port: 8080,
-                        specification: ExecutorSpecification::default()
-                            .with_task_slots(1),
-                        os_info: ExecutorOperatingSystemSpecification::default(),
                     }),
                     partition_stats: PartitionStats {
                         num_rows: Some(rows),
@@ -1439,13 +1433,11 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
                     host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
                 }),
                 partition_stats: PartitionStats {
                     num_rows: Some(1),
@@ -1490,13 +1482,11 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
                     host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
                 }),
                 partition_stats: PartitionStats {
                     num_rows: Some(1),
@@ -1542,13 +1532,11 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
                     host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
                 }),
                 partition_stats: PartitionStats {
                     num_rows: Some(1),
@@ -1594,13 +1582,11 @@ mod tests {
                     stage_id: input_stage_id,
                     partition_id,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
                     host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
                 }),
                 partition_stats: Default::default(),
                 file_id: None,
@@ -1964,13 +1950,11 @@ mod tests {
                     stage_id: 1,
                     partition_id,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
                     host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
                 }),
                 partition_stats: Default::default(),
                 file_id,
@@ -2200,13 +2184,11 @@ mod tests {
                     stage_id: 7,
                     partition_id,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "executor_1".to_string(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
                     host: "localhost".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
                 }),
                 partition_stats: PartitionStats::new(Some(100), Some(1), Some(1024)),
                 file_id: None,

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -134,6 +134,11 @@ pub struct ShuffleReaderPartition {
     /// each partition of a shuffle read can read data from multiple locations
     #[prost(message, repeated, tag = "1")]
     pub location: ::prost::alloc::vec::Vec<PartitionLocation>,
+    #[prost(map = "string, message", tag = "2")]
+    pub executor_map: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ExecutorMetadata,
+    >,
 }
 /// CoalescePartitionsRule output: groups upstream partitions into coalesced output partitions.
 /// Empty when no coalesce is applied (the optional field on the parent message is absent).
@@ -405,8 +410,8 @@ pub struct PartitionLocation {
     /// partition_id of the shuffle, a composition of(job_id + map_stage_id + partition_id).
     #[prost(message, optional, tag = "2")]
     pub partition_id: ::core::option::Option<PartitionId>,
-    #[prost(message, optional, tag = "3")]
-    pub executor_meta: ::core::option::Option<ExecutorMetadata>,
+    #[prost(string, tag = "3")]
+    pub executor_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "4")]
     pub partition_stats: ::core::option::Option<PartitionStats>,
     #[prost(uint64, optional, tag = "6")]
@@ -1096,11 +1101,16 @@ pub struct GetJobMetricsResult {
 pub struct SuccessfulJob {
     #[prost(message, repeated, tag = "1")]
     pub partition_location: ::prost::alloc::vec::Vec<PartitionLocation>,
-    #[prost(uint64, tag = "2")]
-    pub queued_at: u64,
+    #[prost(map = "string, message", tag = "2")]
+    pub executor_map: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ExecutorMetadata,
+    >,
     #[prost(uint64, tag = "3")]
-    pub started_at: u64,
+    pub queued_at: u64,
     #[prost(uint64, tag = "4")]
+    pub started_at: u64,
+    #[prost(uint64, tag = "5")]
     pub ended_at: u64,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -133,12 +133,7 @@ pub struct ShuffleReaderExecNode {
 pub struct ShuffleReaderPartition {
     /// each partition of a shuffle read can read data from multiple locations
     #[prost(message, repeated, tag = "1")]
-    pub location: ::prost::alloc::vec::Vec<PartitionLocation>,
-    #[prost(map = "string, message", tag = "2")]
-    pub executor_map: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ExecutorMetadata,
-    >,
+    pub locations: ::prost::alloc::vec::Vec<PartitionLocationExt>,
 }
 /// CoalescePartitionsRule output: groups upstream partitions into coalesced output partitions.
 /// Empty when no coalesce is applied (the optional field on the parent message is absent).
@@ -419,6 +414,17 @@ pub struct PartitionLocation {
     #[prost(bool, tag = "7")]
     pub is_sort_shuffle: bool,
 }
+/// Holding both partition info and executor metadata for connection
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PartitionLocationExt {
+    #[prost(message, repeated, tag = "1")]
+    pub location: ::prost::alloc::vec::Vec<PartitionLocation>,
+    #[prost(map = "string, message", tag = "2")]
+    pub executor_map: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ExecutorConnection,
+    >,
+}
 /// Unique identifier for a materialized partition of data
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PartitionId {
@@ -547,6 +553,15 @@ pub mod operator_metric {
         #[prost(uint64, tag = "15")]
         OutputBatches(u64),
     }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ExecutorConnection {
+    #[prost(string, tag = "2")]
+    pub host: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "3")]
+    pub port: u32,
+    #[prost(uint32, tag = "4")]
+    pub grpc_port: u32,
 }
 /// Used by scheduler
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1099,18 +1114,13 @@ pub struct GetJobMetricsResult {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessfulJob {
-    #[prost(message, repeated, tag = "1")]
-    pub partition_location: ::prost::alloc::vec::Vec<PartitionLocation>,
-    #[prost(map = "string, message", tag = "2")]
-    pub executor_map: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ExecutorMetadata,
-    >,
-    #[prost(uint64, tag = "3")]
+    #[prost(message, optional, tag = "1")]
+    pub locations: ::core::option::Option<PartitionLocationExt>,
+    #[prost(uint64, tag = "2")]
     pub queued_at: u64,
-    #[prost(uint64, tag = "4")]
+    #[prost(uint64, tag = "3")]
     pub started_at: u64,
-    #[prost(uint64, tag = "5")]
+    #[prost(uint64, tag = "4")]
     pub ended_at: u64,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -19,6 +19,7 @@
 //! as convenience code for interacting with the generated code.
 
 use crate::extension::BallistaCacheNode;
+use crate::serde::scheduler::ExecutorMetadata as SchedulerExecutorMetadata;
 use crate::{error::BallistaError, serde::scheduler::Action as BallistaAction};
 
 use arrow_flight::sql::ProstMessageExt;
@@ -47,6 +48,7 @@ use datafusion_proto::{
 };
 
 use prost::Message;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -446,16 +448,62 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     .partition
                     .iter()
                     .map(|p| {
+                        // Build Arc map once
+                        let executor_map: HashMap<
+                            String,
+                            Arc<SchedulerExecutorMetadata>,
+                        > = p
+                            .executor_map
+                            .iter()
+                            .map(|(id, meta)| {
+                                let converted: SchedulerExecutorMetadata =
+                                    meta.clone().into();
+                                (id.clone(), Arc::new(converted))
+                            })
+                            .collect();
+
                         p.location
                             .iter()
                             .map(|l| {
-                                l.clone().try_into().map_err(|e| {
-                                    DataFusionError::Internal(format!(
-                                        "Fail to get partition location due to {e:?}"
-                                    ))
+                                let executor_meta = executor_map
+                                    .get(&l.executor_id)
+                                    .ok_or_else(|| {
+                                        DataFusionError::Internal(format!(
+                                            "executor {} not in map",
+                                            l.executor_id
+                                        ))
+                                    })?
+                                    // cheap Arc clone
+                                    .clone();
+
+                                Ok(PartitionLocation {
+                                    map_partition_id: l.map_partition_id as usize,
+                                    partition_id: l
+                                        .partition_id
+                                        .as_ref()
+                                        .ok_or_else(|| {
+                                            DataFusionError::Internal(
+                                                "missing partition_id".to_string(),
+                                            )
+                                        })?
+                                        .clone()
+                                        .into(),
+                                    executor_meta,
+                                    partition_stats: l
+                                        .partition_stats
+                                        .as_ref()
+                                        .ok_or_else(|| {
+                                            DataFusionError::Internal(
+                                                "missing partition_stats".to_string(),
+                                            )
+                                        })?
+                                        .clone()
+                                        .into(),
+                                    file_id: l.file_id,
+                                    is_sort_shuffle: l.is_sort_shuffle,
                                 })
                             })
-                            .collect::<Result<Vec<_>, _>>()
+                            .collect()
                     })
                     .collect::<Result<Vec<_>, DataFusionError>>()?;
                 let partitioning = parse_protobuf_partitioning(
@@ -641,6 +689,16 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             let stage_id = exec.stage_id as u32;
             let mut partition = vec![];
             for location in &exec.partition {
+                let mut executor_map: HashMap<String, protobuf::ExecutorMetadata> =
+                    HashMap::new();
+
+                // Build dedup map as a side effect, reuse existing try_into() for locations
+                for l in location {
+                    executor_map
+                        .entry(l.executor_meta.id.clone())
+                        .or_insert_with(|| l.executor_meta.as_ref().clone().into());
+                }
+
                 partition.push(protobuf::ShuffleReaderPartition {
                     location: location
                         .iter()
@@ -652,6 +710,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                             })
                         })
                         .collect::<Result<Vec<_>, _>>()?,
+                    executor_map,
                 });
             }
             let converter = DefaultPhysicalProtoConverter {};

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -19,7 +19,6 @@
 //! as convenience code for interacting with the generated code.
 
 use crate::extension::BallistaCacheNode;
-use crate::serde::scheduler::ExecutorMetadata as SchedulerExecutorMetadata;
 use crate::{error::BallistaError, serde::scheduler::Action as BallistaAction};
 
 use arrow_flight::sql::ProstMessageExt;
@@ -63,7 +62,7 @@ use crate::serde::protobuf::{
     ballista_logical_plan_node::LogicalPlanType,
     ballista_physical_plan_node::PhysicalPlanType,
 };
-use crate::serde::scheduler::PartitionLocation;
+use crate::serde::scheduler::{ExecutorConnection, PartitionLocation};
 pub use generated::ballista as protobuf;
 
 /// Generated protobuf code from Ballista protocol definitions.
@@ -448,62 +447,65 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     .partition
                     .iter()
                     .map(|p| {
-                        // Build Arc map once
-                        let executor_map: HashMap<
-                            String,
-                            Arc<SchedulerExecutorMetadata>,
-                        > = p
-                            .executor_map
-                            .iter()
-                            .map(|(id, meta)| {
-                                let converted: SchedulerExecutorMetadata =
-                                    meta.clone().into();
-                                (id.clone(), Arc::new(converted))
-                            })
-                            .collect();
+                        let mut all_locations = vec![];
+                        for ext in &p.locations {
+                            let executor_map: HashMap<String, Arc<ExecutorConnection>> =
+                                ext.executor_map
+                                    .iter()
+                                    .map(|(id, conn)| {
+                                        let converted: ExecutorConnection =
+                                            conn.clone().into();
+                                        (id.clone(), Arc::new(converted))
+                                    })
+                                    .collect();
 
-                        p.location
-                            .iter()
-                            .map(|l| {
-                                let executor_meta = executor_map
-                                    .get(&l.executor_id)
-                                    .ok_or_else(|| {
-                                        DataFusionError::Internal(format!(
-                                            "executor {} not in map",
-                                            l.executor_id
-                                        ))
-                                    })?
-                                    // cheap Arc clone
-                                    .clone();
+                            let locs = ext
+                                .location
+                                .iter()
+                                .map(|l| {
+                                    let executor_connection = executor_map
+                                        .get(&l.executor_id)
+                                        .ok_or_else(|| {
+                                            DataFusionError::Internal(format!(
+                                                "executor {} not in map",
+                                                l.executor_id
+                                            ))
+                                        })?
+                                        .clone();
 
-                                Ok(PartitionLocation {
-                                    map_partition_id: l.map_partition_id as usize,
-                                    partition_id: l
-                                        .partition_id
-                                        .as_ref()
-                                        .ok_or_else(|| {
-                                            DataFusionError::Internal(
-                                                "missing partition_id".to_string(),
-                                            )
-                                        })?
-                                        .clone()
-                                        .into(),
-                                    executor_meta,
-                                    partition_stats: l
-                                        .partition_stats
-                                        .as_ref()
-                                        .ok_or_else(|| {
-                                            DataFusionError::Internal(
-                                                "missing partition_stats".to_string(),
-                                            )
-                                        })?
-                                        .clone()
-                                        .into(),
-                                    file_id: l.file_id,
-                                    is_sort_shuffle: l.is_sort_shuffle,
+                                    Ok(PartitionLocation {
+                                        map_partition_id: l.map_partition_id as usize,
+                                        partition_id: l
+                                            .partition_id
+                                            .as_ref()
+                                            .ok_or_else(|| {
+                                                DataFusionError::Internal(
+                                                    "missing partition_id".to_string(),
+                                                )
+                                            })?
+                                            .clone()
+                                            .into(),
+                                        executor_id: l.executor_id.clone(),
+                                        executor_connection,
+                                        partition_stats: l
+                                            .partition_stats
+                                            .as_ref()
+                                            .ok_or_else(|| {
+                                                DataFusionError::Internal(
+                                                    "missing partition_stats".to_string(),
+                                                )
+                                            })?
+                                            .clone()
+                                            .into(),
+                                        file_id: l.file_id,
+                                        is_sort_shuffle: l.is_sort_shuffle,
+                                    })
                                 })
-                            })
-                            .collect()
+                                .collect::<Result<Vec<_>, DataFusionError>>()?;
+
+                            all_locations.extend(locs);
+                        }
+                        Ok(all_locations)
                     })
                     .collect::<Result<Vec<_>, DataFusionError>>()?;
                 let partitioning = parse_protobuf_partitioning(
@@ -688,29 +690,35 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
         } else if let Some(exec) = node.downcast_ref::<ShuffleReaderExec>() {
             let stage_id = exec.stage_id as u32;
             let mut partition = vec![];
-            for location in &exec.partition {
-                let mut executor_map: HashMap<String, protobuf::ExecutorMetadata> =
+            for location_group in &exec.partition {
+                let mut executor_map: HashMap<String, protobuf::ExecutorConnection> =
                     HashMap::new();
 
-                // Build dedup map as a side effect, reuse existing try_into() for locations
-                for l in location {
-                    executor_map
-                        .entry(l.executor_meta.id.clone())
-                        .or_insert_with(|| l.executor_meta.as_ref().clone().into());
-                }
+                let locations = location_group
+                    .iter()
+                    .map(|l| {
+                        // Build dedup map as side effect
+                        executor_map
+                            .entry(l.executor_id.clone())
+                            .or_insert_with(|| protobuf::ExecutorConnection {
+                                host: l.executor_connection.host.clone(),
+                                port: l.executor_connection.port as u32,
+                                grpc_port: l.executor_connection.grpc_port as u32,
+                            });
+
+                        l.clone().try_into().map_err(|e| {
+                            DataFusionError::Internal(format!(
+                                "Fail to get partition location due to {e:?}"
+                            ))
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 partition.push(protobuf::ShuffleReaderPartition {
-                    location: location
-                        .iter()
-                        .map(|l| {
-                            l.clone().try_into().map_err(|e| {
-                                DataFusionError::Internal(format!(
-                                    "Fail to get partition location due to {e:?}"
-                                ))
-                            })
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                    executor_map,
+                    locations: vec![protobuf::PartitionLocationExt {
+                        location: locations,
+                        executor_map,
+                    }],
                 });
             }
             let converter = DefaultPhysicalProtoConverter {};

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -37,7 +37,8 @@ use crate::extension::SessionConfigHelperExt;
 use crate::serde::protobuf::{NamedPruningMetrics, NamedRatio};
 use crate::serde::scheduler::{
     Action, BallistaFunctionRegistry, ExecutorData, ExecutorMetadata,
-    ExecutorOperatingSystemSpecification, ExecutorSpecification, PartitionId, PartitionStats, TaskDefinition,
+    ExecutorOperatingSystemSpecification, ExecutorSpecification, PartitionId,
+    PartitionStats, TaskDefinition,
 };
 
 use crate::serde::{BallistaCodec, protobuf};

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -228,8 +228,8 @@ impl Into<ExecutorMetadata> for protobuf::ExecutorMetadata {
             host: self.host,
             port: self.port as u16,
             grpc_port: self.grpc_port as u16,
-            specification: self.specification.unwrap().into(),
-            os_info: self.os_info.unwrap().into(),
+            specification: self.specification.map(|s| s.into()).unwrap_or_default(),
+            os_info: self.os_info.map(|o| o.into()).unwrap_or_default(),
         }
     }
 }

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -36,7 +36,7 @@ use crate::error::BallistaError;
 use crate::extension::SessionConfigHelperExt;
 use crate::serde::protobuf::{NamedPruningMetrics, NamedRatio};
 use crate::serde::scheduler::{
-    Action, BallistaFunctionRegistry, ExecutorData, ExecutorMetadata,
+    Action, BallistaFunctionRegistry, ExecutorConnection, ExecutorData, ExecutorMetadata,
     ExecutorOperatingSystemSpecification, ExecutorSpecification, PartitionId,
     PartitionStats, TaskDefinition,
 };
@@ -231,6 +231,17 @@ impl Into<ExecutorMetadata> for protobuf::ExecutorMetadata {
             grpc_port: self.grpc_port as u16,
             specification: self.specification.map(|s| s.into()).unwrap_or_default(),
             os_info: self.os_info.map(|o| o.into()).unwrap_or_default(),
+        }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<ExecutorConnection> for protobuf::ExecutorConnection {
+    fn into(self) -> ExecutorConnection {
+        ExecutorConnection {
+            host: self.host,
+            port: self.port as u16,
+            grpc_port: self.grpc_port as u16,
         }
     }
 }

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -37,8 +37,7 @@ use crate::extension::SessionConfigHelperExt;
 use crate::serde::protobuf::{NamedPruningMetrics, NamedRatio};
 use crate::serde::scheduler::{
     Action, BallistaFunctionRegistry, ExecutorData, ExecutorMetadata,
-    ExecutorOperatingSystemSpecification, ExecutorSpecification, PartitionId,
-    PartitionLocation, PartitionStats, TaskDefinition,
+    ExecutorOperatingSystemSpecification, ExecutorSpecification, PartitionId, PartitionStats, TaskDefinition,
 };
 
 use crate::serde::{BallistaCodec, protobuf};
@@ -92,42 +91,6 @@ impl Into<PartitionStats> for protobuf::PartitionStats {
 
 fn foo(n: i64) -> Option<u64> {
     if n < 0 { None } else { Some(n as u64) }
-}
-
-impl TryInto<PartitionLocation> for protobuf::PartitionLocation {
-    type Error = BallistaError;
-
-    fn try_into(self) -> Result<PartitionLocation, Self::Error> {
-        Ok(PartitionLocation {
-            map_partition_id: self.map_partition_id as usize,
-            partition_id: self
-                .partition_id
-                .ok_or_else(|| {
-                    BallistaError::General(
-                        "partition_id in PartitionLocation is missing.".to_owned(),
-                    )
-                })?
-                .into(),
-            executor_meta: self
-                .executor_meta
-                .ok_or_else(|| {
-                    BallistaError::General(
-                        "executor_meta in PartitionLocation is missing".to_owned(),
-                    )
-                })?
-                .into(),
-            partition_stats: self
-                .partition_stats
-                .ok_or_else(|| {
-                    BallistaError::General(
-                        "partition_stats in PartitionLocation is missing".to_owned(),
-                    )
-                })?
-                .into(),
-            file_id: self.file_id,
-            is_sort_shuffle: self.is_sort_shuffle,
-        })
-    }
 }
 
 impl TryInto<MetricValue> for protobuf::OperatorMetric {

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -88,7 +88,7 @@ pub struct PartitionLocation {
     /// The partition identifier.
     pub partition_id: PartitionId,
     /// Metadata about the executor hosting this partition.
-    pub executor_meta: ExecutorMetadata,
+    pub executor_meta: Arc<ExecutorMetadata>,
     /// Statistics about the partition data.
     pub partition_stats: PartitionStats,
     /// shuffle file id

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -87,14 +87,27 @@ pub struct PartitionLocation {
     pub map_partition_id: usize,
     /// The partition identifier.
     pub partition_id: PartitionId,
+    /// ID of current executor
+    pub executor_id: String,
     /// Metadata about the executor hosting this partition.
-    pub executor_meta: Arc<ExecutorMetadata>,
+    pub executor_connection: Arc<ExecutorConnection>,
     /// Statistics about the partition data.
     pub partition_stats: PartitionStats,
     /// shuffle file id
     pub file_id: Option<u64>,
     /// whether this partition uses sort shuffle
     pub is_sort_shuffle: bool,
+}
+
+/// Connection information about the executor.
+#[derive(Debug, Clone)]
+pub struct ExecutorConnection {
+    /// Host of the executor.
+    pub host: String,
+    /// Port of the executor.
+    pub port: u16,
+    /// gRPC port of the executor.
+    pub grpc_port: u16,
 }
 
 impl PartitionLocation {

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -78,7 +78,7 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
         Ok(protobuf::PartitionLocation {
             map_partition_id: self.map_partition_id as u32,
             partition_id: Some(self.partition_id.into()),
-            executor_id: self.executor_meta.clone().id.clone(),
+            executor_id: self.executor_meta.id.clone(),
             partition_stats: Some(self.partition_stats.into()),
             file_id: self.file_id,
             is_sort_shuffle: self.is_sort_shuffle,

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -78,7 +78,7 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
         Ok(protobuf::PartitionLocation {
             map_partition_id: self.map_partition_id as u32,
             partition_id: Some(self.partition_id.into()),
-            executor_meta: Some(self.executor_meta.into()),
+            executor_id: self.executor_meta.clone().id.clone(),
             partition_stats: Some(self.partition_stats.into()),
             file_id: self.file_id,
             is_sort_shuffle: self.is_sort_shuffle,

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -25,8 +25,9 @@ use crate::serde::protobuf::{self, NamedPruningMetrics, NamedRatio};
 use datafusion_proto::protobuf as datafusion_protobuf;
 
 use crate::serde::scheduler::{
-    Action, ExecutorData, ExecutorMetadata, ExecutorOperatingSystemSpecification,
-    ExecutorSpecification, PartitionId, PartitionLocation, PartitionStats,
+    Action, ExecutorConnection, ExecutorData, ExecutorMetadata,
+    ExecutorOperatingSystemSpecification, ExecutorSpecification, PartitionId,
+    PartitionLocation, PartitionStats,
 };
 use datafusion::physical_plan::Partitioning;
 use protobuf::{NamedCount, NamedGauge, NamedTime, action::ActionType, operator_metric};
@@ -78,11 +79,22 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
         Ok(protobuf::PartitionLocation {
             map_partition_id: self.map_partition_id as u32,
             partition_id: Some(self.partition_id.into()),
-            executor_id: self.executor_meta.id.clone(),
+            executor_id: self.executor_id,
             partition_stats: Some(self.partition_stats.into()),
             file_id: self.file_id,
             is_sort_shuffle: self.is_sort_shuffle,
         })
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<protobuf::ExecutorConnection> for ExecutorConnection {
+    fn into(self) -> protobuf::ExecutorConnection {
+        protobuf::ExecutorConnection {
+            host: self.host,
+            port: self.port as u32,
+            grpc_port: self.grpc_port as u32,
+        }
     }
 }
 

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -35,6 +35,7 @@ use ballista_core::serde::scheduler::{
 use ballista_core::utils::get_current_time;
 use ballista_core::{BALLISTA_VERSION, JobId};
 use datafusion::DATAFUSION_VERSION;
+use datafusion::error::DataFusionError;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::{MetricsSet, Time};
@@ -767,13 +768,22 @@ fn format_job_status(status: &Option<Status>, elapsed_ms: u64) -> (String, Strin
             ("Failed".to_string(), format!("Failed: {}", error.error))
         }
         Some(Status::Successful(completed)) => {
-            let num_rows = completed
-                .partition_location
+            let locations = completed
+                .locations
+                .as_ref()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "SuccessfulJob missing locations".to_string(),
+                    )
+                })
+                .unwrap();
+            let num_rows = locations
+                .location
                 .iter()
                 .map(|p| p.partition_stats.as_ref().map(|s| s.num_rows).unwrap_or(0))
                 .sum::<i64>();
             let num_rows_term = if num_rows == 1 { "row" } else { "rows" };
-            let num_partitions = completed.partition_location.len();
+            let num_partitions = locations.location.len();
             let num_partitions_term = if num_partitions == 1 {
                 "partition"
             } else {

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -727,6 +727,7 @@ mod test {
     use ballista_core::error::BallistaError;
     use ballista_core::execution_plans::{SortShuffleWriterExec, UnresolvedShuffleExec};
     use ballista_core::serde::BallistaCodec;
+    use ballista_core::serde::scheduler::ExecutorConnection;
     use datafusion::arrow::compute::SortOptions;
 
     use datafusion::execution::TaskContext;
@@ -1512,8 +1513,7 @@ order by
     {
         use ballista_core::execution_plans::ShuffleReaderExec;
         use ballista_core::serde::scheduler::{
-            ExecutorMetadata, ExecutorOperatingSystemSpecification,
-            ExecutorSpecification, PartitionId, PartitionLocation, PartitionStats,
+            PartitionId, PartitionLocation, PartitionStats,
         };
         use datafusion::arrow::datatypes::{DataType, Field, Schema};
 
@@ -1529,13 +1529,11 @@ order by
                 stage_id: 42,
                 partition_id,
             },
-            executor_meta: Arc::new(ExecutorMetadata {
-                id: format!("exec-{partition_id}"),
+            executor_id: "executor_1".to_string(),
+            executor_connection: Arc::new(ExecutorConnection {
                 host: "localhost".to_string(),
-                port: 50050,
-                grpc_port: 50051,
-                specification: ExecutorSpecification::default().with_task_slots(1),
-                os_info: ExecutorOperatingSystemSpecification::default(),
+                port: 7070,
+                grpc_port: 8080,
             }),
             partition_stats: PartitionStats::new(Some(10), None, Some(1)),
             file_id: None,

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -1529,14 +1529,14 @@ order by
                 stage_id: 42,
                 partition_id,
             },
-            executor_meta: ExecutorMetadata {
+            executor_meta: Arc::new(ExecutorMetadata {
                 id: format!("exec-{partition_id}"),
                 host: "localhost".to_string(),
                 port: 50050,
                 grpc_port: 50051,
                 specification: ExecutorSpecification::default().with_task_slots(1),
                 os_info: ExecutorOperatingSystemSpecification::default(),
-            },
+            }),
             partition_stats: PartitionStats::new(Some(10), None, Some(1)),
             file_id: None,
             is_sort_shuffle: false,

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -584,7 +584,10 @@ mod test {
         assert_eq!(final_graph.output_locations().len(), 4);
 
         for output_location in final_graph.output_locations() {
-            assert_eq!(output_location.executor_meta.host, "localhost1".to_owned())
+            assert_eq!(
+                output_location.executor_connection.host,
+                "localhost1".to_owned()
+            )
         }
 
         Ok(())
@@ -664,11 +667,8 @@ mod test {
         let (status, job_id) = test.run("", &plan).await.expect("running plan");
 
         match status.status {
-            Some(job_status::Status::Successful(SuccessfulJob {
-                partition_location,
-                ..
-            })) => {
-                assert_eq!(partition_location.len(), 4);
+            Some(job_status::Status::Successful(SuccessfulJob { locations, .. })) => {
+                assert_eq!(locations.unwrap().location.len(), 4);
             }
             other => {
                 panic!("Expected success status but found {other:?}");
@@ -706,11 +706,8 @@ mod test {
             .expect("running plan");
 
         match status.status {
-            Some(job_status::Status::Successful(SuccessfulJob {
-                partition_location,
-                ..
-            })) => {
-                assert_eq!(partition_location.len(), 4);
+            Some(job_status::Status::Successful(SuccessfulJob { locations, .. })) => {
+                assert_eq!(locations.unwrap().location.len(), 4);
             }
             other => {
                 panic!("Expected success status but found {other:?}");

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -31,8 +31,8 @@ use ballista_core::execution_plans::ShuffleWriter;
 use ballista_core::serde::protobuf::failed_task::FailedReason;
 use ballista_core::serde::protobuf::job_status::Status;
 use ballista_core::serde::protobuf::{
-    FailedJob, FailedTask, JobStatus, ResultLost, RunningJob, SuccessfulJob, TaskStatus,
-    job_status, task_status,
+    self, FailedJob, FailedTask, JobStatus, ResultLost, RunningJob, SuccessfulJob,
+    TaskStatus, job_status, task_status,
 };
 use ballista_core::serde::scheduler::{ExecutorMetadata, PartitionLocation};
 use datafusion::execution::context::SessionContext;
@@ -1197,8 +1197,18 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
             )));
         }
 
-        let partition_location = self
-            .output_locations()
+        let output_locations = self.output_locations();
+
+        let executor_map = output_locations
+            .iter()
+            .map(|l| {
+                let proto_meta: protobuf::ExecutorMetadata =
+                    (*l.executor_meta).clone().into();
+                (l.executor_meta.id.clone(), proto_meta)
+            })
+            .collect::<HashMap<String, protobuf::ExecutorMetadata>>();
+
+        let partition_location = output_locations
             .into_iter()
             .map(|l| l.try_into())
             .collect::<ballista_core::error::Result<Vec<_>>>()?;
@@ -1210,6 +1220,7 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
             job_name: self.job_name.clone(),
             status: Some(job_status::Status::Successful(SuccessfulJob {
                 partition_location,
+                executor_map,
 
                 queued_at: self.queued_at,
                 started_at: self.start_time,

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -414,7 +414,7 @@ impl AdaptiveExecutionGraph {
                     stage_output.partition_locations.iter_mut().for_each(
                         |(_partition, locs)| {
                             let before_len = locs.len();
-                            locs.retain(|loc| loc.executor_meta.id != executor_id);
+                            locs.retain(|loc| loc.executor_id != executor_id);
                             if locs.len() < before_len {
                                 match_found = true;
                             }
@@ -1199,29 +1199,31 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
 
         let output_locations = self.output_locations();
 
-        let executor_map = output_locations
+        let executor_conn_map = output_locations
             .iter()
             .map(|l| {
-                let proto_meta: protobuf::ExecutorMetadata =
-                    (*l.executor_meta).clone().into();
-                (l.executor_meta.id.clone(), proto_meta)
+                let proto_meta: protobuf::ExecutorConnection =
+                    (*l.executor_connection).clone().into();
+                (l.executor_id.clone(), proto_meta)
             })
-            .collect::<HashMap<String, protobuf::ExecutorMetadata>>();
+            .collect::<HashMap<String, protobuf::ExecutorConnection>>();
 
         let partition_location = output_locations
             .into_iter()
             .map(|l| l.try_into())
             .collect::<ballista_core::error::Result<Vec<_>>>()?;
-
         self.end_time = timestamp_millis();
+        // Constructing extended version of PartitionLocations
+        let locations = protobuf::PartitionLocationExt {
+            location: partition_location,
+            executor_map: executor_conn_map,
+        };
 
         self.status = JobStatus {
             job_id: self.job_id.clone().into(),
             job_name: self.job_name.clone(),
             status: Some(job_status::Status::Successful(SuccessfulJob {
-                partition_location,
-                executor_map,
-
+                locations: Some(locations),
                 queued_at: self.queued_at,
                 started_at: self.start_time,
                 ended_at: self.end_time,

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -21,8 +21,7 @@ use crate::state::aqe::test::{
     mock_batch, mock_context, mock_partitions_with_statistics_no_data,
 };
 use ballista_core::serde::scheduler::{
-    ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
-    PartitionId, PartitionLocation, PartitionStats,
+    ExecutorConnection, PartitionId, PartitionLocation, PartitionStats,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::stats::Precision;
@@ -515,13 +514,11 @@ fn small_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: Arc::new(ExecutorMetadata {
-            id: "executor_1".to_string(),
-            host: "executor_1".to_string(),
+        executor_id: "executor_1".to_string(),
+        executor_connection: Arc::new(ExecutorConnection {
+            host: "localhost".to_string(),
             port: 7070,
             grpc_port: 8080,
-            specification: ExecutorSpecification::default().with_task_slots(1),
-            os_info: ExecutorOperatingSystemSpecification::default(),
         }),
         // next few properties are needed
         partition_stats: PartitionStats::new(
@@ -547,13 +544,11 @@ fn big_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: Arc::new(ExecutorMetadata {
-            id: "executor_1".to_string(),
-            host: "executor_1".to_string(),
+        executor_id: "executor_1".to_string(),
+        executor_connection: Arc::new(ExecutorConnection {
+            host: "localhost".to_string(),
             port: 7070,
             grpc_port: 8080,
-            specification: ExecutorSpecification::default().with_task_slots(1),
-            os_info: ExecutorOperatingSystemSpecification::default(),
         }),
         // next few properties are needed
         partition_stats: PartitionStats::new(

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -515,14 +515,14 @@ fn small_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: ExecutorMetadata {
-            id: "".to_string(),
-            host: "".to_string(),
-            port: 0,
-            grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
+        executor_meta: Arc::new(ExecutorMetadata {
+            id: "executor_1".to_string(),
+            host: "executor_1".to_string(),
+            port: 7070,
+            grpc_port: 8080,
+            specification: ExecutorSpecification::default().with_task_slots(1),
             os_info: ExecutorOperatingSystemSpecification::default(),
-        },
+        }),
         // next few properties are needed
         partition_stats: PartitionStats::new(
             Some(threshold_num_rows as u64 / 128),
@@ -547,15 +547,14 @@ fn big_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: ExecutorMetadata {
-            id: "".to_string(),
-            host: "".to_string(),
-            port: 0,
-            grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
+        executor_meta: Arc::new(ExecutorMetadata {
+            id: "executor_1".to_string(),
+            host: "executor_1".to_string(),
+            port: 7070,
+            grpc_port: 8080,
+            specification: ExecutorSpecification::default().with_task_slots(1),
             os_info: ExecutorOperatingSystemSpecification::default(),
-        },
-
+        }),
         // next few properties are needed
         partition_stats: PartitionStats::new(
             Some(threshold_num_rows as u64 * 2),

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -29,8 +29,7 @@ use crate::state::aqe::planner::AdaptivePlanner;
 use crate::state::aqe::test::{mock_batch, mock_schema};
 use ballista_core::extension::SessionConfigExt;
 use ballista_core::serde::scheduler::{
-    ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
-    PartitionId, PartitionLocation, PartitionStats,
+    ExecutorConnection, PartitionId, PartitionLocation, PartitionStats,
 };
 use datafusion::datasource::MemTable;
 use datafusion::execution::SessionStateBuilder;
@@ -101,13 +100,11 @@ fn partitions_with_byte_sizes(
                     stage_id: 0,
                     partition_id: idx,
                 },
-                executor_meta: Arc::new(ExecutorMetadata {
-                    id: "".to_string(),
-                    host: "".to_string(),
-                    port: 0,
-                    grpc_port: 0,
-                    specification: ExecutorSpecification::default().with_task_slots(0),
-                    os_info: ExecutorOperatingSystemSpecification::default(),
+                executor_id: "executor_1".to_string(),
+                executor_connection: Arc::new(ExecutorConnection {
+                    host: "localhost".to_string(),
+                    port: 7070,
+                    grpc_port: 8080,
                 }),
                 partition_stats: PartitionStats::new(Some(1), None, Some(bytes)),
                 file_id: None,

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -101,14 +101,14 @@ fn partitions_with_byte_sizes(
                     stage_id: 0,
                     partition_id: idx,
                 },
-                executor_meta: ExecutorMetadata {
+                executor_meta: Arc::new(ExecutorMetadata {
                     id: "".to_string(),
                     host: "".to_string(),
                     port: 0,
                     grpc_port: 0,
                     specification: ExecutorSpecification::default().with_task_slots(0),
                     os_info: ExecutorOperatingSystemSpecification::default(),
-                },
+                }),
                 partition_stats: PartitionStats::new(Some(1), None, Some(bytes)),
                 file_id: None,
                 is_sort_shuffle: false,

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -29,8 +29,7 @@ mod plan_to_stages;
 use ballista_core::config::BALLISTA_SHUFFLE_SORT_BASED_ENABLED;
 use ballista_core::extension::SessionConfigExt;
 use ballista_core::serde::scheduler::{
-    ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
-    PartitionId, PartitionLocation, PartitionStats,
+    ExecutorConnection, PartitionId, PartitionLocation, PartitionStats,
 };
 use datafusion::arrow::array::{Int32Array, RecordBatch};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -49,13 +48,11 @@ pub(crate) fn mock_partitions_with_statistics() -> Vec<Vec<PartitionLocation>> {
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: Arc::new(ExecutorMetadata {
-            id: "".to_string(),
-            host: "".to_string(),
-            port: 0,
-            grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
-            os_info: ExecutorOperatingSystemSpecification::default(),
+        executor_id: "executor_1".to_string(),
+        executor_connection: Arc::new(ExecutorConnection {
+            host: "localhost".to_string(),
+            port: 7070,
+            grpc_port: 8080,
         }),
         // next few properties are needed
         partition_stats: PartitionStats::new(Some(42), None, Some(10)),
@@ -74,13 +71,11 @@ pub(crate) fn mock_partitions_with_statistics_no_data() -> Vec<Vec<PartitionLoca
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: Arc::new(ExecutorMetadata {
-            id: "".to_string(),
-            host: "".to_string(),
-            port: 0,
-            grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
-            os_info: ExecutorOperatingSystemSpecification::default(),
+        executor_id: "executor_1".to_string(),
+        executor_connection: Arc::new(ExecutorConnection {
+            host: "localhost".to_string(),
+            port: 7070,
+            grpc_port: 8080,
         }),
         // next few properties are needed
         partition_stats: PartitionStats::new(Some(0), None, Some(0)),

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -49,14 +49,14 @@ pub(crate) fn mock_partitions_with_statistics() -> Vec<Vec<PartitionLocation>> {
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: ExecutorMetadata {
+        executor_meta: Arc::new(ExecutorMetadata {
             id: "".to_string(),
             host: "".to_string(),
             port: 0,
             grpc_port: 0,
             specification: ExecutorSpecification::default().with_task_slots(0),
             os_info: ExecutorOperatingSystemSpecification::default(),
-        },
+        }),
         // next few properties are needed
         partition_stats: PartitionStats::new(Some(42), None, Some(10)),
         file_id: None,
@@ -74,14 +74,14 @@ pub(crate) fn mock_partitions_with_statistics_no_data() -> Vec<Vec<PartitionLoca
             stage_id: 0,
             partition_id: 0,
         },
-        executor_meta: ExecutorMetadata {
+        executor_meta: Arc::new(ExecutorMetadata {
             id: "".to_string(),
             host: "".to_string(),
             port: 0,
             grpc_port: 0,
             specification: ExecutorSpecification::default().with_task_slots(0),
             os_info: ExecutorOperatingSystemSpecification::default(),
-        },
+        }),
         // next few properties are needed
         partition_stats: PartitionStats::new(Some(0), None, Some(0)),
         file_id: None,

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -42,7 +42,7 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::protobuf::{RunningTask, task_status};
 use ballista_core::serde::scheduler::{
-    ExecutorMetadata, PartitionId, PartitionLocation, PartitionStats,
+    ExecutorConnection, ExecutorMetadata, PartitionId, PartitionLocation, PartitionStats,
 };
 
 use crate::display::print_stage_metrics;
@@ -569,7 +569,7 @@ impl StaticExecutionGraph {
                     stage_output.partition_locations.iter_mut().for_each(
                         |(_partition, locs)| {
                             let before_len = locs.len();
-                            locs.retain(|loc| loc.executor_meta.id != executor_id);
+                            locs.retain(|loc| loc.executor_id != executor_id);
                             if locs.len() < before_len {
                                 match_found = true;
                             }
@@ -1405,14 +1405,14 @@ impl ExecutionGraph for StaticExecutionGraph {
 
         let output_locations = self.output_locations();
 
-        let executor_map = output_locations
+        let executor_conn_map = output_locations
             .iter()
             .map(|l| {
-                let proto_meta: protobuf::ExecutorMetadata =
-                    (*l.executor_meta).clone().into();
-                (l.executor_meta.id.clone(), proto_meta)
+                let proto_executor_conn: protobuf::ExecutorConnection =
+                    (*l.executor_connection).clone().into();
+                (l.executor_id.clone(), proto_executor_conn)
             })
-            .collect::<HashMap<String, protobuf::ExecutorMetadata>>();
+            .collect::<HashMap<String, protobuf::ExecutorConnection>>();
 
         let partition_location = output_locations
             .into_iter()
@@ -1420,14 +1420,17 @@ impl ExecutionGraph for StaticExecutionGraph {
             .collect::<Result<Vec<_>>>()?;
 
         self.end_time = timestamp_millis();
+        // Constructing extended version of PartitionLocations
+        let locations = protobuf::PartitionLocationExt {
+            location: partition_location,
+            executor_map: executor_conn_map,
+        };
 
         self.status = JobStatus {
             job_id: self.job_id.clone().into(),
             job_name: self.job_name.clone(),
             status: Some(job_status::Status::Successful(SuccessfulJob {
-                partition_location,
-                executor_map,
-
+                locations: Some(locations),
                 queued_at: self.queued_at,
                 started_at: self.start_time,
                 ended_at: self.end_time,
@@ -1767,6 +1770,12 @@ pub(crate) fn partition_to_location(
     executor: &ExecutorMetadata,
     shuffles: Vec<ShuffleWritePartition>,
 ) -> Vec<PartitionLocation> {
+    let executor_id = executor.id.clone();
+    let executor_connection = Arc::new(ExecutorConnection {
+        host: executor.host.clone(),
+        port: executor.port,
+        grpc_port: executor.grpc_port,
+    });
     shuffles
         .into_iter()
         .map(|shuffle| PartitionLocation {
@@ -1776,7 +1785,8 @@ pub(crate) fn partition_to_location(
                 stage_id,
                 partition_id: shuffle.partition_id as usize,
             },
-            executor_meta: Arc::new(executor.clone()),
+            executor_id: executor_id.clone(),
+            executor_connection: executor_connection.clone(),
             partition_stats: PartitionStats::new(
                 Some(shuffle.num_rows),
                 Some(shuffle.num_batches),
@@ -1939,7 +1949,7 @@ mod test {
         let outputs = agg_graph.output_locations();
 
         for location in outputs {
-            assert_eq!(location.executor_meta.host, "localhost2".to_owned());
+            assert_eq!(location.executor_connection.host, "localhost2".to_owned());
         }
 
         Ok(())

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -34,7 +34,9 @@ use ballista_core::execution_plans::{
 };
 use ballista_core::serde::protobuf::failed_task::FailedReason;
 use ballista_core::serde::protobuf::job_status::Status;
-use ballista_core::serde::protobuf::{FailedJob, ShuffleWritePartition, job_status};
+use ballista_core::serde::protobuf::{
+    self, FailedJob, ShuffleWritePartition, job_status,
+};
 use ballista_core::serde::protobuf::{
     FailedTask, JobStatus, ResultLost, RunningJob, SuccessfulJob, TaskStatus,
 };
@@ -1401,8 +1403,18 @@ impl ExecutionGraph for StaticExecutionGraph {
             )));
         }
 
-        let partition_location = self
-            .output_locations()
+        let output_locations = self.output_locations();
+
+        let executor_map = output_locations
+            .iter()
+            .map(|l| {
+                let proto_meta: protobuf::ExecutorMetadata =
+                    (*l.executor_meta).clone().into();
+                (l.executor_meta.id.clone(), proto_meta)
+            })
+            .collect::<HashMap<String, protobuf::ExecutorMetadata>>();
+
+        let partition_location = output_locations
             .into_iter()
             .map(|l| l.try_into())
             .collect::<Result<Vec<_>>>()?;
@@ -1414,6 +1426,7 @@ impl ExecutionGraph for StaticExecutionGraph {
             job_name: self.job_name.clone(),
             status: Some(job_status::Status::Successful(SuccessfulJob {
                 partition_location,
+                executor_map,
 
                 queued_at: self.queued_at,
                 started_at: self.start_time,
@@ -1763,7 +1776,7 @@ pub(crate) fn partition_to_location(
                 stage_id,
                 partition_id: shuffle.partition_id as usize,
             },
-            executor_meta: executor.clone(),
+            executor_meta: Arc::new(executor.clone()),
             partition_stats: PartitionStats::new(
                 Some(shuffle.num_rows),
                 Some(shuffle.num_batches),

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -354,12 +354,12 @@ impl UnresolvedStage {
                 .iter_mut()
                 .for_each(|(_partition, locs)| {
                     locs.iter().for_each(|loc| {
-                        if loc.executor_meta.id == executor_id {
+                        if loc.executor_id == executor_id {
                             bad_map_partitions.insert(loc.map_partition_id);
                         }
                     });
 
-                    locs.retain(|loc| loc.executor_meta.id != executor_id);
+                    locs.retain(|loc| loc.executor_id != executor_id);
                 });
             stage_output.complete = false;
             Ok(bad_map_partitions)
@@ -861,12 +861,12 @@ impl RunningStage {
                 .iter_mut()
                 .for_each(|(_partition, locs)| {
                     locs.iter().for_each(|loc| {
-                        if loc.executor_meta.id == executor_id {
+                        if loc.executor_id == executor_id {
                             bad_map_partitions.insert(loc.map_partition_id);
                         }
                     });
 
-                    locs.retain(|loc| loc.executor_meta.id != executor_id);
+                    locs.retain(|loc| loc.executor_id != executor_id);
                 });
             stage_output.complete = false;
             Ok(bad_map_partitions)

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -1024,7 +1024,7 @@ mod prune_partition_tests {
         CoalescePlan, PartitionGroup, ShuffleReaderExec,
     };
     use ballista_core::serde::scheduler::{
-        ExecutorMetadata, PartitionId, PartitionLocation,
+        ExecutorConnection, PartitionId, PartitionLocation,
     };
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_expr::Partitioning;
@@ -1039,14 +1039,12 @@ mod prune_partition_tests {
                 stage_id: 0,
                 partition_id: partition,
             },
-            executor_meta: ExecutorMetadata {
-                id: "1".to_string(),
-                host: "1.1.1.1".to_string(),
-                port: 0,
-                grpc_port: 0,
-                specification: Default::default(),
-                os_info: Default::default(),
-            },
+            executor_id: String::from("id"),
+            executor_connection: Arc::new(ExecutorConnection {
+                host: "localhost".to_string(),
+                port: 50050,
+                grpc_port: 50052,
+            }),
             partition_stats: Default::default(),
             file_id: None,
             is_sort_shuffle: false,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1851.

 # Rationale for this change
In the current implementation there is a problem - in the `PartitionLocation` that is used in each shuffle operation (for each partition in the previous stage) there was `executor_metadata` field (which is of `ExecutorMetadata` type) filled with unnecessary info, because it did not add up any information that could be used by `ShuffleReaderExec` to extract partition (or i.e resume the execution from a failed stage)


# What changes are included in this PR?
`ExecutorMetadata` was decoupled from `PartitionLocation` and now it is used as a separate struct for:
- registering executor
- in heartbeats
- REST API info fetch

`PartitionLocation` is now exposed only to the `executor_id`, `host` and `port`, which is sufficient for fetching needed partitions by the `ShuffleReaderExec`
This way we can save up a lot of space and data-transfer during each shuffle operation (potentially removing possibility of `Scheduler`'s OOM errors and improving speed of queries with lots of partitions)

# Are there any user-facing changes?
Yes. 
In the REST API interface `ExecutorResponse` doesnt contain nested struct with `Executor`'s hardware and OS info. It was flattened.

# Potential follow-up:
- check the TUI REST API integration
