### PR TITLE
chore(docs): Update docs website to bring inline with Datafusion style

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-sphinx
+sphinx>=9,<10
 Jinja2
-pydata-sphinx-theme==0.8.0
+pydata-sphinx-theme>=0.16,<1
 myst-parser
 maturin

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -29,7 +29,6 @@
   --pst-color-h2: var(--color-text-base);
   /* Use softer blue from bootstrap's default info color */
   --pst-color-info: 23, 162, 184;
-  --pst-header-height: 0px;
 }
 
 code {
@@ -40,23 +39,38 @@ code {
   text-align: center;
 }
 
-/* Ensure the logo is properly displayed */
-
-.navbar-brand {
-  height: auto;
+/* Limit both light and dark mode logos in the navbar */
+.logo__image {
+  height: 32px;
   width: auto;
+  max-height: 2.5rem;
 }
 
-a.navbar-brand img {
-  height: auto;
-  width: auto;
-  max-height: 15vh;
-  max-width: 100%;
+/* Display appropriate logo for dark and light mode */
+.light-logo {
+  display: inline;
 }
 
+.dark-logo {
+  display: none;
+}
+
+html[data-theme="dark"] .light-logo {
+  display: none;
+}
+
+html[data-theme="dark"] .dark-logo {
+  display: inline;
+  background-color: transparent !important;
+}
+
+/* Align search bar & theme switch right */
+.navbar-header-items__end {
+  margin-left: auto;
+}
 
 /* This is the bootstrap CSS style for "table-striped". Since the theme does
-not yet provide an easy way to configure this globaly, it easier to simply
+not yet provide an easy way to configure this globally, it easier to simply
 include this snippet here than updating each table in all rst files to
 add ":class: table-striped" */
 
@@ -66,15 +80,15 @@ add ":class: table-striped" */
 
 
 /* Limit the max height of the sidebar navigation section. Because in our
-custimized template, there is more content above the navigation, i.e.
+customized template, there is more content above the navigation, i.e.
 larger logo: if we don't decrease the max-height, it will overlap with
 the footer.
-Details: min(15vh, 110px) for the logo size, 8rem for search box etc*/
+Details: 8rem for search box etc*/
 
 @media (min-width:720px) {
   @supports (position:-webkit-sticky) or (position:sticky) {
     .bd-links {
-      max-height: calc(100vh - min(15vh, 110px) - 8rem)
+      max-height: calc(100vh - 8rem)
     }
   }
 }
@@ -90,4 +104,55 @@ Details: min(15vh, 110px) for the logo size, 8rem for search box etc*/
           this as on RTD they are loaded after this stylesheet */
         white-space: normal !important;
     }
+}
+
+/* Make wide tables scroll within the content area to avoid overlapping the
+   right sidebar. Prevents tables from bleeding underneath the sticky sidebar. */
+.bd-content table {
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+}
+
+/* Make table container width fit content instead of spanning full width. */
+.pst-scrollable-table-container {
+  display: inline-block;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* Restore proper table display to maintain column alignment */
+.bd-content table thead,
+.bd-content table tbody { display: table-row-group; }
+
+.bd-content table tr { display: table-row; }
+
+.bd-content table th,
+.bd-content table td {
+  display: table-cell;
+  white-space: normal;
+}
+
+/* Maintain striped styling when table scrolls */
+.bd-content table tbody tr:nth-of-type(odd) {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+
+/* Ensure the config tables are readable without having to scroll horizontally. */
+
+#ballista-configuration-settings table {
+  display: table;
+  table-layout: fixed;
+}
+
+#ballista-configuration-settings th,
+#ballista-configuration-settings td {
+  word-wrap: break-word;
+}
+
+#ballista-configuration-settings th:nth-child(2),
+#ballista-configuration-settings td:nth-child(2) {
+  width: 15%;
 }

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -69,6 +69,16 @@ html[data-theme="dark"] .dark-logo {
   margin-left: auto;
 }
 
+/* Render in-page toctree listings (e.g. the home page index) at body text
+size. The theme default enlarges links to 1.1em and captions to 1.5em. */
+.toctree-wrapper li[class^="toctree-l"] > a {
+  font-size: 1em;
+}
+
+.toctree-wrapper p.caption {
+  font-size: 1em;
+}
+
 /* This is the bootstrap CSS style for "table-striped". Since the theme does
 not yet provide an easy way to configure this globally, it easier to simply
 include this snippet here than updating each table in all rst files to

--- a/docs/source/_templates/docs-sidebar.html
+++ b/docs/source/_templates/docs-sidebar.html
@@ -1,19 +1,10 @@
-
-<a class="navbar-brand" href="{{ pathto(master_doc) }}">
-  <img src="{{ pathto('_static/images/ballista-logo.png', 1) }}" class="logo" alt="logo">
-</a>
-
-<form class="bd-search d-flex align-items-center" action="{{ pathto('search') }}" method="get">
-  <i class="icon fas fa-search"></i>
-  <input type="search" class="form-control" name="q" id="search-input" placeholder="{{ theme_search_bar_text }}" aria-label="{{ theme_search_bar_text }}" autocomplete="off" >
-</form>
-
 <nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+
   <div class="bd-toc-item active">
     {% if "python/api" in pagename or "python/generated" in pagename %}
-    {{ generate_nav_html("sidebar", startdepth=0, maxdepth=3, collapse=False, includehidden=True, titles_only=True) }}
+    {{ generate_toctree_html("sidebar", startdepth=0, maxdepth=3, collapse=False, includehidden=True, titles_only=True) }}
     {% else %}
-    {{ generate_nav_html("sidebar", startdepth=0, maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+    {{ generate_toctree_html("sidebar", startdepth=0, maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
     {% endif %}
   </div>
 </nav>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,9 +1,5 @@
 {% extends "pydata_sphinx_theme/layout.html" %}
 
-{# Silence the navbar #}
-{% block docs_navbar %}
-{% endblock %}
-
 <!--
     Custom footer
 -->

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,13 @@ autosummary_generate = True
 html_theme = 'pydata_sphinx_theme'
 
 html_theme_options = {
+    "logo": {
+        "image_light": "_static/images/ballista_black.svg",
+        "image_dark": "_static/images/ballista_white.svg",
+    },
     "use_edit_page_button": True,
+    "navbar_center": [],
+    "navbar_end": ["theme-switcher"],
 }
 
 html_context = {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1856 

 # Rationale for this change
I really just wanted dark mode, and the dependencies seemed a bit dated (Python 3.10 is EOL later this year, so a bump couldn't hurt). It also brings it more in line with the official Datafusion docs, and I now realize that I assumed that to be something positive while this project might actually want to pursue its own style to set it apart from the Datafusion website.

# What changes are included in this PR?
- Python bump in Github Action
- Sfinx and theme plugin version bump (automatically brings the dark mode toggle)
- Theme overrides update (CSS)
- Update some HTML with new API from Sfinx and enable the top navbar (which holds the dark mode toggle)
- Make sure the logo is nice in both light and dark mode.  

I have ran it locally and clicked around, didn't see any visual glitches but admittedly I have only tested it in Firefox. 

**Disclaimer:** The changes were AI generated based on the Datafusion repository, manually reviewed by me. I would normally submit AI generated PR's but this is the type of stuff that I guess I want AI to take it out of my hands to be honest. Apologies if this is against policy!

# Are there any user-facing changes?
Not code-wise, but documentation wise certainly.

