### PR TITLE
fix: use DataFrame.__name__ instead of hardcoded string in metaclass method wrapping

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "futures",
  "http",
  "insta",
+ "itertools",
  "log",
  "object_store",
  "parking_lot",
@@ -652,6 +653,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower-http",
  "uuid",
 ]
 

--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -72,12 +72,11 @@ class RedefiningDataFrameMeta(type):
 
         for base_name, base_value in bases[0].__dict__.items():
             #
-            # TODO: could we not use 'DataFrame' as a string here?
             #
             if (
                 callable(base_value)
                 and not base_name.startswith("__")
-                and base_value.__annotations__.get("return") == "DataFrame"
+                and base_value.__annotations__.get("return") == DataFrame.__name__
             ):
                 #
                 # functions which return DataFrame are redefined
@@ -112,12 +111,11 @@ class RedefiningSessionContextMeta(type):
 
         for base_name, base_value in bases[0].__dict__.items():
             #
-            # could we not use 'DataFrame' as a string here?
             #
             if (
                 callable(base_value)
                 and not base_name.startswith("__")
-                and base_value.__annotations__.get("return") == "DataFrame"
+                and base_value.__annotations__.get("return") == DataFrame.__name__
             ):
                 #
                 # functions which return DataFrame are redefined

--- a/python/python/ballista/extension.py
+++ b/python/python/ballista/extension.py
@@ -71,8 +71,6 @@ class RedefiningDataFrameMeta(type):
             return method_wrapper
 
         for base_name, base_value in bases[0].__dict__.items():
-            #
-            #
             if (
                 callable(base_value)
                 and not base_name.startswith("__")
@@ -110,8 +108,6 @@ class RedefiningSessionContextMeta(type):
             return method_wrapper
 
         for base_name, base_value in bases[0].__dict__.items():
-            #
-            #
             if (
                 callable(base_value)
                 and not base_name.startswith("__")

--- a/python/python/tests/test_context.py
+++ b/python/python/tests/test_context.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from ballista import BallistaSessionContext, setup_test_cluster
+from ballista.extension import DataFrame, DistributedDataFrame, SessionContext
 from datafusion import col, lit
 import pytest
 import pyarrow as pa
@@ -140,31 +141,29 @@ def test_write_json(ctx, tmp_path):
     assert len(json_files) > 0
 
 
-def test_distributed_dataframe_wraps_dataframe_returning_methods():
-    from ballista.extension import DistributedDataFrame, DataFrame
-
+def _assert_dataframe_returning_methods_wrapped(base_cls, sub_cls):
     should_be_wrapped = {
         name
-        for name, val in DataFrame.__dict__.items()
+        for name, val in base_cls.__dict__.items()
         if callable(val)
         and not name.startswith("__")
         and val.__annotations__.get("return") == DataFrame.__name__
     }
 
     assert should_be_wrapped
-    assert should_be_wrapped.issubset(DistributedDataFrame.__dict__)
+    for name in should_be_wrapped:
+        assert name in sub_cls.__dict__, f"{name} not found in {sub_cls.__name__}"
+        assert callable(sub_cls.__dict__[name]), (
+            f"{name} is not callable in {sub_cls.__name__}"
+        )
+        assert sub_cls.__dict__[name] is not base_cls.__dict__[name], (
+            f"{name} was not replaced in {sub_cls.__name__}"
+        )
+
+
+def test_distributed_dataframe_wraps_dataframe_returning_methods():
+    _assert_dataframe_returning_methods_wrapped(DataFrame, DistributedDataFrame)
 
 
 def test_ballista_session_context_wraps_dataframe_returning_methods():
-    from ballista.extension import BallistaSessionContext, SessionContext, DataFrame
-
-    should_be_wrapped = {
-        name
-        for name, val in SessionContext.__dict__.items()
-        if callable(val)
-        and not name.startswith("__")
-        and val.__annotations__.get("return") == DataFrame.__name__
-    }
-
-    assert should_be_wrapped
-    assert should_be_wrapped.issubset(BallistaSessionContext.__dict__)
+    _assert_dataframe_returning_methods_wrapped(SessionContext, BallistaSessionContext)

--- a/python/python/tests/test_context.py
+++ b/python/python/tests/test_context.py
@@ -138,3 +138,33 @@ def test_write_json(ctx, tmp_path):
     df.write_json(out_dir)
     json_files = list((tmp_path / "out").glob("*.json"))
     assert len(json_files) > 0
+
+
+def test_distributed_dataframe_wraps_dataframe_returning_methods():
+    from ballista.extension import DistributedDataFrame, DataFrame
+
+    should_be_wrapped = {
+        name
+        for name, val in DataFrame.__dict__.items()
+        if callable(val)
+        and not name.startswith("__")
+        and val.__annotations__.get("return") == DataFrame.__name__
+    }
+
+    assert should_be_wrapped
+    assert should_be_wrapped.issubset(DistributedDataFrame.__dict__)
+
+
+def test_ballista_session_context_wraps_dataframe_returning_methods():
+    from ballista.extension import BallistaSessionContext, SessionContext, DataFrame
+
+    should_be_wrapped = {
+        name
+        for name, val in SessionContext.__dict__.items()
+        if callable(val)
+        and not name.startswith("__")
+        and val.__annotations__.get("return") == DataFrame.__name__
+    }
+
+    assert should_be_wrapped
+    assert should_be_wrapped.issubset(BallistaSessionContext.__dict__)


### PR DESCRIPTION
# Which issue does this PR close?

Fixes an existing TODO, which required removing the string comparison 
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
The metaclass in extension.py identifies DataFrame-returning methods by comparing` __annotations__["return"]` against the hardcoded string `"DataFrame"`. This works only by coincidence. It happens to match because the class name is DataFrame. If the class were renamed or imported under an alias, the comparison would silently stop matching and methods would no longer be wrapped, breaking distributed execution without any error.

  Replacing `"DataFrame"` with `DataFrame.__name__` ties the comparison to the actual imported class, so it stays correct automatically if the name ever changes. Two unit tests are added to guard this behavior. They verify at class-creation time that all DataFrame-returning methods on DataFrame and SessionContext are correctly wrapped in DistributedDataFrame and BallistaSessionContext respectively, without requiring a live cluster.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Touched upon in the rationale section above. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
N/A
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
