### PR TITLE
chore(ci): Deploy WebTUI to nightlies.a.o

### DIFF
--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -89,16 +89,8 @@ jobs:
 
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
-        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # v8.0.5
-        with:
-          switches: -rlptDvz
-          path: target/web-tui/*
-          remote_path: datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
-          remote_host: https://nightlies.apache.org
-          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
-          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
-          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
-
+        run: |
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} -i ${{ secrets.NIGHTLIES_RSYNC_KEY }}" target/web-tui/* nightlies.apache.org:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   web-tui:
     name: Build Web TUI WASM32 application
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6.0.3
         with:
@@ -76,6 +76,8 @@ jobs:
       - name: Get package.version
         id: cargo_metadata
         run: |
+          set -x
+          rsync --version
           BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
           echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -68,11 +68,36 @@ jobs:
         with:
           tool: trunk@0.21.14
 
+      - name: Install cargo-get
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-get@1.4.0
+
+      - name: Get package.version
+        id: cargo_metadata
+        run: |
+          BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
+          echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build
         working-directory: ballista-cli
         run: |
+          echo "==== DEBUG BALLISTA_VERSION: ${{ steps.cargo_metadata.outputs.ballista_version }}"
           trunk build --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
+
+      - name: Deploy to Nightlies
+        #if: ${{ github.ref == 'refs/heads/main' }}
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        with:
+          switches: -rlptDvz
+          path: target/web-tui/*
+          remote_path: datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          remote_host: https://nightlies.apache.org
+          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # v8.0.5
         with:
           switches: -rlptDvz
           path: target/web-tui/*

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   web-tui:
     name: Build Web TUI WASM32 application
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
         with:
@@ -82,7 +82,6 @@ jobs:
       - name: Build
         working-directory: ballista-cli
         run: |
-          echo "==== DEBUG BALLISTA_VERSION: ${{ steps.cargo_metadata.outputs.ballista_version }}"
           trunk build --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1841 

# Rationale for this change

Automatically deploy the WebTUI WASM32 application to https://nightlies.apache.org/datafusion/ballista/tui/<<BALLISTA_VERSION>>/

# What changes are included in this PR?

Update the web-tui.yaml CI workflow to upload the latest version of the WebTUI on push to `main`

# Are there any user-facing changes?

No.