### PR TITLE
chore(ci): Use Ubuntu ARM64 for some tests on Linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,7 +138,9 @@ jobs:
           submodules: true
           fetch-depth: 1
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Run Ballista tests
         run: |
@@ -177,7 +179,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
       - name: Verify that benchmark queries return expected results
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,8 +135,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
         with:
-          submodules: true
           fetch-depth: 1
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install stable
@@ -178,6 +181,10 @@ jobs:
       - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,9 +131,7 @@ jobs:
 
   ballista-test:
     name: test linux ballista
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6.0.3
         with:
@@ -173,9 +171,7 @@ jobs:
   # verify that the benchmark queries return the correct results
   verify-benchmark-results:
     name: verify benchmark results (amd64)
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6.0.3
         with:

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -54,16 +54,16 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y netcat-traditional
+          sudo apt-get install -y netcat-traditional protobuf-compiler
 
       - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 1
 
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
+        run: |
+          rustup toolchain install stable
+          rustup default stable
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -53,8 +53,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y netcat-traditional
+          sudo apt-get update
+          sudo apt-get install -y netcat-traditional
 
       - uses: actions/checkout@v6.0.3
         with:

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -26,7 +26,7 @@ concurrency:
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "ballista/**"
       - "benchmarks/**"
@@ -49,9 +49,7 @@ on:
 jobs:
   tpch-sf10:
     name: TPC-H SF10 (all queries)
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Linux AMD64 runners are in shortage.
Experiment with ARM64

# What changes are included in this PR?

Change 'ubuntu-latest` with `ubuntu-24.04-arm` for few Linux CI jobs

# Are there any user-facing changes?

No
