### PR TITLE
feat(tui): Show job failed status below the Jobs table

### DIFF
--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -553,7 +553,7 @@ impl App {
     #[cfg(not(feature = "web"))]
     async fn load_job_dot_data(&self) {
         if let Some(selected_job) = self.jobs_data.selected_job(&self.search_term) {
-            if selected_job.status == "Completed"
+            if selected_job.is_completed()
                 && let Err(e) = load_job_dot(self, &selected_job.job_id).await
             {
                 tracing::error!("Failed to load job dot: {e:?}");
@@ -669,7 +669,7 @@ impl App {
     #[cfg(not(feature = "web"))]
     async fn cancel_selected_job(&mut self) {
         if let Some(job) = self.jobs_data.selected_job(&self.search_term)
-            && (job.status == "Running" || job.status == "Queued")
+            && (job.is_running() || job.is_queued())
         {
             let job_id = job.job_id.clone();
             let cancel_job_result = match self.http_client.cancel_job(&job_id).await {
@@ -695,16 +695,16 @@ impl App {
         self.jobs_data.selected_job(&self.search_term).is_some()
     }
 
-    pub fn is_selected_job_completed_or_running(&self) -> bool {
+    pub fn does_job_have_plan(&self) -> bool {
         self.jobs_data
             .selected_job(&self.search_term)
-            .is_some_and(|j| j.status == "Completed" || j.status == "Running")
+            .is_some_and(|j| !j.is_queued())
     }
 
     pub fn is_selected_job_cancelable(&self) -> bool {
         self.jobs_data
             .selected_job(&self.search_term)
-            .is_some_and(|j| j.status == "Running" || j.status == "Queued")
+            .is_some_and(|j| j.is_running() || j.is_queued())
     }
 
     pub fn has_more_than_one_job(&self) -> bool {
@@ -746,7 +746,7 @@ impl App {
     }
 
     fn open_job_plan_popup(&mut self) {
-        if self.is_selected_job_completed_or_running()
+        if self.does_job_have_plan()
             && let Some(details) = &self.job_details
         {
             self.job_plan_popup =
@@ -1148,7 +1148,7 @@ impl App {
                 let job_id = self
                     .jobs_data
                     .selected_job(&self.search_term)
-                    .filter(|j| j.status == "Completed")
+                    .filter(|j| j.is_completed())
                     .map(|j| j.job_id.clone());
                 job_id.map(WebKeyAsyncAction::LoadJobDot)
             }
@@ -1243,7 +1243,7 @@ impl App {
                 let job_id = self
                     .jobs_data
                     .selected_job(&self.search_term)
-                    .filter(|j| j.status == "Running" || j.status == "Queued")
+                    .filter(|j| j.is_running() || j.is_queued())
                     .map(|j| j.job_id.clone());
                 job_id.map(WebKeyAsyncAction::CancelJob)
             }
@@ -1743,35 +1743,35 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_job_completed_or_running_for_completed() {
+    fn does_job_have_plan_for_completed() {
         let mut app = make_app();
         app.jobs_data.jobs = vec![make_job("j1", "Completed")];
         app.jobs_data.table_state.select(Some(0));
-        assert!(app.is_selected_job_completed_or_running());
+        assert!(app.does_job_have_plan());
     }
 
     #[test]
-    fn is_selected_job_completed_or_running_for_running() {
+    fn does_job_have_plan_for_running() {
         let mut app = make_app();
         app.jobs_data.jobs = vec![make_job("j1", "Running")];
         app.jobs_data.table_state.select(Some(0));
-        assert!(app.is_selected_job_completed_or_running());
+        assert!(app.does_job_have_plan());
     }
 
     #[test]
-    fn is_selected_job_completed_or_running_for_queued() {
+    fn does_job_have_plan_for_queued() {
         let mut app = make_app();
         app.jobs_data.jobs = vec![make_job("j1", "Queued")];
         app.jobs_data.table_state.select(Some(0));
-        assert!(!app.is_selected_job_completed_or_running());
+        assert!(!app.does_job_have_plan());
     }
 
     #[test]
-    fn is_selected_job_completed_or_running_for_failed() {
+    fn does_job_have_plan_for_failed() {
         let mut app = make_app();
         app.jobs_data.jobs = vec![make_job("j1", "Failed")];
         app.jobs_data.table_state.select(Some(0));
-        assert!(!app.is_selected_job_completed_or_running());
+        assert!(app.does_job_have_plan());
     }
 
     // --- has_selected_job with selection ---

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -1329,6 +1329,7 @@ mod tests {
             job_id: id.to_string(),
             job_name: format!("Job {id}"),
             status: status.to_string(),
+            job_status: status.to_string(),
             start_time: 0,
             end_time: 1,
             num_stages: 1,

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -25,7 +25,8 @@ use std::collections::BTreeMap;
 pub struct Job {
     pub job_id: String,
     pub job_name: String,
-    pub status: String, // Running, Completed, Failed, Canceled
+    pub status: String,     // Running, Completed, Failed, Canceled
+    pub job_status: String, // human-readable status/failure detail, e.g. "Failed: <reason>"
     pub start_time: i64,
     pub end_time: i64,
     pub num_stages: usize,
@@ -440,6 +441,7 @@ mod tests {
             job_id: id.to_string(),
             job_name: name.to_string(),
             status: status.to_string(),
+            job_status: status.to_string(),
             start_time,
             end_time,
             num_stages,
@@ -679,6 +681,23 @@ mod tests {
         data.table_state.select(Some(1));
         let job = data.selected_job("").unwrap();
         assert_eq!(job.job_id, "j2");
+    }
+
+    #[test]
+    fn job_status_carries_failure_detail_independent_of_status() {
+        let job = Job {
+            job_id: "j1".to_string(),
+            job_name: "Job One".to_string(),
+            status: "Failed".to_string(),
+            job_status: "Failed: division by zero".to_string(),
+            start_time: 1,
+            end_time: 2,
+            num_stages: 1,
+            completed_stages: 0,
+            percent_complete: 0,
+        };
+        assert_eq!(job.status, "Failed");
+        assert_eq!(job.job_status, "Failed: division by zero");
     }
 
     #[test]

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -34,6 +34,24 @@ pub struct Job {
     pub percent_complete: u8,
 }
 
+impl Job {
+    pub fn is_queued(&self) -> bool {
+        self.status == "Queued"
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.status == "Running"
+    }
+
+    pub fn is_completed(&self) -> bool {
+        self.status == "Completed"
+    }
+
+    pub fn is_failed(&self) -> bool {
+        self.status == "Failed"
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SortColumn {
     None,

--- a/ballista-cli/src/tui/ui/footer.rs
+++ b/ballista-cli/src/tui/ui/footer.rs
@@ -81,7 +81,7 @@ pub(super) fn render_footer(f: &mut Frame, area: Rect, app: &App) {
                                     .push(Span::from("[c] Cancel job, "));
                             }
 
-                            if app.is_selected_job_completed_or_running() {
+                            if app.does_job_have_plan() {
                                 current_view_key_bindings
                                     .push(Span::from("[p] View job plans, "));
                             }

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -49,7 +49,7 @@ use ratatui::{
     style::Style,
     text::Text,
     widgets::{
-        Block, Borders, Cell, HighlightSpacing, Paragraph, Row, Table, TableState,
+        Block, Borders, Cell, HighlightSpacing, Paragraph, Row, Table, TableState, Wrap,
     },
 };
 
@@ -200,22 +200,63 @@ pub fn render_jobs(f: &mut Frame, area: Rect, app: &App) {
     app.jobs_data.sort_jobs(&mut sorted_jobs);
 
     if !sorted_jobs.is_empty() {
+        let selected_job = app
+            .jobs_data
+            .table_state
+            .selected()
+            .and_then(|idx| sorted_jobs.get(idx).copied());
+
+        let (table_area, failed_status_area) =
+            split_area_for_table_and_failure(selected_job, rects[1]);
+
         let mut scroll_state = app.jobs_data.scrollbar_state;
         let mut table_state = app.jobs_data.table_state;
-        let table_area = vertical_scrollbar::split_area(rects[1]);
+        let [table_area, scrollbar_area] = vertical_scrollbar::split_area(table_area);
         render_jobs_table(
             f,
-            table_area[0],
+            table_area,
             &sorted_jobs,
             &mut table_state,
             &app.jobs_data.sort_column,
             &app.jobs_data.sort_order,
             app,
         );
-        render_scrollbar(f, table_area[1], &mut scroll_state);
+        render_scrollbar(f, scrollbar_area, &mut scroll_state);
+
+        if let Some((area, job)) = failed_status_area {
+            render_job_failure_reason(f, area, job, app);
+        }
     } else {
         render_no_jobs(f, rects[1], app.theme.text_info);
     }
+}
+
+fn split_area_for_table_and_failure(
+    selected_job: Option<&Job>,
+    area: Rect,
+) -> (Rect, Option<(Rect, &Job)>) {
+    match selected_job {
+        Some(job) if job.status == "Failed" => {
+            let areas = Layout::vertical([
+                Constraint::Min(5),    // Table
+                Constraint::Length(5), // Failure reason
+            ])
+            .split(area);
+            (areas[0], Some((areas[1], job)))
+        }
+        _ => (area, None),
+    }
+}
+
+fn render_job_failure_reason(f: &mut Frame, area: Rect, job: &Job, app: &App) {
+    let block = Block::default()
+        .borders(Borders::all())
+        .style(app.theme.text_error);
+    let paragraph = Paragraph::new(job.job_status.as_str())
+        .style(app.theme.text_error)
+        .wrap(Wrap { trim: true })
+        .block(block);
+    f.render_widget(paragraph, area);
 }
 
 fn render_no_jobs(f: &mut Frame, area: Rect, style: Style) {

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -236,7 +236,7 @@ fn split_area_for_table_and_failure(
     area: Rect,
 ) -> (Rect, Option<(Rect, &Job)>) {
     match selected_job {
-        Some(job) if job.status == "Failed" => {
+        Some(job) if job.is_failed() => {
             let areas = Layout::vertical([
                 Constraint::Percentage(80), // Table
                 Constraint::Percentage(20), // Failure reason

--- a/ballista-cli/src/tui/ui/main/jobs/mod.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/mod.rs
@@ -238,8 +238,8 @@ fn split_area_for_table_and_failure(
     match selected_job {
         Some(job) if job.status == "Failed" => {
             let areas = Layout::vertical([
-                Constraint::Min(5),    // Table
-                Constraint::Length(5), // Failure reason
+                Constraint::Percentage(80), // Table
+                Constraint::Percentage(20), // Failure reason
             ])
             .split(area);
             (areas[0], Some((areas[1], job)))

--- a/ballista-cli/src/tui/ui/vertical_scrollbar.rs
+++ b/ballista-cli/src/tui/ui/vertical_scrollbar.rs
@@ -18,7 +18,6 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
-use std::rc::Rc;
 
 pub(crate) fn render_scrollbar(
     frame: &mut Frame,
@@ -38,10 +37,10 @@ pub(crate) fn render_scrollbar(
 /// Splits the given area into two parts:
 /// * the first part is the table area
 /// * the second part is the scrollbar area.
-pub(crate) fn split_area(area: Rect) -> Rc<[Rect]> {
+pub(crate) fn split_area(area: Rect) -> [Rect; 2] {
     Layout::horizontal([
         Constraint::Min(1),    // Table
         Constraint::Length(1), // Scrollbar
     ])
-    .split(area)
+    .areas(area)
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1785 

# Rationale for this change

It would be nice to see the reason for the failure of a job.

# What changes are included in this PR?

In the main Jobs table while navigating over the jobs if the selected job' status is "Failed" then show a text box below the table with the job's detailed status.

# Are there any user-facing changes?

UI only.
