### PR TITLE
minor: remove redundant scheduler info loggers

### DIFF
--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -47,7 +47,7 @@ use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMerge
 use datafusion::physical_plan::{
     ExecutionPlan, Partitioning, with_new_children_if_necessary,
 };
-use log::{debug, info};
+use log::debug;
 
 use crate::physical_optimizer::join_selection::should_swap_join_order;
 
@@ -110,7 +110,7 @@ impl DistributedPlanner for DefaultDistributedPlanner {
         execution_plan: Arc<dyn ExecutionPlan>,
         config: &ConfigOptions,
     ) -> Result<Vec<Arc<dyn ShuffleWriter>>> {
-        info!("planning query stages for job {job_id}");
+        debug!("Planning query stages for job: [{job_id}]");
         // Workaround until DF 54 migration : <https://github.com/apache/datafusion/pull/21885>
         let serde_safe_plan = make_filter_projection_serde_safe(execution_plan)?;
         let (new_plan, mut stages) =

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -395,7 +395,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                 .and_then(|s| s.value.clone())
                 .unwrap_or_default();
 
-            info!(
+            debug!(
                 "execution query (PUSH) job received - session_id: {session_id}, operation_id: {operation_id}, job_name: {job_name}"
             );
 
@@ -441,7 +441,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                     Status::internal(msg)
                 })?;
 
-            info!(
+            debug!(
                 "execution query (PUSH) job submitted - session_id: {session_id}, operation_id: {operation_id}, job_name: {job_name}, job_id: {job_id}"
             );
 

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ballista_core::serde::protobuf::{FailedJob, JobStatus};
-use log::{error, info, trace, warn};
+use log::{debug, error, info, trace, warn};
 
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::event_loop::{EventAction, EventSender};
@@ -96,7 +96,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 queued_at,
                 subscriber,
             } => {
-                info!("Job {job_id} queued with name {job_name:?}");
+                info!("Job queued: [{job_id}]");
 
                 if let Err(e) = self
                     .state
@@ -225,7 +225,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 self.metrics_collector
                     .record_failed(&job_id, queued_at, failed_at);
 
-                error!("Job {job_id} running failed");
+                error!("Job failed: [{job_id}]");
                 match self
                     .state
                     .task_manager
@@ -248,7 +248,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 self.state.clean_up_failed_job(job_id);
             }
             QueryStageSchedulerEvent::JobUpdated(job_id) => {
-                info!("Job {job_id} Updated");
+                debug!("Job updated, job_id: [{job_id}]");
                 if let Err(e) = self.state.task_manager.update_job(&job_id).await {
                     error!("Fail to invoke update_job for job {job_id} due to {e:?}");
                 }
@@ -256,7 +256,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
             QueryStageSchedulerEvent::JobCancel(job_id) => {
                 self.metrics_collector.record_cancelled(&job_id);
 
-                info!("Job {job_id} Cancelled");
+                info!("Job cancelled: [{job_id}]");
                 match self.state.task_manager.cancel_job(&job_id).await {
                     Ok((running_tasks, _pending_tasks)) => {
                         event_sender
@@ -303,7 +303,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                         error!(
                             "Failed to update {num_status} task statuses for Executor {executor_id}: {e:?}"
                         );
-                        // TODO error handling
                     }
                 }
             }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -385,7 +385,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
 
         let elapsed = start.elapsed();
 
-        info!("Planned job {job_id} in {elapsed:?}");
+        info!("Job [{job_id}] planning took {elapsed:?}");
 
         Ok(())
     }

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -330,7 +330,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 .indent(false)
                 .to_string();
 
-        info!("Submitting execution graph for job_id: {job_id}:\n\n{string_plan}");
+        info!("Submitting execution graph for job_id [{job_id}]:\n{string_plan}");
 
         self.state
             .submit_job(job_id.to_owned(), &graph, subscriber)
@@ -593,8 +593,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             let curr_available_tasks = graph.available_tasks();
 
             graph.revive();
-
-            info!("Saving job with status {:?}", graph.status());
+            let status = graph.status();
+            debug!(
+                "Saving status, job_id: [{}], status: {:?}",
+                status.job_id, status.status
+            );
 
             self.state.save_job(job_id, &graph).await?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

some scheduler info logs are repeating making them a less useful 

# What changes are included in this PR?

- some INFO logs downgraded to DEBUG
- some log statements have a bit different format to align them with other statements 

# Are there any user-facing changes?

No