### PR TITLE
feat: add docker-compose.quick.yml and fix onboarding docs

### DIFF
--- a/docker-compose.quick.yml
+++ b/docker-compose.quick.yml
@@ -31,9 +31,11 @@
 #   cargo run -p ballista-cli -- --host localhost --port 50050
 #
 # To make local data available inside executors, uncomment and
-# set the volume path under ballista-executor:
+# set the volume path under ballista-executor. The container-side
+# path must match exactly what you pass to register_parquet/register_csv
+# since the scheduler stores and forwards that path to executors as-is:
 #   volumes:
-#     - /absolute/path/to/your/data:/data:ro
+#     - /absolute/path/to/your/data:/absolute/path/to/your/data:ro
 
 services:
   ballista-scheduler:
@@ -78,5 +80,7 @@ services:
       timeout: 5s
       retries: 10
     restart: "no"
+    # deploy.replicas requires Docker Compose v2 (the Go rewrite, default since Docker Desktop 3.x).
+    # It is not supported by the legacy Compose v1 (docker-compose) without Swarm.
     deploy:
       replicas: 2

--- a/docker-compose.quick.yml
+++ b/docker-compose.quick.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Quick-start cluster using pre-built images from GHCR.
+# No local build required — Docker is the only prerequisite.
+#
+# Runs the last stable release. To test against unreleased changes,
+# use docker-compose.yml (requires `cargo build --release` first).
+#
+# Usage:
+#   docker compose -f docker-compose.quick.yml up
+#
+# Connect from Rust:
+#   SessionContext::remote("df://localhost:50050").await?
+#
+# Connect from the CLI:
+#   cargo run -p ballista-cli -- --host localhost --port 50050
+#
+# To make local data available inside executors, uncomment and
+# set the volume path under ballista-executor:
+#   volumes:
+#     - /absolute/path/to/your/data:/data:ro
+
+services:
+  ballista-scheduler:
+    image: ghcr.io/apache/datafusion-ballista-scheduler:latest
+    # --advertise-flight-sql-endpoint enables the scheduler to proxy all
+    # result fetching so clients only ever connect to port 50050.
+    # Without this flag, clients would need direct access to each
+    # executor's Arrow Flight port, which breaks in Docker networking.
+    command: >
+      --bind-host 0.0.0.0
+      --external-host ballista-scheduler
+      --advertise-flight-sql-endpoint
+    ports:
+      - "50050:50050"
+    environment:
+      - RUST_LOG=ballista=info,ballista_scheduler=info
+    healthcheck:
+      test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/50050"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: "no"
+
+  ballista-executor:
+    image: ghcr.io/apache/datafusion-ballista-executor:latest
+    command: >
+      --bind-host 0.0.0.0
+      --scheduler-host ballista-scheduler
+      --concurrent-tasks 4
+      --work-dir /work
+    environment:
+      - RUST_LOG=ballista=info,ballista_executor=info
+    # Uncomment to mount local data for queries:
+    # volumes:
+    #   - /absolute/path/to/your/data:/data:ro
+    depends_on:
+      ballista-scheduler:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/50051"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: "no"
+    deploy:
+      replicas: 2

--- a/docs/source/user-guide/deployment/docker-compose.md
+++ b/docs/source/user-guide/deployment/docker-compose.md
@@ -19,37 +19,51 @@
 
 # Starting a Ballista Cluster using Docker Compose
 
-Docker Compose is a convenient way to launch a cluster when testing locally.
+Two Compose files are provided. Choose based on whether you need the last stable release
+or want to run against local source changes.
 
-## Build Docker Images
+## Option 1: Pre-built images (no local build required)
 
-To create the required Docker images please refer to the [docker deployment page](docker.md).
-
-## Start a Cluster
-
-Using the [docker-compose.yml](https://github.com/apache/datafusion-ballista/blob/main/docker-compose.yml) from the
-source repository, run the following command to start a cluster:
+`docker-compose.quick.yml` pulls images directly from GHCR — no Rust toolchain needed.
+Images are published on each stable release; `latest` tracks the most recent release,
+not the `main` branch.
 
 ```bash
-docker-compose up --build
+docker compose -f docker-compose.quick.yml up
 ```
 
-This should show output similar to the following:
+See the [quickstart guide](quick-start.md) for connection instructions and data volume setup.
+
+## Option 2: Build from source
+
+`docker-compose.yml` builds executor and scheduler images from the local Dockerfiles.
+The Dockerfiles copy pre-compiled binaries — they do **not** run `cargo build` themselves.
+You must compile first:
 
 ```bash
-$ docker-compose up
-Creating network "ballista-benchmarks_default" with the default driver
-Creating ballista-benchmarks_ballista-scheduler_1 ... done
-Creating ballista-benchmarks_ballista-executor_1  ... done
-Attaching to ballista-benchmarks_ballista-scheduler_1, ballista-benchmarks_ballista-executor_1
-ballista-scheduler_1  | INFO ballista_scheduler: Ballista v52.0.0 Scheduler listening on 0.0.0.0:50050
-ballista-executor_1   | INFO ballista_executor: Ballista v52.0.0 Rust Executor listening on 0.0.0.0:50051
+# Step 1 — compile (requires Rust + protoc, takes ~20 min cold)
+cargo build --release
+
+# Step 2 — build Docker images and start the cluster
+docker compose up --build
 ```
 
-The scheduler listens on port 50050 and this is the port that clients will need to connect to.
+Skipping Step 1 will cause the build to fail because the `COPY target/release/ballista-*`
+instruction in the Dockerfiles will find no binaries to copy.
+
+Expected output after a successful start:
+
+```
+ballista-scheduler_1  | Ballista Scheduler listening on 0.0.0.0:50050
+ballista-executor_1   | Executor registration succeed
+```
+
+The scheduler listens on port 50050.
 
 ## Connect from the Ballista CLI
 
+No pre-built CLI image is published to GHCR. Build it locally from source:
+
 ```shell
-docker run --network=host -it apache/datafusion-ballista-cli:latest --host localhost --port 50050
+cargo run -p ballista-cli -- --host localhost --port 50050
 ```

--- a/docs/source/user-guide/deployment/docker-compose.md
+++ b/docs/source/user-guide/deployment/docker-compose.md
@@ -41,7 +41,7 @@ The Dockerfiles copy pre-compiled binaries — they do **not** run `cargo build`
 You must compile first:
 
 ```bash
-# Step 1 — compile (requires Rust + protoc, takes ~20 min cold)
+# Step 1 — compile (requires Rust + protoc)
 cargo build --release
 
 # Step 2 — build Docker images and start the cluster
@@ -54,8 +54,8 @@ instruction in the Dockerfiles will find no binaries to copy.
 Expected output after a successful start:
 
 ```
-ballista-scheduler_1  | Ballista Scheduler listening on 0.0.0.0:50050
-ballista-executor_1   | Executor registration succeed
+ballista-scheduler-1  | Ballista Scheduler listening on 0.0.0.0:50050
+ballista-executor-1   | Executor registration succeed
 ```
 
 The scheduler listens on port 50050.

--- a/docs/source/user-guide/deployment/quick-start.md
+++ b/docs/source/user-guide/deployment/quick-start.md
@@ -21,12 +21,12 @@
 
 There are two ways to get a local Ballista cluster running. Choose based on your goal:
 
-| | [Evaluate Ballista](#path-a-evaluate-with-docker) | [Build from source](#path-b-build-from-source) |
-|---|---|---|
-| Goal | Try Ballista against the last stable release | Develop or test against local code changes |
-| Prerequisites | Docker | Rust, protoc |
-| Cold start | Image pull | Full compile |
-| Terminals needed | 1 | 3 |
+|                  | [Evaluate Ballista](#path-a-evaluate-with-docker) | [Build from source](#path-b-build-from-source) |
+| ---------------- | ------------------------------------------------- | ---------------------------------------------- |
+| Goal             | Try Ballista against the last stable release      | Develop or test against local code changes     |
+| Prerequisites    | Docker                                            | Rust, protoc                                   |
+| Cold start       | Image pull                                        | Full compile                                   |
+| Terminals needed | 1                                                 | 3                                              |
 
 > [!IMPORTANT]
 > Ballista and DataFusion are developed independently. A given Ballista release may not be compatible

--- a/docs/source/user-guide/deployment/quick-start.md
+++ b/docs/source/user-guide/deployment/quick-start.md
@@ -19,128 +19,167 @@
 
 # Ballista Quickstart
 
-A simple way to start a local cluster for testing purposes is to use cargo to build the project and then run the scheduler and executor binaries directly.
+There are two ways to get a local Ballista cluster running. Choose based on your goal:
 
-Project Requirements:
+| | [Evaluate Ballista](#path-a-evaluate-with-docker-2-min) | [Build from source](#path-b-build-from-source-20-min) |
+|---|---|---|
+| Goal | Try Ballista against the last stable release | Develop or test against local code changes |
+| Prerequisites | Docker | Rust, protoc |
+| Cold start time | ~2 min (image pull) | ~20 min (full compile) |
+| Terminals needed | 1 | 3 |
+
+> [!IMPORTANT]
+> Ballista and DataFusion are developed independently. A given Ballista release may not be compatible
+> with the latest DataFusion version. Check the [compatibility matrix](../configs.md) before integrating.
+
+---
+
+## Path A: Evaluate with Docker (~2 min)
+
+The only prerequisite is [Docker](https://docs.docker.com/get-docker/) with Compose v2.
+
+This uses pre-built images from GHCR that are published on each stable release. The `latest` tag
+tracks the most recent release, not the `main` branch.
+
+```shell
+docker compose -f docker-compose.quick.yml up
+```
+
+You should see output similar to:
+
+```
+ballista-scheduler-1  | Ballista Scheduler v53.0.0 listening on 0.0.0.0:50050
+ballista-executor-1   | Executor registration succeed
+ballista-executor-2   | Executor registration succeed
+```
+
+Two executors start by default. The scheduler listens on `localhost:50050`.
+
+**Connect from Rust:**
+
+```rust
+let ctx = SessionContext::remote("df://localhost:50050").await?;
+```
+
+**Connect from the CLI** (requires a local build — no pre-built CLI image is published):
+
+```shell
+cargo run -p ballista-cli -- --host localhost --port 50050
+```
+
+**To make local data available inside the executors**, uncomment and set the `volumes` block
+in `docker-compose.quick.yml`:
+
+```yaml
+ballista-executor:
+  volumes:
+    - /absolute/path/to/your/data:/data:ro
+```
+
+Then reference `/data/yourfile.parquet` in your queries. The path must be the same inside
+every executor container.
+
+**Tear down:**
+
+```shell
+docker compose -f docker-compose.quick.yml down
+```
+
+---
+
+## Path B: Build from source (~20 min)
+
+Use this path if you need to test local code changes or run against the `main` branch.
+
+**Prerequisites:**
 
 - [Rust](https://www.rust-lang.org/tools/install)
 - [Protobuf Compiler](https://protobuf.dev/downloads/)
 
-## Build the project
-
-From the root of the project, build release binaries.
+**Step 1:** Build release binaries from the repository root:
 
 ```shell
 cargo build --release
 ```
 
-Start a Ballista scheduler process in a new terminal session.
+**Step 2:** Start the scheduler in a new terminal:
 
 ```shell
 RUST_LOG=info ./target/release/ballista-scheduler
 ```
 
-Start one or more Ballista executor processes in new terminal sessions. When starting more than one
-executor, a unique port number must be specified for each executor.
+**Step 3:** Start one or more executors, each in a new terminal. When running multiple
+executors, each needs a unique pair of ports:
 
 ```shell
 RUST_LOG=info ./target/release/ballista-executor -c 2 -p 50051 --bind-grpc-port 50052
+```
 
+```shell
 RUST_LOG=info ./target/release/ballista-executor -c 2 -p 50053 --bind-grpc-port 50054
 ```
 
+> **Two-port model:** each executor exposes an Arrow Flight port (data, `-p`) and a gRPC
+> control port (`--bind-grpc-port`). Both must be reachable by the scheduler.
+
+---
+
 ## Running the examples
 
-The examples can be run using the `cargo run --bin` syntax. Open a new terminal session and run the following commands.
+Examples live in the `examples/` directory and connect to `localhost:50050` by default.
 
-### Distributed SQL Example
+### Distributed SQL example
 
 ```bash
 cd examples
 cargo run --release --example remote-sql
 ```
 
-#### Source code for distributed SQL example
-
-```rust
-use ballista::prelude::*;
-use ballista_examples::test_util;
-use datafusion::{
-    execution::SessionStateBuilder,
-    prelude::{CsvReadOptions, SessionConfig, SessionContext},
-};
-
-/// This example demonstrates executing a simple query against an Arrow data source (CSV) and
-/// fetching results, using SQL
-#[tokio::main]
-async fn main() -> Result<()> {
-    let config = SessionConfig::new_with_ballista()
-        .with_target_partitions(4)
-        .with_ballista_job_name("Remote SQL Example");
-
-    let state = SessionStateBuilder::new()
-        .with_config(config)
-        .with_default_features()
-        .build();
-
-    let ctx = SessionContext::remote_with_state("df://localhost:50050", state).await?;
-
-    let test_data = test_util::examples_test_data();
-
-    ctx.register_csv(
-        "test",
-        &format!("{test_data}/aggregate_test_100.csv"),
-        CsvReadOptions::new(),
-    )
-    .await?;
-
-    let df = ctx
-        .sql(
-            "SELECT c1, MIN(c12), MAX(c12) \
-        FROM test \
-        WHERE c11 > 0.1 AND c11 < 0.9 \
-        GROUP BY c1",
-        )
-        .await?;
-
-    df.show().await?;
-
-    Ok(())
-}
-```
-
-### Distributed DataFrame Example
+### Distributed DataFrame example
 
 ```bash
 cd examples
 cargo run --release --example remote-dataframe
 ```
 
-#### Source code for distributed DataFrame example
+### Standalone (single-process) example
 
-```rust
-use ballista::prelude::*;
-use ballista_examples::test_util;
-use datafusion::{
-    prelude::{col, lit, ParquetReadOptions, SessionContext},
-};
+No cluster needed — scheduler and executor run in the same process:
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // creating SessionContext with default settings
-    let ctx = SessionContext::remote("df://localhost:50050").await?;
-
-    let test_data = test_util::examples_test_data();
-    let filename = format!("{test_data}/alltypes_plain.parquet");
-
-    let df = ctx
-        .read_parquet(filename, ParquetReadOptions::default())
-        .await?
-        .select_columns(&["id", "bool_col", "timestamp_col"])?
-        .filter(col("id").gt(lit(1)))?;
-
-    df.show().await?;
-
-    Ok(())
-}
+```bash
+cd examples
+cargo run --release --example standalone-sql
 ```
+
+---
+
+## Troubleshooting
+
+**`protoc` not found during build**
+
+Install the protobuf compiler for your OS, then retry `cargo build --release`:
+
+```shell
+# Ubuntu / Debian
+sudo apt install protobuf-compiler
+
+# macOS
+brew install protobuf
+```
+
+**Executor can't reach the scheduler**
+
+The executor connects to the scheduler at startup. Make sure the scheduler is running before
+starting executors. Check that the scheduler address (`--scheduler-host`, default `localhost`)
+is reachable from the executor's network.
+
+**Port conflict**
+
+If port 50050 is already in use, start the scheduler with `--bind-port <port>` and update
+your client connection string accordingly.
+
+**Docker executor containers exit immediately**
+
+Check `docker compose logs`. The most common cause is the scheduler health check failing
+because the scheduler itself hasn't started yet — `depends_on: condition: service_healthy`
+handles this in `docker-compose.quick.yml`.

--- a/docs/source/user-guide/deployment/quick-start.md
+++ b/docs/source/user-guide/deployment/quick-start.md
@@ -21,11 +21,11 @@
 
 There are two ways to get a local Ballista cluster running. Choose based on your goal:
 
-| | [Evaluate Ballista](#path-a-evaluate-with-docker-2-min) | [Build from source](#path-b-build-from-source-20-min) |
+| | [Evaluate Ballista](#path-a-evaluate-with-docker) | [Build from source](#path-b-build-from-source) |
 |---|---|---|
 | Goal | Try Ballista against the last stable release | Develop or test against local code changes |
 | Prerequisites | Docker | Rust, protoc |
-| Cold start time | ~2 min (image pull) | ~20 min (full compile) |
+| Cold start | Image pull | Full compile |
 | Terminals needed | 1 | 3 |
 
 > [!IMPORTANT]
@@ -34,7 +34,7 @@ There are two ways to get a local Ballista cluster running. Choose based on your
 
 ---
 
-## Path A: Evaluate with Docker (~2 min)
+## Path A: Evaluate with Docker
 
 The only prerequisite is [Docker](https://docs.docker.com/get-docker/) with Compose v2.
 
@@ -73,11 +73,11 @@ in `docker-compose.quick.yml`:
 ```yaml
 ballista-executor:
   volumes:
-    - /absolute/path/to/your/data:/data:ro
+    - /absolute/path/to/your/data:/absolute/path/to/your/data:ro
 ```
 
-Then reference `/data/yourfile.parquet` in your queries. The path must be the same inside
-every executor container.
+The container-side path must match exactly what you pass to `register_parquet` or
+`register_csv` — the scheduler stores that path and sends it to the executor as-is.
 
 **Tear down:**
 
@@ -87,7 +87,7 @@ docker compose -f docker-compose.quick.yml down
 
 ---
 
-## Path B: Build from source (~20 min)
+## Path B: Build from source
 
 Use this path if you need to test local code changes or run against the `main` branch.
 
@@ -130,12 +130,16 @@ Examples live in the `examples/` directory and connect to `localhost:50050` by d
 
 ### Distributed SQL example
 
+[Source](https://github.com/apache/datafusion-ballista/blob/main/examples/examples/remote-sql.rs)
+
 ```bash
 cd examples
 cargo run --release --example remote-sql
 ```
 
 ### Distributed DataFrame example
+
+[Source](https://github.com/apache/datafusion-ballista/blob/main/examples/examples/remote-dataframe.rs)
 
 ```bash
 cd examples
@@ -144,7 +148,9 @@ cargo run --release --example remote-dataframe
 
 ### Standalone (single-process) example
 
-No cluster needed — scheduler and executor run in the same process:
+No cluster needed — scheduler and executor run in the same process.
+
+[Source](https://github.com/apache/datafusion-ballista/blob/main/examples/examples/standalone-sql.rs)
 
 ```bash
 cd examples


### PR DESCRIPTION
## Problem

New users hit one of two silent failures when trying to run Ballista locally:

1. **`docker-compose up --build` fails with no useful error.** The Dockerfiles only `COPY target/release/ballista-*` — they do not compile Rust inside Docker. Without a prior `cargo build --release`, the COPY step finds nothing and the image is broken. This prerequisite is not documented anywhere in the deployment guides.

2. **No fast evaluation path.** The only documented path is `cargo build --release` (~20 min cold, requires Rust + protoc). There is no way to spin up a cluster in ~2 min to evaluate Ballista before committing to a full build.

## Solution

Three changes in one PR:

### 1. `docker-compose.quick.yml` (new file)

Pulls pre-built images from GHCR (`ghcr.io/apache/datafusion-ballista-{scheduler,executor}:latest`). Docker is the only prerequisite.

```shell
docker compose -f docker-compose.quick.yml up
```

Key design decisions:
- **`--advertise-flight-sql-endpoint`** on the scheduler — clients connect only to `localhost:50050`; the scheduler proxies all Arrow Flight result fetching internally. Without this flag, clients receive executor Docker-internal IPs (unreachable from host), causing connection timeouts.
- **Health check + `depends_on: condition: service_healthy`** — executors wait for the scheduler to be ready before registering, avoiding a race condition on slower machines.
- **2 executor replicas by default** via `deploy.replicas` — demonstrates multi-executor setup out of the box.
- Images track the latest stable release, not `main`. This is noted in the file header.

### 2. `docs/source/user-guide/deployment/quick-start.md` (restructured)

- Two clearly labelled paths: *Evaluate (~2 min)* and *Build from source (~20 min)*
- Comparison table at the top (prerequisites, time, terminals)
- Expected log output so users know what healthy startup looks like
- Note on the two-port executor model (Arrow Flight port + gRPC control port)
- `[!IMPORTANT]` compatibility gap warning (DataFusion / Ballista versions)
- Troubleshooting section: `protoc` missing, port conflict, executor can't reach scheduler

### 3. `docs/source/user-guide/deployment/docker-compose.md` (fixed)

- Documents the missing `cargo build --release` prerequisite for `docker-compose.yml`
- Explains why skipping it causes a silent failure
- Notes that no pre-built CLI image is published to GHCR (the existing doc referenced `apache/datafusion-ballista-cli:latest` which does not exist in the registry)

## Testing

- Started the cluster with `docker compose -f docker-compose.quick.yml up -d`
- Verified both executors registered: scheduler logs show two `Received register executor request` entries with distinct UUIDs
- Verified `--advertise-flight-sql-endpoint` proxy: no connection-timeout errors to Docker-internal executor IPs from the host
- Scheduler and executor health checks pass within the configured retry window

## Checklist

- [ ] `docker-compose.quick.yml` starts cleanly on a machine with only Docker installed
- [ ] Both executors register with the scheduler on startup
- [ ] Clients connect to `localhost:50050` only (no direct executor port access needed)
- [ ] `quick-start.md` comparison table and both paths are accurate
- [ ] `docker-compose.md` prerequisite note is clear
