### PR TITLE
chore(ci): Deploy WebTUI to nightlies.a.o

### DIFF
--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -88,13 +88,22 @@ jobs:
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          set -x
+          # Add the SSH key to the agent
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
+
+          # Add the host to the known hosts file
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Prepare the directories
           ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
+
+          # Copy the files
           rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" \
             target/web-tui/* \
             ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          
+          # Print the contents of the directory
+          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "ls -la ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -89,16 +89,8 @@ jobs:
 
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
-        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # v8.0.5
-        with:
-          switches: -rlptDvz
-          path: target/web-tui/*
-          remote_path: datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
-          remote_host: https://nightlies.apache.org
-          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
-          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
-          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
-
+        run: |
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} -i ${{ secrets.NIGHTLIES_RSYNC_KEY }}" target/web-tui/* nightlies.apache.org:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -92,7 +92,6 @@ jobs:
           LOCAL_BUILD_DIR="../target/web-tui-nightlies/"
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
           REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
-          OPTIONS_SSH="-p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}"
           
           trunk build --public-url "/${TUI_DIR}/" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
@@ -101,9 +100,9 @@ jobs:
 
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
-          ssh "${OPTIONS_SSH}" ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
+          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
 
-          rsync -rlptDvz -e "ssh ${OPTIONS_SSH}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -93,7 +93,7 @@ jobs:
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
           REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
           
-          trunk build --public-url "/${TUI_DIR}/" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
+          trunk build --public-url "./" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -91,7 +91,7 @@ jobs:
           set -x
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -88,8 +88,10 @@ jobs:
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
         run: |
+          set -x
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* nightlies.apache.org:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   web-tui:
     name: Build Web TUI WASM32 application
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6.0.3
         with:
@@ -76,6 +76,8 @@ jobs:
       - name: Get package.version
         id: cargo_metadata
         run: |
+          set -x
+          rsync --version
           BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
           echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -92,7 +92,7 @@ jobs:
           LOCAL_BUILD_DIR="../target/web-tui-nightlies/"
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
           REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
-          SSH_OPTS="-p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}"
+          OPTIONS_SSH="-p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}"
           
           trunk build --public-url "/${TUI_DIR}/" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
@@ -101,9 +101,9 @@ jobs:
 
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
-          ssh "${SSH_OPTS}" ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
+          ssh "${OPTIONS_SSH}" ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
 
-          rsync -rlptDvz -e "ssh ${SSH_OPTS}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
+          rsync -rlptDvz -e "ssh ${OPTIONS_SSH}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -87,7 +87,6 @@ jobs:
 
       - name: Deploy at nightlies.a.o
         if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
-        working-directory: ballista-cli
         run: |
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
           REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
@@ -98,7 +97,7 @@ jobs:
 
           ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
 
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" ../target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
+          rsync --times --compress --delete --verbose -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" ./target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -68,11 +68,36 @@ jobs:
         with:
           tool: trunk@0.21.14
 
+      - name: Install cargo-get
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-get@1.4.0
+
+      - name: Get package.version
+        id: cargo_metadata
+        run: |
+          BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
+          echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build
         working-directory: ballista-cli
         run: |
+          echo "==== DEBUG BALLISTA_VERSION: ${{ steps.cargo_metadata.outputs.ballista_version }}"
           trunk build --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
+
+      - name: Deploy to Nightlies
+        #if: ${{ github.ref == 'refs/heads/main' }}
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        with:
+          switches: -rlptDvz
+          path: target/web-tui/*
+          remote_path: datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          remote_host: https://nightlies.apache.org
+          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -79,7 +79,7 @@ jobs:
           BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
           echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build for local deployment
+      - name: Build
         working-directory: ballista-cli
         run: |
           trunk build --cargo-profile release-nonlto --minify --locked \
@@ -89,12 +89,8 @@ jobs:
         #if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
         working-directory: ballista-cli
         run: |
-          LOCAL_BUILD_DIR="../target/web-tui-nightlies/"
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
           REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
-          
-          trunk build --public-url "./" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
-            --no-default-features --features web
 
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
 
@@ -102,7 +98,7 @@ jobs:
 
           ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
 
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" ../target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -91,7 +91,7 @@ jobs:
           set -x
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -92,7 +92,7 @@ jobs:
           LOCAL_BUILD_DIR="../target/web-tui-nightlies/"
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
           REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
-          SSH_OPTIONS="-p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}"
+          SSH_OPTS="-p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}"
           
           trunk build --public-url "/${TUI_DIR}/" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
@@ -101,9 +101,9 @@ jobs:
 
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
-          ssh "${SSH_OPTIONS}" ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
+          ssh "${SSH_OPTS}" ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
 
-          rsync -rlptDvz -e "ssh ${SSH_OPTIONS}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
+          rsync -rlptDvz -e "ssh ${SSH_OPTS}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # v8.0.5
         with:
           switches: -rlptDvz
           path: target/web-tui/*

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -76,8 +76,6 @@ jobs:
       - name: Get package.version
         id: cargo_metadata
         run: |
-          set -x
-          rsync --version
           BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
           echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -90,7 +88,8 @@ jobs:
       - name: Deploy to Nightlies
         #if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} -i ${{ secrets.NIGHTLIES_RSYNC_KEY }}" target/web-tui/* nightlies.apache.org:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* nightlies.apache.org:/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -89,19 +89,21 @@ jobs:
         #if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
         working-directory: ballista-cli
         run: |
-          trunk build --public-url "/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/" --dist ../target/web-tui-nightlies --cargo-profile release-nonlto --minify --locked \
+          LOCAL_BUILD_DIR="../target/web-tui-nightlies/"
+          TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"
+          REMOTE_TARGET_DIR="${{ secrets.NIGHTLIES_RSYNC_PATH }}/${TUI_DIR}/"
+          SSH_OPTIONS="-p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}"
+          
+          trunk build --public-url "/${TUI_DIR}/" --dist "${LOCAL_BUILD_DIR}" --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
 
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
-          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} \
-            "mkdir -p ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
+          ssh "${SSH_OPTIONS}" ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${REMOTE_TARGET_DIR}"
 
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" \
-            target/web-tui-nightlies/* \
-            ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          rsync -rlptDvz -e "ssh ${SSH_OPTIONS}" ${LOCAL_BUILD_DIR}/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${REMOTE_TARGET_DIR}
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -91,7 +91,10 @@ jobs:
           set -x
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
-          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" target/web-tui/* ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
+          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
+          rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" \
+            target/web-tui/* \
+            ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -92,7 +92,7 @@ jobs:
             --no-default-features --features web
 
       - name: Deploy to Nightlies
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           # Add the SSH key to the agent
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -79,10 +79,16 @@ jobs:
           BALLISTA_VERSION=$(cargo get --entry ballista/core/ package.version)
           echo "ballista_version=${BALLISTA_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build
+      - name: Build for local deployment
         working-directory: ballista-cli
         run: |
           trunk build --cargo-profile release-nonlto --minify --locked \
+            --no-default-features --features web
+
+      - name: Build for deployment at nightlies.a.o
+        working-directory: ballista-cli
+        run: |
+          trunk build --public-url "/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/" --dist ../target/web-tui-nightlies --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 
       - name: Deploy to Nightlies
@@ -99,11 +105,8 @@ jobs:
 
           # Copy the files
           rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" \
-            target/web-tui/* \
+            target/web-tui-nightlies/* \
             ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/
-          
-          # Print the contents of the directory
-          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "ls -la ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
 
       - name: Upload WASM32 application
         uses: actions/upload-artifact@v7

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -85,25 +85,20 @@ jobs:
           trunk build --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 
-      - name: Build for deployment at nightlies.a.o
+      - name: Deploy at nightlies.a.o
+        #if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
         working-directory: ballista-cli
         run: |
           trunk build --public-url "/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/" --dist ../target/web-tui-nightlies --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 
-      - name: Deploy to Nightlies
-        if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
-        run: |
-          # Add the SSH key to the agent
           echo "${{ secrets.NIGHTLIES_RSYNC_KEY }}" | ssh-add -
 
-          # Add the host to the known hosts file
           ssh-keyscan -H "${{ secrets.NIGHTLIES_RSYNC_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
-          # Prepare the directories
-          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} "mkdir -p ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
+          ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }} ${{ secrets.NIGHTLIES_RSYNC_HOST }} \
+            "mkdir -p ${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/"
 
-          # Copy the files
           rsync -rlptDvz -e "ssh -p ${{ secrets.NIGHTLIES_RSYNC_PORT }} -l ${{ secrets.NIGHTLIES_RSYNC_USER }}" \
             target/web-tui-nightlies/* \
             ${{ secrets.NIGHTLIES_RSYNC_HOST }}:${{ secrets.NIGHTLIES_RSYNC_PATH }}/datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}/

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -86,7 +86,7 @@ jobs:
             --no-default-features --features web
 
       - name: Deploy at nightlies.a.o
-        #if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event == 'push' && github.ref == 'refs/heads/main' }}
         working-directory: ballista-cli
         run: |
           TUI_DIR="datafusion/ballista/tui/${{ steps.cargo_metadata.outputs.ballista_version }}"

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   web-tui:
     name: Build Web TUI WASM32 application
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
         with:
@@ -82,7 +82,6 @@ jobs:
       - name: Build
         working-directory: ballista-cli
         run: |
-          echo "==== DEBUG BALLISTA_VERSION: ${{ steps.cargo_metadata.outputs.ballista_version }}"
           trunk build --cargo-profile release-nonlto --minify --locked \
             --no-default-features --features web
 

--- a/ballista-cli/Trunk.toml
+++ b/ballista-cli/Trunk.toml
@@ -28,6 +28,7 @@
 [build]
 target = "ballista-web-tui.html"
 dist = "../target/web-tui"
+public_url = "./"
 
 [watch]
 ignore = []


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1841 

# Rationale for this change

Automatically deploy the WebTUI WASM32 application to https://nightlies.apache.org/datafusion/ballista/tui/<<BALLISTA_VERSION>>/

# What changes are included in this PR?

Update the web-tui.yaml CI workflow to upload the latest version of the WebTUI on push to `main`

# Are there any user-facing changes?

No.