### PR TITLE
Fix/python cargo lock drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,21 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "sqlparser"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: cargo
+    directory: "/python"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels: [auto-dependencies]
+    ignore:
+      # arrow and datafusion are bumped manually
+      - dependency-name: "arrow*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "datafusion*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "sqlparser"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -53,3 +53,23 @@ jobs:
         run: |
           cd dev/msrvcheck
           cargo run
+
+  python-lock:
+    name: python Cargo.lock up to date
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-macos-builder
+        with:
+          rust-version: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
+      - name: Verify python/Cargo.lock is in sync with manifests
+        run: |
+          cd python
+          if ! cargo metadata --locked --format-version 1 >/dev/null; then
+            echo "::error::python/Cargo.lock is out of date with the manifests. Run 'cd python && cargo update' and commit the updated Cargo.lock."
+            exit 1
+          fi

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,6 +17,9 @@
 
 name: Dependencies
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1887.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`python/` is a **separate Cargo workspace** (excluded from the root workspace) with its own `python/Cargo.lock`, and it path-depends on the main ballista crates. Two gaps make that lock drift out of sync:

1. **Dependabot only covers the root workspace** (`directory: "/"`)- there is no `/python` entry, so dep bumps update `/Cargo.lock` but never `python/Cargo.lock`.
2. **No CI catches the drift early.** `rust.yml` runs `--locked` only against the main workspace (python is excluded). A stale python lock only surfaces *later* and cryptically, in `build.yml`'s maturin steps (which run with `locked = true` from `python/pyproject.toml`): error: cannot update the lock file python/Cargo.lock because --locked was passed
3. Added an explicit least-privilege permissions: contents: read block to dependencies.yml (resolves a CodeQL finding; matches the other workflows).

Net effect: when a dep moves in a ballista crate manifest (e.g. `itertools`, `tower-http` were bumped to `0.15`/`0.7`), `python/Cargo.lock` is left behind on `main`, and the next contributor inherits a red maturin build with an unhelpful message. This PR fixes the current drift and adds a guard so future drift is caught on the PR that introduces it.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- **`python/Cargo.lock`** - minimally reconciled with the manifests (picks up the already-published `itertools 0.15.0` / `tower-http 0.7.0` that flow in via the ballista path-deps; lockfile format v4 preserved). This fixes the current drift so the new guard passes from day one.
- **`.github/workflows/dependencies.yml`** - new `python-lock` job that runs `cargo metadata --locked` in `python/` and fails with an actionable message (`run 'cd python && cargo update' and commit`) if the lock is stale. The workflow already triggers on `**/Cargo.toml` / `**/Cargo.lock`, so both main-workspace and python changes exercise it.
- **`.github/dependabot.yml`** - new `cargo` entry for `directory: "/python"` (mirroring the root block's manual-bump ignore list for arrow/datafusion/sqlparser), so python's **direct** deps stay fresh.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No runtime/API changes - this is CI/tooling only.

One contributor-facing note: dependabot bumps a **transitive** dep into python via the ballista path-deps (which python doesn't declare directly, so dependabot can't sync python's lock for it). Such a PR will now trip the `python-lock` guard and needs a one-line `cd python && cargo update` + commit on that branch. This isn't new breakage - that drift already broke the next `python/**` PR cryptically; the guard just relocates it to the PR that caused it, with a clear fix message.

No breaking changes to public APIs.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
