### PR TITLE
feat: cancel running stages and tasks on job failure or cancellation

### DIFF
--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -1187,15 +1187,6 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
         };
     }
 
-    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
-        let running_tasks = self.running_tasks();
-        self.fail_job(error.clone());
-        for stage_id in self.running_stages() {
-            self.fail_stage(stage_id, error.clone());
-        }
-        running_tasks
-    }
-
     /// Mark the job success
     fn succeed_job(&mut self) -> ballista_core::error::Result<()> {
         if !self.is_successful() {

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -1187,6 +1187,15 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
         };
     }
 
+    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
+        let running_tasks = self.running_tasks();
+        self.fail_job(error.clone());
+        for stage_id in self.running_stages() {
+            self.fail_stage(stage_id, error.clone());
+        }
+        running_tasks
+    }
+
     /// Mark the job success
     fn succeed_job(&mut self) -> ballista_core::error::Result<()> {
         if !self.is_successful() {

--- a/ballista/scheduler/src/state/aqe/test/job_failure.rs
+++ b/ballista/scheduler/src/state/aqe/test/job_failure.rs
@@ -19,9 +19,12 @@
 
 use crate::state::aqe::AdaptiveExecutionGraph;
 use crate::state::execution_graph::ExecutionGraph;
+use crate::state::execution_stage::ExecutionStage;
 use crate::test_utils::mock_executor;
 use ballista_core::error::Result;
-use ballista_core::serde::protobuf::{JobStatus, job_status};
+use ballista_core::serde::protobuf::{
+    FailedTask, JobStatus, failed_task, job_status, task_status,
+};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::execution::context::{SessionConfig, SessionContext};
 use datafusion::functions_aggregate::sum::sum;
@@ -110,6 +113,26 @@ async fn test_abort_running_cancels_stages_and_returns_inflight_tasks() -> Resul
             }
         ),
         "the job must be Failed after abort"
+    );
+
+    // In-flight tasks of the cancelled stage are recorded as Failed(TaskKilled)
+    let has_killed_task = graph.stages.values().any(|stage| match stage {
+        ExecutionStage::Failed(failed) => {
+            failed.task_infos.iter().flatten().any(|info| {
+                matches!(
+                    &info.task_status,
+                    task_status::Status::Failed(FailedTask {
+                        failed_reason: Some(failed_task::FailedReason::TaskKilled(_)),
+                        ..
+                    })
+                )
+            })
+        }
+        _ => false,
+    });
+    assert!(
+        has_killed_task,
+        "in-flight tasks must be recorded as Failed(TaskKilled) after abort"
     );
 
     Ok(())

--- a/ballista/scheduler/src/state/aqe/test/job_failure.rs
+++ b/ballista/scheduler/src/state/aqe/test/job_failure.rs
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Job-failure lifecycle tests for the adaptive execution graph.
+
+use crate::state::aqe::AdaptiveExecutionGraph;
+use crate::state::execution_graph::ExecutionGraph;
+use crate::test_utils::mock_executor;
+use ballista_core::error::Result;
+use ballista_core::serde::protobuf::{JobStatus, job_status};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::execution::context::{SessionConfig, SessionContext};
+use datafusion::functions_aggregate::sum::sum;
+use datafusion::logical_expr::SortExpr;
+use datafusion::prelude::{JoinType, col};
+use datafusion::test_util::scan_empty_with_partitions;
+
+/// Builds an adaptive graph for a join (two concurrent leaf stages).
+async fn test_join_plan(partition: usize) -> AdaptiveExecutionGraph {
+    let mut config = SessionConfig::new().with_target_partitions(partition);
+    config
+        .options_mut()
+        .optimizer
+        .enable_round_robin_repartition = false;
+    let ctx = SessionContext::new_with_config(config);
+
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("gmv", DataType::UInt64, false),
+    ]);
+
+    let left_plan = scan_empty_with_partitions(Some("left"), &schema, None, 2).unwrap();
+    let right_plan = scan_empty_with_partitions(Some("right"), &schema, None, 2)
+        .unwrap()
+        .build()
+        .unwrap();
+    let sort_expr = SortExpr::new(col("id"), false, false);
+    let logical_plan = left_plan
+        .join(right_plan, JoinType::Inner, (vec!["id"], vec!["id"]), None)
+        .unwrap()
+        .aggregate(vec![col("left.id")], vec![sum(col("left.gmv"))])
+        .unwrap()
+        .sort(vec![sort_expr])
+        .unwrap()
+        .build()
+        .unwrap();
+
+    AdaptiveExecutionGraph::try_new(
+        "localhost:50050",
+        &"job".into(),
+        "",
+        &ctx,
+        &logical_plan,
+        0,
+    )
+    .await
+    .unwrap()
+}
+
+// Same contract as the static graph's test: aborting transitions every running
+// stage to Failed and returns its in-flight tasks for cancellation.
+#[tokio::test]
+async fn test_abort_running_cancels_stages_and_returns_inflight_tasks() -> Result<()> {
+    let executor = mock_executor("executor-id1".to_string());
+    let mut graph = test_join_plan(2).await;
+
+    // Call revive to move the two leaf Resolved stages to Running
+    graph.revive();
+    assert!(
+        graph.running_stages().len() >= 2,
+        "expected two concurrently running leaf stages, found {:?}",
+        graph.running_stages()
+    );
+
+    // Dispatch a task so there is an in-flight task to cancel
+    let _task = graph.pop_next_task(&executor.id)?.unwrap();
+
+    // Aborting cancels every running stage and returns its in-flight tasks
+    let cancelled = graph.abort_running("job aborted".to_string());
+
+    assert!(
+        !cancelled.is_empty(),
+        "abort_running must return the in-flight tasks to cancel"
+    );
+    assert!(
+        graph.running_stages().is_empty(),
+        "every running stage must be cancelled, found {:?}",
+        graph.running_stages()
+    );
+    assert!(
+        matches!(
+            graph.status(),
+            JobStatus {
+                status: Some(job_status::Status::Failed(_)),
+                ..
+            }
+        ),
+        "the job must be Failed after abort"
+    );
+
+    Ok(())
+}

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -19,6 +19,8 @@
 mod alter_stages;
 /// Functional tests for the CoalescePartitionsRule end-to-end through the planner
 mod coalesce_rule;
+/// Job-failure lifecycle tests for the adaptive graph
+mod job_failure;
 /// covers join selection tests
 mod join_selection;
 /// Tests if plan is going to be split to stages correctly

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -2161,6 +2161,52 @@ mod test {
         Ok(())
     }
 
+    // Aborting a running job (failure or cancellation) must transition every
+    // running stage to Failed and return its in-flight tasks for cancellation.
+    // `abort_running` is the shared teardown invoked by `abort_job`.
+    #[tokio::test]
+    async fn test_abort_running_cancels_stages_and_returns_inflight_tasks() -> Result<()>
+    {
+        let executor = mock_executor("executor-id1".to_string());
+        let mut graph = test_join_plan(2).await;
+
+        // Call revive to move the two leaf Resolved stages to Running
+        graph.revive();
+        assert!(
+            graph.running_stages().len() >= 2,
+            "expected two concurrently running leaf stages, found {:?}",
+            graph.running_stages()
+        );
+
+        // Dispatch a task so there is an in-flight task to cancel
+        let _task = graph.pop_next_task(&executor.id)?.unwrap();
+
+        // Aborting cancels every running stage and returns its in-flight tasks
+        let cancelled = graph.abort_running("job aborted".to_string());
+
+        assert!(
+            !cancelled.is_empty(),
+            "abort_running must return the in-flight tasks to cancel"
+        );
+        assert!(
+            graph.running_stages().is_empty(),
+            "every running stage must be cancelled, found {:?}",
+            graph.running_stages()
+        );
+        assert!(
+            matches!(
+                graph.status(),
+                JobStatus {
+                    status: Some(job_status::Status::Failed(_)),
+                    ..
+                }
+            ),
+            "the job must be Failed after abort"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_long_delayed_failed_task_after_executor_lost() -> Result<()> {
         let executor1 = mock_executor("executor-id1".to_string());

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -222,7 +222,14 @@ pub trait ExecutionGraph: Debug {
     /// Abort a running job: fail it, transition every running stage to Failed,
     /// and return the in-flight tasks that should be cancelled. Used for both the
     /// failure and cancellation teardown paths.
-    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo>;
+    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
+        let running_tasks = self.running_tasks();
+        self.fail_job(error.clone());
+        for stage_id in self.running_stages() {
+            self.fail_stage(stage_id, error.clone());
+        }
+        running_tasks
+    }
 
     /// Marks the job as successfully completed.
     ///
@@ -1373,15 +1380,6 @@ impl ExecutionGraph for StaticExecutionGraph {
                 ended_at: self.end_time,
             })),
         };
-    }
-
-    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
-        let running_tasks = self.running_tasks();
-        self.fail_job(error.clone());
-        for stage_id in self.running_stages() {
-            self.fail_stage(stage_id, error.clone());
-        }
-        running_tasks
     }
 
     /// Mark the job success

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -219,6 +219,18 @@ pub trait ExecutionGraph: Debug {
     /// fail job with error message
     fn fail_job(&mut self, error: String);
 
+    /// Abort a running job: fail it, transition every running stage to Failed,
+    /// and return the in-flight tasks that should be cancelled. Used for both the
+    /// failure and cancellation teardown paths.
+    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
+        let running_tasks = self.running_tasks();
+        self.fail_job(error.clone());
+        for stage_id in self.running_stages() {
+            self.fail_stage(stage_id, error.clone());
+        }
+        running_tasks
+    }
+
     /// Marks the job as successfully completed.
     ///
     /// This should only be called after all stages have completed successfully.

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1781,10 +1781,11 @@ mod test {
     use ballista_core::error::Result;
     use ballista_core::serde::protobuf::{
         self, ExecutionError, FailedTask, FetchPartitionError, IoError, JobStatus,
-        TaskKilled, failed_task, job_status,
+        TaskKilled, failed_task, job_status, task_status,
     };
 
     use crate::state::execution_graph::ExecutionGraph;
+    use crate::state::execution_stage::ExecutionStage;
     use crate::test_utils::{
         mock_completed_task, mock_executor, mock_failed_task,
         revive_graph_and_complete_next_stage,
@@ -2216,6 +2217,26 @@ mod test {
                 }
             ),
             "the job must be Failed after abort"
+        );
+
+        // In-flight tasks of the cancelled stage are recorded as Failed(TaskKilled)
+        let has_killed_task = graph.stages.values().any(|stage| match stage {
+            ExecutionStage::Failed(failed) => {
+                failed.task_infos.iter().flatten().any(|info| {
+                    matches!(
+                        &info.task_status,
+                        task_status::Status::Failed(FailedTask {
+                            failed_reason: Some(failed_task::FailedReason::TaskKilled(_)),
+                            ..
+                        })
+                    )
+                })
+            }
+            _ => false,
+        });
+        assert!(
+            has_killed_task,
+            "in-flight tasks must be recorded as Failed(TaskKilled) after abort"
         );
 
         Ok(())

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -222,14 +222,7 @@ pub trait ExecutionGraph: Debug {
     /// Abort a running job: fail it, transition every running stage to Failed,
     /// and return the in-flight tasks that should be cancelled. Used for both the
     /// failure and cancellation teardown paths.
-    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
-        let running_tasks = self.running_tasks();
-        self.fail_job(error.clone());
-        for stage_id in self.running_stages() {
-            self.fail_stage(stage_id, error.clone());
-        }
-        running_tasks
-    }
+    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo>;
 
     /// Marks the job as successfully completed.
     ///
@@ -1380,6 +1373,15 @@ impl ExecutionGraph for StaticExecutionGraph {
                 ended_at: self.end_time,
             })),
         };
+    }
+
+    fn abort_running(&mut self, error: String) -> Vec<RunningTaskInfo> {
+        let running_tasks = self.running_tasks();
+        self.fail_job(error.clone());
+        for stage_id in self.running_stages() {
+            self.fail_stage(stage_id, error.clone());
+        }
+        running_tasks
     }
 
     /// Mark the job success

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -35,7 +35,7 @@ use ballista_core::error::{BallistaError, Result};
 use ballista_core::execution_plans::{ShuffleWriterExec, SortShuffleWriterExec};
 use ballista_core::serde::protobuf::failed_task::FailedReason;
 use ballista_core::serde::protobuf::{
-    FailedTask, OperatorMetricsSet, ResultLost, SuccessfulTask, TaskStatus,
+    FailedTask, OperatorMetricsSet, ResultLost, SuccessfulTask, TaskKilled, TaskStatus,
 };
 use ballista_core::serde::protobuf::{RunningTask, task_status};
 use ballista_core::serde::scheduler::PartitionLocation;
@@ -554,15 +554,40 @@ impl RunningStage {
         }
     }
 
-    /// Converts this running stage to a failed stage with the given error message.
+    /// Converts this running stage to a failed stage. Still-running tasks are recorded
+    /// as cancelled (`Failed(TaskKilled)`) since failing the stage cancels them.
     pub fn to_failed(&self, error_message: String) -> FailedStage {
+        let task_infos = self
+            .task_infos
+            .iter()
+            .map(|task_info| {
+                task_info.as_ref().map(|info| {
+                    if matches!(info.task_status, task_status::Status::Running(_)) {
+                        TaskInfo {
+                            task_status: task_status::Status::Failed(FailedTask {
+                                error: "cancelled".to_string(),
+                                retryable: false,
+                                count_to_failures: false,
+                                failed_reason: Some(FailedReason::TaskKilled(
+                                    TaskKilled {},
+                                )),
+                            }),
+                            ..info.clone()
+                        }
+                    } else {
+                        info.clone()
+                    }
+                })
+            })
+            .collect();
+
         FailedStage {
             stage_id: self.stage_id,
             stage_attempt_num: self.stage_attempt_num,
             partitions: self.partitions,
             output_links: self.output_links.clone(),
             plan: self.plan.clone(),
-            task_infos: self.task_infos.clone(),
+            task_infos,
             stage_metrics: self.stage_metrics.clone(),
             error_message,
         }

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -565,7 +565,7 @@ impl RunningStage {
                     if matches!(info.task_status, task_status::Status::Running(_)) {
                         TaskInfo {
                             task_status: task_status::Status::Failed(FailedTask {
-                                error: "cancelled".to_string(),
+                                error: "killed".to_string(),
                                 retryable: false,
                                 count_to_failures: false,
                                 failed_reason: Some(FailedReason::TaskKilled(

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -548,15 +548,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             let mut guard = graph.write().await;
 
             let pending_tasks = guard.available_tasks();
-            let running_tasks = guard.running_tasks();
+            let running_tasks = guard.abort_running(failure_reason);
 
             info!(
                 "Cancelling {} running tasks for job {}",
                 running_tasks.len(),
                 job_id
             );
-
-            guard.fail_job(failure_reason);
 
             self.state.save_job(job_id, &guard).await?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes partially https://github.com/apache/datafusion-ballista/issues/1795 (needs a follow up REST/TUI fix)

# Rationale for this change

When a job fails or is cancelled, only the job status was set to `Failed`. Its running stages and tasks stayed stuck in `Running` (`fail_stage` was never called).

# What changes are included in this PR?

- Add `ExecutionGraph::abort_running`, called from `task_manager::abort_job` (used by both the failure and cancel paths): it fails the job and runs `fail_stage` over the running stages.
- `RunningStage::to_failed` marks still-running tasks as `Failed(TaskKilled)`.
- Tests for both static and adaptive graphs.

1626af4872587b400d1dc6e588f383160f3c4918 can be dropped if you prefer a default trait method over two per-impl copies (i figured there was no default trait method so far in existing code)

Tested locally with TPC-H under the chaos fault generator:

```bash
cargo run --bin ballista-scheduler --features prometheus-metrics
cargo run --bin ballista-executor
cargo run --bin tpch -- benchmark ballista -p /path/to/tpch/sf10 -f parquet -i 1 \
  --port 50050 --host 127.0.0.1 \
  -c datafusion.execution.target_partitions=24 \
  -c ballista.planner.adaptive.enabled=true \
  -c ballista.testing.chaos_execution.enabled=true \
  -c ballista.testing.chaos_execution.fault_type=fatal \
  -c ballista.testing.chaos_execution.probability=0.6 \
  -q 1
```

Failed job in the TUI:

**Global view** (job shows `Failed`):
<img width="794" height="131" alt="Screenshot from 2026-06-26 17-03-39" src="https://github.com/user-attachments/assets/92e64d42-8abb-4aed-967d-c9b77f6d9048" />

**Stage detail** (stage now shows `Failed`, was stuck `Running`):
<img width="1170" height="161" alt="Screenshot from 2026-06-26 17-04-07" src="https://github.com/user-attachments/assets/0e291ce5-0b2d-4b4b-9501-2c5658f9b398" />

**Stage tasks** (empty for a failed stage, surfaced in the follow-up):
<img width="1162" height="147" alt="Screenshot from 2026-06-26 17-04-19" src="https://github.com/user-attachments/assets/01fc217b-d3e3-4a34-a40f-9754c58562e1" />

I will do a follow-up PR to update the REST API and expose the failed /cancelled task over a failed stage, with TUI handling (I have a draft already)

Note: this PR made use of LLM tooling

# Are there any user-facing changes?

Failed/cancelled jobs now show their stages as `Failed` instead of stuck `Running`.
