### PR TITLE
ci: run TPC-H SF10 under AQE off + on, and build it faster

### DIFF
--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build Ballista binaries
         run: |
-          cargo build --profile release-nonlto --locked \
+          cargo build --profile tpch-ci --locked \
             -p ballista-scheduler \
             -p ballista-executor \
             -p ballista-benchmarks
@@ -101,12 +101,12 @@ jobs:
 
           mkdir -p "$WORK_DIR"
 
-          ./target/release-nonlto/ballista-scheduler \
+          ./target/tpch-ci/ballista-scheduler \
             --bind-host 127.0.0.1 \
             > "$SCHEDULER_LOG" 2>&1 &
           SCHEDULER_PID=$!
 
-          ./target/release-nonlto/ballista-executor \
+          ./target/tpch-ci/ballista-executor \
             --bind-host 127.0.0.1 \
             --bind-port 50051 \
             --scheduler-host 127.0.0.1 \
@@ -156,7 +156,7 @@ jobs:
             # q16 omitted: still unsupported (matches benchmarks/run.sh).
             for q in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22; do
               echo "::group::[$label] Query $q"
-              ./target/release-nonlto/tpch benchmark ballista \
+              ./target/tpch-ci/tpch benchmark ballista \
                 --host 127.0.0.1 --port 50050 \
                 --query "$q" \
                 --path "$DATA_DIR" \

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -48,7 +48,7 @@ on:
 
 jobs:
   tpch-sf10:
-    name: TPC-H SF10 (all queries)
+    name: TPC-H SF10 (all queries, AQE off + on)
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -147,19 +147,32 @@ jobs:
           done
           nc -z 127.0.0.1 50051 || { echo "executor did not start"; exit 1; }
 
-          # q16 omitted: still unsupported (matches benchmarks/run.sh).
-          for q in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22; do
-            echo "::group::Query $q"
-            ./target/release-nonlto/tpch benchmark ballista \
-              --host 127.0.0.1 --port 50050 \
-              --query "$q" \
-              --path "$DATA_DIR" \
-              --format parquet \
-              --partitions 16 \
-              --iterations 1 \
-              -c datafusion.optimizer.prefer_hash_join=false
-            echo "::endgroup::"
-          done
+          # Run the suite once per planner mode against the same data and
+          # cluster. AQE on/off is a per-query session setting, so the scheduler
+          # picks the planner per job; no need to regenerate data or restart the
+          # cluster.
+          run_suite() {
+            local label="$1"; shift
+            # q16 omitted: still unsupported (matches benchmarks/run.sh).
+            for q in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 17 18 19 20 21 22; do
+              echo "::group::[$label] Query $q"
+              ./target/release-nonlto/tpch benchmark ballista \
+                --host 127.0.0.1 --port 50050 \
+                --query "$q" \
+                --path "$DATA_DIR" \
+                --format parquet \
+                --partitions 16 \
+                --iterations 1 \
+                "$@"
+              echo "::endgroup::"
+            done
+          }
+
+          run_suite "AQE off" \
+            -c datafusion.optimizer.prefer_hash_join=false
+          run_suite "AQE on" \
+            -c datafusion.optimizer.prefer_hash_join=false \
+            -c ballista.planner.adaptive.enabled=true
 
       - name: Upload cluster logs on failure
         if: failure()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,17 @@ debug = false
 debug-assertions = false
 strip = "debuginfo"
 incremental = false
+
+# Build profile for the TPC-H integration CI job. That job only checks that the
+# distributed suite runs correctly (no timing gate), so it trades some runtime
+# speed for much faster compilation: opt-level 1 keeps queries fast enough while
+# compiling dependencies far quicker than the opt-level 3 release profiles. Do
+# not use this for performance numbers — use release-nonlto / release-lto.
+[profile.tpch-ci]
+inherits = "release"
+opt-level = 1
+codegen-units = 256
+lto = false
+debug = false
+debug-assertions = false
+incremental = false


### PR DESCRIPTION
# Which issue does this PR close?

N/A — CI coverage + speed improvement.

# Rationale for this change

Two related improvements to the `TPC-H SF10` CI job:

1. **AQE coverage.** The job ran the suite only with AQE off
   (`prefer_hash_join=false`). The adaptive (AQE-on) planner is a different
   planner with different join behavior — it does dynamic broadcast join
   selection — and had **no CI coverage**. A change can pass CI while breaking
   the adaptive path (e.g. a broadcast-under-AQE change failing a query that the
   AQE-off run never exercises).

2. **Faster build.** This job is an integration/correctness check — it asserts
   only that the queries run (no timing gate; real perf numbers come from the
   release profiles and the benchmark-verify job). It was built at opt-level 3
   (`release-nonlto`), and that compile dominates the job's wall time. It does
   not need an opt-level 3 build to check correctness.

# What changes are included in this PR?

- Run the suite a second time with `-c ballista.planner.adaptive.enabled=true`
  (AQE on), in addition to AQE off, using the **same generated data and the same
  cluster** (AQE on/off is a per-query session setting, so the scheduler selects
  the planner per job — no need to regenerate data or restart the cluster). The
  query loop is refactored into a `run_suite` shell function called once per
  mode.
- Add a `tpch-ci` build profile (opt-level 1, codegen-units 256, no LTO) and
  build this job with it. Dependencies compile far faster; SF10 queries stay
  fast enough for a correctness run. Adding the second (AQE-on) pass is cheap
  by comparison, so net job time should drop despite the extra coverage.
- Job renamed to `TPC-H SF10 (all queries, AQE off + on)`.

No change to data generation, query set (q16 still omitted), partitions (16),
iterations, or cluster shape.

# Are there any user-facing changes?

No. CI-only change. The new `tpch-ci` profile is for this job only; performance
benchmarking still uses the `release-nonlto` / `release-lto` profiles.
