### PR TITLE
ci: verify TPC-H query results against single-process DataFusion

### DIFF
--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -169,8 +169,10 @@ jobs:
           }
 
           run_suite "AQE off" \
+            --verify \
             -c datafusion.optimizer.prefer_hash_join=false
           run_suite "AQE on" \
+            --verify \
             -c datafusion.optimizer.prefer_hash_join=false \
             -c ballista.planner.adaptive.enabled=true
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -301,19 +301,19 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
     let ctx = SessionContext::new_with_config(config);
 
     // register tables
-    for table in TABLES {
-        let table_provider = {
-            let mut session_state = ctx.state();
-            get_table(
-                &mut session_state,
-                opt.path.to_str().unwrap(),
-                table,
-                opt.file_format.as_str(),
-                opt.partitions,
-            )
-            .await?
-        };
-        if opt.mem_table {
+    if opt.mem_table {
+        for table in TABLES {
+            let table_provider = {
+                let mut session_state = ctx.state();
+                get_table(
+                    &mut session_state,
+                    opt.path.to_str().unwrap(),
+                    table,
+                    opt.file_format.as_str(),
+                    opt.partitions,
+                )
+                .await?
+            };
             println!("Loading table '{table}' into memory");
             let start = Instant::now();
             let memtable =
@@ -325,9 +325,15 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
                 start.elapsed().as_millis()
             );
             ctx.register_table(*table, Arc::new(memtable))?;
-        } else {
-            ctx.register_table(*table, table_provider)?;
         }
+    } else {
+        register_datafusion_tables(
+            &ctx,
+            opt.path.to_str().unwrap(),
+            opt.file_format.as_str(),
+            opt.partitions,
+        )
+        .await?;
     }
 
     // Determine which queries to run
@@ -352,19 +358,9 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
         for i in 0..opt.iterations {
             let start = Instant::now();
             // Execute each SQL statement sequentially (required for queries like q15
-            // that create views and then reference them), but keep the result of
+            // that create views and then reference them), keeping the result of
             // the answer statement, not a trailing DROP VIEW.
-            let answer_idx = answer_statement_index(&sqls);
-            for (idx, sql) in sqls.iter().enumerate() {
-                if opt.debug {
-                    println!("Executing: {sql}");
-                }
-                let df = ctx.sql(sql).await?;
-                let collected = df.collect().await?;
-                if idx == answer_idx {
-                    result = collected;
-                }
-            }
+            result = execute_query_capturing_answer(&ctx, &sqls, opt.debug).await?;
             let elapsed = start.elapsed().as_secs_f64();
             if opt.debug {
                 pretty::print_batches(&result)?;
@@ -531,7 +527,8 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
         }
 
         if let Some(oracle_ctx) = &oracle_ctx {
-            let expected = execute_query_capturing_answer(oracle_ctx, &sqls).await?;
+            let expected =
+                execute_query_capturing_answer(oracle_ctx, &sqls, opt.debug).await?;
             compare_results(&expected, &batches).map_err(|e| {
                 DataFusionError::Execution(format!(
                     "query {query} verification failed: {e}"
@@ -706,10 +703,14 @@ async fn register_datafusion_tables(
 async fn execute_query_capturing_answer(
     ctx: &SessionContext,
     statements: &[String],
+    debug: bool,
 ) -> Result<Vec<RecordBatch>> {
     let answer_idx = answer_statement_index(statements);
     let mut answer = vec![];
     for (idx, sql) in statements.iter().enumerate() {
+        if debug {
+            println!("Executing: {sql}");
+        }
         let df = ctx.sql(sql).await?;
         let collected = df.collect().await?;
         if idx == answer_idx {
@@ -1213,11 +1214,20 @@ impl BenchmarkRun {
 /// queries can differ in their last digits.
 const FLOAT_TOLERANCE: f64 = 1e-6;
 
-#[derive(PartialEq)]
 enum Cell {
     Null,
     Float(f64),
     Text(String),
+}
+
+impl std::fmt::Display for Cell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Cell::Null => f.write_str("NULL"),
+            Cell::Float(x) => write!(f, "{x}"),
+            Cell::Text(s) => f.write_str(s),
+        }
+    }
 }
 
 fn cell_at(column: &ArrayRef, row: usize) -> Cell {
@@ -1266,14 +1276,6 @@ fn cells_equal(a: &Cell, b: &Cell) -> bool {
         (Cell::Float(x), Cell::Float(y)) => floats_close(*x, *y),
         (Cell::Text(x), Cell::Text(y)) => x == y,
         _ => false,
-    }
-}
-
-fn cell_display(c: &Cell) -> String {
-    match c {
-        Cell::Null => "NULL".to_string(),
-        Cell::Float(x) => x.to_string(),
-        Cell::Text(s) => s.clone(),
     }
 }
 
@@ -1328,9 +1330,7 @@ fn compare_results(expected: &[RecordBatch], actual: &[RecordBatch]) -> Result<(
         for (j, (ecell, acell)) in erow.iter().zip(arow.iter()).enumerate() {
             if !cells_equal(ecell, acell) {
                 return Err(DataFusionError::Execution(format!(
-                    "result mismatch at row {i}, column {j}: expected `{}`, got `{}`",
-                    cell_display(ecell),
-                    cell_display(acell)
+                    "result mismatch at row {i}, column {j}: expected `{ecell}`, got `{acell}`"
                 )));
             }
         }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -347,13 +347,18 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
         for i in 0..opt.iterations {
             let start = Instant::now();
             // Execute each SQL statement sequentially (required for queries like q15
-            // that create views and then reference them)
-            for sql in &sqls {
+            // that create views and then reference them), but keep the result of
+            // the answer statement, not a trailing DROP VIEW.
+            let answer_idx = answer_statement_index(&sqls);
+            for (idx, sql) in sqls.iter().enumerate() {
                 if opt.debug {
                     println!("Executing: {sql}");
                 }
                 let df = ctx.sql(sql).await?;
-                result = df.collect().await?;
+                let collected = df.collect().await?;
+                if idx == answer_idx {
+                    result = collected;
+                }
             }
             let elapsed = start.elapsed().as_secs_f64();
             if opt.debug {
@@ -456,9 +461,10 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
             println!("Running benchmark with query {}:\n {:?}", query, sqls);
         }
         let mut batches = vec![];
+        let answer_idx = answer_statement_index(&sqls);
         for i in 0..opt.iterations {
             let start = Instant::now();
-            for sql in &sqls {
+            for (idx, sql) in sqls.iter().enumerate() {
                 let df = ctx
                     .sql(sql)
                     .await
@@ -468,11 +474,14 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
                 if opt.debug {
                     println!("=== Optimized logical plan ===\n{plan:?}\n");
                 }
-                batches = df
+                let collected = df
                     .collect()
                     .await
                     .map_err(|e| DataFusionError::Plan(format!("{e:?}")))
                     .unwrap();
+                if idx == answer_idx {
+                    batches = collected;
+                }
             }
             let elapsed = start.elapsed().as_secs_f64();
             secs.push(elapsed);
@@ -714,6 +723,20 @@ fn find_path(path: &str, table: &str, ext: &str) -> Result<String> {
             "Could not find {ext} files at {path1} or {path2}"
         )))
     }
+}
+
+/// Index of the statement whose result is the query answer: the last `SELECT`
+/// or `WITH` statement, or the last statement if none qualifies. TPC-H query
+/// files may wrap the answer in setup/teardown statements (e.g. q15 creates and
+/// drops a view); only the query statement's result is the answer.
+fn answer_statement_index(statements: &[String]) -> usize {
+    statements
+        .iter()
+        .rposition(|s| {
+            let head = s.trim_start().to_ascii_lowercase();
+            head.starts_with("select") || head.starts_with("with")
+        })
+        .unwrap_or_else(|| statements.len().saturating_sub(1))
 }
 
 /// Get the SQL statements from the specified query file
@@ -1763,6 +1786,28 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn answer_statement_index_picks_select_not_drop() {
+        let stmts = vec![
+            "create view revenue0 as select 1".to_string(),
+            "select * from revenue0 order by a".to_string(),
+            "drop view revenue0".to_string(),
+        ];
+        assert_eq!(super::answer_statement_index(&stmts), 1);
+    }
+
+    #[test]
+    fn answer_statement_index_single_select() {
+        let stmts = vec!["select 1".to_string()];
+        assert_eq!(super::answer_statement_index(&stmts), 0);
+    }
+
+    #[test]
+    fn answer_statement_index_with_cte() {
+        let stmts = vec!["WITH t AS (select 1) select * from t".to_string()];
+        assert_eq!(super::answer_statement_index(&stmts), 0);
     }
 }
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -423,7 +423,14 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     let oracle_ctx = if opt.verify {
         let cfg = SessionConfig::new()
             .with_target_partitions(opt.partitions)
-            .with_batch_size(opt.batch_size);
+            .with_batch_size(opt.batch_size)
+            // Match Ballista's session defaults so the oracle reads Parquet
+            // strings as Utf8 (not Utf8View) and result schemas line up.
+            .set_bool(
+                "datafusion.execution.parquet.schema_force_view_types",
+                false,
+            )
+            .set_bool("datafusion.sql_parser.map_string_types_to_utf8view", false);
         let ctx = SessionContext::new_with_config(cfg);
         register_datafusion_tables(
             &ctx,

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -125,6 +125,11 @@ struct BallistaBenchmarkOpt {
     /// -c datafusion.execution.target_partitions=16
     #[structopt(short = "c", long = "config", number_of_values = 1)]
     config_overrides: Vec<String>,
+
+    /// Verify each Ballista result against single-process DataFusion over the
+    /// same data.
+    #[structopt(long = "verify")]
+    verify: bool,
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -415,6 +420,23 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
         .map(|q| vec![q])
         .unwrap_or_else(|| (1..=22).collect());
 
+    let oracle_ctx = if opt.verify {
+        let cfg = SessionConfig::new()
+            .with_target_partitions(opt.partitions)
+            .with_batch_size(opt.batch_size);
+        let ctx = SessionContext::new_with_config(cfg);
+        register_datafusion_tables(
+            &ctx,
+            opt.path.to_str().unwrap(),
+            opt.file_format.as_str(),
+            opt.partitions,
+        )
+        .await?;
+        Some(ctx)
+    } else {
+        None
+    };
+
     let mut benchmark_run = BenchmarkRun::new();
     let mut total_elapsed = 0.0;
 
@@ -506,6 +528,16 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
                 let expected = get_expected_results(query, expected_results_path).await?;
                 compare_results(&expected, &batches)?;
             }
+        }
+
+        if let Some(oracle_ctx) = &oracle_ctx {
+            let expected = execute_query_capturing_answer(oracle_ctx, &sqls).await?;
+            compare_results(&expected, &batches).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "query {query} verification failed: {e}"
+                ))
+            })?;
+            println!("Query {query} verified against DataFusion: OK");
         }
 
         if opt.iterations > 1 {
@@ -649,6 +681,42 @@ fn get_query_sql_by_path(query: usize, mut sql_path: String) -> Result<String> {
             "invalid query. Expected value between 1 and 22".to_owned(),
         ))
     }
+}
+
+/// Registers all TPC-H tables on a single-process DataFusion context (the
+/// correctness oracle for `--verify`).
+async fn register_datafusion_tables(
+    ctx: &SessionContext,
+    path: &str,
+    file_format: &str,
+    partitions: usize,
+) -> Result<()> {
+    for table in TABLES {
+        let table_provider = {
+            let mut session_state = ctx.state();
+            get_table(&mut session_state, path, table, file_format, partitions).await?
+        };
+        ctx.register_table(*table, table_provider)?;
+    }
+    Ok(())
+}
+
+/// Executes all statements of a query in order and returns the batches of the
+/// answer statement (see `answer_statement_index`).
+async fn execute_query_capturing_answer(
+    ctx: &SessionContext,
+    statements: &[String],
+) -> Result<Vec<RecordBatch>> {
+    let answer_idx = answer_statement_index(statements);
+    let mut answer = vec![];
+    for (idx, sql) in statements.iter().enumerate() {
+        let df = ctx.sql(sql).await?;
+        let collected = df.collect().await?;
+        if idx == answer_idx {
+            answer = collected;
+        }
+    }
+    Ok(answer)
 }
 
 async fn register_tables(
@@ -1861,26 +1929,22 @@ mod tests {
     }
 
     fn f64_batch(values: Vec<f64>) -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "x",
-            DataType::Float64,
-            false,
-        )]));
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("x", DataType::Float64, false)]));
         RecordBatch::try_new(schema, vec![Arc::new(Float64Array::from(values))]).unwrap()
     }
 
     fn i64_batch(values: Vec<i64>) -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "n",
-            DataType::Int64,
-            false,
-        )]));
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, false)]));
         RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(values))]).unwrap()
     }
 
     #[test]
     fn compare_results_equal_ok() {
-        assert!(super::compare_results(&[i64_batch(vec![1, 2])], &[i64_batch(vec![1, 2])]).is_ok());
+        assert!(
+            super::compare_results(&[i64_batch(vec![1, 2])], &[i64_batch(vec![1, 2])])
+                .is_ok()
+        );
     }
 
     #[test]
@@ -1902,20 +1966,21 @@ mod tests {
     #[test]
     fn compare_results_floats_within_tolerance_ok() {
         // differ only beyond the tolerance's significant digits
-        assert!(super::compare_results(
-            &[f64_batch(vec![123.4567890])],
-            &[f64_batch(vec![123.4567891])]
-        )
-        .is_ok());
+        assert!(
+            super::compare_results(
+                &[f64_batch(vec![123.4567890])],
+                &[f64_batch(vec![123.4567891])]
+            )
+            .is_ok()
+        );
     }
 
     #[test]
     fn compare_results_floats_outside_tolerance_err() {
-        assert!(super::compare_results(
-            &[f64_batch(vec![100.0])],
-            &[f64_batch(vec![100.5])]
-        )
-        .is_err());
+        assert!(
+            super::compare_results(&[f64_batch(vec![100.0])], &[f64_batch(vec![100.5])])
+                .is_err()
+        );
     }
 
     #[test]

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -423,14 +423,7 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     let oracle_ctx = if opt.verify {
         let cfg = SessionConfig::new()
             .with_target_partitions(opt.partitions)
-            .with_batch_size(opt.batch_size)
-            // Match Ballista's session defaults so the oracle reads Parquet
-            // strings as Utf8 (not Utf8View) and result schemas line up.
-            .set_bool(
-                "datafusion.execution.parquet.schema_force_view_types",
-                false,
-            )
-            .set_bool("datafusion.sql_parser.map_string_types_to_utf8view", false);
+            .with_batch_size(opt.batch_size);
         let ctx = SessionContext::new_with_config(cfg);
         register_datafusion_tables(
             &ctx,
@@ -1284,6 +1277,28 @@ fn cell_display(c: &Cell) -> String {
     }
 }
 
+/// Canonicalizes Arrow string/binary representation variants so that physical
+/// differences (e.g. `Utf8` vs `Utf8View`) are not treated as result
+/// differences: single-process DataFusion may infer Parquet strings as
+/// `Utf8View` while Ballista produces `Utf8`, but both stringify identically.
+fn canonical_type(dt: &DataType) -> DataType {
+    match dt {
+        DataType::Utf8View | DataType::LargeUtf8 => DataType::Utf8,
+        DataType::BinaryView | DataType::LargeBinary => DataType::Binary,
+        _ => dt.clone(),
+    }
+}
+
+/// Schema reduced to (name, canonical type) pairs, ignoring nullability and
+/// string/binary representation, for result comparison.
+fn comparable_schema(schema: &Schema) -> Vec<(String, DataType)> {
+    schema
+        .fields()
+        .iter()
+        .map(|f| (f.name().clone(), canonical_type(f.data_type())))
+        .collect()
+}
+
 /// Compares two result sets, tolerating tiny floating-point differences.
 /// Returns an error describing the first mismatch instead of panicking, so the
 /// benchmark binary exits non-zero with a useful message.
@@ -1300,8 +1315,8 @@ fn compare_results(expected: &[RecordBatch], actual: &[RecordBatch]) -> Result<(
     }
 
     if let (Some(e), Some(a)) = (expected.first(), actual.first()) {
-        let e_schema = nullable_schema(e.schema());
-        let a_schema = nullable_schema(a.schema());
+        let e_schema = comparable_schema(&e.schema());
+        let a_schema = comparable_schema(&a.schema());
         if e_schema != a_schema {
             return Err(DataFusionError::Execution(format!(
                 "schema mismatch:\n expected: {e_schema:?}\n actual:   {a_schema:?}"
@@ -1364,20 +1379,6 @@ async fn get_expected_results(n: usize, path: &str) -> Result<Vec<RecordBatch>> 
             .collect::<Vec<Expr>>(),
     )?;
     df.collect().await
-}
-
-// convert the schema to the same but with all columns set to nullable=true.
-// this allows direct schema comparison ignoring nullable.
-fn nullable_schema(schema: Arc<Schema>) -> Schema {
-    Schema::new(
-        schema
-            .fields()
-            .iter()
-            .map(|field| {
-                Field::new(Field::name(field), Field::data_type(field).to_owned(), true)
-            })
-            .collect::<Vec<Field>>(),
-    )
 }
 
 fn get_answer_schema(n: usize) -> Schema {
@@ -2010,6 +2011,28 @@ mod tests {
     fn answer_statement_index_with_cte() {
         let stmts = vec!["WITH t AS (select 1) select * from t".to_string()];
         assert_eq!(super::answer_statement_index(&stmts), 0);
+    }
+
+    #[test]
+    fn compare_results_ignores_utf8view_vs_utf8() {
+        let view_schema = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            DataType::Utf8View,
+            false,
+        )]));
+        let utf8_schema =
+            Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, false)]));
+        let a = RecordBatch::try_new(
+            view_schema,
+            vec![Arc::new(StringViewArray::from(vec!["x", "y"]))],
+        )
+        .unwrap();
+        let b = RecordBatch::try_new(
+            utf8_schema,
+            vec![Arc::new(StringArray::from(vec!["x", "y"]))],
+        )
+        .unwrap();
+        assert!(super::compare_results(&[a], &[b]).is_ok());
     }
 }
 

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -504,7 +504,7 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
 
             if let Some(expected_results_path) = opt.expected_results.as_ref() {
                 let expected = get_expected_results(query, expected_results_path).await?;
-                assert_expected_results(&expected, &batches)
+                compare_results(&expected, &batches)?;
             }
         }
 
@@ -1139,25 +1139,114 @@ impl BenchmarkRun {
     }
 }
 
-/// Compare actual results against expected results at scale factor 1
-fn assert_expected_results(expected: &[RecordBatch], actual: &[RecordBatch]) {
-    // assert schema equality without comparing nullable values
-    assert_eq!(
-        nullable_schema(expected[0].schema()),
-        nullable_schema(actual[0].schema())
-    );
+/// Maximum relative-or-absolute difference tolerated between floating-point
+/// cells. Distributed (Ballista) and single-process (DataFusion) execution
+/// aggregate in different orders, and float `sum` is non-associative, so ratio
+/// queries can differ in their last digits.
+const FLOAT_TOLERANCE: f64 = 1e-6;
 
-    // convert both datasets to Vec<Vec<String>> for simple comparison
-    let expected_vec = result_vec(expected);
-    let actual_vec = result_vec(actual);
+#[derive(PartialEq)]
+enum Cell {
+    Null,
+    Float(f64),
+    Text(String),
+}
 
-    // basic result comparison
-    assert_eq!(expected_vec.len(), actual_vec.len());
-
-    // compare each row. this works as all TPC-H queries have deterministically ordered results
-    for i in 0..actual_vec.len() {
-        assert_eq!(expected_vec[i], actual_vec[i]);
+fn cell_at(column: &ArrayRef, row: usize) -> Cell {
+    if column.is_null(row) {
+        return Cell::Null;
     }
+    match column.data_type() {
+        DataType::Float64 => Cell::Float(
+            column
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .value(row),
+        ),
+        DataType::Float32 => Cell::Float(
+            column
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .unwrap()
+                .value(row) as f64,
+        ),
+        _ => Cell::Text(col_str(column, row)),
+    }
+}
+
+fn rows_as_cells(batches: &[RecordBatch]) -> Vec<Vec<Cell>> {
+    let mut rows = vec![];
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            rows.push(batch.columns().iter().map(|c| cell_at(c, row)).collect());
+        }
+    }
+    rows
+}
+
+fn floats_close(a: f64, b: f64) -> bool {
+    if a == b {
+        return true;
+    }
+    (a - b).abs() <= FLOAT_TOLERANCE * a.abs().max(b.abs()).max(1.0)
+}
+
+fn cells_equal(a: &Cell, b: &Cell) -> bool {
+    match (a, b) {
+        (Cell::Null, Cell::Null) => true,
+        (Cell::Float(x), Cell::Float(y)) => floats_close(*x, *y),
+        (Cell::Text(x), Cell::Text(y)) => x == y,
+        _ => false,
+    }
+}
+
+fn cell_display(c: &Cell) -> String {
+    match c {
+        Cell::Null => "NULL".to_string(),
+        Cell::Float(x) => x.to_string(),
+        Cell::Text(s) => s.clone(),
+    }
+}
+
+/// Compares two result sets, tolerating tiny floating-point differences.
+/// Returns an error describing the first mismatch instead of panicking, so the
+/// benchmark binary exits non-zero with a useful message.
+fn compare_results(expected: &[RecordBatch], actual: &[RecordBatch]) -> Result<()> {
+    let expected_rows = rows_as_cells(expected);
+    let actual_rows = rows_as_cells(actual);
+
+    if expected_rows.len() != actual_rows.len() {
+        return Err(DataFusionError::Execution(format!(
+            "result mismatch: expected {} rows, got {} rows",
+            expected_rows.len(),
+            actual_rows.len()
+        )));
+    }
+
+    if let (Some(e), Some(a)) = (expected.first(), actual.first()) {
+        let e_schema = nullable_schema(e.schema());
+        let a_schema = nullable_schema(a.schema());
+        if e_schema != a_schema {
+            return Err(DataFusionError::Execution(format!(
+                "schema mismatch:\n expected: {e_schema:?}\n actual:   {a_schema:?}"
+            )));
+        }
+    }
+
+    for (i, (erow, arow)) in expected_rows.iter().zip(actual_rows.iter()).enumerate() {
+        for (j, (ecell, acell)) in erow.iter().zip(arow.iter()).enumerate() {
+            if !cells_equal(ecell, acell) {
+                return Err(DataFusionError::Execution(format!(
+                    "result mismatch at row {i}, column {j}: expected `{}`, got `{}`",
+                    cell_display(ecell),
+                    cell_display(acell)
+                )));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Get the expected answer for a specific query at scale factor 1
@@ -1214,23 +1303,6 @@ fn nullable_schema(schema: Arc<Schema>) -> Schema {
             })
             .collect::<Vec<Field>>(),
     )
-}
-
-/// Converts the results into a 2d array of strings, `result[row][column]`
-/// Special cases nulls to NULL for testing
-fn result_vec(results: &[RecordBatch]) -> Vec<Vec<String>> {
-    let mut result = vec![];
-    for batch in results {
-        for row_index in 0..batch.num_rows() {
-            let row_vec = batch
-                .columns()
-                .iter()
-                .map(|column| col_str(column, row_index))
-                .collect();
-            result.push(row_vec);
-        }
-    }
-    result
 }
 
 fn get_answer_schema(n: usize) -> Schema {
@@ -1780,12 +1852,70 @@ mod tests {
             let expected_schema = get_answer_schema(n);
             let normalized = normalize_for_verification(actual, expected_schema).await?;
 
-            assert_expected_results(&expected, &normalized)
+            compare_results(&expected, &normalized)?;
         } else {
             println!("TPCH_DATA environment variable not set, skipping test");
         }
 
         Ok(())
+    }
+
+    fn f64_batch(values: Vec<f64>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "x",
+            DataType::Float64,
+            false,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(Float64Array::from(values))]).unwrap()
+    }
+
+    fn i64_batch(values: Vec<i64>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "n",
+            DataType::Int64,
+            false,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(values))]).unwrap()
+    }
+
+    #[test]
+    fn compare_results_equal_ok() {
+        assert!(super::compare_results(&[i64_batch(vec![1, 2])], &[i64_batch(vec![1, 2])]).is_ok());
+    }
+
+    #[test]
+    fn compare_results_row_count_mismatch() {
+        let err = super::compare_results(&[i64_batch(vec![1])], &[i64_batch(vec![1, 2])])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("expected 1 rows, got 2 rows"), "{err}");
+    }
+
+    #[test]
+    fn compare_results_value_mismatch() {
+        let err = super::compare_results(&[i64_batch(vec![1])], &[i64_batch(vec![2])])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("row 0, column 0"), "{err}");
+    }
+
+    #[test]
+    fn compare_results_floats_within_tolerance_ok() {
+        // differ only beyond the tolerance's significant digits
+        assert!(super::compare_results(
+            &[f64_batch(vec![123.4567890])],
+            &[f64_batch(vec![123.4567891])]
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn compare_results_floats_outside_tolerance_err() {
+        assert!(super::compare_results(
+            &[f64_batch(vec![100.0])],
+            &[f64_batch(vec![100.5])]
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

No dedicated issue; this strengthens the TPC-H CI added in #1913 by turning it
into a correctness gate. The Q11 scale-factor threshold noted below is left for
a separate follow-up.

# Rationale for this change

The TPC-H CI job runs all queries under AQE off and AQE on, but only checks that
each query *runs without erroring* — it never checks results. A change that made
Ballista return wrong rows (a broadcast/shuffle/serialization bug that drops,
duplicates, or corrupts rows) would pass CI silently.

This makes the job a correctness gate by comparing every Ballista result against
single-process DataFusion over the same data. Ballista embeds DataFusion, so for
a correct distributed execution the two must agree. This catches
Ballista-specific divergence — the highest-value class — and is scale-factor
agnostic (no committed answer files).

# What changes are included in this PR?

- Add a `--verify` flag to `tpch benchmark ballista`. For each query it runs the
  same SQL through a single-process DataFusion `SessionContext` over the same
  Parquet data and compares the result.
- Add `compare_results`, replacing the old `assert_expected_results`. It returns
  a descriptive error (row-count, schema, or first differing cell) instead of
  panicking, so a mismatch fails the binary with a useful message. Decimal,
  integer, date, and string columns are compared exactly; only `Float32`/
  `Float64` columns use a small relative-or-absolute tolerance, since
  distributed vs single-process aggregation order differs and float `sum` is
  non-associative. `Utf8`/`Utf8View` (and the large/binary view variants) are
  treated as equal representations.
- Fix multi-statement result capture: a query file may wrap the answer in
  setup/teardown statements (q15 creates and drops a view). The run loops now
  execute every statement but capture the result of the answer statement (the
  last `SELECT`/`WITH`), instead of reporting a trailing `DROP VIEW`. Applied to
  both the Ballista and DataFusion paths.
- Wire `--verify` into `.github/workflows/tpch.yml` for both the AQE-off and
  AQE-on suites.

Validated locally on TPC-H SF10 (1 scheduler, 1 executor, 4 task slots, 16
partitions): all 21 queries (q16 omitted, as in CI) pass `--verify` under both
AQE off and AQE on, including the ratio queries (q14/q17/q19/q22) under the float
tolerance and the multi-statement q15.

Known follow-up (out of scope here): q11's `HAVING` threshold literal `0.0001`
is the SF1 value and is not scaled by `1/SF`, so it returns 0 rows at SF10 in
both Ballista and single-process DataFusion. Since both engines agree, the
cross-check passes; the fix belongs in the query file and will be handled
separately.

# Are there any user-facing changes?

No. The change adds an opt-in `--verify` flag to the benchmark tool and enables
it in CI; there are no changes to Ballista's runtime behavior or public APIs.
