### PR TITLE
docs: add versioned upgrade guide (54.0.0)

### DIFF
--- a/docs/source/contributors-guide/development.md
+++ b/docs/source/contributors-guide/development.md
@@ -156,3 +156,12 @@ This includes instructions for:
 - Running benchmarks against DataFusion and Ballista
 - Comparing performance with Apache Spark
 - Running load tests
+
+## Upgrade notes
+
+When a change breaks a public API, renames or removes a configuration key or CLI
+flag, changes a default that alters query plans or results, or changes the
+wire/serialization format, add an entry describing the change and the required
+action to the current unreleased page under
+[`docs/source/upgrading/`](../upgrading/index.rst). This keeps the upgrade guide
+complete for the next release.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,6 +64,12 @@ Table of content
 
    changelog/index
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Upgrade Guides
+
+   upgrading/index
+
 .. _toc.contributors:
 
 .. toctree::

--- a/docs/source/upgrading/54.0.0.md
+++ b/docs/source/upgrading/54.0.0.md
@@ -24,3 +24,100 @@
 **Note:** Ballista `54.0.0` has not been released yet. The information provided
 in this section pertains to features and changes that have already been merged
 to the main branch and are awaiting release in this version.
+
+### For library and embedding users
+
+#### Upgrade to DataFusion 54
+
+Ballista `54.0.0` upgrades its DataFusion dependency to `54.0.0`. Code built on
+`ballista-core` / DataFusion APIs must move with it. See DataFusion's own
+[Upgrade Guide for 54.0.0](https://datafusion.apache.org/library-user-guide/upgrading/54.0.0.html)
+for the DataFusion-side API changes.
+
+#### `job_id` is now a newtype
+
+Scheduler job identifiers are no longer bare `String`s. `ballista-core` now
+exports a transparent `JobId` newtype (`ballista_core::JobId`) so a job id can
+no longer be confused with another string identifier at the type level. Public
+signatures that previously carried a `String`/`&str` job id now carry a `JobId`
+/ `&JobId` — for example `DistributedQueryExec::job_id()` now returns
+`Option<JobId>` instead of `Option<String>`. Construct one with
+`JobId::new(...)` or `.into()`, and recover the inner string with `.as_str()`
+or `.into_inner()`.
+
+```rust
+// before
+let id: Option<String> = query_exec.job_id();
+
+// after
+use ballista_core::JobId;
+let id: Option<JobId> = query_exec.job_id();
+let id_str: Option<String> = id.map(|id| id.into_inner());
+```
+
+### For cluster operators
+
+#### CORS origins and methods are configured via CLI flags
+
+The scheduler REST API no longer reads CORS configuration from environment
+variables. The `BALLISTA_CORS_ALLOWED_ORIGINS` and
+`BALLISTA_CORS_ALLOWED_METHODS` environment variables are removed and replaced
+by the `--cors-allowed-origins` and `--cors-allowed-methods` scheduler CLI
+flags (each a comma-separated list; `*` allows any). If you set these
+environment variables, move the values to the flags — otherwise the scheduler
+falls back to its defaults (origins `http://localhost:8080` and
+`https://nightlies.apache.org`; methods `GET`, `PATCH`, `OPTIONS`).
+
+```
+# before (environment variables)
+BALLISTA_CORS_ALLOWED_ORIGINS=https://example.com \
+BALLISTA_CORS_ALLOWED_METHODS=GET,PATCH \
+  ballista-scheduler
+
+# after (scheduler CLI flags)
+ballista-scheduler \
+  --cors-allowed-origins https://example.com \
+  --cors-allowed-methods GET,PATCH
+```
+
+### Changed default behavior
+
+#### The static planner now broadcasts small join build sides
+
+Ballista previously disabled `CollectLeft` broadcast joins entirely (both
+`datafusion.optimizer.hash_join_single_partition_threshold` and
+`hash_join_single_partition_threshold_rows` defaulted to `0`). In `54.0.0`
+those defaults are raised to `10 MB` (`10485760`) and `1000000` rows, and the
+static `DefaultDistributedPlanner` now converts a `SortMergeJoinExec` whose
+smaller side fits under `ballista.optimizer.broadcast_join_threshold_bytes`
+(default `10 MB`) into a broadcast `CollectLeft` hash join. This conversion is
+governed by the new `ballista.optimizer.broadcast_sort_merge_join_enabled`
+config key, which defaults to `true`.
+
+The consequence is that join plans — and therefore performance and shuffle
+behavior — change on upgrade **even with AQE off**. Broadcast is applied only
+to join types that are safe to broadcast (inner and right-side variants); other
+join types remain repartitioned. To restore the previous behavior, set
+`ballista.optimizer.broadcast_sort_merge_join_enabled = false` and
+`ballista.optimizer.broadcast_join_threshold_bytes = 0`.
+
+#### Serialized empty projections
+
+The plan serialization for a filter that projects to zero columns changed. In
+`53.x` an empty projection (`Some([])`) and "all columns" (`None`) both encoded
+to an empty list and decoded back to `None`, shifting downstream column indices;
+the scheduler now rewrites such filters into a serde-safe form before
+serialization. Together with the DataFusion 54 protobuf bump, this means a
+`54.0.0` scheduler and a `53.x` executor (or vice versa) cannot reliably
+exchange serialized plans. Upgrade schedulers and executors together — do not
+run a mixed-version cluster across this upgrade.
+
+#### AQE join behavior (opt-in)
+
+If you have enabled `ballista.planner.adaptive.enabled = true`, adaptive join
+selection now delays the join decision and can promote a small build side to a
+broadcast (`CollectLeft`) hash join at runtime, and empty-join inputs are
+short-circuited by the propagate-empty rule. This changes the runtime join
+plans (and their results' timing/shape) for adaptive clusters; it is gated by
+`ballista.planner.adaptive_join.enabled` (default `true`). Clusters using the
+default (AQE off) are unaffected.

--- a/docs/source/upgrading/54.0.0.md
+++ b/docs/source/upgrading/54.0.0.md
@@ -17,7 +17,7 @@
   under the License.
 -->
 
-# Upgrade Guide
+# Upgrade Guides
 
 ## Ballista 54.0.0
 
@@ -80,7 +80,7 @@ ballista-scheduler \
   --cors-allowed-methods GET,PATCH
 ```
 
-### Changed default behavior
+### Planner and execution behavior changes
 
 #### The static planner now broadcasts small join build sides
 
@@ -98,8 +98,10 @@ The consequence is that join plans — and therefore performance and shuffle
 behavior — change on upgrade **even with AQE off**. Broadcast is applied only
 to join types that are safe to broadcast (inner and right-side variants); other
 join types remain repartitioned. To restore the previous behavior, set
-`ballista.optimizer.broadcast_sort_merge_join_enabled = false` and
-`ballista.optimizer.broadcast_join_threshold_bytes = 0`.
+`ballista.optimizer.broadcast_sort_merge_join_enabled = false`,
+`ballista.optimizer.broadcast_join_threshold_bytes = 0`,
+`datafusion.optimizer.hash_join_single_partition_threshold = 0`, and
+`hash_join_single_partition_threshold_rows = 0`.
 
 #### Serialized empty projections
 

--- a/docs/source/upgrading/54.0.0.md
+++ b/docs/source/upgrading/54.0.0.md
@@ -1,0 +1,26 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Upgrade Guide
+
+## Ballista 54.0.0
+
+**Note:** Ballista `54.0.0` has not been released yet. The information provided
+in this section pertains to features and changes that have already been merged
+to the main branch and are awaiting release in this version.

--- a/docs/source/upgrading/index.rst
+++ b/docs/source/upgrading/index.rst
@@ -1,0 +1,24 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+Upgrade Guides
+==============
+
+.. toctree::
+   :maxdepth: 1
+
+   Ballista 54.0.0 <54.0.0>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1938.

# Rationale for this change

Ballista has no per-release upgrade guide. Upstream DataFusion maintains one under `docs/source/library-user-guide/upgrading/`, giving users a single authoritative place to learn what breaks and what action to take when moving between releases. The auto-generated changelog is not a substitute — it lists merged PRs but does not tell a user what they must change. This PR establishes the same kind of hand-curated, versioned upgrade guide for Ballista.

# What changes are included in this PR?

- New `docs/source/upgrading/` directory with an `index.rst` toctree, wired into the top-level docs navigation as an "Upgrade Guides" section.
- A `54.0.0.md` page documenting the **breaking changes** since `53.0.0`. Because Ballista serves both cluster operators and library/embedding users, entries are separated by audience:
  - **For library and embedding users:** the DataFusion 54 upgrade, and `job_id` becoming a newtype.
  - **For cluster operators:** CORS origins/methods moving from environment variables to CLI flags.
  - **Planner and execution behavior changes:** the static planner now broadcasting small join build sides (changed defaults), the empty-projection serialization fix (wire compatibility for mixed-version clusters), and the opt-in AQE join changes.
- A short note in the contributors guide asking contributors to add an upgrade-guide entry when they introduce a breaking change, so the guide stays current release over release.

Scope is deliberately limited to breaking changes (breaking API/trait/signature changes, removed/renamed config keys or CLI flags, changed defaults that alter plans/results, and wire/serialization-format changes); additive features and cosmetic changes are left to the changelog.

# Are there any user-facing changes?

Documentation only — no code changes. Adds a new Upgrade Guides section to the rendered documentation.
