### PR TITLE
refactor(scheduler): keep submit_job non-breaking, add submit_physical_plan

### DIFF
--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -429,7 +429,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             });
 
             let job_id = self
-                .submit_job(&job_name, session_ctx, &plan, Some(subscriber))
+                .submit_plan(&job_name, session_ctx, &plan, Some(subscriber))
                 .await
                 .map_err(|e| {
                     let msg =
@@ -504,7 +504,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
 
             log::trace!("setting job name: {job_name}");
             let job_id = self
-                .submit_job(&job_name, session_ctx, &plan, None)
+                .submit_plan(&job_name, session_ctx, &plan, None)
                 .await
                 .map_err(|e| {
                     let msg =

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -25,6 +25,8 @@ use ballista_core::serde::protobuf::TaskStatus;
 use ballista_core::{JobId, JobStatusSubscriber};
 
 use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
@@ -216,8 +218,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         Ok(())
     }
 
-    /// Submits a job to executor returning job_id
-    pub async fn submit_job(
+    /// Shared entry point for logical and physical submissions.
+    pub async fn submit_plan(
         &self,
         job_name: &str,
         ctx: Arc<SessionContext>,
@@ -239,6 +241,37 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
             .await?;
 
         Ok(job_id)
+    }
+
+    /// Submit a logical plan for distributed execution, returning the job id.
+    pub async fn submit_job(
+        &self,
+        job_name: &str,
+        ctx: Arc<SessionContext>,
+        plan: &LogicalPlan,
+        subscriber: Option<JobStatusSubscriber>,
+    ) -> Result<JobId> {
+        self.submit_plan(
+            job_name,
+            ctx,
+            &SubmitPlan::Logical(plan.clone()),
+            subscriber,
+        )
+        .await
+    }
+
+    /// Submit an already-built physical plan for distributed execution. The physical
+    /// plan is planned with the static distributed planner; adaptive query planning
+    /// (AQE) is not available for this path.
+    pub async fn submit_physical_plan(
+        &self,
+        job_name: &str,
+        ctx: Arc<SessionContext>,
+        plan: Arc<dyn ExecutionPlan>,
+        subscriber: Option<JobStatusSubscriber>,
+    ) -> Result<JobId> {
+        self.submit_plan(job_name, ctx, &SubmitPlan::Physical(plan), subscriber)
+            .await
     }
 
     /// It just send task status update event to the channel,
@@ -437,7 +470,6 @@ mod test {
         ExecutorSpecification,
     };
 
-    use crate::scheduler_server::event::SubmitPlan;
     use crate::scheduler_server::{SchedulerServer, timestamp_millis};
 
     use crate::test_utils::{
@@ -484,14 +516,8 @@ mod test {
         // Submit job
         scheduler
             .state
-            .submit_job(
-                &job_id,
-                "",
-                ctx,
-                &SubmitPlan::Logical(plan.clone()),
-                0,
-                None,
-            )
+            .task_manager
+            .submit_job(&job_id, "", ctx, &plan, 0, None)
             .await
             .expect("submitting plan");
 
@@ -560,6 +586,60 @@ mod test {
         for output_location in final_graph.output_locations() {
             assert_eq!(output_location.executor_meta.host, "localhost1".to_owned())
         }
+
+        Ok(())
+    }
+
+    // Verify a job can be submitted as an already-built physical plan.
+    #[tokio::test]
+    async fn test_submit_physical_plan() -> Result<()> {
+        let logical_plan = test_plan();
+        let task_slots = 4;
+
+        let scheduler = test_scheduler(TaskSchedulingPolicy::PullStaged).await?;
+
+        let executors = test_executors(task_slots);
+        for (executor_metadata, executor_data) in executors {
+            scheduler
+                .state
+                .executor_manager
+                .register_executor(executor_metadata, executor_data)
+                .await?;
+        }
+
+        let config =
+            SessionConfig::new_with_ballista().with_target_partitions(task_slots);
+
+        let ctx = scheduler
+            .state
+            .session_manager
+            .create_or_update_session("session_id", &config)
+            .await?;
+
+        // Plan the logical plan into a physical plan and submit it directly.
+        let physical_plan = ctx.state().create_physical_plan(&logical_plan).await?;
+
+        let job_id: JobId = "physical_job".into();
+
+        scheduler
+            .state
+            .task_manager
+            .queue_job(&job_id, "", timestamp_millis())?;
+
+        scheduler
+            .state
+            .task_manager
+            .submit_physical_plan(&job_id, "", ctx, physical_plan, 0, None)
+            .await
+            .expect("submitting physical plan");
+
+        assert!(
+            scheduler
+                .state
+                .task_manager
+                .get_active_execution_graph(&job_id)
+                .is_some()
+        );
 
         Ok(())
     }

--- a/ballista/scheduler/src/state/mod.rs
+++ b/ballista/scheduler/src/state/mod.rs
@@ -372,7 +372,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerState<T,
         let start = Instant::now();
 
         self.task_manager
-            .submit_job(job_id, job_name, session_ctx, plan, queued_at, subscriber)
+            .submit_plan(job_id, job_name, session_ctx, plan, queued_at, subscriber)
             .await?;
 
         let elapsed = start.elapsed();

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -37,6 +37,7 @@ use ballista_core::{JobId, JobStatusSubscriber};
 use dashmap::DashMap;
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
@@ -276,8 +277,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     /// Generate an ExecutionGraph for the job and save it to the persistent state.
     /// By default, this job will be curated by the scheduler which receives it.
     /// Then we will also save it to the active execution graph
+    ///
+    /// Shared entry point for logical and physical submissions.
     #[allow(clippy::too_many_arguments)]
-    pub async fn submit_job(
+    pub async fn submit_plan(
         &self,
         job_id: &JobId,
         job_name: &str,
@@ -368,6 +371,52 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .insert(job_id.to_owned(), JobInfoCache::new(graph));
 
         Ok(())
+    }
+
+    /// Submit a logical plan for distributed execution.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn submit_job(
+        &self,
+        job_id: &JobId,
+        job_name: &str,
+        ctx: Arc<SessionContext>,
+        plan: &LogicalPlan,
+        queued_at: u64,
+        subscriber: Option<JobStatusSubscriber>,
+    ) -> Result<()> {
+        self.submit_plan(
+            job_id,
+            job_name,
+            ctx,
+            &SubmitPlan::Logical(plan.clone()),
+            queued_at,
+            subscriber,
+        )
+        .await
+    }
+
+    /// Submit an already-built physical plan for distributed execution. The physical
+    /// plan is planned with the static distributed planner; adaptive query planning
+    /// (AQE) is not available for this path.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn submit_physical_plan(
+        &self,
+        job_id: &JobId,
+        job_name: &str,
+        ctx: Arc<SessionContext>,
+        plan: Arc<dyn ExecutionPlan>,
+        queued_at: u64,
+        subscriber: Option<JobStatusSubscriber>,
+    ) -> Result<()> {
+        self.submit_plan(
+            job_id,
+            job_name,
+            ctx,
+            &SubmitPlan::Physical(plan),
+            queued_at,
+            subscriber,
+        )
+        .await
     }
 
     /// Returns a snapshot of currently running jobs from the cache.

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -54,7 +54,7 @@ use datafusion::prelude::{CsvReadOptions, JoinType, col};
 use datafusion::test_util::scan_empty_with_partitions;
 
 use crate::cluster::BallistaCluster;
-use crate::scheduler_server::event::{QueryStageSchedulerEvent, SubmitPlan};
+use crate::scheduler_server::event::QueryStageSchedulerEvent;
 
 use crate::state::execution_graph::{
     ExecutionGraph, ExecutionStage, StaticExecutionGraph, TaskDescription,
@@ -503,10 +503,7 @@ impl SchedulerTest {
             .create_or_update_session("session_id", &self.session_config)
             .await?;
 
-        let job_id = self
-            .scheduler
-            .submit_job(job_name, ctx, &SubmitPlan::Logical(plan.clone()), None)
-            .await?;
+        let job_id = self.scheduler.submit_job(job_name, ctx, plan, None).await?;
 
         Ok(job_id)
     }
@@ -645,12 +642,7 @@ impl SchedulerTest {
 
         let job_id = self
             .scheduler
-            .submit_job(
-                job_name,
-                ctx,
-                &SubmitPlan::Logical(plan.clone()),
-                subscriber,
-            )
+            .submit_job(job_name, ctx, plan, subscriber)
             .await?;
 
         let mut receiver = self.status_receiver.take().unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1940.

# Rationale for this change

#1924 added support for submitting an already-built physical plan to the scheduler. To carry both a logical and a physical plan, it changed the parameter of two public methods — `SchedulerServer::submit_job` and `TaskManager::submit_job` — from `&LogicalPlan` to a new `&SubmitPlan` enum. That is a breaking change for anyone driving the scheduler programmatically: existing `submit_job(&logical_plan)` calls no longer compile.

54.0.0 has not been released yet, so we can keep the new capability without breaking the existing API.

# What changes are included in this PR?

- Restore `SchedulerServer::submit_job` and `TaskManager::submit_job` to their original `&LogicalPlan` signatures (unchanged for existing callers).
- Add `SchedulerServer::submit_physical_plan` and `TaskManager::submit_physical_plan`, taking `Arc<dyn ExecutionPlan>`, for the already-built-physical-plan path.
- Extract the shared logic into a `submit_plan(&SubmitPlan)` method on each type; the `submit_job` / `submit_physical_plan` methods are thin wrappers over it. `SubmitPlan`, the job-queued event, and the wire format are unchanged.
- Internal callers use `submit_plan` directly (the gRPC handler already holds a `SubmitPlan`; `SchedulerState::submit_job` — which is `pub(crate)` — forwards to `task_manager.submit_plan`).
- The tests that #1924 rewrote to construct a `SubmitPlan` are reverted to pass a `&LogicalPlan` through the restored `submit_job`, and a new test covers `submit_physical_plan`.

# Are there any user-facing changes?

The public `submit_job(&LogicalPlan)` API is preserved (no breaking change). A new `submit_physical_plan` method is added. No wire-format or configuration changes.
