### PR TITLE
feat: support running TPC-H benchmarks against S3-compatible object storage

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,7 +32,9 @@ default = ["mimalloc"]
 
 [dependencies]
 ballista = { path = "../ballista/client", version = "53.0.0" }
-ballista-core = { path = "../ballista/core", version = "53.0.0" }
+ballista-core = { path = "../ballista/core", version = "53.0.0", features = [
+    "build-binary",
+] }
 clap = { workspace = true }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -19,6 +19,9 @@
 
 use ballista::extension::SessionConfigExt;
 use ballista::prelude::SessionContextExt;
+use ballista_core::object_store::{
+    session_config_with_s3_support, session_state_with_s3_support,
+};
 use datafusion::arrow::array::*;
 use datafusion::arrow::datatypes::SchemaBuilder;
 use datafusion::arrow::util::display::array_value_to_string;
@@ -92,9 +95,11 @@ struct BallistaBenchmarkOpt {
     #[structopt(short = "s", long = "batch-size", default_value = "8192")]
     batch_size: usize,
 
-    /// Path to data files
-    #[structopt(parse(from_os_str), required = true, short = "p", long = "path")]
-    path: PathBuf,
+    /// Path to data files. May be a local path or an object-store URL such as
+    /// `s3://bucket/prefix` (credentials/endpoint via AWS_* env vars or
+    /// `-c s3.*` config overrides).
+    #[structopt(required = true, short = "p", long = "path")]
+    path: String,
 
     /// File format: `csv` or `parquet`
     #[structopt(short = "f", long = "format", default_value = "csv")]
@@ -423,7 +428,7 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
         let ctx = SessionContext::new_with_config(cfg);
         register_datafusion_tables(
             &ctx,
-            opt.path.to_str().unwrap(),
+            opt.path.as_str(),
             opt.file_format.as_str(),
             opt.partitions,
         )
@@ -439,7 +444,7 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     for query in query_numbers {
         let mut query_run = QueryRun::new(query);
 
-        let mut config = SessionConfig::new_with_ballista()
+        let mut config = session_config_with_s3_support()
             .with_target_partitions(opt.partitions)
             .with_ballista_job_name(&format!("Query derived from TPC-H q{}", query))
             .with_batch_size(opt.batch_size)
@@ -459,14 +464,11 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
             }
         }
 
-        let state = SessionStateBuilder::new()
-            .with_default_features()
-            .with_config(config)
-            .build();
+        let state = session_state_with_s3_support(config)?;
         let ctx = SessionContext::remote_with_state(&address, state).await?;
 
         // register tables with Ballista context
-        let path = opt.path.to_str().unwrap();
+        let path = opt.path.as_str();
         let file_format = opt.file_format.as_str();
 
         register_tables(path, file_format, &ctx, opt.debug).await?;
@@ -781,6 +783,14 @@ async fn register_tables(
 }
 
 fn find_path(path: &str, table: &str, ext: &str) -> Result<String> {
+    // Object-store URLs (e.g. `s3://bucket/prefix`) cannot be probed with the
+    // local filesystem, so register the per-table directory under the base URL
+    // directly. The trailing slash marks it as a directory so the listing table
+    // enumerates the Parquet files inside (e.g. `s3://bucket/prefix/lineitem/`).
+    if path.contains("://") {
+        return Ok(format!("{path}/{table}/"));
+    }
+
     let path1 = format!("{path}/{table}.{ext}");
     let path2 = format!("{path}/{table}");
     if Path::new(&path1).exists() {


### PR DESCRIPTION
# Which issue does this PR close?

<!-- Draft — happy to file a tracking issue if the maintainers prefer one. -->

N/A (draft)

# Rationale for this change

The `tpch` benchmark's `benchmark ballista` command can currently only read
data from the local filesystem: `--path` is parsed as a `PathBuf` (which
corrupts URL schemes such as `s3://bucket` into `s3:/bucket`), table
registration probes the local filesystem with `Path::exists()`, and the
benchmark's client `SessionState` is built without object-store support.

This makes it impossible to benchmark Ballista against data held in
S3-compatible object storage (e.g. MinIO or AWS S3), which is the natural way
to run larger scale factors on a distributed cluster where the data does not
fit on a single node's local disk. The `ballista-scheduler` and
`ballista-executor` binaries already register S3 support via
`session_*_with_s3_support`; only the benchmark client was missing it.

# What changes are included in this PR?

Scoped to `benchmark ballista` in `benchmarks/src/bin/tpch.rs`:

- `BallistaBenchmarkOpt::path` changes from `PathBuf` to `String` so URL
  schemes survive argument parsing.
- The client session is now built from `session_config_with_s3_support()` and
  `session_state_with_s3_support()` (the same helpers the scheduler/executor
  binaries use), so the client can plan against an object store. Because this
  registers the `S3Options` config extension, the existing `-c key=value`
  override flag now also accepts `s3.*` keys (`s3.endpoint`,
  `s3.access_key_id`, `s3.secret_access_key`, `s3.region`, `s3.allow_http`).
  Standard `AWS_*` environment variables continue to work as well.
- `find_path()` registers the per-table directory directly for object-store
  URLs (paths containing `://`), bypassing the local `Path::exists()` check.
- `benchmarks/Cargo.toml` enables `ballista-core/build-binary`, which gates the
  `object_store` module (and pulls in the `aws-config`/`object_store` deps).

Local-filesystem behavior is unchanged: non-URL paths still go through the
existing `find_path()` resolution.

Example:

```
AWS_ENDPOINT=http://localhost:9000 AWS_ALLOW_HTTP=true \
AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_REGION=us-east-1 \
tpch benchmark ballista --host <scheduler> --port 50050 \
  --path s3://tpch/sf1000 --format parquet --iterations 3
```

# How was this tested?

Deployed a distributed Ballista cluster (scheduler + 2 executors) on Kubernetes
with the executors and benchmark client configured against a MinIO instance via
`AWS_*` env vars, and ran the full TPC-H suite:

```
tpch benchmark ballista --host ballista-scheduler --port 50050 \
  --path s3://tpch/sf100 --format parquet --iterations 1
```

All 22 queries completed successfully reading Parquet from object storage, with
result cardinalities matching the expected TPC-H answers (Q1=4, Q2=100, Q9=175,
Q18=100, Q22=7, …). Local-filesystem `--path` behavior was confirmed unchanged.

# Are there any user-facing changes?

Yes — the `tpch benchmark ballista --path` option now additionally accepts
object-store URLs (e.g. `s3://bucket/prefix`), and `-c s3.*` config overrides
are now honored. This is additive and backward compatible for local paths. No
public library API changes.
