### PR TITLE
fix: hold pooled shuffle connection for the response stream lifetime

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::client::BallistaClient;
-use crate::client_pool::BallistaClientPool;
+use crate::client_pool::{BallistaClientPool, PooledClient};
 use crate::error::BallistaError;
 use crate::execution_plans::sort_shuffle::{
     get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
@@ -576,6 +576,52 @@ impl RecordBatchStream for LocalShuffleStream {
     }
 }
 
+/// Wraps a remote shuffle-fetch stream and holds the [PooledClient] it was fetched
+/// over for the lifetime of the stream. This keeps the underlying connection
+/// checked out of the pool until the response body has been fully read, so it
+/// cannot be reused, evicted, or closed mid-stream. On a transport error the
+/// connection is discarded rather than returned, since it is no longer trustworthy.
+struct PooledPartitionStream {
+    inner: SendableRecordBatchStream,
+    /// `Some` until the stream errors. Dropping it returns the connection to the
+    /// pool for reuse; `discard()` on error prevents reuse of a broken connection.
+    pooled: Option<PooledClient>,
+}
+
+impl PooledPartitionStream {
+    fn new(inner: SendableRecordBatchStream, pooled: PooledClient) -> Self {
+        Self {
+            inner,
+            pooled: Some(pooled),
+        }
+    }
+}
+
+impl Stream for PooledPartitionStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let poll = self.inner.poll_next_unpin(cx);
+        // A transport/body error mid-stream leaves the connection in an unknown
+        // state; drop the guard via discard() so it is not returned to the pool.
+        if let Poll::Ready(Some(Err(_))) = &poll
+            && let Some(pooled) = self.pooled.take()
+        {
+            pooled.discard();
+        }
+        poll
+    }
+}
+
+impl RecordBatchStream for PooledPartitionStream {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+}
+
 /// Adapter for a tokio ReceiverStream that implements the SendableRecordBatchStream interface
 struct AbortableReceiverStream {
     inner: ReceiverStream<result::Result<SendableRecordBatchStream, BallistaError>>,
@@ -763,7 +809,7 @@ async fn fetch_partition_remote(
                 other => other,
             })?;
 
-        let result = pooled
+        match pooled
             .fetch_partition(
                 &metadata.id,
                 partition_id,
@@ -771,11 +817,22 @@ async fn fetch_partition_remote(
                 is_sort_shuffle,
                 prefer_flight,
             )
-            .await;
-        if result.is_err() {
-            pooled.discard();
+            .await
+        {
+            // Keep the pooled connection checked out for the lifetime of the
+            // response stream. Returning it to the pool here (the previous
+            // behavior) marked the connection idle/reusable/evictable while its
+            // body was still streaming, racing connection teardown against the
+            // in-flight read and causing intermittent broken-pipe FetchFailed at
+            // high target_partitions. The guard is dropped (connection returned to
+            // the pool, or discarded on a transport error) only once the stream
+            // finishes.
+            Ok(stream) => Ok(Box::pin(PooledPartitionStream::new(stream, pooled))),
+            Err(e) => {
+                pooled.discard();
+                Err(e)
+            }
         }
-        result
     } else {
         // TODO for shuffle client connections, we should avoid creating new connections again and again.
         // And we should also avoid to keep alive too many connections for long time.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1943.

# Rationale for this change

At high `target_partitions`, distributed TPC-H queries intermittently failed with
`FetchFailed` during shuffle reads. Two symptoms, one root:

- with client connection caching **off** (default, `--client-ttl 0`):
  `EADDRNOTAVAIL` / "Cannot assign requested address" — ephemeral-port exhaustion;
- with caching **on** (`--client-ttl > 0`): an `h2` `BrokenPipe` — "error reading a
  body from connection", i.e. the connection broke **mid-stream while reading data
  batches**.

Instrumented `h2=debug` runs (2 executors × 8 cores, TPC-H SF100 from S3) showed the
shuffle client opening and tearing down **thousands of connections per query**
(client-initiated `GOAWAY`s; zero `RST_STREAM`, so not h2 rapid-reset), and the failure
being an intermittent **race**: the same `target_partitions=128` run failed on some
attempts and passed on others.

Root cause for the broken-pipe case: `fetch_partition_remote` returned the pooled
connection to the pool **as soon as `fetch_partition` returned the response stream**.
The `PooledClient` guard was a local that dropped at that point, returning (a clone of)
the connection to the idle pool while the response **body was still streaming**. That
marks the connection idle/reusable/evictable mid-fetch, racing connection
teardown/reuse against the in-flight body read. And because `execute_do_get`'s retry
only covers the request + first (schema) message — not the body phase — the break
surfaces as a hard failure rather than a retry.

# What changes are included in this PR?

Keep the `PooledClient` checked out for the **lifetime of the response stream**.
`fetch_partition_remote` now wraps the returned stream in a small
`PooledPartitionStream` that owns the `PooledClient`, so the connection is only
returned to the pool — or `discard()`ed, if the stream yields a transport error — once
the stream has been fully consumed. This prevents a connection from being reused,
evicted, or closed while its body is still being read.

Scoped, ~60-line change to `ballista/core/src/execution_plans/shuffle_reader.rs`; no
public API changes.

# Are there any user-facing changes?

No API changes. Fixes intermittent shuffle `FetchFailed` at high `target_partitions`.

<!-- Verification (in progress, this is a draft): reproduced on a 2-executor × 8-core
cluster reading TPC-H SF100 from S3/MinIO. Without this change, target_partitions=128
fails roughly 2 of 3 runs; with it, repeated 128/256 runs are being confirmed to pass.
Will post the final tally and mark ready for review. -->
