### PR TITLE
fix(cli): sort jobs by stage completion ratio

### DIFF
--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -119,14 +119,12 @@ impl JobsData {
             SortColumn::StagesCompleted => jobs.sort_by(|a, b| {
                 let stage_completion = |job: &Job| {
                     if job.num_stages == 0 {
-                        (0_u128, 1_u128)
+                        0.0
                     } else {
-                        (job.completed_stages as u128, job.num_stages as u128)
+                        job.completed_stages as f64 / job.num_stages as f64
                     }
                 };
-                let (a_completed, a_total) = stage_completion(a);
-                let (b_completed, b_total) = stage_completion(b);
-                let cmp = (a_completed * b_total).cmp(&(b_completed * a_total));
+                let cmp = stage_completion(a).total_cmp(&stage_completion(b));
                 if self.sort_order == crate::tui::domain::SortOrder::Descending {
                     cmp.reverse()
                 } else {

--- a/ballista-cli/src/tui/domain/jobs.rs
+++ b/ballista-cli/src/tui/domain/jobs.rs
@@ -117,9 +117,16 @@ impl JobsData {
                 }
             }),
             SortColumn::StagesCompleted => jobs.sort_by(|a, b| {
-                let a_stages = a.completed_stages / a.num_stages;
-                let b_stages = b.completed_stages / b.num_stages;
-                let cmp = a_stages.cmp(&b_stages);
+                let stage_completion = |job: &Job| {
+                    if job.num_stages == 0 {
+                        (0_u128, 1_u128)
+                    } else {
+                        (job.completed_stages as u128, job.num_stages as u128)
+                    }
+                };
+                let (a_completed, a_total) = stage_completion(a);
+                let (b_completed, b_total) = stage_completion(b);
+                let cmp = (a_completed * b_total).cmp(&(b_completed * a_total));
                 if self.sort_order == crate::tui::domain::SortOrder::Descending {
                     cmp.reverse()
                 } else {
@@ -586,6 +593,36 @@ mod tests {
         assert_eq!(refs[0].status, "Running");
         assert_eq!(refs[1].status, "Failed");
         assert_eq!(refs[2].status, "Completed");
+    }
+
+    #[test]
+    fn sort_by_stages_completed_uses_completion_ratio() {
+        let jobs = vec![
+            make_job("quarter", "A", "Running", 1, 2, 4, 1, 0),
+            make_job("three_quarters", "B", "Running", 2, 3, 4, 3, 0),
+            make_job("half", "C", "Running", 3, 4, 4, 2, 0),
+        ];
+        let data =
+            make_jobs_data(jobs, SortColumn::StagesCompleted, SortOrder::Ascending);
+        let mut refs: Vec<&Job> = data.jobs.iter().collect();
+        data.sort_jobs(&mut refs);
+        assert_eq!(refs[0].job_id, "quarter");
+        assert_eq!(refs[1].job_id, "half");
+        assert_eq!(refs[2].job_id, "three_quarters");
+    }
+
+    #[test]
+    fn sort_by_stages_completed_handles_zero_stages() {
+        let jobs = vec![
+            make_job("zero", "A", "Running", 1, 2, 0, 0, 0),
+            make_job("half", "B", "Running", 2, 3, 2, 1, 0),
+        ];
+        let data =
+            make_jobs_data(jobs, SortColumn::StagesCompleted, SortOrder::Ascending);
+        let mut refs: Vec<&Job> = data.jobs.iter().collect();
+        data.sort_jobs(&mut refs);
+        assert_eq!(refs[0].job_id, "zero");
+        assert_eq!(refs[1].job_id, "half");
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The TUI jobs table sorted the stage completion column with integer division:

`completed_stages / num_stages`

This could panic when `num_stages` was zero, and it also collapsed partial ratios such as `1/4`, `2/4`, and `3/4` to the same value.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This PR updates the jobs table stage-completion sorting to compare the actual completion ratio safely, treating zero-stage jobs as `0%` complete. It also adds regression tests for ratio-based sorting and zero-stage jobs.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes. Sorting the TUI jobs table by stage completion now reflects the real completion ratio and no longer panics for jobs with zero stages.
