### PR TITLE
feat(scheduler): call try_acquire_job on active cache miss in update_task_statuses

### DIFF
--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -1004,7 +1004,12 @@ mod tests {
 
     #[async_trait::async_trait]
     impl JobState for MockJobState {
-        fn accept_job(&self, _job_id: &JobId, _job_name: &str, _queued_at: u64) -> Result<()> {
+        fn accept_job(
+            &self,
+            _job_id: &JobId,
+            _job_name: &str,
+            _queued_at: u64,
+        ) -> Result<()> {
             Ok(())
         }
 
@@ -1040,7 +1045,11 @@ mod tests {
             Ok(None)
         }
 
-        async fn save_job(&self, _job_id: &JobId, _graph: &ExecutionGraphBox) -> Result<()> {
+        async fn save_job(
+            &self,
+            _job_id: &JobId,
+            _graph: &ExecutionGraphBox,
+        ) -> Result<()> {
             Ok(())
         }
 
@@ -1061,10 +1070,7 @@ mod tests {
             job_id: &JobId,
         ) -> Result<Option<ExecutionGraphBox>> {
             self.try_acquire_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(self
-                .acquirable
-                .remove(job_id)
-                .map(|(_, graph)| graph))
+            Ok(self.acquirable.remove(job_id).map(|(_, graph)| graph))
         }
 
         async fn job_state_events(&self) -> Result<JobStateEventStream> {
@@ -1178,7 +1184,8 @@ mod tests {
         let cached_graph = Box::new(test_aggregation_plan_with_job_id(2, &job_id).await)
             as ExecutionGraphBox;
         let acquirable_graph =
-            Box::new(test_aggregation_plan_with_job_id(4, &job_id).await) as ExecutionGraphBox;
+            Box::new(test_aggregation_plan_with_job_id(4, &job_id).await)
+                as ExecutionGraphBox;
 
         let mock_state = Arc::new(MockJobState::new());
         mock_state.insert_acquirable(acquirable_graph);

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -963,3 +963,240 @@ impl From<&ExecutionGraphBox> for JobOverview {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::{JobState, JobStateEventStream};
+    use crate::config::SchedulerConfig;
+    use crate::test_utils::test_aggregation_plan_with_job_id;
+    use ballista_core::serde::BallistaCodec;
+    use dashmap::DashMap;
+    use datafusion::prelude::SessionConfig;
+    use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
+    use futures::stream;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct MockJobState {
+        acquirable: DashMap<JobId, ExecutionGraphBox>,
+        try_acquire_calls: Arc<AtomicUsize>,
+    }
+
+    impl MockJobState {
+        fn new() -> Self {
+            Self {
+                acquirable: DashMap::new(),
+                try_acquire_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn try_acquire_calls(&self) -> usize {
+            self.try_acquire_calls.load(Ordering::SeqCst)
+        }
+
+        fn insert_acquirable(&self, graph: ExecutionGraphBox) {
+            let job_id = graph.job_id().to_owned();
+            self.acquirable.insert(job_id, graph);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl JobState for MockJobState {
+        fn accept_job(&self, _job_id: &JobId, _job_name: &str, _queued_at: u64) -> Result<()> {
+            Ok(())
+        }
+
+        fn pending_job_number(&self) -> usize {
+            0
+        }
+
+        async fn submit_job(
+            &self,
+            _job_id: JobId,
+            _graph: &ExecutionGraphBox,
+            _subscriber: Option<JobStatusSubscriber>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_jobs(&self) -> Result<HashSet<JobId>> {
+            Ok(HashSet::new())
+        }
+
+        async fn get_all_jobs(&self) -> Result<HashSet<JobId>> {
+            Ok(HashSet::new())
+        }
+
+        async fn get_job_status(&self, _job_id: &JobId) -> Result<Option<JobStatus>> {
+            Ok(None)
+        }
+
+        async fn get_execution_graph(
+            &self,
+            _job_id: &JobId,
+        ) -> Result<Option<ExecutionGraphBox>> {
+            Ok(None)
+        }
+
+        async fn save_job(&self, _job_id: &JobId, _graph: &ExecutionGraphBox) -> Result<()> {
+            Ok(())
+        }
+
+        async fn fail_unscheduled_job(
+            &self,
+            _job_id: &JobId,
+            _reason: String,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn remove_job(&self, _job_id: &JobId) -> Result<()> {
+            Ok(())
+        }
+
+        async fn try_acquire_job(
+            &self,
+            job_id: &JobId,
+        ) -> Result<Option<ExecutionGraphBox>> {
+            self.try_acquire_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .acquirable
+                .remove(job_id)
+                .map(|(_, graph)| graph))
+        }
+
+        async fn job_state_events(&self) -> Result<JobStateEventStream> {
+            Ok(Box::pin(stream::empty()))
+        }
+
+        async fn create_or_update_session(
+            &self,
+            _session_id: &str,
+            _config: &SessionConfig,
+        ) -> Result<Arc<SessionContext>> {
+            Err(BallistaError::NotImplemented(
+                "not used in task_manager tests".to_string(),
+            ))
+        }
+
+        async fn remove_session(&self, _session_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn produce_config(&self) -> SessionConfig {
+            SessionConfig::new()
+        }
+    }
+
+    fn test_task_manager(
+        state: Arc<dyn JobState>,
+    ) -> TaskManager<LogicalPlanNode, PhysicalPlanNode> {
+        TaskManager::new(
+            state,
+            BallistaCodec::default(),
+            "test-scheduler".to_owned(),
+            Arc::new(SchedulerConfig::default()),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_or_acquire_returns_cached_graph_without_acquire() -> Result<()> {
+        let job_id: JobId = "cached1".into();
+        let graph = Box::new(test_aggregation_plan_with_job_id(2, &job_id).await)
+            as ExecutionGraphBox;
+
+        let mock_state = Arc::new(MockJobState::new());
+        let task_manager = test_task_manager(mock_state.clone());
+        task_manager
+            .active_job_cache
+            .insert(job_id.clone(), JobInfoCache::new(graph));
+
+        let acquired = task_manager
+            .get_or_acquire_active_execution_graph(&job_id)
+            .await?;
+
+        assert!(acquired.is_some());
+        assert_eq!(mock_state.try_acquire_calls(), 0);
+        assert_eq!(task_manager.running_job_number(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_or_acquire_rehydrates_cache_on_acquire() -> Result<()> {
+        let job_id: JobId = "acquire1".into();
+        let graph = Box::new(test_aggregation_plan_with_job_id(2, &job_id).await)
+            as ExecutionGraphBox;
+
+        let mock_state = Arc::new(MockJobState::new());
+        mock_state.insert_acquirable(graph);
+
+        let task_manager = test_task_manager(mock_state.clone());
+        assert_eq!(task_manager.running_job_number(), 0);
+
+        let acquired = task_manager
+            .get_or_acquire_active_execution_graph(&job_id)
+            .await?;
+
+        let graph = acquired.expect("graph should be acquired");
+        assert_eq!(graph.read().await.job_id(), &job_id);
+        assert_eq!(mock_state.try_acquire_calls(), 1);
+        assert_eq!(task_manager.running_job_number(), 1);
+
+        // Second call should hit the cache, not acquire again.
+        let cached = task_manager
+            .get_or_acquire_active_execution_graph(&job_id)
+            .await?;
+        assert!(cached.is_some());
+        assert_eq!(mock_state.try_acquire_calls(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_or_acquire_returns_none_when_not_acquirable() -> Result<()> {
+        let job_id: JobId = "missing1".into();
+        let mock_state = Arc::new(MockJobState::new());
+        let task_manager = test_task_manager(mock_state.clone());
+
+        let acquired = task_manager
+            .get_or_acquire_active_execution_graph(&job_id)
+            .await?;
+
+        assert!(acquired.is_none());
+        assert_eq!(mock_state.try_acquire_calls(), 1);
+        assert_eq!(task_manager.running_job_number(), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_or_acquire_or_insert_preserves_existing_cache_entry() -> Result<()> {
+        let job_id: JobId = "existing1".into();
+        let cached_graph = Box::new(test_aggregation_plan_with_job_id(2, &job_id).await)
+            as ExecutionGraphBox;
+        let acquirable_graph =
+            Box::new(test_aggregation_plan_with_job_id(4, &job_id).await) as ExecutionGraphBox;
+
+        let mock_state = Arc::new(MockJobState::new());
+        mock_state.insert_acquirable(acquirable_graph);
+
+        let task_manager = test_task_manager(mock_state.clone());
+        let cached = task_manager
+            .active_job_cache
+            .insert(job_id.clone(), JobInfoCache::new(cached_graph));
+        assert!(cached.is_none(), "cache should not already contain the job");
+
+        let acquired = task_manager
+            .get_or_acquire_active_execution_graph(&job_id)
+            .await?;
+
+        assert!(acquired.is_some());
+        assert_eq!(mock_state.try_acquire_calls(), 0);
+        assert_eq!(task_manager.running_job_number(), 1);
+
+        Ok(())
+    }
+}

--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -558,9 +558,9 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             let num_tasks = statuses.len();
             debug!("Updating {num_tasks} tasks in job {job_id}");
 
-            // let graph = self.get_active_execution_graph(&job_id).await;
-            let job_events = if let Some(cached) =
-                self.get_active_execution_graph(&job_id.clone().into())
+            let job_events = if let Some(cached) = self
+                .get_or_acquire_active_execution_graph(&job_id.clone().into())
+                .await?
             {
                 let mut graph = cached.write().await;
                 graph.update_task_status(
@@ -570,9 +570,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                     self.stage_max_failures,
                 )?
             } else {
-                // TODO Deal with curator changed case
-                error!(
-                    "Fail to find job {job_id} in the active cache and it may not be curated by this scheduler"
+                warn!(
+                    "Job {job_id} is not in the active cache and could not be acquired by this scheduler"
                 );
                 vec![]
             };
@@ -863,6 +862,32 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .get(job_id)
             .as_deref()
             .map(|cached| cached.execution_graph.clone())
+    }
+
+    /// Returns the cached execution graph for a job, attempting to acquire curation on cache miss.
+    ///
+    /// On miss, calls [`JobState::try_acquire_job`] to take over a running job from a failed
+    /// scheduler and rehydrates `active_job_cache` when acquisition succeeds.
+    async fn get_or_acquire_active_execution_graph(
+        &self,
+        job_id: &JobId,
+    ) -> Result<Option<Arc<RwLock<ExecutionGraphBox>>>> {
+        if let Some(cached) = self.get_active_execution_graph(job_id) {
+            return Ok(Some(cached));
+        }
+
+        let Some(graph) = self.state.try_acquire_job(job_id).await? else {
+            return Ok(None);
+        };
+
+        info!("Acquired curation of job {job_id} and rehydrated active cache");
+
+        let job_info = JobInfoCache::new(graph);
+        self.active_job_cache
+            .entry(job_id.clone())
+            .or_insert(job_info);
+
+        Ok(self.get_active_execution_graph(job_id))
     }
 
     /// Remove the `ExecutionGraph` for the given job ID from cache


### PR DESCRIPTION
# Which issue does this PR close?
No linked issue — this is preparatory work for our distributed scheduler HA. Current Problem is once scheduler is restarted active job cache does not contain previous job state this causes our concern in HA Scheduler. The try_acquire_job hook existed on JobState but was never called from TaskManager.

Closes #

 # Rationale for this change
When an executor sends task status updates, TaskManager::update_task_statuses only processes jobs present in the local active_job_cache. On a cache miss (e.g. after scheduler failover or when a different scheduler receives status for a job it did not originally curate), updates were dropped with an error log and a TODO for “curator changed” handling.

JobState::try_acquire_job is the intended mechanism for a scheduler to take over curation of a still-running job. Calling it on cache miss lets a failover scheduler rehydrate active_job_cache and apply pending task updates, which is the “acquire-on-update” path described in the HA design doc.

# What changes are included in this PR?
Add get_or_acquire_active_execution_graph on TaskManager: returns the cached graph if present; otherwise calls JobState::try_acquire_job and inserts the result into active_job_cache via DashMap::entry().or_insert() (safe under concurrent acquire attempts).
Update update_task_statuses to use this helper instead of failing immediately on cache miss.
Downgrade the cache-miss log from error! to warn! when acquisition is not possible.
No change to the in-memory JobState backend: try_acquire_job still returns None, so single-scheduler behavior is unchanged until a distributed backend implements acquisition.

# Are there any user-facing changes?
No user-facing changes. This is internal scheduler behavior only and has no effect until a JobState implementation that supports try_acquire_job is added. No API, config, or documentation updates required for this PR.
