### PR TITLE
feat(tui + rest): surface failed tasks

### DIFF
--- a/ballista-cli/src/tui/domain/jobs/stages.rs
+++ b/ballista-cli/src/tui/domain/jobs/stages.rs
@@ -43,11 +43,19 @@ pub struct JobStageResponse {
     pub tasks: Vec<Option<StageTaskResponse>>,
 }
 
+// TaskStatus
+#[derive(Deserialize, Clone, Debug)]
+pub enum StageTaskStatus {
+    Running,
+    Successful,
+    Failed { reason: String },
+}
+
 // TaskSummary
 #[derive(Deserialize, Clone, Debug)]
 pub struct StageTaskResponse {
     pub id: usize,
-    pub status: String,
+    pub status: StageTaskStatus,
     pub partition_id: u32,
     pub input_rows: usize,
     pub output_rows: usize,
@@ -364,7 +372,7 @@ impl StagesGraph {
 mod tests {
     use super::{
         JobStageResponse, JobStagesPopup, JobStagesResponse, StageTaskResponse,
-        StagesGraph, TaskPercentiles,
+        StageTaskStatus, StagesGraph, TaskPercentiles,
     };
 
     fn make_percentiles() -> TaskPercentiles {
@@ -608,7 +616,7 @@ mod tests {
     fn make_task(id: usize) -> StageTaskResponse {
         StageTaskResponse {
             id,
-            status: "Completed".to_string(),
+            status: StageTaskStatus::Successful,
             partition_id: id as u32,
             input_rows: 0,
             output_rows: 0,

--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::tui::app::App;
-use crate::tui::domain::jobs::stages::StageTaskResponse;
+use crate::tui::domain::jobs::stages::{StageTaskResponse, StageTaskStatus};
 use crate::tui::ui::components::clear_area::clear_area;
 use crate::tui::ui::vertical_scrollbar;
 use ratatui::Frame;
@@ -101,18 +101,16 @@ fn build_stage_task_row(i: usize, task: &StageTaskResponse, app: &App) -> Row<'s
         app.theme.row_odd
     };
 
-    let status_style = match task.status.as_str() {
-        "Running" => app.theme.status_running,
-        "Queued" => app.theme.status_queued,
-        "Successful" | "Completed" => app.theme.status_completed,
-        "Failed" => app.theme.status_failed,
-        _ => app.theme.status_unknown,
+    let (status_label, status_style) = match &task.status {
+        StageTaskStatus::Running => ("Running", app.theme.status_running),
+        StageTaskStatus::Successful => ("Successful", app.theme.status_completed),
+        StageTaskStatus::Failed { reason } => (reason.as_str(), app.theme.status_failed),
     };
 
     Row::new(vec![
         Cell::from(Text::from(task.id.to_string()).right_aligned()),
         Cell::from(
-            Text::from(task.status.clone())
+            Text::from(status_label.to_string())
                 .style(status_style)
                 .centered(),
         ),

--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -101,19 +101,19 @@ fn build_stage_task_row(i: usize, task: &StageTaskResponse, app: &App) -> Row<'s
         app.theme.row_odd
     };
 
-    let (status_label, status_style) = match &task.status {
-        StageTaskStatus::Running => ("Running", app.theme.status_running),
-        StageTaskStatus::Successful => ("Successful", app.theme.status_completed),
-        StageTaskStatus::Failed { reason } => (reason.as_str(), app.theme.status_failed),
+    let status_text = match &task.status {
+        StageTaskStatus::Running => Text::from("Running").style(app.theme.status_running),
+        StageTaskStatus::Successful => {
+            Text::from("Successful").style(app.theme.status_completed)
+        }
+        StageTaskStatus::Failed { reason } => {
+            Text::from(reason.clone()).style(app.theme.status_failed)
+        }
     };
 
     Row::new(vec![
         Cell::from(Text::from(task.id.to_string()).right_aligned()),
-        Cell::from(
-            Text::from(status_label.to_string())
-                .style(status_style)
-                .centered(),
-        ),
+        Cell::from(status_text.centered()),
         Cell::from(Text::from(app.format_count(task.input_rows)).right_aligned()),
         Cell::from(Text::from(app.format_count(task.output_rows)).right_aligned()),
         Cell::from(Text::from(task.partition_id.to_string()).right_aligned()),

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -22,9 +22,10 @@ use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},
 };
+use ballista_core::serde::protobuf::failed_task::FailedReason::*;
 use ballista_core::serde::protobuf::job_status::Status;
 use ballista_core::serde::protobuf::{
-    ExecutorMetric, executor_metric::Metric, task_status,
+    ExecutorMetric, FailedTask, executor_metric::Metric, task_status,
 };
 use ballista_core::serde::scheduler::{
     ExecutorOperatingSystemSpecification, ExecutorSpecification,
@@ -165,14 +166,17 @@ pub struct TaskSummary {
 pub enum TaskStatus {
     Running,
     Successful,
-    Failed,
+    Failed { reason: String, error: String },
 }
 
 impl From<&task_status::Status> for TaskStatus {
     fn from(value: &task_status::Status) -> Self {
         match value {
             task_status::Status::Running(_) => TaskStatus::Running,
-            task_status::Status::Failed(_) => TaskStatus::Failed,
+            task_status::Status::Failed(failed) => TaskStatus::Failed {
+                reason: failed_reason(failed),
+                error: failed.error.clone(),
+            },
             task_status::Status::Successful(_) => TaskStatus::Successful,
         }
     }
@@ -637,6 +641,54 @@ pub async fn get_query_stages<
                             })
                             .collect();
                     }
+                    ExecutionStage::Failed(failed_stage) => {
+                        let metrics = failed_stage.stage_metrics.as_deref().unwrap_or(&[]);
+                        summary.stage_plan = Some(match plan_format {
+                            PlanFormat::Default => displayable(failed_stage.plan.as_ref()).indent(false).to_string(),
+                            PlanFormat::Tree    => displayable(failed_stage.plan.as_ref()).tree_render().to_string(),
+                            PlanFormat::Metrics => format_stage_metrics(failed_stage.plan.as_ref(), metrics),
+                        });
+                        summary.input_rows = get_combined_count(metrics, "input_rows");
+                        summary.output_rows = get_combined_count(metrics, "output_rows");
+                        summary.elapsed_compute = get_finished_stage_time(
+                            &failed_stage
+                                .task_infos
+                                .iter()
+                                .flatten()
+                                .cloned()
+                                .collect::<Vec<_>>(),
+                        );
+
+                        summary.tasks = failed_stage
+                            .task_infos
+                            .iter()
+                            .enumerate()
+                            .map(|(partition_id, task_info)| {
+                                task_info.as_ref().map(|info| {
+                                    let (input_rows, output_rows) =
+                                        get_partition_counts(metrics, partition_id);
+
+                                    let start_exec_time = info.start_exec_time as u64;
+                                    let end_exec_time = info.end_exec_time as u64;
+                                    let task_status: TaskStatus = (&info.task_status).into();
+
+                                    TaskSummary {
+                                        id: info.task_id,
+                                        partition_id: partition_id as u32,
+                                        scheduled_time: info.scheduled_time as u64,
+                                        launch_time: info.launch_time as u64,
+                                        start_exec_time,
+                                        end_exec_time,
+                                        exec_duration: end_exec_time.saturating_sub(start_exec_time),
+                                        finish_time: info.finish_time as u64,
+                                        input_rows,
+                                        output_rows,
+                                        status: task_status,
+                                    }
+                                })
+                            })
+                            .collect();
+                    }
                     _ => {}
                 }
                 summary.task_duration_percentiles = task_duration_percentiles(&summary.tasks);
@@ -759,6 +811,19 @@ fn get_running_stage_time(
         }
         _ => None,
     }
+}
+
+fn failed_reason(failed: &FailedTask) -> String {
+    match &failed.failed_reason {
+        Some(ExecutionError(_)) => "ExecutionError",
+        Some(FetchPartitionError(_)) => "FetchPartitionError",
+        Some(IoError(_)) => "IoError",
+        Some(ExecutorLost(_)) => "ExecutorLost",
+        Some(ResultLost(_)) => "ResultLost",
+        Some(TaskKilled(_)) => "TaskKilled",
+        None => "Failed",
+    }
+    .to_string()
 }
 
 fn get_finished_stage_time(task_infos: &[TaskInfo]) -> Option<String> {

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -22,7 +22,9 @@ use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},
 };
-use ballista_core::serde::protobuf::failed_task::FailedReason::*;
+use ballista_core::serde::protobuf::failed_task::FailedReason::{
+    ExecutionError, ExecutorLost, FetchPartitionError, IoError, ResultLost, TaskKilled,
+};
 use ballista_core::serde::protobuf::job_status::Status;
 use ballista_core::serde::protobuf::{
     ExecutorMetric, FailedTask, executor_metric::Metric, task_status,
@@ -645,7 +647,7 @@ pub async fn get_query_stages<
                         let metrics = failed_stage.stage_metrics.as_deref().unwrap_or(&[]);
                         summary.stage_plan = Some(match plan_format {
                             PlanFormat::Default => displayable(failed_stage.plan.as_ref()).indent(false).to_string(),
-                            PlanFormat::Tree    => displayable(failed_stage.plan.as_ref()).tree_render().to_string(),
+                            PlanFormat::Tree => displayable(failed_stage.plan.as_ref()).tree_render().to_string(),
                             PlanFormat::Metrics => format_stage_metrics(failed_stage.plan.as_ref(), metrics),
                         });
                         summary.input_rows = get_combined_count(metrics, "input_rows");


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/datafusion-ballista/issues/1795, follow up to https://github.com/apache/datafusion-ballista/pull/1903

# Rationale for this change

Expose tasks for failed stages in REST API, handle it in TUI

# What changes are included in this PR?

- Switch StageTaskResponse->status to use new `StageTaskStatus`
- Expose stage error with both `reason` and original `error` (common wrapping for underlying errors)
- Display short label (only `reason`) in failed task for TUI

Tested locally with TPC-H under the chaos fault generator:

```bash
cargo run --bin ballista-scheduler --features prometheus-metrics
cargo run --bin ballista-executor
cargo run --bin tpch -- benchmark ballista -p /path/to/tpch/sf10 -f parquet -i 1 \
  --port 50050 --host 127.0.0.1 \
  -c datafusion.execution.target_partitions=24 \
  -c ballista.planner.adaptive.enabled=true \
  -c ballista.testing.chaos_execution.enabled=true \
  -c ballista.testing.chaos_execution.fault_type=fatal \
  -c ballista.testing.chaos_execution.probability=0.6 \
  -q 1
```

Failed job in the TUI:

**Global view** (job shows `Failed`):
<img width="1897" height="151" alt="Screenshot from 2026-07-05 14-28-05" src="https://github.com/user-attachments/assets/982bb369-9f46-4dad-90b1-748f8df3341d" />

**Stage detail**:
<img width="1619" height="116" alt="Screenshot from 2026-07-05 14-28-59" src="https://github.com/user-attachments/assets/7fd63fc0-4aff-4a02-9c9b-562e90e04f86" />

**Stage tasks** (was empty for a failed stage, now proper list):
<img width="1878" height="460" alt="Screenshot from 2026-07-05 14-28-29" src="https://github.com/user-attachments/assets/f374e623-8141-445f-9bbd-888417a14b1a" />

Note: using `String` value for status was hiding a bug with invalid states for stage in the TUI : `Queued` was dead code.
We might want to move the other pieces of the TUI to use the enum instead of a string to avoid similar bug.

# Are there any user-facing changes?

`Failed` task will now display `ExecutionError` or other reason, but they were not displayed anyway before this fix, so no real user facing change.
