### PR TITLE
feat: bound shuffle fetch with a reduce-side in-flight governor

### DIFF
--- a/ballista/client/tests/sort_shuffle.rs
+++ b/ballista/client/tests/sort_shuffle.rs
@@ -30,7 +30,12 @@ mod common;
 mod sort_shuffle_tests {
     use ballista::prelude::{SessionConfigExt, SessionContextExt};
     use ballista_core::config::{
-        BALLISTA_ADAPTIVE_PLANNER_ENABLED, BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ,
+        BALLISTA_ADAPTIVE_PLANNER_ENABLED,
+        BALLISTA_CLIENT_INITIAL_CONNECTION_WINDOW_SIZE,
+        BALLISTA_CLIENT_INITIAL_STREAM_WINDOW_SIZE,
+        BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ,
+        BALLISTA_SHUFFLE_READER_MAX_BLOCKS_PER_ADDRESS,
+        BALLISTA_SHUFFLE_READER_MAX_BYTES_IN_FLIGHT,
         BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT,
         BALLISTA_SHUFFLE_SORT_BASED_ENABLED,
     };
@@ -87,6 +92,28 @@ mod sort_shuffle_tests {
             .with_default_features()
             .build();
 
+        SessionContext::standalone_with_state(state).await.unwrap()
+    }
+
+    /// Remote-flight sort-shuffle context with a deliberately tiny governor
+    /// budget (64 KiB in-flight, 2 blocks/address) but a large connection window
+    /// (8 MiB). This forces many partition fetches to serialize through the
+    /// governor while multiplexing over the pooled connection — the scenario
+    /// that deadlocked before the governor existed. The query must still
+    /// complete and return correct results.
+    async fn create_tiny_budget_remote_context() -> SessionContext {
+        let config = SessionConfig::new_with_ballista()
+            .set_str(BALLISTA_SHUFFLE_SORT_BASED_ENABLED, "true")
+            .set_str(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, "true")
+            .set_str(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, "true")
+            .set_str(BALLISTA_SHUFFLE_READER_MAX_BYTES_IN_FLIGHT, "65536")
+            .set_str(BALLISTA_SHUFFLE_READER_MAX_BLOCKS_PER_ADDRESS, "2")
+            .set_str(BALLISTA_CLIENT_INITIAL_CONNECTION_WINDOW_SIZE, "8388608")
+            .set_str(BALLISTA_CLIENT_INITIAL_STREAM_WINDOW_SIZE, "8388608");
+        let state = SessionStateBuilder::new()
+            .with_config(config)
+            .with_default_features()
+            .build();
         SessionContext::standalone_with_state(state).await.unwrap()
     }
 
@@ -564,6 +591,32 @@ mod sort_shuffle_tests {
 
         let expected = vec![
             "+----+", "| id |", "+----+", "| 0  |", "| 1  |", "| 2  |", "+----+",
+        ];
+        assert_result_eq(expected, &results);
+        Ok(())
+    }
+
+    // ==================== Governor Budget ====================
+
+    #[tokio::test]
+    async fn test_shuffle_completes_under_tiny_governor_budget() -> Result<()> {
+        let ctx = create_tiny_budget_remote_context().await;
+        register_test_data(&ctx).await;
+
+        // GROUP BY forces a shuffle; the reducer fetches every upstream partition
+        // remotely under the tiny in-flight budget.
+        let df = ctx
+            .sql("SELECT bool_col, COUNT(*) as cnt FROM test GROUP BY bool_col ORDER BY bool_col")
+            .await?;
+        let results = df.collect().await?;
+
+        let expected = vec![
+            "+----------+-----+",
+            "| bool_col | cnt |",
+            "+----------+-----+",
+            "| false    | 4   |",
+            "| true     | 4   |",
+            "+----------+-----+",
         ];
         assert_result_eq(expected, &results);
         Ok(())

--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -62,6 +62,7 @@ pub struct BallistaClient {
 impl BallistaClient {
     /// Create a new BallistaClient to connect to the executor listening on the specified
     /// host and port
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_new(
         host: &str,
         port: u16,
@@ -70,6 +71,8 @@ impl BallistaClient {
         customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
         io_retries_times: u8,
         io_retry_wait_time_ms: u64,
+        initial_connection_window_size: u32,
+        initial_stream_window_size: u32,
     ) -> BResult<Self> {
         let scheme = if use_tls { "https" } else { "http" };
 
@@ -82,6 +85,15 @@ impl BallistaClient {
                     "Error creating endpoint to Ballista scheduler or executor at {addr}: {e:?}"
                 ))
             })?;
+
+        if initial_connection_window_size > 0 {
+            endpoint = endpoint
+                .initial_connection_window_size(Some(initial_connection_window_size));
+        }
+        if initial_stream_window_size > 0 {
+            endpoint =
+                endpoint.initial_stream_window_size(Some(initial_stream_window_size));
+        }
 
         if let Some(customize) = customize_endpoint {
             endpoint = customize

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -172,7 +172,7 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          DataType::Boolean,
                          Some((false).to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_READER_MAX_BYTES_IN_FLIGHT.to_string(),
-                         "Reduce-side shuffle governor: maximum total in-flight bytes across concurrent remote partition fetches. Mirrors Spark's spark.reducer.maxSizeInFlight.".to_string(),
+                         "Reduce-side shuffle governor: maximum total in-flight bytes across concurrent remote partition fetches. Mirrors Spark's spark.reducer.maxSizeInFlight. Values above 4 GiB are clamped to 4 GiB (u32 semaphore limit).".to_string(),
                          DataType::UInt64,
                          Some((50331648).to_string())),
         ConfigEntry::new(BALLISTA_SHUFFLE_READER_MAX_BLOCKS_PER_ADDRESS.to_string(),

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -41,6 +41,21 @@ pub const BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ: &str =
 /// Configuration key to prefer Flight protocol for remote shuffle reads.
 pub const BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT: &str =
     "ballista.shuffle.remote_read_prefer_flight";
+/// Configuration key for the reduce-side in-flight-bytes governor budget.
+pub const BALLISTA_SHUFFLE_READER_MAX_BYTES_IN_FLIGHT: &str =
+    "ballista.shuffle.reader.max_bytes_in_flight";
+/// Configuration key for the per-address in-flight block cap.
+pub const BALLISTA_SHUFFLE_READER_MAX_BLOCKS_PER_ADDRESS: &str =
+    "ballista.shuffle.reader.max_blocks_in_flight_per_address";
+/// Configuration key for the assumed block size when partition stats lack a byte count.
+pub const BALLISTA_SHUFFLE_READER_DEFAULT_BLOCK_SIZE: &str =
+    "ballista.shuffle.reader.default_block_size_bytes";
+/// Configuration key for the gRPC client HTTP/2 initial connection-level flow-control window.
+pub const BALLISTA_CLIENT_INITIAL_CONNECTION_WINDOW_SIZE: &str =
+    "ballista.client.initial_connection_window_size";
+/// Configuration key for the gRPC client HTTP/2 initial stream-level flow-control window.
+pub const BALLISTA_CLIENT_INITIAL_STREAM_WINDOW_SIZE: &str =
+    "ballista.client.initial_stream_window_size";
 /// max message size for gRPC clients
 pub const BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE: &str =
     "ballista.client.grpc_max_message_size";
@@ -156,6 +171,26 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          "Forces the shuffle reader to use flight reader instead of block reader for remote read. Block reader usually has better performance and resource utilization".to_string(),
                          DataType::Boolean,
                          Some((false).to_string())),
+        ConfigEntry::new(BALLISTA_SHUFFLE_READER_MAX_BYTES_IN_FLIGHT.to_string(),
+                         "Reduce-side shuffle governor: maximum total in-flight bytes across concurrent remote partition fetches. Mirrors Spark's spark.reducer.maxSizeInFlight.".to_string(),
+                         DataType::UInt64,
+                         Some((50331648).to_string())),
+        ConfigEntry::new(BALLISTA_SHUFFLE_READER_MAX_BLOCKS_PER_ADDRESS.to_string(),
+                         "Reduce-side shuffle governor: maximum concurrent in-flight partition fetches to a single executor address.".to_string(),
+                         DataType::UInt64,
+                         Some((128).to_string())),
+        ConfigEntry::new(BALLISTA_SHUFFLE_READER_DEFAULT_BLOCK_SIZE.to_string(),
+                         "Assumed per-partition byte size charged to the shuffle governor when partition stats carry no byte count.".to_string(),
+                         DataType::UInt64,
+                         Some((1048576).to_string())),
+        ConfigEntry::new(BALLISTA_CLIENT_INITIAL_CONNECTION_WINDOW_SIZE.to_string(),
+                         "HTTP/2 initial connection-level flow-control window for gRPC data-plane clients, in bytes. Should be >= the shuffle governor byte budget so the governor, not the transport window, is the binding backpressure. 0 leaves the tonic default.".to_string(),
+                         DataType::UInt64,
+                         Some((67108864).to_string())),
+        ConfigEntry::new(BALLISTA_CLIENT_INITIAL_STREAM_WINDOW_SIZE.to_string(),
+                         "HTTP/2 initial stream-level flow-control window for gRPC data-plane clients, in bytes. 0 leaves the tonic default.".to_string(),
+                         DataType::UInt64,
+                         Some((16777216).to_string())),
         ConfigEntry::new(BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE.to_string(),
                          "Configuration for max message size in gRPC clients".to_string(),
                          DataType::UInt64,
@@ -423,6 +458,31 @@ impl BallistaConfig {
     /// Returns the maximum number of concurrent shuffle reader requests.
     pub fn shuffle_reader_maximum_concurrent_requests(&self) -> usize {
         self.get_usize_setting(BALLISTA_SHUFFLE_READER_MAX_REQUESTS)
+    }
+
+    /// Reduce-side shuffle governor byte budget (`max_bytes_in_flight`).
+    pub fn shuffle_reader_max_bytes_in_flight(&self) -> u64 {
+        self.get_usize_setting(BALLISTA_SHUFFLE_READER_MAX_BYTES_IN_FLIGHT) as u64
+    }
+
+    /// Reduce-side shuffle governor per-address in-flight block cap.
+    pub fn shuffle_reader_max_blocks_in_flight_per_address(&self) -> usize {
+        self.get_usize_setting(BALLISTA_SHUFFLE_READER_MAX_BLOCKS_PER_ADDRESS)
+    }
+
+    /// Assumed block size charged to the governor when stats lack a byte count.
+    pub fn shuffle_reader_default_block_size_bytes(&self) -> u64 {
+        self.get_usize_setting(BALLISTA_SHUFFLE_READER_DEFAULT_BLOCK_SIZE) as u64
+    }
+
+    /// HTTP/2 initial connection-level flow-control window (bytes) for data-plane clients.
+    pub fn grpc_client_initial_connection_window_size(&self) -> u32 {
+        self.get_usize_setting(BALLISTA_CLIENT_INITIAL_CONNECTION_WINDOW_SIZE) as u32
+    }
+
+    /// HTTP/2 initial stream-level flow-control window (bytes) for data-plane clients.
+    pub fn grpc_client_initial_stream_window_size(&self) -> u32 {
+        self.get_usize_setting(BALLISTA_CLIENT_INITIAL_STREAM_WINDOW_SIZE) as u32
     }
 
     /// Returns the gRPC client connection timeout in seconds.

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -825,6 +825,8 @@ async fn fetch_partition(
         customize_endpoint,
         io_retries_times,
         io_retry_wait_time_ms,
+        0,
+        0,
     )
     .await
     .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -56,7 +56,7 @@ use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::sync::{Semaphore, mpsc};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
 /// Coalesce plan attached to a `ShuffleReaderExec` or `UnresolvedShuffleExec`.
@@ -612,6 +612,82 @@ impl Stream for AbortableReceiverStream {
             .map_err(|e| ArrowError::ExternalError(Box::new(e)))
     }
 }
+
+/// In-flight bytes charged to the governor for a block. Uses the partition's
+/// recorded byte size, falling back to `default` when stats carry none. Never 0,
+/// so every block occupies at least one permit.
+#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
+fn block_size(location: &PartitionLocation, default: u64) -> u64 {
+    location
+        .partition_stats
+        .num_bytes()
+        .unwrap_or(default)
+        .max(1)
+}
+
+/// Size of the byte semaphore. tokio permits are `usize`; clamp so it is at least
+/// 1 and never exceeds `u32::MAX` (the `acquire_many` argument type).
+#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
+fn byte_permits_cap(max_bytes: u64) -> usize {
+    max_bytes.clamp(1, u32::MAX as u64) as usize
+}
+
+/// Byte permits to acquire for a block: `min(size, max_bytes)`, clamped to
+/// `[1, u32::MAX]`. Capping at `max_bytes` means an oversized block requests the
+/// entire budget and can only proceed once all other fetches drain — the
+/// application-layer analog of Spark's `bytesInFlight == 0` progress clause.
+#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
+fn byte_permits_for(size: u64, max_bytes: u64) -> u32 {
+    let cap = max_bytes.clamp(1, u32::MAX as u64);
+    size.clamp(1, cap) as u32
+}
+
+/// Wraps a fetched partition stream and holds the governor permits for its
+/// lifetime. Dropping the stream — on normal end, consumer cancellation, or a
+/// mid-body error — releases all three permits, freeing budget for the next
+/// fetch. This is the release-on-body-completion behavior the governor needs.
+#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
+struct GovernedStream {
+    inner: SendableRecordBatchStream,
+    _byte_permit: OwnedSemaphorePermit,
+    _req_permit: OwnedSemaphorePermit,
+    _addr_permit: OwnedSemaphorePermit,
+}
+
+impl GovernedStream {
+    #[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
+    fn new(
+        inner: SendableRecordBatchStream,
+        byte_permit: OwnedSemaphorePermit,
+        req_permit: OwnedSemaphorePermit,
+        addr_permit: OwnedSemaphorePermit,
+    ) -> Self {
+        Self {
+            inner,
+            _byte_permit: byte_permit,
+            _req_permit: req_permit,
+            _addr_permit: addr_permit,
+        }
+    }
+}
+
+impl Stream for GovernedStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl RecordBatchStream for GovernedStream {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+}
+
 /// Splits the provided partition locations into local and remote partitions.
 /// Local partitions are read directly from local Arrow IPC files,
 /// while remote partitions are fetched using the Arrow Flight client.
@@ -1845,5 +1921,54 @@ mod tests {
         assert_eq!(90, *stats1.total_byte_size.get_value().unwrap());
         assert_eq!(9, *stats1.num_rows.get_value().unwrap());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod governor_tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+    #[test]
+    fn byte_permits_for_caps_at_budget() {
+        // A block larger than the budget requests exactly the whole budget,
+        // so it can only run when all other fetches have drained.
+        assert_eq!(byte_permits_for(10, 100), 10);
+        assert_eq!(byte_permits_for(500, 100), 100);
+        // Never zero (a zero acquire is a no-op and would under-account).
+        assert_eq!(byte_permits_for(0, 100), 1);
+    }
+
+    #[test]
+    fn byte_permits_cap_is_nonzero_and_bounded() {
+        assert_eq!(byte_permits_cap(0), 1);
+        assert_eq!(byte_permits_cap(48 * 1024 * 1024), 48 * 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn governed_stream_releases_permits_on_drop() {
+        let byte_sem = Arc::new(Semaphore::new(100));
+        let req_sem = Arc::new(Semaphore::new(4));
+        let addr_sem = Arc::new(Semaphore::new(2));
+
+        let byte = byte_sem.clone().acquire_many_owned(30).await.unwrap();
+        let req = req_sem.clone().acquire_owned().await.unwrap();
+        let addr = addr_sem.clone().acquire_owned().await.unwrap();
+        assert_eq!(byte_sem.available_permits(), 70);
+        assert_eq!(req_sem.available_permits(), 3);
+        assert_eq!(addr_sem.available_permits(), 1);
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let empty = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::empty(),
+        )) as SendableRecordBatchStream;
+        let governed = GovernedStream::new(empty, byte, req, addr);
+        drop(governed);
+
+        assert_eq!(byte_sem.available_permits(), 100);
+        assert_eq!(req_sem.available_permits(), 4);
+        assert_eq!(addr_sem.available_permits(), 2);
     }
 }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -50,12 +50,14 @@ use rand::rng;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs::File;
+use std::future::Future;
 use std::io::BufReader;
 use std::path::Path;
 use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -795,17 +797,21 @@ fn send_fetch_partitions(
                 .await
                 .unwrap();
 
-            let r = fetch_partition_remote(
-                &p,
-                grpc_config,
-                prefer_flight,
-                customize_endpoint,
-                client_pool,
-            )
+            let io_retries = grpc_config.io_retries_times;
+            let io_wait = grpc_config.io_retry_wait_time_ms;
+            let r = with_retry(io_retries, io_wait, || {
+                fetch_partition_buffered(
+                    &p,
+                    grpc_config.clone(),
+                    prefer_flight,
+                    customize_endpoint.clone(),
+                    client_pool.clone(),
+                )
+            })
             .await
-            .map(|stream| {
+            .map(|(schema, batches)| {
                 Box::pin(GovernedStream::new(
-                    stream,
+                    buffered_stream(schema, batches),
                     byte_permit,
                     req_permit,
                     addr_permit,
@@ -819,6 +825,84 @@ fn send_fetch_partitions(
     }
 
     AbortableReceiverStream::create(response_receiver, spawned_tasks)
+}
+
+/// Retry an idempotent async operation up to `retries` times after the initial
+/// attempt, sleeping `wait_ms` between tries. Shuffle partition fetches are
+/// idempotent (the server re-reads the file), so a transport error — including
+/// one mid-body — can be recovered by refetching the whole partition.
+async fn with_retry<T, F, Fut>(
+    retries: u8,
+    wait_ms: u64,
+    mut f: F,
+) -> result::Result<T, BallistaError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = result::Result<T, BallistaError>>,
+{
+    let mut attempt: u8 = 0;
+    loop {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if attempt >= retries {
+                    return Err(e);
+                }
+                attempt += 1;
+                debug!(
+                    "retrying shuffle fetch (attempt {attempt}/{retries}) after error: {e}"
+                );
+                if wait_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+                }
+            }
+        }
+    }
+}
+
+/// Fetch a remote partition and buffer its entire body into memory, turning the
+/// open-ended stream into a discrete, refetchable unit. Buffering is what makes
+/// a mid-body transport failure retriable without emitting duplicate batches
+/// downstream. Total buffered memory across concurrent fetches is bounded by the
+/// governor's byte budget.
+async fn fetch_partition_buffered(
+    location: &PartitionLocation,
+    config: Arc<GrpcClientConfig>,
+    prefer_flight: bool,
+    customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+    client_pool: Option<Arc<dyn BallistaClientPool>>,
+) -> result::Result<(SchemaRef, Vec<RecordBatch>), BallistaError> {
+    let stream = fetch_partition_remote(
+        location,
+        config,
+        prefer_flight,
+        customize_endpoint,
+        client_pool,
+    )
+    .await?;
+    let schema = stream.schema();
+    let metadata = &location.executor_meta;
+    let partition_id = &location.partition_id;
+    let batches = stream.try_collect::<Vec<_>>().await.map_err(|e| {
+        BallistaError::FetchFailed(
+            metadata.id.clone(),
+            partition_id.stage_id,
+            partition_id.partition_id,
+            e.to_string(),
+        )
+    })?;
+    Ok((schema, batches))
+}
+
+/// Build an in-memory `SendableRecordBatchStream` from already-buffered batches.
+fn buffered_stream(
+    schema: SchemaRef,
+    batches: Vec<RecordBatch>,
+) -> SendableRecordBatchStream {
+    Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        futures::stream::iter(batches.into_iter().map(Ok)),
+    ))
 }
 
 async fn new_ballista_client(
@@ -2003,5 +2087,38 @@ mod governor_tests {
         assert_eq!(byte_sem.available_permits(), 100);
         assert_eq!(req_sem.available_permits(), 4);
         assert_eq!(addr_sem.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn with_retry_succeeds_after_transient_failures() {
+        use std::sync::atomic::{AtomicU8, Ordering};
+        let calls = AtomicU8::new(0);
+        let result: result::Result<u32, BallistaError> = with_retry(3, 0, || {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(BallistaError::General("transient".to_string()))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn with_retry_gives_up_after_max_attempts() {
+        use std::sync::atomic::{AtomicU8, Ordering};
+        let calls = AtomicU8::new(0);
+        let result: result::Result<u32, BallistaError> = with_retry(2, 0, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async move { Err(BallistaError::General("always".to_string())) }
+        })
+        .await;
+        assert!(result.is_err());
+        // initial attempt + 2 retries = 3 calls
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
     }
 }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -731,6 +731,8 @@ async fn new_ballista_client(
         customize_endpoint,
         io_retries_times,
         io_retry_wait_time_ms,
+        config.initial_connection_window_size,
+        config.initial_stream_window_size,
     )
     .await
 }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -765,13 +765,24 @@ fn send_fetch_partitions(
     let customize_endpoint = config.ballista_override_create_grpc_client_endpoint();
     let prefer_flight = config.ballista_shuffle_reader_remote_prefer_flight();
 
+    // The reduce-side with_retry owns fetch retries; disable the client's inner
+    // establish-retry loop (set to a single attempt) so the two layers don't
+    // multiply. Read the retry budget BEFORE overriding it for the client.
+    let outer_retries = grpc_config.io_retries_times;
+    let io_wait = grpc_config.io_retry_wait_time_ms;
+    let client_grpc_config: Arc<GrpcClientConfig> = {
+        let mut c = (*grpc_config).clone();
+        c.io_retries_times = 1;
+        Arc::new(c)
+    };
+
     for p in remote_locations.into_iter() {
         let byte_sem = byte_sem.clone();
         let req_sem = req_sem.clone();
         let addr_sems = addr_sems.clone();
         let response_sender = response_sender.clone();
         let customize_endpoint = customize_endpoint.clone();
-        let grpc_config = grpc_config.clone();
+        let client_grpc_config = client_grpc_config.clone();
         let client_pool = client_pool.clone();
 
         spawned_tasks.push(SpawnedTask::spawn(async move {
@@ -797,12 +808,10 @@ fn send_fetch_partitions(
                 .await
                 .unwrap();
 
-            let io_retries = grpc_config.io_retries_times;
-            let io_wait = grpc_config.io_retry_wait_time_ms;
-            let r = with_retry(io_retries, io_wait, || {
+            let r = with_retry(outer_retries, io_wait, is_retriable_fetch_error, || {
                 fetch_partition_buffered(
                     &p,
-                    grpc_config.clone(),
+                    client_grpc_config.clone(),
                     prefer_flight,
                     customize_endpoint.clone(),
                     client_pool.clone(),
@@ -830,10 +839,13 @@ fn send_fetch_partitions(
 /// Retry an idempotent async operation up to `retries` times after the initial
 /// attempt, sleeping `wait_ms` between tries. Shuffle partition fetches are
 /// idempotent (the server re-reads the file), so a transport error — including
-/// one mid-body — can be recovered by refetching the whole partition.
+/// one mid-body — can be recovered by refetching the whole partition. Only
+/// errors accepted by `should_retry` are retried; anything else is returned
+/// immediately on the first failure.
 async fn with_retry<T, F, Fut>(
     retries: u8,
     wait_ms: u64,
+    should_retry: impl Fn(&BallistaError) -> bool,
     mut f: F,
 ) -> result::Result<T, BallistaError>
 where
@@ -845,7 +857,7 @@ where
         match f().await {
             Ok(v) => return Ok(v),
             Err(e) => {
-                if attempt >= retries {
+                if attempt >= retries || !should_retry(&e) {
                     return Err(e);
                 }
                 attempt += 1;
@@ -860,11 +872,25 @@ where
     }
 }
 
+/// Transport/fetch failures worth refetching an idempotent shuffle block for.
+/// Deterministic failures (bad config, schema/decoding logic errors) are not
+/// retried. Mirrors the transport-only retry policy of the client's inner loop.
+fn is_retriable_fetch_error(e: &BallistaError) -> bool {
+    matches!(
+        e,
+        BallistaError::GrpcConnectionError(_) | BallistaError::FetchFailed(..)
+    )
+}
+
 /// Fetch a remote partition and buffer its entire body into memory, turning the
 /// open-ended stream into a discrete, refetchable unit. Buffering is what makes
 /// a mid-body transport failure retriable without emitting duplicate batches
-/// downstream. Total buffered memory across concurrent fetches is bounded by the
-/// governor's byte budget.
+/// downstream. The governor charges each block its compressed (serialized) size,
+/// so the byte budget bounds concurrent in-flight **wire** bytes — which is the
+/// quantity the h2 window must accommodate. The decoded in-memory footprint is
+/// larger by the Arrow/compression expansion ratio, so peak buffered RAM exceeds
+/// the byte budget by that factor. Bounding decoded memory precisely is the
+/// deferred disk-spill work.
 async fn fetch_partition_buffered(
     location: &PartitionLocation,
     config: Arc<GrpcClientConfig>,
@@ -2093,17 +2119,18 @@ mod governor_tests {
     async fn with_retry_succeeds_after_transient_failures() {
         use std::sync::atomic::{AtomicU8, Ordering};
         let calls = AtomicU8::new(0);
-        let result: result::Result<u32, BallistaError> = with_retry(3, 0, || {
-            let n = calls.fetch_add(1, Ordering::SeqCst);
-            async move {
-                if n < 2 {
-                    Err(BallistaError::General("transient".to_string()))
-                } else {
-                    Ok(42)
+        let result: result::Result<u32, BallistaError> =
+            with_retry(3, 0, is_retriable_fetch_error, || {
+                let n = calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if n < 2 {
+                        Err(BallistaError::GrpcConnectionError("transient".to_string()))
+                    } else {
+                        Ok(42)
+                    }
                 }
-            }
-        })
-        .await;
+            })
+            .await;
         assert_eq!(result.unwrap(), 42);
         assert_eq!(calls.load(Ordering::SeqCst), 3);
     }
@@ -2112,13 +2139,31 @@ mod governor_tests {
     async fn with_retry_gives_up_after_max_attempts() {
         use std::sync::atomic::{AtomicU8, Ordering};
         let calls = AtomicU8::new(0);
-        let result: result::Result<u32, BallistaError> = with_retry(2, 0, || {
-            calls.fetch_add(1, Ordering::SeqCst);
-            async move { Err(BallistaError::General("always".to_string())) }
-        })
-        .await;
+        let result: result::Result<u32, BallistaError> =
+            with_retry(2, 0, is_retriable_fetch_error, || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    Err(BallistaError::GrpcConnectionError("always".to_string()))
+                }
+            })
+            .await;
         assert!(result.is_err());
         // initial attempt + 2 retries = 3 calls
         assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn with_retry_does_not_retry_non_retriable() {
+        use std::sync::atomic::{AtomicU8, Ordering};
+        let calls = AtomicU8::new(0);
+        let result: result::Result<u32, BallistaError> =
+            with_retry(3, 0, is_retriable_fetch_error, || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async move { Err(BallistaError::General("deterministic".to_string())) }
+            })
+            .await;
+        assert!(result.is_err());
+        // A non-retriable error must not trigger any retry attempts.
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -616,7 +616,6 @@ impl Stream for AbortableReceiverStream {
 /// In-flight bytes charged to the governor for a block. Uses the partition's
 /// recorded byte size, falling back to `default` when stats carry none. Never 0,
 /// so every block occupies at least one permit.
-#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
 fn block_size(location: &PartitionLocation, default: u64) -> u64 {
     location
         .partition_stats
@@ -627,7 +626,6 @@ fn block_size(location: &PartitionLocation, default: u64) -> u64 {
 
 /// Size of the byte semaphore. tokio permits are `usize`; clamp so it is at least
 /// 1 and never exceeds `u32::MAX` (the `acquire_many` argument type).
-#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
 fn byte_permits_cap(max_bytes: u64) -> usize {
     max_bytes.clamp(1, u32::MAX as u64) as usize
 }
@@ -636,7 +634,6 @@ fn byte_permits_cap(max_bytes: u64) -> usize {
 /// `[1, u32::MAX]`. Capping at `max_bytes` means an oversized block requests the
 /// entire budget and can only proceed once all other fetches drain — the
 /// application-layer analog of Spark's `bytesInFlight == 0` progress clause.
-#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
 fn byte_permits_for(size: u64, max_bytes: u64) -> u32 {
     let cap = max_bytes.clamp(1, u32::MAX as u64);
     size.clamp(1, cap) as u32
@@ -646,7 +643,6 @@ fn byte_permits_for(size: u64, max_bytes: u64) -> u32 {
 /// lifetime. Dropping the stream — on normal end, consumer cancellation, or a
 /// mid-body error — releases all three permits, freeing budget for the next
 /// fetch. This is the release-on-body-completion behavior the governor needs.
-#[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
 struct GovernedStream {
     inner: SendableRecordBatchStream,
     _byte_permit: OwnedSemaphorePermit,
@@ -655,7 +651,6 @@ struct GovernedStream {
 }
 
 impl GovernedStream {
-    #[allow(dead_code)] // consumed by send_fetch_partitions in a follow-up task
     fn new(
         inner: SendableRecordBatchStream,
         byte_permit: OwnedSemaphorePermit,
@@ -712,11 +707,30 @@ fn send_fetch_partitions(
     config: &SessionConfig,
     client_pool: Option<Arc<dyn BallistaClientPool>>,
 ) -> AbortableReceiverStream {
-    let max_request_num = config.ballista_shuffle_reader_maximum_concurrent_requests();
+    let ballista_config = config.ballista_config();
+    let max_reqs = config.ballista_shuffle_reader_maximum_concurrent_requests();
+    let max_bytes = ballista_config.shuffle_reader_max_bytes_in_flight();
+    let max_blocks_per_addr =
+        ballista_config.shuffle_reader_max_blocks_in_flight_per_address();
+    let default_block_size = ballista_config.shuffle_reader_default_block_size_bytes();
     let sort_shuffle_enabled = config.ballista_sort_shuffle_enabled();
 
-    let (response_sender, response_receiver) = mpsc::channel(max_request_num);
-    let semaphore = Arc::new(Semaphore::new(max_request_num));
+    let (response_sender, response_receiver) = mpsc::channel(max_reqs.max(1));
+
+    // Reduce-side in-flight governor. Each remote fetch acquires:
+    //   * `byte_sem`  — min(block_size, max_bytes) permits (in-flight-bytes budget)
+    //   * `req_sem`   — 1 permit (in-flight-request count)
+    //   * an addr semaphore — 1 permit (per-address in-flight cap)
+    // All three are held for the lifetime of the returned stream (see
+    // GovernedStream), so budget is released only when the body is fully
+    // consumed. Because total in-flight bytes stay <= the sized h2 window, the
+    // governor — not the 64 KB transport window — is the binding backpressure,
+    // which is what makes multiplexing over few connections safe.
+    let byte_sem = Arc::new(Semaphore::new(byte_permits_cap(max_bytes)));
+    let req_sem = Arc::new(Semaphore::new(max_reqs.max(1)));
+    let addr_sems: Arc<std::sync::Mutex<HashMap<String, Arc<Semaphore>>>> =
+        Arc::new(std::sync::Mutex::new(HashMap::new()));
+
     let mut spawned_tasks: Vec<SpawnedTask<()>> = vec![];
 
     let (local_locations, remote_locations): (Vec<_>, Vec<_>) = local_remote_read_split(
@@ -733,10 +747,6 @@ fn send_fetch_partitions(
 
     // keep local shuffle files reading in serial order for memory control.
     let response_sender_c = response_sender.clone();
-
-    //
-    // fetching local partitions (read from file)
-    //
     let work_dir = work_dir.to_string();
     spawned_tasks.push(SpawnedTask::spawn_blocking({
         move || {
@@ -749,38 +759,61 @@ fn send_fetch_partitions(
         }
     }));
 
-    //
-    // fetching remote partitions (uses grpc flight protocol)
-    //
     let grpc_config: Arc<GrpcClientConfig> = Arc::new((&config.ballista_config()).into());
     let customize_endpoint = config.ballista_override_create_grpc_client_endpoint();
     let prefer_flight = config.ballista_shuffle_reader_remote_prefer_flight();
 
     for p in remote_locations.into_iter() {
-        let semaphore = semaphore.clone();
+        let byte_sem = byte_sem.clone();
+        let req_sem = req_sem.clone();
+        let addr_sems = addr_sems.clone();
         let response_sender = response_sender.clone();
+        let customize_endpoint = customize_endpoint.clone();
+        let grpc_config = grpc_config.clone();
+        let client_pool = client_pool.clone();
 
-        spawned_tasks.push(SpawnedTask::spawn({
-            let customize_endpoint = customize_endpoint.clone();
-            let grpc_config = grpc_config.clone();
-            let client_pool = client_pool.clone();
-            async move {
-                // Block if exceeds max request number.
-                let permit = semaphore.acquire_owned().await.unwrap();
-                let r = fetch_partition_remote(
-                    &p,
-                    grpc_config,
-                    prefer_flight,
-                    customize_endpoint,
-                    client_pool,
-                )
-                .await;
-                // Block if the channel buffer is full.
-                if let Err(e) = response_sender.send(r).await {
-                    error!("Fail to send response event to the channel due to {e}");
-                }
-                // Increase semaphore by dropping existing permits.
-                drop(permit);
+        spawned_tasks.push(SpawnedTask::spawn(async move {
+            let addr = p.executor_meta.id.clone();
+            let size = block_size(&p, default_block_size);
+
+            // Acquire the cheap count/address gates first, then the byte budget
+            // last, so a fetch does not hold scarce byte permits while blocked
+            // on a per-address slot. All acquires are on Arc<Semaphore>s that
+            // are never closed, so `unwrap()` cannot panic.
+            let req_permit = req_sem.acquire_owned().await.unwrap();
+            let addr_sem = {
+                let mut map = addr_sems.lock().unwrap();
+                map.entry(addr.clone())
+                    .or_insert_with(|| {
+                        Arc::new(Semaphore::new(max_blocks_per_addr.max(1)))
+                    })
+                    .clone()
+            };
+            let addr_permit = addr_sem.acquire_owned().await.unwrap();
+            let byte_permit = byte_sem
+                .acquire_many_owned(byte_permits_for(size, max_bytes))
+                .await
+                .unwrap();
+
+            let r = fetch_partition_remote(
+                &p,
+                grpc_config,
+                prefer_flight,
+                customize_endpoint,
+                client_pool,
+            )
+            .await
+            .map(|stream| {
+                Box::pin(GovernedStream::new(
+                    stream,
+                    byte_permit,
+                    req_permit,
+                    addr_permit,
+                )) as SendableRecordBatchStream
+            });
+
+            if let Err(e) = response_sender.send(r).await {
+                error!("Fail to send response event to the channel due to {e}");
             }
         }));
     }

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -72,6 +72,10 @@ pub struct GrpcClientConfig {
     pub io_retries_times: u8,
     /// Wait time in milliseconds between IO retries.
     pub io_retry_wait_time_ms: u64,
+    /// HTTP/2 initial connection-level flow-control window in bytes. 0 = tonic default.
+    pub initial_connection_window_size: u32,
+    /// HTTP/2 initial stream-level flow-control window in bytes. 0 = tonic default.
+    pub initial_stream_window_size: u32,
 }
 
 impl From<&BallistaConfig> for GrpcClientConfig {
@@ -87,6 +91,9 @@ impl From<&BallistaConfig> for GrpcClientConfig {
             max_message_size: config.grpc_client_max_message_size(),
             io_retries_times: config.io_retries_times() as u8,
             io_retry_wait_time_ms: config.io_retry_wait_time_ms() as u64,
+            initial_connection_window_size: config
+                .grpc_client_initial_connection_window_size(),
+            initial_stream_window_size: config.grpc_client_initial_stream_window_size(),
         }
     }
 }
@@ -102,6 +109,8 @@ impl Default for GrpcClientConfig {
             max_message_size: 16 * 1024 * 1024,
             io_retries_times: 3,
             io_retry_wait_time_ms: 3000,
+            initial_connection_window_size: 67108864,
+            initial_stream_window_size: 16777216,
         }
     }
 }
@@ -294,7 +303,7 @@ where
 {
     let endpoint = tonic::transport::Endpoint::new(dst)?;
     if let Some(config) = config {
-        Ok(endpoint
+        let mut endpoint = endpoint
             .connect_timeout(Duration::from_secs(config.connect_timeout_seconds))
             .timeout(Duration::from_secs(config.timeout_seconds))
             .tcp_nodelay(true)
@@ -303,7 +312,17 @@ where
                 config.http2_keepalive_interval_seconds,
             ))
             .keep_alive_timeout(Duration::from_secs(20))
-            .keep_alive_while_idle(true))
+            .keep_alive_while_idle(true);
+        if config.initial_connection_window_size > 0 {
+            endpoint = endpoint.initial_connection_window_size(Some(
+                config.initial_connection_window_size,
+            ));
+        }
+        if config.initial_stream_window_size > 0 {
+            endpoint = endpoint
+                .initial_stream_window_size(Some(config.initial_stream_window_size));
+        }
+        Ok(endpoint)
     } else {
         Ok(endpoint)
     }
@@ -396,6 +415,8 @@ mod tests {
             max_message_size: 16 * 1024 * 1024,
             io_retries_times: 3,
             io_retry_wait_time_ms: 3000,
+            initial_connection_window_size: 67108864,
+            initial_stream_window_size: 16777216,
         };
         let result = create_grpc_client_endpoint("http://localhost:50051", Some(&config));
         assert!(result.is_ok());

--- a/ballista/executor/src/client_pool.rs
+++ b/ballista/executor/src/client_pool.rs
@@ -185,6 +185,8 @@ impl BallistaClientPool for DefaultBallistaClientPool {
                     customize_endpoint,
                     config.io_retries_times,
                     config.io_retry_wait_time_ms,
+                    config.initial_connection_window_size,
+                    config.initial_stream_window_size,
                 )
                 .await?
             }

--- a/examples/examples/standalone-substrait.rs
+++ b/examples/examples/standalone-substrait.rs
@@ -422,6 +422,8 @@ impl SubstraitSchedulerClient {
             None,
             io_retries_times,
             io_retry_wait_time_ms,
+            0,
+            0,
         )
         .await
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1943.

There is follow on issue https://github.com/apache/datafusion-ballista/issues/1952 for adding disk spilling, to make it even more robust.

# Rationale for this change

The shuffle reader fetches each remote partition as an open-ended `do_get` stream with **no global in-flight-bytes / in-flight-requests governor**. That forces a lose-lose choice between three failure corners:

| Corner | Symptom |
|---|---|
| Multiplex many streams over one h2 connection | h2 64 KB connection-window deadlock |
| One exclusive connection per stream | connection churn / **ephemeral-port exhaustion** at high `target_partitions` (#1943) |
| Broken pipe mid-body | fatal — a partition is an unbounded, non-retriable stream |

Spark solves the same problem with a **reduce-side in-flight governor** (`maxBytesInFlight` / `maxReqsInFlight` / `maxBlocksInFlightPerAddress`, see `ShuffleBlockFetcherIterator`). That governor is what makes *multiplexing over very few connections* safe: it bounds how much data is in flight at the application layer, so the transport is never flooded and a small, reused connection set is sufficient. This PR ports that model onto Ballista's gRPC/Arrow-Flight transport.

# What changes are included in this PR?

1. **Reduce-side in-flight governor.** Each remote fetch acquires three tokio semaphore permits — an in-flight-**bytes** budget (acquiring `min(block_size, max_bytes)`, charged from `PartitionStats.num_bytes`), an in-flight-**request** count, and a **per-address** slot — and holds them (via a drop-guard on the returned stream) until the body is fully consumed. This replaces the previous count-only semaphore whose permit was released as soon as the stream handle was obtained (before the body was read), so it bounds concurrent *in-flight data*, not just connection establishment. By bounding concurrency it sharply reduces how many connections are opened per peer, which is what resolves the ephemeral-port exhaustion in #1943.

2. **h2 flow-control window sizing.** The shuffle data-plane client's HTTP/2 initial connection and stream windows are made configurable and default `>=` the governor byte budget, so the application-level governor — not the 64 KB transport window — is the binding backpressure (the property Spark gets for free from Netty). Control-plane clients are unchanged.

3. **Retriable, buffered block fetch.** Each partition body is buffered into memory as a discrete, idempotent unit and the whole fetch is retried on a transport error (up to `io_retries_times`), so a mid-body broken pipe refetches the block instead of failing the task. The outer retry owns retry policy (transport-error-gated) and disables the client's inner establish-retry to avoid multiplying attempts.

4. **Configuration** (all with Spark-parity defaults):
   - `ballista.shuffle.reader.max_bytes_in_flight` (48 MiB)
   - `ballista.shuffle.reader.max_blocks_in_flight_per_address` (128)
   - `ballista.shuffle.reader.default_block_size_bytes` (1 MiB, used when partition stats carry no byte count)
   - `ballista.client.initial_connection_window_size` (64 MiB) / `ballista.client.initial_stream_window_size` (16 MiB)
   - reuses the existing `ballista.shuffle.max_concurrent_read_requests` (64) as the request-count cap and `io_retries_times` (3) for fetch retry.

**Testing.** Unit tests cover the permit helpers, the `GovernedStream` release-on-drop guard, and the transport-gated retry (retriable vs non-retriable, attempt counts). A standalone integration test runs a shuffle query under a deliberately tiny in-flight budget (64 KiB, 2 blocks/address) to prove it completes without deadlock. The full `sort_shuffle` standalone suite passes.

**Preliminary cluster result (SF100, 2×8 = 16 task slots):** with this change, `target_partitions=128` — which previously died very early on shuffle-fetch port exhaustion — runs the full TPC-H set, and `target_partitions=32` completes ~10% faster than before. (Larger-partition runs also exposed an unrelated scheduler memory ceiling that is a separate concern.)

**Deferred (follow-ups, not in this PR):** spilling oversized partition bodies to disk (`spark.maxRemoteBlockSizeFetchToMem` analog — until then a single partition larger than the budget is buffered in full, and the byte budget bounds compressed *wire* bytes, so decoded RAM is larger by the compression ratio), and a hard `connections_per_peer` cap (which would require a shared-connection pool model).

# Are there any user-facing changes?

New configuration keys are added (listed above), all with defaults, so existing deployments behave sensibly with no changes. The shuffle read path now bounds in-flight bytes/requests and buffers each partition body into memory before yielding it downstream. No public API breakage.
