### PR TITLE
fix: satisfy clippy 1.97 useless_borrows_in_formatting

### DIFF
--- a/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
+++ b/ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs
@@ -77,7 +77,7 @@ pub(crate) fn render_stage_tasks_popup(f: &mut Frame, app: &App) {
         Block::default()
             .title(format!(
                 " Tasks for stage '{}' of job '{}' ",
-                stage.id, &popup.job_id
+                stage.id, popup.job_id
             ))
             .borders(Borders::ALL)
             .border_style(app.theme.popup_border_alt)

--- a/ballista/client/src/extension.rs
+++ b/ballista/client/src/extension.rs
@@ -169,7 +169,7 @@ impl Extension {
             "hostname should be provided".to_string(),
         ))?;
         let port = url.port().unwrap_or(DEFAULT_SCHEDULER_PORT);
-        let scheduler_url = format!("http://{}:{}", &host, port);
+        let scheduler_url = format!("http://{}:{}", host, port);
 
         Ok(scheduler_url)
     }

--- a/ballista/core/src/object_store.rs
+++ b/ballista/core/src/object_store.rs
@@ -145,7 +145,7 @@ impl ObjectStoreRegistry for CustomObjectStoreRegistry {
 
     fn get_store(&self, url: &Url) -> Result<Arc<dyn ObjectStore>> {
         let scheme = url.scheme();
-        log::trace!("get_store: {:?}", &self.s3options.config.read());
+        log::trace!("get_store: {:?}", self.s3options.config.read());
         match scheme {
             "" | "file" => Ok(self.local.clone()),
             "http" | "https" => Ok(Arc::new(

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -728,7 +728,7 @@ async fn clean_all_shuffle_data(work_dir: &str) -> ballista_core::error::Result<
         }
     }
 
-    info!("The work_dir {:?} will be deleted", &to_deleted);
+    info!("The work_dir {:?} will be deleted", to_deleted);
     for del in to_deleted {
         if let Err(e) = fs::remove_dir_all(&del).await {
             error!("Fail to remove the directory {del:?} due to {e}");

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -778,14 +778,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskRunnerPool<T,
                 if let Some(curator_task) = maybe_task {
                     let task_identity = format!(
                         "TID {} {}/{}.{}/{}.{}",
-                        &curator_task.task.task_id,
-                        &curator_task.task.job_id,
-                        &curator_task.task.stage_id,
-                        &curator_task.task.stage_attempt_num,
-                        &curator_task.task.partition_id,
-                        &curator_task.task.task_attempt_num,
+                        curator_task.task.task_id,
+                        curator_task.task.job_id,
+                        curator_task.task.stage_id,
+                        curator_task.task.stage_attempt_num,
+                        curator_task.task.partition_id,
+                        curator_task.task.task_attempt_num,
                     );
-                    debug!("Received task {:?}", &task_identity);
+                    debug!("Received task {:?}", task_identity);
 
                     let server = executor_server.clone();
                     dedicated_executor.spawn(async move {

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -117,7 +117,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                 .map_err(|e| {
                     let msg = format!(
                         "Fail to update tasks status from executor {:?} due to {:?}",
-                        &executor_id, e
+                        executor_id, e
                     );
                     error!("{msg}");
                     Status::internal(msg)
@@ -326,7 +326,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
             .map_err(|e| {
                 let msg = format!(
                     "Fail to update tasks status from executor {:?} due to {:?}",
-                    &executor_id, e
+                    executor_id, e
                 );
                 error!("{msg}");
                 Status::internal(msg)

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -146,7 +146,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                             }
                         }
 
-                        error!("{}", &fail_message);
+                        error!("{}", fail_message);
                         QueryStageSchedulerEvent::JobPlanningFailed {
                             job_id,
                             fail_message,

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -614,7 +614,7 @@ async fn loadtest_ballista(opt: BallistaLoadtestOpt) -> Result<()> {
         .split(',')
         .map(|s| s.parse().unwrap())
         .collect();
-    println!("query list: {:?} ", &query_list);
+    println!("query list: {:?} ", query_list);
 
     let total = Instant::now();
     let mut futures = vec![];
@@ -636,7 +636,7 @@ async fn loadtest_ballista(opt: BallistaLoadtestOpt) -> Result<()> {
                         .unwrap();
                 println!(
                     "Client {} Round {} Query {} started",
-                    &client_id, &i, query_id
+                    client_id, i, query_id
                 );
                 let start = Instant::now();
                 let df = client
@@ -652,7 +652,7 @@ async fn loadtest_ballista(opt: BallistaLoadtestOpt) -> Result<()> {
                 let elapsed = start.elapsed().as_secs_f64() * 1000.0;
                 println!(
                     "Client {} Round {} Query {} took {:.1} ms ",
-                    &client_id, &i, query_id, elapsed
+                    client_id, i, query_id, elapsed
                 );
                 if opt.debug && !batches.is_empty() {
                     pretty::print_batches(&batches).unwrap();
@@ -945,7 +945,7 @@ async fn convert_tbl(opt: ConvertOpt) -> Result<()> {
 
         println!(
             "Converting '{}' to {} files in directory '{}'",
-            &input_path, &opt.file_format, &output_path
+            input_path, opt.file_format, output_path
         );
         match opt.file_format.as_str() {
             "csv" => ctx.write_csv(csv, output_path).await?,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Stable `clippy` 1.97 (released 2026-07-07) tightened the `useless_borrows_in_formatting` lint to flag `&expr` arguments passed to formatting macros (`format!`, `println!`, `log::trace!`, `info!`, `debug!`, `error!`) where the reference is redundant. As a result, the `Clippy` CI job (`ci/scripts/rust_clippy.sh`, which runs with `-D warnings`) now fails on `main` and on every open PR, on pre-existing code untouched by those PRs.

# What changes are included in this PR?

Drop the redundant `&` at each flagged site (21 arguments across 8 files):

- `ballista/core/src/object_store.rs`, `ballista/client/src/extension.rs`
- `ballista/scheduler/src/scheduler_server/grpc.rs`, `query_stage_scheduler.rs`
- `ballista/executor/src/executor_process.rs`, `executor_server.rs`
- `ballista-cli/src/tui/ui/main/jobs/stage_tasks_popup.rs`
- `benchmarks/src/bin/tpch.rs`

`ci/scripts/rust_clippy.sh` and `cargo fmt --all -- --check` both pass cleanly after the change.

# Are there any user-facing changes?

No. The values were already `Display`/`Debug`-formatted through the reference, so the formatted output is byte-for-byte identical. No behavior or API change.
