### PR TITLE
docs: document TPC-H plan-stability golden files and regeneration

### DIFF
--- a/docs/source/contributors-guide/development.md
+++ b/docs/source/contributors-guide/development.md
@@ -59,6 +59,31 @@ cargo build --release
 cargo test
 ```
 
+### TPC-H plan-stability golden files
+
+The `tpch_plan_stability` test suite in the `ballista-scheduler` crate guards the shape of the
+distributed physical plans that Ballista produces for the 22 TPC-H queries. For each query it plans
+the SQL and compares the staged plan text — the stage boundaries (`=== Stage N ===` banners),
+`ShuffleWriterExec` / `UnresolvedShuffleExec` nodes, and any exchange reuse — against an approved
+"golden" file. The queries are planned against a synthetic statistics-only table, so the suite is
+deterministic and runs without TPC-H data or a running cluster.
+
+The golden files live in
+[`ballista/scheduler/tests/tpch_plan_stability/approved/`](https://github.com/apache/datafusion-ballista/tree/main/ballista/scheduler/tests/tpch_plan_stability/approved)
+(`q1.txt` through `q22.txt`). When a change alters distributed planning, the suite fails with a
+plan-drift diff. Review the diff: if the change is unintended, fix the regression; if the new plans
+are correct, regenerate the golden files:
+
+```shell
+./dev/update-tpch-plan-stability.sh
+```
+
+This runs the suite in generate mode
+(`BALLISTA_GENERATE_GOLDEN=1 cargo test -p ballista-scheduler --test tpch_plan_stability`) and
+rewrites the approved files. Review the resulting changes under
+`ballista/scheduler/tests/tpch_plan_stability/approved/` and commit them together with the code
+change that caused them.
+
 ## Running the examples
 
 ```shell


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

The `tpch_plan_stability` suite in `ballista-scheduler` compares the distributed physical plans for the 22 TPC-H queries against approved golden files. When a change intentionally alters distributed planning, the suite fails with a plan-drift diff and the goldens must be regenerated. This workflow was not documented anywhere in the contributor guide, so a contributor hitting the failure has no pointer to `dev/update-tpch-plan-stability.sh` or an explanation of what the goldens represent.

# What changes are included in this PR?

Add a "TPC-H plan-stability golden files" subsection to the contributor development guide (`docs/source/contributors-guide/development.md`). It explains what the golden plans capture (stage boundaries, shuffles, exchange reuse), that they are planned deterministically against a synthetic statistics-only table so no TPC-H data or running cluster is needed, where the approved files live, and how to regenerate and review them with `dev/update-tpch-plan-stability.sh`.

Docs-only change. `npx prettier@2.7.1` reports no formatting changes.

# Are there any user-facing changes?

No. Documentation only; no code, API, or behavior changes.
