### PR TITLE
perf: avoid redundant TaskStatus clones in scheduler update_task_status

### DIFF
--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -656,7 +656,7 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
                             );
                             continue;
                         }
-                        let partition_id = task_status.clone().partition_id as usize;
+                        let partition_id = task_status.partition_id as usize;
                         let task_identity = format!(
                             "TID {} {}/{}.{}/{}",
                             task_status.task_id,
@@ -665,19 +665,20 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
                             task_stage_attempt_num,
                             partition_id
                         );
-                        let operator_metrics = task_status.metrics.clone();
 
-                        if !running_stage
-                            .update_task_info(partition_id, task_status.clone())
-                        {
+                        if !running_stage.update_task_info(partition_id, &task_status) {
                             continue;
                         }
+
+                        let TaskStatus {
+                            status,
+                            metrics: operator_metrics,
+                            ..
+                        } = task_status;
                         //
                         // handle task failure
                         //
-                        if let Some(task_status::Status::Failed(failed_task)) =
-                            task_status.status
-                        {
+                        if let Some(task_status::Status::Failed(failed_task)) = status {
                             let failed_reason = failed_task.failed_reason;
 
                             match failed_reason {
@@ -786,7 +787,7 @@ impl ExecutionGraph for AdaptiveExecutionGraph {
                         //
                         else if let Some(task_status::Status::Successful(
                             successful_task,
-                        )) = task_status.status
+                        )) = status
                         {
                             // update task metrics for successfu task
                             running_stage

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -791,7 +791,7 @@ impl ExecutionGraph for StaticExecutionGraph {
                             );
                             continue;
                         }
-                        let partition_id = task_status.clone().partition_id as usize;
+                        let partition_id = task_status.partition_id as usize;
                         let task_identity = format!(
                             "TID {} {}/{}.{}/{}",
                             task_status.task_id,
@@ -966,7 +966,7 @@ impl ExecutionGraph for StaticExecutionGraph {
                     for task_status in stage_task_statuses.into_iter() {
                         let task_stage_attempt_num =
                             task_status.stage_attempt_num as usize;
-                        let partition_id = task_status.clone().partition_id as usize;
+                        let partition_id = task_status.partition_id as usize;
                         let task_identity = format!(
                             "TID {} {}/{}.{}/{}",
                             task_status.task_id,

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -800,17 +800,17 @@ impl ExecutionGraph for StaticExecutionGraph {
                             task_stage_attempt_num,
                             partition_id
                         );
-                        let operator_metrics = task_status.metrics.clone();
-
-                        if !running_stage
-                            .update_task_info(partition_id, task_status.clone())
-                        {
+                        if !running_stage.update_task_info(partition_id, &task_status) {
                             continue;
                         }
 
-                        if let Some(task_status::Status::Failed(failed_task)) =
-                            task_status.status
-                        {
+                        let TaskStatus {
+                            status,
+                            metrics: operator_metrics,
+                            ..
+                        } = task_status;
+
+                        if let Some(task_status::Status::Failed(failed_task)) = status {
                             let failed_reason = failed_task.failed_reason;
 
                             match failed_reason {
@@ -915,7 +915,7 @@ impl ExecutionGraph for StaticExecutionGraph {
                             }
                         } else if let Some(task_status::Status::Successful(
                             successful_task,
-                        )) = task_status.status
+                        )) = status
                         {
                             // update task metrics for successfu task
                             running_stage

--- a/ballista/scheduler/src/state/execution_stage.rs
+++ b/ballista/scheduler/src/state/execution_stage.rs
@@ -669,7 +669,7 @@ impl RunningStage {
     }
 
     /// Update the TaskInfo for task partition
-    pub fn update_task_info(&mut self, partition_id: usize, status: TaskStatus) -> bool {
+    pub fn update_task_info(&mut self, partition_id: usize, status: &TaskStatus) -> bool {
         debug!("Updating TaskInfo for partition {partition_id}");
         let Some(task_info) = self.task_infos[partition_id].as_ref() else {
             warn!(
@@ -686,7 +686,7 @@ impl RunningStage {
             return false;
         }
         let scheduled_time = task_info.scheduled_time;
-        let task_status = status.status.unwrap();
+        let task_status = status.status.as_ref().unwrap();
         let updated_task_info = TaskInfo {
             task_id,
             scheduled_time,
@@ -1178,7 +1178,7 @@ mod tests {
         // Simulates receiving a status update for a task that was already
         // reset (e.g., executor heartbeat timed out).
         let status = make_task_status(0, 0);
-        let result = stage.update_task_info(0, status);
+        let result = stage.update_task_info(0, &status);
 
         // Should return false (update rejected), not panic.
         assert!(!result);
@@ -1203,7 +1203,7 @@ mod tests {
         });
 
         let status = make_task_status(0, 0);
-        let result = stage.update_task_info(0, status);
+        let result = stage.update_task_info(0, &status);
 
         assert!(result);
         assert!(matches!(
@@ -1240,7 +1240,7 @@ mod tests {
 
         // Executor sends a late status update for partition 0.
         let status = make_task_status(0, 0);
-        let result = stage.update_task_info(0, status);
+        let result = stage.update_task_info(0, &status);
 
         // Should gracefully reject the update, not panic.
         assert!(!result);


### PR DESCRIPTION
# Which issue does this PR close?

None — small, self-contained hot-path allocation cleanup.

# Rationale for this change

`ExecutionGraph::update_task_status` runs on the scheduler's hot path — it is
invoked for every batch of task status updates from executors. Its running-stage
loop performed several redundant clones of the `TaskStatus` protobuf message per
task:

- `task_status.clone().partition_id` deep-cloned the entire `TaskStatus`
  (including its `metrics` vector and nested `status`) only to copy out a single
  `u32`, then dropped the clone.
- `task_status.metrics.clone()` cloned the metrics vector unconditionally, even
  on the failure path where it is unused.
- `RunningStage::update_task_info(partition_id, task_status.clone())` passed a
  full clone even though the method only reads a few `Copy` fields and needs to
  clone the inner status enum for storage in `TaskInfo`.

This applies to both `StaticExecutionGraph` and the AQE `AdaptiveExecutionGraph`,
which carry duplicate copies of this loop.

# What changes are included in this PR?

Two commits:

1. Read `partition_id` directly instead of via `task_status.clone().partition_id`.
2. Change `RunningStage::update_task_info` to borrow `&TaskStatus` instead of
   taking it by value, and destructure the owned `TaskStatus` once at the call
   site to move its `status` and `metrics` into the match arms. This removes the
   per-update metrics clone and the full-message clone on both hot paths, leaving
   only the single inner-status clone that `update_task_info` must persist.

No behavior change; the existing `update_task_info` and task-status-update tests
in `execution_graph.rs` / `execution_stage.rs` continue to pass.

# Are there any user-facing changes?

No.
