### PR TITLE
Log task execution duration in the executor "Finished task" message

### DIFF
--- a/ballista/executor/src/execution_loop.rs
+++ b/ballista/executor/src/execution_loop.rs
@@ -44,7 +44,7 @@ use std::any::Any;
 use std::convert::TryInto;
 use std::error::Error;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use std::{sync::Arc, time::Duration};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tonic::codegen::{Body, Bytes, StdError};
@@ -297,6 +297,7 @@ async fn run_received_task<T: 'static + AsLogicalPlan, U: 'static + AsExecutionP
             partition_id: partition_id as usize,
         };
 
+        let task_start = Instant::now();
         let execution_result = match AssertUnwindSafe(executor.execute_query_stage(
             task_id as usize,
             part.clone(),
@@ -314,7 +315,10 @@ async fn run_received_task<T: 'static + AsLogicalPlan, U: 'static + AsExecutionP
             }
         };
 
-        info!("Finished task : [{task_identity}]");
+        info!(
+            "Finished task : [{task_identity}] in {:?}",
+            task_start.elapsed()
+        );
         debug!("Task statistics: [{task_identity}] {execution_result:?}");
 
         let plan_metrics = query_stage_exec.collect_plan_metrics();

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use sysinfo::{MemoryRefreshKind, System};
 use tokio::sync::mpsc;
 
@@ -407,6 +407,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
 
                 info!("Execute task  : [{task_identity}]");
 
+                let task_start = Instant::now();
                 let execution_result = self
                     .executor
                     .execute_query_stage(
@@ -416,7 +417,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
                         task_context,
                     )
                     .await;
-                info!("Finished task : [{task_identity}]");
+                info!(
+                    "Finished task : [{task_identity}] in {:?}",
+                    task_start.elapsed()
+                );
                 debug!(
                     "Task [{task_identity}], execution statistics: {execution_result:?}"
                 );


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1998.

# Rationale for this change

The executor logs `Execute task : [...]` at the start of a task and `Finished task : [...]` at the end, but neither reports the task's duration. To spot a slow or skewed task from the logs today you have to correlate the two lines by timestamp or inspect the task-status reports. Per-task duration is the most useful number when scanning executor logs for long-pole stages, so this adds it directly to the finished-task line.

# What changes are included in this PR?

Capture an `Instant` immediately before `execute_query_stage` and format its `elapsed()` into the `Finished task` log message, at both task-dispatch sites:

- `ballista/executor/src/executor_server.rs` — the push-based path
- `ballista/executor/src/execution_loop.rs` — the pull-based path

The message becomes `Finished task : [<task>] in <duration>` (e.g. `in 2.31s`). A monotonic `Instant` is used rather than differencing the existing wall-clock timestamps so the duration is unaffected by clock adjustments.

# Are there any user-facing changes?

Only the executor log line changes; the `Finished task` message now includes the elapsed execution time. No API or behavior changes.
