### PR TITLE
chore: bump Ballista version to 54.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "async-trait",
  "ballista-core",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-benchmarks"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "ballista",
  "ballista-core",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-cli"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "ballista",
  "chrono",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-core"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-examples"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow-flight",
  "ballista",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-executor"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-scheduler"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow-flight",
  "async-trait",

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-cli"
 description = "Command Line Client for Ballista distributed query engine."
-version = "53.0.0"
+version = "54.0.0"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 edition = { workspace = true }
 rust-version = { workspace = true }
@@ -33,7 +33,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # CLI-only deps (DataFusion/Ballista) — gated by `cli` feature
-ballista = { path = "../ballista/client", version = "53.0.0", features = ["standalone"], optional = true }
+ballista = { path = "../ballista/client", version = "54.0.0", features = ["standalone"], optional = true }
 datafusion = { workspace = true, optional = true }
 datafusion-cli = { workspace = true, optional = true }
 rustyline = { version = "18.0.0", optional = true }

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista"
 description = "Ballista Distributed Compute"
 license = "Apache-2.0"
-version = "53.0.0"
+version = "54.0.0"
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
@@ -29,9 +29,9 @@ rust-version = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
-ballista-core = { path = "../core", version = "53.0.0" }
-ballista-executor = { path = "../executor", version = "53.0.0", optional = true, default-features = false, features = ["arrow-ipc-optimizations"] }
-ballista-scheduler = { path = "../scheduler", version = "53.0.0", optional = true, default-features = false }
+ballista-core = { path = "../core", version = "54.0.0" }
+ballista-executor = { path = "../executor", version = "54.0.0", optional = true, default-features = false, features = ["arrow-ipc-optimizations"] }
+ballista-scheduler = { path = "../scheduler", version = "54.0.0", optional = true, default-features = false }
 datafusion = { workspace = true }
 log = { workspace = true }
 
@@ -39,8 +39,8 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-ballista-executor = { path = "../executor", version = "53.0.0" }
-ballista-scheduler = { path = "../scheduler", version = "53.0.0" }
+ballista-executor = { path = "../executor", version = "54.0.0" }
+ballista-scheduler = { path = "../scheduler", version = "54.0.0" }
 ctor = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-core"
 description = "Ballista Distributed Compute"
 license = "Apache-2.0"
-version = "53.0.0"
+version = "54.0.0"
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-executor"
 description = "Ballista Distributed Compute - Executor"
 license = "Apache-2.0"
-version = "53.0.0"
+version = "54.0.0"
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
@@ -42,7 +42,7 @@ spark-compat = ["ballista-core/spark-compat"]
 arrow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
-ballista-core = { path = "../core", version = "53.0.0" }
+ballista-core = { path = "../core", version = "54.0.0" }
 bytesize = "2"
 clap = { workspace = true, optional = true }
 dashmap = { workspace = true }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -19,7 +19,7 @@
 name = "ballista-scheduler"
 description = "Ballista Distributed Compute - Scheduler"
 license = "Apache-2.0"
-version = "53.0.0"
+version = "54.0.0"
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 readme = "README.md"
@@ -50,7 +50,7 @@ arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.8.9"
 tower-http = { version = "0.7", features = ["cors"] }
-ballista-core = { path = "../core", version = "53.0.0" }
+ballista-core = { path = "../core", version = "54.0.0" }
 clap = { workspace = true, optional = true }
 dashmap = { workspace = true }
 datafusion = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-benchmarks"
 description = "Ballista Benchmarks"
-version = "53.0.0"
+version = "54.0.0"
 edition = "2024"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 homepage = "https://datafusion.apache.org/ballista/"
@@ -31,8 +31,8 @@ ci = []
 default = ["mimalloc"]
 
 [dependencies]
-ballista = { path = "../ballista/client", version = "53.0.0" }
-ballista-core = { path = "../ballista/core", version = "53.0.0", features = [
+ballista = { path = "../ballista/client", version = "54.0.0" }
+ballista-core = { path = "../ballista/core", version = "54.0.0", features = [
     "build-binary",
 ] }
 clap = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-examples"
 description = "Ballista usage examples"
-version = "53.0.0"
+version = "54.0.0"
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
@@ -57,10 +57,10 @@ rustls = { version = "0.23", features = ["ring"], optional = true }
 
 [dev-dependencies]
 arrow-flight = { workspace = true }
-ballista = { path = "../ballista/client", version = "53.0.0" }
-ballista-core = { path = "../ballista/core", version = "53.0.0", default-features = false, features = ["build-binary"] }
-ballista-executor = { path = "../ballista/executor", version = "53.0.0", default-features = false }
-ballista-scheduler = { path = "../ballista/scheduler", version = "53.0.0", default-features = false }
+ballista = { path = "../ballista/client", version = "54.0.0" }
+ballista-core = { path = "../ballista/core", version = "54.0.0", default-features = false, features = ["build-binary"] }
+ballista-executor = { path = "../ballista/executor", version = "54.0.0", default-features = false }
+ballista-scheduler = { path = "../ballista/scheduler", version = "54.0.0", default-features = false }
 ctor = { workspace = true }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "async-trait",
  "ballista-core",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-core"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-executor"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-scheduler"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "pyballista"
-version = "53.0.0"
+version = "54.0.0"
 dependencies = [
  "async-trait",
  "ballista",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "pyballista"
-version = "53.0.0"
+version = "54.0.0"
 homepage = "https://datafusion.apache.org/ballista/"
 repository = "https://github.com/apache/datafusion-ballista"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
@@ -31,10 +31,10 @@ publish = false
 
 [dependencies]
 async-trait = "0.1.89"
-ballista = { path = "../ballista/client", version = "53.0.0" }
-ballista-core = { path = "../ballista/core", version = "53.0.0" }
-ballista-executor = { path = "../ballista/executor", version = "53.0.0", default-features = false }
-ballista-scheduler = { path = "../ballista/scheduler", version = "53.0.0", default-features = false }
+ballista = { path = "../ballista/client", version = "54.0.0" }
+ballista-core = { path = "../ballista/core", version = "54.0.0" }
+ballista-executor = { path = "../ballista/executor", version = "54.0.0", default-features = false }
+ballista-scheduler = { path = "../ballista/scheduler", version = "54.0.0", default-features = false }
 datafusion = { version = "54", features = ["avro"] }
 datafusion-proto = { version = "54" }
 datafusion-python = { version = "54", default-features = false }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #1977.

# Rationale for this change

Preparing for the Ballista 54.0.0 release. DataFusion has already been upgraded to 54 on `main` (#1906), so the next step in the release process is to bump the Ballista crate versions from 53.0.0 to 54.0.0 before cutting `branch-54`.

# What changes are included in this PR?

- Bump all Ballista crate versions from `53.0.0` to `54.0.0` via `./dev/update_ballista_versions.py 54.0.0` (crate versions and inter-crate path dependencies across `ballista-cli`, `ballista/{core,client,executor,scheduler}`, `benchmarks`, `examples`, `python`).
- Refresh `Cargo.lock`.

# Are there any user-facing changes?

Yes, the release version. No API changes.
