### PR TITLE
ci: install Rust via rustup in wheel build to fix release-build startup_failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - name: Install Protoc
@@ -127,7 +130,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
@@ -176,7 +182,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
@@ -218,7 +227,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt
@@ -260,7 +272,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 
       - run: rm LICENSE.txt

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -56,10 +56,10 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: "stable"
-          targets: "wasm32-unknown-unknown"
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
 


### PR DESCRIPTION
# Which issue does this PR close?

<!-- No tracked issue; prevents the release-build startup_failure from recurring on main. -->

Closes #.

# Rationale for this change

The `Python Release Build` workflow fails with `startup_failure` when an `*-rc*` tag is pushed, because the ASF INFRA third-party actions allowlist rejects the run before any job starts:

> The action dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 is not allowed in apache/datafusion-ballista because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ...

That SHA was introduced in #1748 but is not on the allowlist. It went unnoticed because the workflow only runs on `*-rc*` tags and `python/**` PRs, so the pin on `main` was never exercised until the `54.0.0-rc1` tag was cut from `branch-54` ([failing run](https://github.com/apache/datafusion-ballista/actions/runs/29200296372)).

The equivalent fix for the release branch is #2007; this PR mirrors it to `main` so the next release branch does not reintroduce the problem.

# What changes are included in this PR?

Replace `dtolnay/rust-toolchain@<sha>` with plain `rustup` shell commands in `build.yml` (5 steps) and `web-tui.yml` (1 step), matching how `rust.yml` already installs the toolchain. This removes the third-party-action dependency entirely, so a future action bump cannot re-break the release build.

# Are there any user-facing changes?

No. CI-only change.