### PR TITLE
feat: add DistributedQueryExec::explain_executed_plan and show logical plan in display

### DIFF
--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -24,6 +24,8 @@ mod supported {
         standalone_context_with_state,
     };
     use ballista_core::config::BallistaConfig;
+    use ballista_core::execution_plans::DistributedQueryExec;
+    use datafusion_proto::protobuf::LogicalPlanNode;
 
     use datafusion::arrow::array::StringArray;
     use datafusion::arrow::record_batch::RecordBatch;
@@ -1208,6 +1210,53 @@ mod supported {
         ];
 
         assert_batches_eq!(expected, &[sanitized]);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::standalone(standalone_context())]
+    #[case::remote(remote_context())]
+    #[tokio::test]
+    async fn should_explain_executed_plan(
+        #[future(awt)]
+        #[case]
+        ctx: SessionContext,
+    ) -> datafusion::error::Result<()> {
+        let df = ctx
+            .sql(
+                "select count(*), id from (select unnest([1,2,3,4,5]) as id) group by id",
+            )
+            .await?;
+
+        let plan = df.create_physical_plan().await?;
+
+        // Execute so the scheduler assigns a job id and completes the stages.
+        let _ = collect(plan.clone(), ctx.task_ctx()).await?;
+
+        let dqe = plan
+            .downcast_ref::<DistributedQueryExec<LogicalPlanNode>>()
+            .expect("top operator should be a DistributedQueryExec<LogicalPlanNode>");
+
+        let config = ctx.copied_config();
+
+        // Plan without metrics.
+        let plan_text = dqe.explain_executed_plan(&config, false).await?;
+        assert!(
+            plan_text.contains("SuccessfulStage"),
+            "expected per-stage plan, got: {plan_text}"
+        );
+        assert!(
+            !plan_text.contains("metrics=["),
+            "expected no metrics, got: {plan_text}"
+        );
+
+        // Same plan with metrics.
+        let plan_with_metrics = dqe.explain_executed_plan(&config, true).await?;
+        assert!(
+            plan_with_metrics.contains("metrics=["),
+            "expected metrics, got: {plan_with_metrics}"
+        );
 
         Ok(())
     }

--- a/ballista/core/src/execution_plans/distributed_explain_analyze.rs
+++ b/ballista/core/src/execution_plans/distributed_explain_analyze.rs
@@ -196,7 +196,7 @@ impl<T: 'static + AsLogicalPlan> ExecutionPlan for DistributedExplainAnalyzeExec
     }
 }
 
-async fn fetch_job_metrics(
+pub(crate) async fn fetch_job_metrics(
     scheduler_url: &str,
     job_id: &JobId,
     session_config: datafusion::prelude::SessionConfig,
@@ -240,13 +240,15 @@ async fn fetch_job_metrics(
         .map_err(|e| DataFusionError::Execution(format!("{e:?}")))
 }
 
-fn format_metrics_as_record_batch(
+/// Render the per-stage executed plan carried in `job_metrics` as a single
+/// string. When `with_metrics` is true, each operator line is suffixed with its
+/// aggregated `metrics=[...]`; when false, only the operator description is
+/// shown.
+pub(crate) fn format_job_plan(
     job_metrics: &GetJobMetricsResult,
-    _job_id: &JobId,
-    schema: SchemaRef,
-    _verbose: bool,
-) -> Result<RecordBatch> {
-    let plan = job_metrics
+    with_metrics: bool,
+) -> Result<String> {
+    job_metrics
         .stages
         .iter()
         .map(|stage| {
@@ -257,28 +259,41 @@ fn format_metrics_as_record_batch(
             ));
 
             for operator in &stage.operators {
-                let metrics_set: datafusion::physical_plan::metrics::MetricsSet =
-                    protobuf::OperatorMetricsSet {
-                        metrics: operator.metrics.clone(),
-                    }
-                    .try_into()
-                    .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
-                let metrics = metrics_set
-                    .aggregate_by_name()
-                    .sorted_for_display()
-                    .timestamps_removed()
-                    .to_string();
                 let indent = "  ".repeat(operator.depth as usize);
-                stage_plan.push(format!(
-                    "{indent}{}, metrics=[{metrics}]",
-                    operator.operator_desc
-                ));
+                if with_metrics {
+                    let metrics_set: datafusion::physical_plan::metrics::MetricsSet =
+                        protobuf::OperatorMetricsSet {
+                            metrics: operator.metrics.clone(),
+                        }
+                        .try_into()
+                        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+                    let metrics = metrics_set
+                        .aggregate_by_name()
+                        .sorted_for_display()
+                        .timestamps_removed()
+                        .to_string();
+                    stage_plan.push(format!(
+                        "{indent}{}, metrics=[{metrics}]",
+                        operator.operator_desc
+                    ));
+                } else {
+                    stage_plan.push(format!("{indent}{}", operator.operator_desc));
+                }
             }
 
             Ok(stage_plan.join("\n"))
         })
-        .collect::<Result<Vec<_>>>()?
-        .join("\n\n");
+        .collect::<Result<Vec<_>>>()
+        .map(|stages| stages.join("\n\n"))
+}
+
+fn format_metrics_as_record_batch(
+    job_metrics: &GetJobMetricsResult,
+    _job_id: &JobId,
+    schema: SchemaRef,
+    _verbose: bool,
+) -> Result<RecordBatch> {
+    let plan = format_job_plan(job_metrics, true)?;
 
     let mut type_builder = StringBuilder::with_capacity(1, "Plan with Metrics".len());
     let mut plan_builder = StringBuilder::with_capacity(1, plan.len());
@@ -298,7 +313,7 @@ fn format_metrics_as_record_batch(
 
 #[cfg(test)]
 mod tests {
-    use super::format_metrics_as_record_batch;
+    use super::{format_job_plan, format_metrics_as_record_batch};
     use datafusion::arrow::array::StringArray;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc;
@@ -307,6 +322,58 @@ mod tests {
         GetJobMetricsResult, JobStageMetrics, OperatorMetric, OperatorWithMetrics,
         operator_metric,
     };
+
+    #[test]
+    fn test_format_job_plan_without_metrics() {
+        let response = GetJobMetricsResult {
+            stages: vec![
+                JobStageMetrics {
+                    stage_id: 0,
+                    partitions: 1,
+                    operators: vec![OperatorWithMetrics {
+                        depth: 0,
+                        operator_type: "ProjectionExec".to_string(),
+                        operator_desc: "ProjectionExec: expr=[a]".to_string(),
+                        metrics: vec![
+                            OperatorMetric {
+                                metric: Some(operator_metric::Metric::OutputRows(4)),
+                            },
+                            OperatorMetric {
+                                metric: Some(operator_metric::Metric::ElapseTime(
+                                    15_000_000,
+                                )),
+                            },
+                        ],
+                    }],
+                },
+                JobStageMetrics {
+                    stage_id: 1,
+                    partitions: 2,
+                    operators: vec![OperatorWithMetrics {
+                        depth: 0,
+                        operator_type: "FilterExec".to_string(),
+                        operator_desc: "FilterExec: a@0 > 1".to_string(),
+                        metrics: vec![OperatorMetric {
+                            metric: Some(operator_metric::Metric::OutputRows(2)),
+                        }],
+                    }],
+                },
+            ],
+        };
+
+        let plan = format_job_plan(&response, false).unwrap();
+
+        let expected = [
+            "=========SuccessfulStage[stage_id=0, partitions=1]=========",
+            "ProjectionExec: expr=[a]",
+            "",
+            "=========SuccessfulStage[stage_id=1, partitions=2]=========",
+            "FilterExec: a@0 > 1",
+        ]
+        .join("\n");
+        assert_eq!(plan, expected);
+        assert!(!plan.contains("metrics=["));
+    }
 
     #[test]
     fn test_format_metrics_as_record_batch() {

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -149,6 +149,9 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
     /// scheduler-assigned job id and the plan is only available once the stages
     /// have completed. Returns an error if the query has not been executed yet.
     ///
+    /// Only stages that completed successfully are included, inherited from the
+    /// scheduler's `get_job_metrics`.
+    ///
     /// When `with_metrics` is true the output matches `EXPLAIN ANALYZE`; when
     /// false the `metrics=[...]` suffixes are omitted.
     pub async fn explain_executed_plan(
@@ -893,6 +896,7 @@ mod test {
     use datafusion::logical_expr::LogicalPlan;
     use datafusion::physical_plan::ExecutionPlan;
     use datafusion::physical_plan::displayable;
+    use datafusion::prelude::SessionConfig;
     use datafusion_proto::protobuf::LogicalPlanNode;
     use std::sync::Arc;
 
@@ -992,6 +996,25 @@ mod test {
         assert!(
             rendered.contains("EmptyRelation"),
             "missing rendered logical plan: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explain_executed_plan_errors_before_execution() {
+        let exec = DistributedQueryExec::<LogicalPlanNode>::new(
+            "http://scheduler:50050".to_string(),
+            BallistaConfig::default(),
+            LogicalPlan::default(),
+            "session".to_string(),
+        );
+        // job_id is None because the query has not been executed
+        let err = exec
+            .explain_executed_plan(&SessionConfig::new(), false)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("has not been executed"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -141,6 +141,42 @@ impl<T: 'static + AsLogicalPlan> DistributedQueryExec<T> {
         self.job_id.lock().clone()
     }
 
+    /// Fetch and render the physical plan that executed on the cluster for this
+    /// query, one section per query stage.
+    ///
+    /// This must be called after the query has run (i.e. after
+    /// [`ExecutionPlan::execute`]/`collect`), because it relies on the
+    /// scheduler-assigned job id and the plan is only available once the stages
+    /// have completed. Returns an error if the query has not been executed yet.
+    ///
+    /// When `with_metrics` is true the output matches `EXPLAIN ANALYZE`; when
+    /// false the `metrics=[...]` suffixes are omitted.
+    pub async fn explain_executed_plan(
+        &self,
+        session_config: &SessionConfig,
+        with_metrics: bool,
+    ) -> Result<String> {
+        let job_id = self.job_id().ok_or_else(|| {
+            DataFusionError::Execution(
+                "Cannot explain executed plan: query has not been executed yet"
+                    .to_string(),
+            )
+        })?;
+
+        let job_metrics =
+            crate::execution_plans::distributed_explain_analyze::fetch_job_metrics(
+                &self.scheduler_url,
+                &job_id,
+                session_config.clone(),
+            )
+            .await?;
+
+        crate::execution_plans::distributed_explain_analyze::format_job_plan(
+            &job_metrics,
+            with_metrics,
+        )
+    }
+
     fn compute_properties(schema: SchemaRef) -> PlanProperties {
         PlanProperties::new(
             EquivalenceProperties::new(schema),

--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -195,11 +195,12 @@ impl<T: 'static + AsLogicalPlan> DisplayAs for DistributedQueryExec<T> {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(
+                writeln!(
                     f,
                     "DistributedQueryExec: scheduler_url={}",
                     self.scheduler_url
-                )
+                )?;
+                write!(f, "logical_plan:\n{}", self.plan.display_indent())
             }
             DisplayFormatType::TreeRender => {
                 writeln!(f, "scheduler_url={}", self.scheduler_url)
@@ -891,6 +892,7 @@ mod test {
     use crate::serde::protobuf::get_job_status_result::FlightProxy;
     use datafusion::logical_expr::LogicalPlan;
     use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::displayable;
     use datafusion_proto::protobuf::LogicalPlanNode;
     use std::sync::Arc;
 
@@ -965,5 +967,31 @@ mod test {
             .unwrap();
 
         assert_eq!(new_exec.job_id(), Some(JobId::new("job-123")));
+    }
+
+    #[test]
+    fn test_display_includes_logical_plan() {
+        let exec = Arc::new(DistributedQueryExec::<LogicalPlanNode>::new(
+            "http://scheduler:50050".to_string(),
+            BallistaConfig::default(),
+            LogicalPlan::default(),
+            "session".to_string(),
+        ));
+
+        let rendered = displayable(exec.as_ref()).indent(false).to_string();
+
+        assert!(
+            rendered.contains("scheduler_url=http://scheduler:50050"),
+            "missing scheduler_url line: {rendered}"
+        );
+        assert!(
+            rendered.contains("logical_plan:"),
+            "missing logical_plan section: {rendered}"
+        );
+        // LogicalPlan::default() renders as EmptyRelation
+        assert!(
+            rendered.contains("EmptyRelation"),
+            "missing rendered logical plan: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

No tracking issue was filed for this change. Happy to open one if preferred.

# Rationale for this change

After running a distributed query, there is no convenient way for a client to see the physical plan that actually executed on the cluster. `DistributedQueryExec` only holds the logical plan, and until now its display showed a single `scheduler_url=...` line. The distributed physical plan (the per-stage DAG with shuffle boundaries) is built and retained on the scheduler and was only surfaced through `EXPLAIN ANALYZE`, always bundled with runtime metrics. This PR lets a client fetch that executed plan on demand (with or without metrics) and makes the operator's default display more informative.

# What changes are included in this PR?

- Add `DistributedQueryExec::explain_executed_plan(&self, session_config, with_metrics)`, which fetches the executed per-stage plan for an already-run query via the existing `get_job_metrics` gRPC and returns it as a printable string. `with_metrics = true` matches the `EXPLAIN ANALYZE` output; `false` omits the `metrics=[...]` suffixes. It returns an error if called before the query has executed.
- Extract the per-stage plan formatting out of the explain-analyze `RecordBatch` builder into a reusable `format_job_plan(job_metrics, with_metrics)`, and widen `fetch_job_metrics` to `pub(crate)`. Existing `EXPLAIN ANALYZE` output is unchanged (the record-batch builder now delegates to `format_job_plan(.., true)`).
- Extend `DistributedQueryExec`'s `DisplayAs` (Default/Verbose) to also render the submitted logical plan via `LogicalPlan::display_indent()`. This is synchronous and makes no scheduler round-trip; the `TreeRender` arm is unchanged.

No proto, planner, or scheduler changes. Covered by unit tests (formatter without metrics, display includes logical plan, error-before-execution) and an end-to-end integration test in `context_checks.rs` that runs a query and asserts the executed plan renders with and without metrics.

# Are there any user-facing changes?

Yes, additive and non-breaking:

- New public method `DistributedQueryExec::explain_executed_plan`.
- `DistributedQueryExec`'s default display now includes the submitted logical plan in addition to the scheduler URL.

No breaking changes to public APIs.
