### PR TITLE
Rename `task_slots` -> `vcores` (executor spec + CLI)

### DIFF
--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -111,7 +111,7 @@ jobs:
             --bind-port 50051 \
             --scheduler-host 127.0.0.1 \
             --scheduler-connect-timeout-seconds 10 \
-            --concurrent-tasks 4 \
+            --vcores 4 \
             --memory-pool-size 2GB \
             --work-dir "$WORK_DIR" \
             > "$EXECUTOR_LOG" 2>&1 &

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For documentation or more examples, please refer to the [Ballista User Guide][us
 Ballista serves several distinct audiences:
 
 - **DataFusion users going multi-node** — you already use [Apache DataFusion](https://github.com/apache/datafusion) on a single machine and have outgrown it. Ballista runs the same SQL and DataFrame workloads across a cluster with minimal code changes and the same results.
-- **Spark users wanting the same execution model** — you run Spark SQL or batch jobs and want a lighter, Rust-native alternative without relearning a new paradigm. Ballista keeps the familiar model: plans split into stages at shuffle boundaries, one task per partition, executors with task slots, and adaptive query execution (AQE).
+- **Spark users wanting the same execution model** — you run Spark SQL or batch jobs and want a lighter, Rust-native alternative without relearning a new paradigm. Ballista keeps the familiar model: plans split into stages at shuffle boundaries, one task per partition, executors with vcores, and adaptive query execution (AQE).
 - **Library users building a specialized engine** — you are building a bespoke distributed query engine and want reusable scheduler, executor, and plan-serialization building blocks with extension points, instead of writing distributed execution from scratch.
 
 These audiences are documented in more detail, along with the guarantees each relies on, in the [User Personas](docs/source/contributors-guide/user-personas.md) guide.

--- a/ballista-cli/README.md
+++ b/ballista-cli/README.md
@@ -35,8 +35,8 @@ OPTIONS:
         --color
             Enables console syntax highlighting
 
-        --concurrent-tasks <CONCURRENT_TASKS>
-            The max concurrent tasks, only for Ballista local mode. Default: all available cores
+        --vcores <VCORES>
+            Virtual cores for the local Ballista executor. Default: all available physical cores.
 
     -f, --file <FILE>...
             Execute commands from file(s), then exit

--- a/ballista-cli/src/main.rs
+++ b/ballista-cli/src/main.rs
@@ -62,10 +62,10 @@ struct Args {
 
     #[clap(
         long,
-        help = "The max concurrent tasks, only for Ballista local mode. Default: all available cores",
-        value_parser(parse_valid_concurrent_tasks_size)
+        help = "Virtual cores for the local Ballista executor. Default: all available physical cores.",
+        value_parser(parse_valid_vcores)
     )]
-    concurrent_tasks: Option<usize>,
+    vcores: Option<usize>,
 
     #[clap(
         short,
@@ -153,9 +153,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             SessionContext::remote_with_state(&address, state).await?
         }
         _ => {
-            if let Some(concurrent_tasks) = args.concurrent_tasks {
-                ballista_config =
-                    ballista_config.with_target_partitions(concurrent_tasks);
+            if let Some(vcores) = args.vcores {
+                ballista_config = ballista_config.with_target_partitions(vcores);
             };
             let state = SessionStateBuilder::new()
                 .with_config(ballista_config)
@@ -225,9 +224,9 @@ fn parse_batch_size(size: &str) -> std::result::Result<usize, String> {
     }
 }
 
-fn parse_valid_concurrent_tasks_size(size: &str) -> std::result::Result<usize, String> {
+fn parse_valid_vcores(size: &str) -> std::result::Result<usize, String> {
     match size.parse::<usize>() {
         Ok(size) if size > 0 => Ok(size),
-        _ => Err(format!("Invalid concurrent_tasks size '{size}'")),
+        _ => Err(format!("Invalid vcores value '{size}'")),
     }
 }

--- a/ballista-cli/src/main.rs
+++ b/ballista-cli/src/main.rs
@@ -68,6 +68,15 @@ struct Args {
     vcores: Option<usize>,
 
     #[clap(
+        long = "concurrent-tasks",
+        hide = true,
+        conflicts_with = "vcores",
+        help = "[deprecated] renamed to --vcores",
+        value_parser(parse_valid_vcores)
+    )]
+    concurrent_tasks: Option<usize>,
+
+    #[clap(
         short,
         long,
         num_args = 0..,
@@ -153,7 +162,16 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             SessionContext::remote_with_state(&address, state).await?
         }
         _ => {
-            if let Some(vcores) = args.vcores {
+            let vcores = match args.concurrent_tasks {
+                Some(value) => {
+                    eprintln!(
+                        "warning: --concurrent-tasks is deprecated; use --vcores instead"
+                    );
+                    Some(value)
+                }
+                None => args.vcores,
+            };
+            if let Some(vcores) = vcores {
                 ballista_config = ballista_config.with_target_partitions(vcores);
             };
             let state = SessionStateBuilder::new()

--- a/ballista-cli/src/tui/app.rs
+++ b/ballista-cli/src/tui/app.rs
@@ -477,7 +477,7 @@ impl App {
                 if self.is_jobs_view() {
                     self.sort_jobs_by(JobsSortColumn::StagesCompleted);
                 } else if self.is_executors_view() {
-                    self.sort_executors_by(ExecutorsSortColumn::TaskSlots);
+                    self.sort_executors_by(ExecutorsSortColumn::Vcores);
                 }
             }
             KeyCode::Char('5') => {
@@ -1209,7 +1209,7 @@ impl App {
                 if self.is_jobs_view() {
                     self.sort_jobs_by(JobsSortColumn::StagesCompleted);
                 } else if self.is_executors_view() {
-                    self.sort_executors_by(ExecutorsSortColumn::TaskSlots);
+                    self.sort_executors_by(ExecutorsSortColumn::Vcores);
                 }
                 None
             }
@@ -1614,7 +1614,7 @@ mod tests {
             port: 8080,
             id: id.to_string(),
             last_seen: None,
-            specification: Specification { task_slots: 4 },
+            specification: Specification { vcores: 4 },
             metrics: vec![],
             os_info: OsInfo {
                 kernel_ver: "5.15".to_string(),

--- a/ballista-cli/src/tui/domain/executors.rs
+++ b/ballista-cli/src/tui/domain/executors.rs
@@ -35,8 +35,8 @@ impl Executor {
         self.os_info.physical_cores
     }
 
-    pub fn task_slots(&self) -> u32 {
-        self.specification.task_slots
+    pub fn vcores(&self) -> u32 {
+        self.specification.vcores
     }
 
     pub fn proc_physical_memory_usage(&self) -> u64 {
@@ -65,7 +65,7 @@ pub struct Metric {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct Specification {
-    pub task_slots: u32,
+    pub vcores: u32,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -113,7 +113,7 @@ pub enum SortColumn {
     Host,
     Id,
     CpuCores,
-    TaskSlots,
+    Vcores,
     ProcPhysicalMemoryUsage,
     PeakPhysicalMemoryUsage,
     LastSeen,
@@ -171,8 +171,8 @@ impl ExecutorsData {
                     cmp
                 }
             }),
-            SortColumn::TaskSlots => self.executors.sort_by(|a, b| {
-                let cmp = a.task_slots().cmp(&b.task_slots());
+            SortColumn::Vcores => self.executors.sort_by(|a, b| {
+                let cmp = a.vcores().cmp(&b.vcores());
                 if self.sort_order == SortOrder::Descending {
                     cmp.reverse()
                 } else {
@@ -270,7 +270,7 @@ mod tests {
         host: &str,
         port: u16,
         id: &str,
-        task_slots: u32,
+        vcores: u32,
         proc_physical_memory_usage: u64,
         peak_physical_memory_usage: u64,
         last_seen: Option<u64>,
@@ -280,7 +280,7 @@ mod tests {
             port,
             id: id.to_string(),
             last_seen,
-            specification: Specification { task_slots },
+            specification: Specification { vcores },
             metrics: vec![
                 Metric {
                     typ: "proc_physical_memory".to_string(),
@@ -468,43 +468,43 @@ mod tests {
     }
 
     #[test]
-    fn sort_by_task_slots_ascending() {
+    fn sort_by_vcores_ascending() {
         let mut data = make_executors_data(
             vec![
                 make_executor("host", 8080, "id-a", 2, 0, 0, Some(100)),
                 make_executor("host", 8080, "id-b", 3, 0, 0, Some(200)),
                 make_executor("host", 8080, "id-c", 1, 0, 0, Some(300)),
             ],
-            SortColumn::TaskSlots,
+            SortColumn::Vcores,
             SortOrder::Ascending,
         );
         data.sort();
         assert_eq!(data.executors[0].id, "id-c");
-        assert_eq!(data.executors[0].task_slots(), 1);
+        assert_eq!(data.executors[0].vcores(), 1);
         assert_eq!(data.executors[1].id, "id-a");
-        assert_eq!(data.executors[1].task_slots(), 2);
+        assert_eq!(data.executors[1].vcores(), 2);
         assert_eq!(data.executors[2].id, "id-b");
-        assert_eq!(data.executors[2].task_slots(), 3);
+        assert_eq!(data.executors[2].vcores(), 3);
     }
 
     #[test]
-    fn sort_by_task_slots_descending() {
+    fn sort_by_vcores_descending() {
         let mut data = make_executors_data(
             vec![
                 make_executor("host", 8080, "id-a", 1, 0, 0, Some(100)),
                 make_executor("host", 8080, "id-c", 2, 0, 0, Some(300)),
                 make_executor("host", 8080, "id-b", 3, 0, 0, Some(200)),
             ],
-            SortColumn::TaskSlots,
+            SortColumn::Vcores,
             SortOrder::Descending,
         );
         data.sort();
         assert_eq!(data.executors[0].id, "id-b");
-        assert_eq!(data.executors[0].task_slots(), 3);
+        assert_eq!(data.executors[0].vcores(), 3);
         assert_eq!(data.executors[1].id, "id-c");
-        assert_eq!(data.executors[1].task_slots(), 2);
+        assert_eq!(data.executors[1].vcores(), 2);
         assert_eq!(data.executors[2].id, "id-a");
-        assert_eq!(data.executors[2].task_slots(), 1);
+        assert_eq!(data.executors[2].vcores(), 1);
     }
 
     #[test]

--- a/ballista-cli/src/tui/ui/main/executors/executors_table.rs
+++ b/ballista-cli/src/tui/ui/main/executors/executors_table.rs
@@ -62,7 +62,7 @@ fn render_executors_table(frame: &mut Frame, area: Rect, app: &App) {
     let host_suffix = sort_suffix!(SortColumn::Host, sort_column, sort_order);
     let id_suffix = sort_suffix!(SortColumn::Id, sort_column, sort_order);
     let cpu_cores_suffix = sort_suffix!(SortColumn::CpuCores, sort_column, sort_order);
-    let task_slots_suffix = sort_suffix!(SortColumn::TaskSlots, sort_column, sort_order);
+    let vcores_suffix = sort_suffix!(SortColumn::Vcores, sort_column, sort_order);
     let proc_physical_memory_suffix =
         sort_suffix!(SortColumn::ProcPhysicalMemoryUsage, sort_column, sort_order);
     let peak_physical_memory_suffix =
@@ -73,7 +73,7 @@ fn render_executors_table(frame: &mut Frame, area: Rect, app: &App) {
         Cell::from(Text::from(format!("Host{host_suffix}")).centered()),
         Cell::from(Text::from(format!("Id{id_suffix}")).centered()),
         Cell::from(Text::from(format!("CPU cores{cpu_cores_suffix}")).right_aligned()),
-        Cell::from(Text::from(format!("Task Slots{task_slots_suffix}")).right_aligned()),
+        Cell::from(Text::from(format!("vCores{vcores_suffix}")).right_aligned()),
         Cell::from(
             Text::from(format!("Physical Memory{proc_physical_memory_suffix}"))
                 .right_aligned(),
@@ -107,8 +107,8 @@ fn render_executors_table(frame: &mut Frame, area: Rect, app: &App) {
                 Text::from(app.format_count(executor.cpu_cores() as usize))
                     .right_aligned(),
             );
-            let task_slots_cell = Cell::from(
-                Text::from(app.format_count(executor.specification.task_slots as usize))
+            let vcores_cell = Cell::from(
+                Text::from(app.format_count(executor.specification.vcores as usize))
                     .right_aligned(),
             );
             let proc_physical_memory_cell = Cell::from(
@@ -129,7 +129,7 @@ fn render_executors_table(frame: &mut Frame, area: Rect, app: &App) {
                 host_cell,
                 id_cell,
                 cpu_cores_cell,
-                task_slots_cell,
+                vcores_cell,
                 proc_physical_memory_cell,
                 peak_physical_memory_cell,
                 last_seen_cell,
@@ -143,7 +143,7 @@ fn render_executors_table(frame: &mut Frame, area: Rect, app: &App) {
             Constraint::Percentage(10), // Host
             Constraint::Percentage(20), // Id
             Constraint::Percentage(8),  // CPU cores
-            Constraint::Percentage(8),  // Task slots
+            Constraint::Percentage(8),  // vCores
             Constraint::Percentage(18), // Proc physical memory
             Constraint::Percentage(18), // Peak physical memory
             Constraint::Percentage(18), // Last seen

--- a/ballista/client/src/extension.rs
+++ b/ballista/client/src/extension.rs
@@ -208,13 +208,13 @@ impl Extension {
             }
         };
 
-        let concurrent_tasks = config.ballista_standalone_parallelism();
+        let vcores = config.ballista_standalone_parallelism();
 
         match session_state {
             None => {
                 ballista_executor::new_standalone_executor(
                     scheduler,
-                    concurrent_tasks,
+                    vcores,
                     BallistaCodec::default(),
                 )
                 .await
@@ -223,7 +223,7 @@ impl Extension {
             Some(session_state) => {
                 ballista_executor::new_standalone_executor_from_state(
                     scheduler,
-                    concurrent_tasks,
+                    vcores,
                     session_state,
                 )
                 .await

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -419,9 +419,14 @@ message ExecutorSpecification {
   repeated ExecutorResource resources = 1;
 }
 
+// Virtual cores this executor has been assigned at runtime — analogous to
+// YARN vcores (yarn.nodemanager.resource.cpu-vcores) or Spark's
+// spark.executor.cores. Not physical `nproc`: may over- or under-subscribe.
+// One task per executor drives this many DataFusion partitions in parallel
+// through one plan-Arc.
 message ExecutorResource {
   oneof resource {
-    uint32 task_slots = 1;
+    uint32 vcores = 1;
   }
 }
 
@@ -437,13 +442,16 @@ message ExecutorOperatingSystemSpecification {
   uint64 open_files_limit = 9;
 }
 
-message AvailableTaskSlots {
+// One instance per executor. Tracks free vcores for scheduler-side task
+// binding. See ExecutorResource for the vcore definition (YARN vcores or
+// Spark's spark.executor.cores).
+message AvailableVcores {
   string executor_id = 1;
-  uint32 slots = 2;
-    }
+  uint32 vcores = 2;
+}
 
-message ExecutorTaskSlots {
-  repeated AvailableTaskSlots task_slots = 1;
+message ExecutorVcores {
+  repeated AvailableVcores vcores = 1;
 }
 
 message ExecutorData {
@@ -536,7 +544,7 @@ message TaskStatus {
 
 message PollWorkParams {
   ExecutorRegistration metadata = 1;
-  uint32 num_free_slots = 2;
+  uint32 num_free_vcores = 2;
   // All tasks must be reported until they reach the failed or completed state
   repeated TaskStatus task_status = 3;
 }

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -231,7 +231,7 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                          "Per-task buffered-bytes budget at which the sort shuffle writer spills its \
                          in-memory batches to disk. Counted independently of the runtime memory pool, so \
                          spilling kicks in even when the pool is unbounded. Total worst-case sort shuffle \
-                         memory per executor is approximately concurrent_tasks * this value.".to_string(),
+                         memory per executor is approximately vcores * this value.".to_string(),
                          DataType::UInt64,
                          Some((256 * 1024 * 1024).to_string())),
         ConfigEntry::new(BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES.to_string(),

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -1325,8 +1325,7 @@ mod tests {
                         host: "executor_1".to_string(),
                         port: 7070,
                         grpc_port: 8080,
-                        specification: ExecutorSpecification::default()
-                            .with_task_slots(1),
+                        specification: ExecutorSpecification::default().with_vcores(1),
                         os_info: ExecutorOperatingSystemSpecification::default(),
                     },
                     partition_stats: PartitionStats {
@@ -1444,7 +1443,7 @@ mod tests {
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
+                    specification: ExecutorSpecification::default().with_vcores(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 partition_stats: PartitionStats {
@@ -1495,7 +1494,7 @@ mod tests {
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
+                    specification: ExecutorSpecification::default().with_vcores(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 partition_stats: PartitionStats {
@@ -1547,7 +1546,7 @@ mod tests {
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
+                    specification: ExecutorSpecification::default().with_vcores(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 partition_stats: PartitionStats {
@@ -1599,7 +1598,7 @@ mod tests {
                     host: "executor_1".to_string(),
                     port: 7070,
                     grpc_port: 8080,
-                    specification: ExecutorSpecification::default().with_task_slots(1),
+                    specification: ExecutorSpecification::default().with_vcores(1),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 partition_stats: Default::default(),
@@ -1673,7 +1672,7 @@ mod tests {
                 host: "executor_1".to_string(),
                 port: 7070,
                 grpc_port: 8080,
-                specification: ExecutorSpecification::default().with_task_slots(1),
+                specification: ExecutorSpecification::default().with_vcores(1),
                 os_info: ExecutorOperatingSystemSpecification::default(),
             },
             partition_stats: Default::default(),
@@ -1969,7 +1968,7 @@ mod tests {
                     host: "localhost".to_string(),
                     port: 50051,
                     grpc_port: 50052,
-                    specification: ExecutorSpecification::default().with_task_slots(12),
+                    specification: ExecutorSpecification::default().with_vcores(12),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 partition_stats: Default::default(),

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -643,6 +643,11 @@ pub struct ExecutorSpecification {
     #[prost(message, repeated, tag = "1")]
     pub resources: ::prost::alloc::vec::Vec<ExecutorResource>,
 }
+/// Virtual cores this executor has been assigned at runtime — analogous to
+/// YARN vcores (yarn.nodemanager.resource.cpu-vcores) or Spark's
+/// spark.executor.cores. Not physical `nproc`: may over- or under-subscribe.
+/// One task per executor drives this many DataFusion partitions in parallel
+/// through one plan-Arc.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecutorResource {
     #[prost(oneof = "executor_resource::Resource", tags = "1")]
@@ -653,7 +658,7 @@ pub mod executor_resource {
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Resource {
         #[prost(uint32, tag = "1")]
-        TaskSlots(u32),
+        Vcores(u32),
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -677,17 +682,20 @@ pub struct ExecutorOperatingSystemSpecification {
     #[prost(uint64, tag = "9")]
     pub open_files_limit: u64,
 }
+/// One instance per executor. Tracks free vcores for scheduler-side task
+/// binding. See ExecutorResource for the vcore definition (YARN vcores or
+/// Spark's spark.executor.cores).
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct AvailableTaskSlots {
+pub struct AvailableVcores {
     #[prost(string, tag = "1")]
     pub executor_id: ::prost::alloc::string::String,
     #[prost(uint32, tag = "2")]
-    pub slots: u32,
+    pub vcores: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExecutorTaskSlots {
+pub struct ExecutorVcores {
     #[prost(message, repeated, tag = "1")]
-    pub task_slots: ::prost::alloc::vec::Vec<AvailableTaskSlots>,
+    pub vcores: ::prost::alloc::vec::Vec<AvailableVcores>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorData {
@@ -822,7 +830,7 @@ pub struct PollWorkParams {
     #[prost(message, optional, tag = "1")]
     pub metadata: ::core::option::Option<ExecutorRegistration>,
     #[prost(uint32, tag = "2")]
-    pub num_free_slots: u32,
+    pub num_free_vcores: u32,
     /// All tasks must be reported until they reach the failed or completed state
     #[prost(message, repeated, tag = "3")]
     pub task_status: ::prost::alloc::vec::Vec<TaskStatus>,

--- a/ballista/core/src/serde/scheduler/from_proto.rs
+++ b/ballista/core/src/serde/scheduler/from_proto.rs
@@ -274,12 +274,12 @@ impl Into<ExecutorMetadata> for protobuf::ExecutorMetadata {
 #[allow(clippy::from_over_into)]
 impl Into<ExecutorSpecification> for protobuf::ExecutorSpecification {
     fn into(self) -> ExecutorSpecification {
-        let mut ret = ExecutorSpecification { task_slots: 0 };
+        let mut ret = ExecutorSpecification { vcores: 0 };
         for resource in self.resources {
             if let Some(resource_spec) = resource.resource {
                 match resource_spec {
-                    protobuf::executor_resource::Resource::TaskSlots(num_slots) => {
-                        ret.task_slots = num_slots
+                    protobuf::executor_resource::Resource::Vcores(vcores) => {
+                        ret.vcores = vcores
                     }
                 }
             }
@@ -313,21 +313,21 @@ impl Into<ExecutorData> for protobuf::ExecutorData {
     fn into(self) -> ExecutorData {
         let mut ret = ExecutorData {
             executor_id: self.executor_id,
-            total_task_slots: 0,
-            available_task_slots: 0,
+            total_vcores: 0,
+            available_vcores: 0,
         };
         for resource in self.resources {
-            if let Some(task_slots) = resource.total
-                && let Some(protobuf::executor_resource::Resource::TaskSlots(task_slots)) =
-                    task_slots.resource
+            if let Some(total) = resource.total
+                && let Some(protobuf::executor_resource::Resource::Vcores(vcores)) =
+                    total.resource
             {
-                ret.total_task_slots = task_slots
+                ret.total_vcores = vcores
             };
-            if let Some(task_slots) = resource.available
-                && let Some(protobuf::executor_resource::Resource::TaskSlots(task_slots)) =
-                    task_slots.resource
+            if let Some(available) = resource.available
+                && let Some(protobuf::executor_resource::Resource::Vcores(vcores)) =
+                    available.resource
             {
-                ret.available_task_slots = task_slots
+                ret.available_vcores = vcores
             };
         }
         ret

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -128,23 +128,27 @@ pub struct ExecutorMetadata {
     pub os_info: ExecutorOperatingSystemSpecification,
 }
 
-/// Specification of an executor, indicating executor resources, like total task slots.
+/// Specification of an executor, indicating its runtime-assigned vcore count.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExecutorSpecification {
-    /// Number of concurrent task slots available on this executor.
-    pub task_slots: u32,
+    /// Virtual cores assigned to this executor at runtime — analogous to YARN
+    /// vcores (`yarn.nodemanager.resource.cpu-vcores`) or Spark's
+    /// `spark.executor.cores`. Not physical `nproc`: may over- or
+    /// under-subscribe. One task per executor drives this many DataFusion
+    /// partitions in parallel through one plan-Arc.
+    pub vcores: u32,
 }
 
 impl Default for ExecutorSpecification {
     fn default() -> Self {
-        Self { task_slots: 1 }
+        Self { vcores: 1 }
     }
 }
 
 impl ExecutorSpecification {
-    /// Setting number of task slots (number of tasks that can be handled by this executor)
-    pub fn with_task_slots(mut self, task_slots: u32) -> Self {
-        self.task_slots = task_slots;
+    /// Set the vcore count. See [`ExecutorSpecification::vcores`].
+    pub fn with_vcores(mut self, vcores: u32) -> Self {
+        self.vcores = vcores;
         self
     }
 }
@@ -247,23 +251,24 @@ impl ExecutorOperatingSystemSpecification {
     }
 }
 
-/// Available resources for an executor, including total and available task slots.
+/// Executor vcore accounting: total assigned vs currently free.
 #[derive(Debug, Clone, Serialize)]
 pub struct ExecutorData {
     /// Unique executor identifier.
     pub executor_id: String,
-    /// Total number of task slots.
-    pub total_task_slots: u32,
-    /// Currently available task slots.
-    pub available_task_slots: u32,
+    /// Total vcores assigned to this executor. See
+    /// [`ExecutorSpecification::vcores`].
+    pub total_vcores: u32,
+    /// Currently free vcores (total minus reserved).
+    pub available_vcores: u32,
 }
 
-/// Represents a change in executor task slot availability.
+/// Represents a change in an executor's free-vcore count.
 pub struct ExecutorDataChange {
     /// Unique executor identifier.
     pub executor_id: String,
-    /// Change in available task slots (positive or negative).
-    pub task_slots: i32,
+    /// Change in free vcores (positive to release, negative to reserve).
+    pub vcores: i32,
 }
 
 /// Summary of executed partition

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -151,6 +151,18 @@ impl ExecutorSpecification {
         self.vcores = vcores;
         self
     }
+
+    /// Deprecated alias for [`Self::with_vcores`].
+    #[deprecated(note = "renamed to `with_vcores`")]
+    pub fn with_task_slots(self, task_slots: u32) -> Self {
+        self.with_vcores(task_slots)
+    }
+
+    /// Deprecated getter that returns [`Self::vcores`].
+    #[deprecated(note = "the `task_slots` field was renamed to `vcores`")]
+    pub fn task_slots(&self) -> u32 {
+        self.vcores
+    }
 }
 
 /// Operating system level specification of an executor
@@ -263,12 +275,36 @@ pub struct ExecutorData {
     pub available_vcores: u32,
 }
 
+impl ExecutorData {
+    /// Deprecated getter that returns [`Self::total_vcores`].
+    #[deprecated(note = "the `total_task_slots` field was renamed to `total_vcores`")]
+    pub fn total_task_slots(&self) -> u32 {
+        self.total_vcores
+    }
+
+    /// Deprecated getter that returns [`Self::available_vcores`].
+    #[deprecated(
+        note = "the `available_task_slots` field was renamed to `available_vcores`"
+    )]
+    pub fn available_task_slots(&self) -> u32 {
+        self.available_vcores
+    }
+}
+
 /// Represents a change in an executor's free-vcore count.
 pub struct ExecutorDataChange {
     /// Unique executor identifier.
     pub executor_id: String,
     /// Change in free vcores (positive to release, negative to reserve).
     pub vcores: i32,
+}
+
+impl ExecutorDataChange {
+    /// Deprecated getter that returns [`Self::vcores`].
+    #[deprecated(note = "the `task_slots` field was renamed to `vcores`")]
+    pub fn task_slots(&self) -> i32 {
+        self.vcores
+    }
 }
 
 /// Summary of executed partition

--- a/ballista/core/src/serde/scheduler/to_proto.rs
+++ b/ballista/core/src/serde/scheduler/to_proto.rs
@@ -252,12 +252,10 @@ impl Into<protobuf::ExecutorMetadata> for ExecutorMetadata {
 impl Into<protobuf::ExecutorSpecification> for ExecutorSpecification {
     fn into(self) -> protobuf::ExecutorSpecification {
         protobuf::ExecutorSpecification {
-            resources: vec![protobuf::executor_resource::Resource::TaskSlots(
-                self.task_slots,
-            )]
-            .into_iter()
-            .map(|r| protobuf::ExecutorResource { resource: Some(r) })
-            .collect(),
+            resources: vec![protobuf::executor_resource::Resource::Vcores(self.vcores)]
+                .into_iter()
+                .map(|r| protobuf::ExecutorResource { resource: Some(r) })
+                .collect(),
         }
     }
 }
@@ -292,11 +290,9 @@ impl Into<protobuf::ExecutorData> for ExecutorData {
         protobuf::ExecutorData {
             executor_id: self.executor_id,
             resources: vec![ExecutorResourcePair {
-                total: protobuf::executor_resource::Resource::TaskSlots(
-                    self.total_task_slots,
-                ),
-                available: protobuf::executor_resource::Resource::TaskSlots(
-                    self.available_task_slots,
+                total: protobuf::executor_resource::Resource::Vcores(self.total_vcores),
+                available: protobuf::executor_resource::Resource::Vcores(
+                    self.available_vcores,
                 ),
             }]
             .into_iter()

--- a/ballista/executor/src/config.rs
+++ b/ballista/executor/src/config.rs
@@ -93,6 +93,16 @@ pub struct Config {
         help = "Virtual cores advertised to the scheduler (defaults to physical CPU count if zero)."
     )]
     pub vcores: usize,
+    /// Deprecated alias for `--vcores`. Retained for one release to keep
+    /// in-place cluster upgrades working; will be removed in the next
+    /// major release.
+    #[arg(
+        long = "concurrent-tasks",
+        hide = true,
+        conflicts_with = "vcores",
+        help = "[deprecated] renamed to --vcores"
+    )]
+    pub concurrent_tasks: Option<usize>,
     /// Task scheduling policy: pull-staged (executor polls) or push-staged (scheduler pushes).
     #[arg(short = 's', long, default_value_t = ballista_core::config::TaskSchedulingPolicy::default(), help = "The task scheduling policy used by scheduler. Configuration must match with scheduler configured policy.")]
     pub task_scheduling_policy: ballista_core::config::TaskSchedulingPolicy,
@@ -197,6 +207,15 @@ impl TryFrom<Config> for ExecutorProcessConfig {
     type Error = BallistaError;
 
     fn try_from(opt: Config) -> Result<Self, Self::Error> {
+        let vcores = match opt.concurrent_tasks {
+            Some(value) => {
+                eprintln!(
+                    "warning: --concurrent-tasks is deprecated; use --vcores instead"
+                );
+                value
+            }
+            None => opt.vcores,
+        };
         Ok(ExecutorProcessConfig {
             special_mod_log_level: opt.log_level_setting,
             external_host: opt.external_host,
@@ -206,7 +225,7 @@ impl TryFrom<Config> for ExecutorProcessConfig {
             scheduler_host: opt.scheduler_host,
             scheduler_port: opt.scheduler_port,
             scheduler_connect_timeout_seconds: opt.scheduler_connect_timeout_seconds,
-            vcores: opt.vcores,
+            vcores,
             task_scheduling_policy: opt.task_scheduling_policy,
             work_dir: opt.work_dir,
             log_dir: opt.log_dir,

--- a/ballista/executor/src/config.rs
+++ b/ballista/executor/src/config.rs
@@ -81,14 +81,18 @@ pub struct Config {
     /// Directory for storing temporary shuffle data and IPC files.
     #[arg(long, help = "Directory for temporary IPC files")]
     pub work_dir: Option<String>,
-    /// Maximum number of concurrent tasks this executor can run (0 = use all CPU cores).
+    /// Number of virtual cores (vcores) this executor advertises to the scheduler
+    /// (0 = use all physical CPU cores). One task per executor drives this many
+    /// DataFusion partitions in parallel through one plan-Arc. Analogous to YARN
+    /// vcores (`yarn.nodemanager.resource.cpu-vcores`) or Spark's
+    /// `spark.executor.cores`.
     #[arg(
         short = 'c',
         long,
         default_value_t = 0,
-        help = "Max concurrent tasks (defaults to all available cores if left as zero)."
+        help = "Virtual cores advertised to the scheduler (defaults to physical CPU count if zero)."
     )]
-    pub concurrent_tasks: usize,
+    pub vcores: usize,
     /// Task scheduling policy: pull-staged (executor polls) or push-staged (scheduler pushes).
     #[arg(short = 's', long, default_value_t = ballista_core::config::TaskSchedulingPolicy::default(), help = "The task scheduling policy used by scheduler. Configuration must match with scheduler configured policy.")]
     pub task_scheduling_policy: ballista_core::config::TaskSchedulingPolicy,
@@ -163,12 +167,12 @@ pub struct Config {
     )]
     pub metric_collection_policy: ExecutorMetricCollectionPolicy,
     /// Optional total memory budget for the executor. Accepts human-readable
-    /// values like "8GB", "512MiB", or a plain byte count. When set, every
-    /// task gets a FairSpillPool of size `memory_pool_size / concurrent_tasks`.
+    /// values like "8GB", "512MiB", or a plain byte count. When set, each
+    /// per-vcore FairSpillPool gets `memory_pool_size / vcores`.
     #[arg(
         long,
         value_parser = parse_memory_pool_size,
-        help = "Optional total executor memory budget (e.g. \"8GB\", \"512MiB\"). Each concurrent task receives an equal share."
+        help = "Optional total executor memory budget (e.g. \"8GB\", \"512MiB\"). Split evenly across vcores."
     )]
     pub memory_pool_size: Option<u64>,
     /// Maximum number of sessions whose shared runtime state (object-store
@@ -202,7 +206,7 @@ impl TryFrom<Config> for ExecutorProcessConfig {
             scheduler_host: opt.scheduler_host,
             scheduler_port: opt.scheduler_port,
             scheduler_connect_timeout_seconds: opt.scheduler_connect_timeout_seconds,
-            concurrent_tasks: opt.concurrent_tasks,
+            vcores: opt.vcores,
             task_scheduling_policy: opt.task_scheduling_policy,
             work_dir: opt.work_dir,
             log_dir: opt.log_dir,

--- a/ballista/executor/src/execution_loop.rs
+++ b/ballista/executor/src/execution_loop.rs
@@ -75,20 +75,19 @@ where
         .unwrap()
         .clone()
         .into();
-    let available_task_slots =
-        Arc::new(Semaphore::new(executor_specification.task_slots as usize));
+    let free_vcores = Arc::new(Semaphore::new(executor_specification.vcores as usize));
 
     let (task_status_sender, mut task_status_receiver) =
         std::sync::mpsc::channel::<TaskStatus>();
     info!("Starting poll work loop with scheduler");
 
     let dedicated_executor =
-        DedicatedExecutor::new("task_runner", executor_specification.task_slots as usize);
+        DedicatedExecutor::new("task_runner", executor_specification.vcores as usize);
 
     loop {
-        // Wait for task slots to be available before asking for new work
-        let permit = available_task_slots.acquire().await.unwrap();
-        // Make the slot available again
+        // Wait for a vcore permit before asking for new work.
+        let permit = free_vcores.acquire().await.unwrap();
+        // Make the vcore available again for the actual bind below.
         drop(permit);
 
         // Keeps track of whether we received task in last iteration
@@ -102,7 +101,7 @@ where
             scheduler
                 .poll_work(PollWorkParams {
                     metadata: Some(executor.metadata.clone()),
-                    num_free_slots: available_task_slots.available_permits() as u32,
+                    num_free_vcores: free_vcores.available_permits() as u32,
                     task_status,
                 })
                 .await;
@@ -135,9 +134,8 @@ where
                 for task in tasks {
                     let task_status_sender = task_status_sender.clone();
 
-                    // Acquire a permit/slot for the task
-                    let permit =
-                        available_task_slots.clone().acquire_owned().await.unwrap();
+                    // Acquire a vcore permit for the task.
+                    let permit = free_vcores.clone().acquire_owned().await.unwrap();
 
                     let start_exec_time = SystemTime::now()
                         .duration_since(UNIX_EPOCH)

--- a/ballista/executor/src/executor.rs
+++ b/ballista/executor/src/executor.rs
@@ -89,8 +89,8 @@ pub struct Executor {
     /// Collector for runtime execution metrics
     pub metrics_collector: Arc<dyn ExecutorMetricsCollector>,
 
-    /// Concurrent tasks can run in executor
-    pub concurrent_tasks: usize,
+    /// Virtual cores assigned to this executor. See CLI docs on `--vcores`.
+    pub vcores: usize,
 
     /// Handles to abort executing tasks
     abort_handles: AbortHandles,
@@ -113,7 +113,7 @@ impl Executor {
         work_dir: &str,
         runtime_producer: RuntimeProducer,
         config_producer: ConfigProducer,
-        concurrent_tasks: usize,
+        vcores: usize,
     ) -> Self {
         Self::new(
             metadata,
@@ -122,7 +122,7 @@ impl Executor {
             config_producer,
             Arc::new(BallistaFunctionRegistry::default()),
             Arc::new(LoggingMetricsCollector::default()),
-            concurrent_tasks,
+            vcores,
             Arc::new(DefaultExecutionEngine::new()),
         )
     }
@@ -137,7 +137,7 @@ impl Executor {
         config_producer: ConfigProducer,
         function_registry: Arc<BallistaFunctionRegistry>,
         metrics_collector: Arc<dyn ExecutorMetricsCollector>,
-        concurrent_tasks: usize,
+        vcores: usize,
         execution_engine: Arc<dyn ExecutionEngine>,
     ) -> Self {
         Self {
@@ -147,7 +147,7 @@ impl Executor {
             runtime_producer,
             config_producer,
             metrics_collector,
-            concurrent_tasks,
+            vcores,
             abort_handles: Default::default(),
             execution_engine,
             session_runtime_cache: None,
@@ -162,7 +162,7 @@ impl Executor {
         config_producer: ConfigProducer,
         function_registry: Arc<BallistaFunctionRegistry>,
         metrics_collector: Arc<dyn ExecutorMetricsCollector>,
-        concurrent_tasks: usize,
+        vcores: usize,
     ) -> Self {
         Self {
             metadata,
@@ -171,7 +171,7 @@ impl Executor {
             runtime_producer,
             config_producer,
             metrics_collector,
-            concurrent_tasks,
+            vcores,
             abort_handles: Default::default(),
             execution_engine: Arc::new(DefaultExecutionEngine::new()),
             session_runtime_cache: None,

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -80,25 +80,25 @@ use crate::{execution_loop, executor_server};
 
 /// Builds a per-task memory-pool policy: each task's runtime is rebuilt from the
 /// shared base env with a fresh [`FairSpillPool`] of size
-/// `total_bytes / concurrent_tasks`. The base env's disk manager, cache manager,
+/// `total_bytes / vcores`. The base env's disk manager, cache manager,
 /// and object-store registry are preserved via
 /// [`RuntimeEnvBuilder::from_runtime_env`].
 ///
 /// Returns an error if the per-task share would be zero (i.e. `total_bytes <
-/// concurrent_tasks`).
+/// vcores`).
 fn memory_pool_policy(
     total_bytes: u64,
-    concurrent_tasks: usize,
+    vcores: usize,
 ) -> Result<MemoryPoolPolicy, BallistaError> {
-    let per_task = (total_bytes / concurrent_tasks as u64) as usize;
-    if per_task == 0 {
+    let per_vcore = (total_bytes / vcores as u64) as usize;
+    if per_vcore == 0 {
         return Err(BallistaError::Configuration(format!(
-            "memory_pool_size ({total_bytes} bytes) is smaller than concurrent_tasks ({concurrent_tasks})"
+            "memory_pool_size ({total_bytes} bytes) is smaller than vcores ({vcores})"
         )));
     }
     Ok(Arc::new(
         move |base: Arc<RuntimeEnv>, _config: &SessionConfig| {
-            let pool: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(per_task));
+            let pool: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(per_vcore));
             RuntimeEnvBuilder::from_runtime_env(&base)
                 .with_memory_pool(pool)
                 .build_arc()
@@ -132,8 +132,8 @@ pub struct ExecutorProcessConfig {
     pub scheduler_port: u16,
     /// Timeout in seconds for establishing scheduler connection.
     pub scheduler_connect_timeout_seconds: u16,
-    /// Maximum number of concurrent tasks this executor can run.
-    pub concurrent_tasks: usize,
+    /// Virtual cores advertised by this executor to the scheduler.
+    pub vcores: usize,
     /// Task scheduling policy (pull-staged or push-staged).
     pub task_scheduling_policy: TaskSchedulingPolicy,
     /// Directory for storing log files.
@@ -162,7 +162,7 @@ pub struct ExecutorProcessConfig {
     pub metric_collection_policy: ExecutorMetricCollectionPolicy,
     /// Optional total memory pool size in bytes. When set, every task's
     /// runtime env receives a FairSpillPool of size
-    /// `memory_pool_size / concurrent_tasks`. When `None`, no pool is
+    /// `memory_pool_size / vcores`. When `None`, no pool is
     /// installed and DataFusion falls back to its unbounded default.
     pub memory_pool_size: Option<u64>,
     /// Maximum number of sessions whose shared base runtime env is retained on
@@ -214,7 +214,7 @@ impl Default for ExecutorProcessConfig {
             scheduler_host: "localhost".into(),
             scheduler_port: 50050,
             scheduler_connect_timeout_seconds: 0,
-            concurrent_tasks: std::thread::available_parallelism().unwrap().get(),
+            vcores: std::thread::available_parallelism().unwrap().get(),
             task_scheduling_policy: Default::default(),
             log_dir: None,
             work_dir: None,
@@ -276,11 +276,11 @@ pub async fn start_executor_process(
         ));
     };
 
-    let concurrent_tasks = if opt.concurrent_tasks == 0 {
+    let vcores = if opt.vcores == 0 {
         // use all available cores if no concurrency level is specified
         std::thread::available_parallelism().unwrap().get()
     } else {
-        opt.concurrent_tasks
+        opt.vcores
     };
     let task_scheduling_policy = opt.task_scheduling_policy;
     // assign this executor an unique ID
@@ -290,13 +290,10 @@ pub async fn start_executor_process(
     );
     info!("Executor id: {executor_id}");
     info!("Executor working directory: {work_dir}");
-    info!(
-        "Executor number of concurrent tasks (available CPU cores): {concurrent_tasks}"
-    );
+    info!("Executor vcores (default: available CPU cores): {vcores}");
     info!("Executor scheduling policy: {task_scheduling_policy:?}");
 
-    let executor_meta =
-        structure_executor_metadata(&executor_id, &opt, concurrent_tasks as u32);
+    let executor_meta = structure_executor_metadata(&executor_id, &opt, vcores as u32);
 
     // put them to session config
     let metrics_collector = Arc::new(LoggingMetricsCollector::default());
@@ -317,10 +314,10 @@ pub async fn start_executor_process(
         });
 
     let pool_policy: MemoryPoolPolicy = if let Some(total) = opt.memory_pool_size {
-        let policy = memory_pool_policy(total, concurrent_tasks)?;
-        let per_task = total / concurrent_tasks as u64;
+        let policy = memory_pool_policy(total, vcores)?;
+        let per_vcore = total / vcores as u64;
         info!(
-            "Memory pool: total {total} bytes split into {concurrent_tasks} tasks ({per_task} bytes each)"
+            "Memory pool: total {total} bytes split into {vcores} tasks ({per_vcore} bytes each)"
         );
         policy
     } else {
@@ -373,7 +370,7 @@ pub async fn start_executor_process(
             config_producer,
             opt.override_function_registry.clone().unwrap_or_default(),
             metrics_collector,
-            concurrent_tasks,
+            vcores,
             opt.override_execution_engine.clone().unwrap_or_else(|| {
                 if opt.client_ttl > 0 {
                     let client_pool =
@@ -896,7 +893,7 @@ pub async fn satisfy_dir_ttl(
 pub fn structure_executor_metadata(
     executor_id: &str,
     options: &Arc<ExecutorProcessConfig>,
-    concurrent_tasks: u32,
+    vcores: u32,
 ) -> ExecutorRegistration {
     let system_name =
         System::name().unwrap_or_else(|| String::from("Unknown system name"));
@@ -925,7 +922,7 @@ pub fn structure_executor_metadata(
         grpc_port: options.grpc_port as u32,
         specification: Some(ExecutorSpecification {
             resources: vec![ExecutorResource {
-                resource: Some(Resource::TaskSlots(concurrent_tasks)),
+                resource: Some(Resource::Vcores(vcores)),
             }],
         }),
         os_info: Some(ExecutorOperatingSystemSpecification {
@@ -1103,26 +1100,26 @@ mod memory_pool_tests {
     use std::sync::Arc;
 
     #[test]
-    fn returns_error_when_total_smaller_than_concurrent_tasks() {
+    fn returns_error_when_total_smaller_than_vcores() {
         let result = memory_pool_policy(4, 8);
         assert!(result.is_err());
         let msg = result.err().unwrap().to_string();
         assert!(msg.contains("memory_pool_size"));
-        assert!(msg.contains("concurrent_tasks"));
+        assert!(msg.contains("vcores"));
     }
 
     #[test]
-    fn produces_runtime_with_fair_spill_pool_of_per_task_size() {
+    fn produces_runtime_with_fair_spill_pool_of_per_vcore_size() {
         let total = 8u64 * 1024 * 1024 * 1024;
-        let concurrent = 8usize;
-        let expected_per_task = (total / concurrent as u64) as usize;
+        let vcores = 8usize;
+        let expected_per_vcore = (total / vcores as u64) as usize;
 
-        let policy = memory_pool_policy(total, concurrent).unwrap();
+        let policy = memory_pool_policy(total, vcores).unwrap();
         let base = Arc::new(RuntimeEnv::default());
         let env = policy(base, &SessionConfig::new()).unwrap();
 
         match env.memory_pool.memory_limit() {
-            MemoryLimit::Finite(n) => assert_eq!(n, expected_per_task),
+            MemoryLimit::Finite(n) => assert_eq!(n, expected_per_vcore),
             MemoryLimit::Infinite => panic!("expected Finite limit, got Infinite"),
             MemoryLimit::Unknown => panic!("expected Finite limit, got Unknown"),
         }

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -102,7 +102,7 @@ pub async fn startup<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>(
     stop_send: mpsc::Sender<bool>,
     shutdown_noti: &ShutdownNotifier,
 ) -> Result<ServerHandle, BallistaError> {
-    let channel_buf_size = executor.concurrent_tasks * 50;
+    let channel_buf_size = executor.vcores * 50;
     let (tx_task, rx_task) = mpsc::channel::<CuratorTaskDefinition>(channel_buf_size);
     let (tx_task_status, rx_task_status) =
         mpsc::channel::<CuratorTaskStatus>(channel_buf_size);
@@ -766,10 +766,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskRunnerPool<T,
 
             // Use a dedicated executor for CPU bound tasks so that the main tokio
             // executor can still answer requests even when under load
-            let dedicated_executor = DedicatedExecutor::new(
-                "task_runner",
-                executor_server.executor.concurrent_tasks,
-            );
+            let dedicated_executor =
+                DedicatedExecutor::new("task_runner", executor_server.executor.vcores);
 
             // As long as the shutdown notification has not been received
             while !task_runner_shutdown.is_shutdown() {

--- a/ballista/executor/src/standalone.rs
+++ b/ballista/executor/src/standalone.rs
@@ -50,7 +50,7 @@ use uuid::Uuid;
 /// components.
 pub async fn new_standalone_executor_from_state(
     scheduler: SchedulerGrpcClient<Channel>,
-    concurrent_tasks: usize,
+    vcores: usize,
     session_state: &SessionState,
 ) -> Result<()> {
     let logical = session_state.config().ballista_logical_extension_codec();
@@ -69,7 +69,7 @@ pub async fn new_standalone_executor_from_state(
 
     new_standalone_executor_from_builder(
         scheduler,
-        concurrent_tasks,
+        vcores,
         config_producer,
         runtime_producer,
         codec,
@@ -87,7 +87,7 @@ pub async fn new_standalone_executor_from_state(
 /// The executor binds to a random available port on localhost.
 pub async fn new_standalone_executor_from_builder(
     scheduler: SchedulerGrpcClient<Channel>,
-    concurrent_tasks: usize,
+    vcores: usize,
     config_producer: ConfigProducer,
     runtime_producer: RuntimeProducer,
     codec: BallistaCodec,
@@ -106,7 +106,7 @@ pub async fn new_standalone_executor_from_builder(
         grpc_port: 50020,
         specification: Some(
             ExecutorSpecification::default()
-                .with_task_slots(concurrent_tasks as u32)
+                .with_vcores(vcores as u32)
                 .into(),
         ),
         os_info: Some(ExecutorOperatingSystemSpecification::default().into()),
@@ -126,7 +126,7 @@ pub async fn new_standalone_executor_from_builder(
         config_producer,
         Arc::new(function_registry),
         Arc::new(LoggingMetricsCollector::default()),
-        concurrent_tasks,
+        vcores,
     ));
 
     let service = BallistaFlightService::new(work_dir);
@@ -150,7 +150,7 @@ pub async fn new_standalone_executor_from_builder(
 /// set as default.
 pub async fn new_standalone_executor(
     scheduler: SchedulerGrpcClient<Channel>,
-    concurrent_tasks: usize,
+    vcores: usize,
     codec: BallistaCodec,
 ) -> Result<()> {
     use ballista_core::extension::{
@@ -170,7 +170,7 @@ pub async fn new_standalone_executor(
 
     new_standalone_executor_from_builder(
         scheduler,
-        concurrent_tasks,
+        vcores,
         Arc::new(default_config_producer),
         runtime_producer,
         codec,

--- a/ballista/scheduler/src/cluster/memory.rs
+++ b/ballista/scheduler/src/cluster/memory.rs
@@ -22,7 +22,7 @@ use crate::cluster::{
 use crate::state::execution_graph::ExecutionGraphBox;
 use ballista_core::error::{BallistaError, Result};
 use ballista_core::serde::protobuf::{
-    AvailableTaskSlots, ExecutorHeartbeat, ExecutorStatus, FailedJob, QueuedJob,
+    AvailableVcores, ExecutorHeartbeat, ExecutorStatus, FailedJob, QueuedJob,
     executor_status,
 };
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
@@ -47,13 +47,13 @@ use super::{ClusterStateEvent, ClusterStateEventStream};
 
 /// In-memory implementation of cluster state.
 ///
-/// This stores all cluster state (executor registration, task slots, heartbeats)
+/// This stores all cluster state (executor registration, free vcores, heartbeats)
 /// in memory without persistence. Suitable for single-scheduler deployments
 /// or testing scenarios.
 #[derive(Default)]
 pub struct InMemoryClusterState {
-    /// Current available task slots for each executor.
-    task_slots: Mutex<HashMap<String, AvailableTaskSlots>>,
+    /// Current free vcores for each executor.
+    available_vcores: Mutex<HashMap<String, AvailableVcores>>,
     /// Current executors and their metadata.
     executors: DashMap<String, ExecutorMetadata>,
     /// Last heartbeat received for each executor.
@@ -70,12 +70,12 @@ impl ClusterState for InMemoryClusterState {
         active_jobs: Arc<HashMap<JobId, JobInfoCache>>,
         executors: Option<HashSet<String>>,
     ) -> Result<Vec<BoundTask>> {
-        let mut guard = self.task_slots.lock().await;
+        let mut guard = self.available_vcores.lock().await;
 
-        let available_slots: Vec<&mut AvailableTaskSlots> = guard
+        let budgets: Vec<&mut AvailableVcores> = guard
             .values_mut()
             .filter_map(|data| {
-                (data.slots > 0
+                (data.vcores > 0
                     && executors
                         .as_ref()
                         .map(|executors| executors.contains(&data.executor_id))
@@ -86,13 +86,13 @@ impl ClusterState for InMemoryClusterState {
 
         let bound_tasks = match distribution {
             TaskDistributionPolicy::Bias => {
-                bind_task_bias(available_slots, active_jobs, |_| false).await
+                bind_task_bias(budgets, active_jobs, |_| false).await
             }
             TaskDistributionPolicy::RoundRobin => {
-                bind_task_round_robin(available_slots, active_jobs, |_| false).await
+                bind_task_round_robin(budgets, active_jobs, |_| false).await
             }
             TaskDistributionPolicy::Custom(ref policy) => {
-                policy.bind_tasks(available_slots, active_jobs).await?
+                policy.bind_tasks(budgets, active_jobs).await?
             }
         };
 
@@ -101,16 +101,16 @@ impl ClusterState for InMemoryClusterState {
 
     async fn unbind_tasks(&self, executor_slots: Vec<ExecutorSlot>) -> Result<()> {
         let mut increments = HashMap::new();
-        for (executor_id, num_slots) in executor_slots {
+        for (executor_id, num_vcores) in executor_slots {
             let v = increments.entry(executor_id).or_insert_with(|| 0);
-            *v += num_slots;
+            *v += num_vcores;
         }
 
-        let mut guard = self.task_slots.lock().await;
+        let mut guard = self.available_vcores.lock().await;
 
-        for (executor_id, num_slots) in increments {
+        for (executor_id, num_vcores) in increments {
             if let Some(data) = guard.get_mut(&executor_id) {
-                data.slots += num_slots;
+                data.vcores += num_vcores;
             }
         }
 
@@ -138,13 +138,13 @@ impl ClusterState for InMemoryClusterState {
         })
         .await?;
 
-        let mut guard = self.task_slots.lock().await;
+        let mut guard = self.available_vcores.lock().await;
 
         guard.insert(
             executor_id.clone(),
-            AvailableTaskSlots {
+            AvailableVcores {
                 executor_id: executor_id.clone(),
-                slots: spec.available_task_slots,
+                vcores: spec.available_vcores,
             },
         );
 
@@ -224,7 +224,7 @@ impl ClusterState for InMemoryClusterState {
     async fn remove_executor(&self, executor_id: &str) -> Result<()> {
         log::debug!("removing executor: {}", executor_id);
         {
-            let mut guard = self.task_slots.lock().await;
+            let mut guard = self.available_vcores.lock().await;
 
             guard.remove(executor_id);
         }
@@ -658,7 +658,7 @@ mod test {
             host: "".to_string(),
             port: 50055,
             grpc_port: 50050,
-            specification: ExecutorSpecification::default().with_task_slots(2),
+            specification: ExecutorSpecification::default().with_vcores(2),
             os_info: ExecutorOperatingSystemSpecification::default(),
         };
 

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -24,7 +24,7 @@ use crate::state::execution_graph::{
 use crate::state::task_manager::JobInfoCache;
 use ballista_core::error::Result;
 use ballista_core::serde::protobuf::{
-    AvailableTaskSlots, ExecutorHeartbeat, JobStatus, job_status,
+    AvailableVcores, ExecutorHeartbeat, JobStatus, job_status,
 };
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata, PartitionId};
 use ballista_core::utils::{default_config_producer, default_session_builder};
@@ -153,7 +153,7 @@ pub type ExecutorSlot = (String, u32);
 
 /// Trait for maintaining a globally consistent view of cluster resources.
 ///
-/// Implementations track executor registration, heartbeats, and available task slots.
+/// Implementations track executor registration, heartbeats, and free vcores.
 #[async_trait::async_trait]
 pub trait ClusterState: Send + Sync + 'static {
     /// Initializes the cluster state backend.
@@ -163,9 +163,9 @@ pub trait ClusterState: Send + Sync + 'static {
         Ok(())
     }
 
-    /// Binds ready-to-run tasks from active jobs to available executor slots.
+    /// Binds ready-to-run tasks from active jobs to executor vcores.
     ///
-    /// If `executors` is provided, only bind slots from the specified executor IDs.
+    /// If `executors` is provided, only bind on the specified executor IDs.
     async fn bind_schedulable_tasks(
         &self,
         distribution: TaskDistributionPolicy,
@@ -173,9 +173,9 @@ pub trait ClusterState: Send + Sync + 'static {
         executors: Option<HashSet<String>>,
     ) -> Result<Vec<BoundTask>>;
 
-    /// Unbinds executor slots when tasks finish or fail.
+    /// Releases reserved vcores when tasks finish or fail.
     ///
-    /// This operation is atomic: either all slots are released or none are.
+    /// This operation is atomic: either all vcores are released or none are.
     async fn unbind_tasks(&self, executor_slots: Vec<ExecutorSlot>) -> Result<()>;
 
     /// Registers a new executor in the cluster.
@@ -352,23 +352,23 @@ pub trait JobState: Send + Sync {
 }
 
 pub(crate) async fn bind_task_bias(
-    mut slots: Vec<&mut AvailableTaskSlots>,
+    mut budgets: Vec<&mut AvailableVcores>,
     running_jobs: Arc<HashMap<JobId, JobInfoCache>>,
     if_skip: fn(Arc<dyn ExecutionPlan>) -> bool,
 ) -> Vec<BoundTask> {
     let mut schedulable_tasks: Vec<BoundTask> = vec![];
 
-    let total_slots = slots.iter().fold(0, |acc, s| acc + s.slots);
-    if total_slots == 0 {
-        debug!("Not enough available executor slots for task running!!!");
+    let total_vcores = budgets.iter().fold(0, |acc, b| acc + b.vcores);
+    if total_vcores == 0 {
+        debug!("No executor vcores available for task binding");
         return schedulable_tasks;
     }
 
-    // Sort the slots by descending order
-    slots.sort_by(|a, b| Ord::cmp(&b.slots, &a.slots));
+    // Sort budgets by free-vcore count, descending.
+    budgets.sort_by(|a, b| Ord::cmp(&b.vcores, &a.vcores));
 
-    let mut idx_slot = 0usize;
-    let mut slot = &mut slots[idx_slot];
+    let mut idx = 0usize;
+    let mut current = &mut budgets[idx];
     for (job_id, job_info) in running_jobs.iter() {
         if !matches!(job_info.status, Some(job_status::Status::Running(_))) {
             debug!("Job {job_id} is not in running status and will be skipped");
@@ -395,18 +395,18 @@ pub(crate) async fn bind_task_bias(
                 .iter_mut()
                 .enumerate()
                 .filter(|(_partition, info)| info.is_none())
-                .take(total_slots as usize)
+                .take(total_vcores as usize)
                 .collect::<Vec<_>>();
             for (partition_id, task_info) in runnable_tasks {
-                // Assign [`slot`] with a slot available slot number larger than 0
-                while slot.slots == 0 {
-                    idx_slot += 1;
-                    if idx_slot >= slots.len() {
+                // Advance to a budget with free vcores.
+                while current.vcores == 0 {
+                    idx += 1;
+                    if idx >= budgets.len() {
                         return schedulable_tasks;
                     }
-                    slot = &mut slots[idx_slot];
+                    current = &mut budgets[idx];
                 }
-                let executor_id = slot.executor_id.clone();
+                let executor_id = current.executor_id.clone();
                 let task_id = *task_id_gen;
                 *task_id_gen += 1;
                 *task_info = Some(create_task_info(executor_id.clone(), task_id));
@@ -427,7 +427,7 @@ pub(crate) async fn bind_task_bias(
                 };
                 schedulable_tasks.push((executor_id, task_desc));
 
-                slot.slots -= 1;
+                current.vcores -= 1;
             }
         }
     }
@@ -436,23 +436,23 @@ pub(crate) async fn bind_task_bias(
 }
 
 pub(crate) async fn bind_task_round_robin(
-    mut slots: Vec<&mut AvailableTaskSlots>,
+    mut budgets: Vec<&mut AvailableVcores>,
     running_jobs: Arc<HashMap<JobId, JobInfoCache>>,
     if_skip: fn(Arc<dyn ExecutionPlan>) -> bool,
 ) -> Vec<BoundTask> {
     let mut schedulable_tasks: Vec<BoundTask> = vec![];
 
-    let mut total_slots = slots.iter().fold(0, |acc, s| acc + s.slots);
-    if total_slots == 0 {
-        debug!("Not enough available executor slots for task running!!!");
+    let mut total_vcores = budgets.iter().fold(0, |acc, b| acc + b.vcores);
+    if total_vcores == 0 {
+        debug!("No executor vcores available for task binding");
         return schedulable_tasks;
     }
-    debug!("Total slot number is {total_slots}");
+    debug!("Total free vcores: {total_vcores}");
 
-    // Sort the slots by descending order
-    slots.sort_by(|a, b| Ord::cmp(&b.slots, &a.slots));
+    // Sort budgets by free-vcore count, descending.
+    budgets.sort_by(|a, b| Ord::cmp(&b.vcores, &a.vcores));
 
-    let mut idx_slot = 0usize;
+    let mut idx = 0usize;
     for (job_id, job_info) in running_jobs.iter() {
         if !matches!(job_info.status, Some(job_status::Status::Running(_))) {
             debug!("Job {job_id} is not in running status and will be skipped");
@@ -479,20 +479,20 @@ pub(crate) async fn bind_task_round_robin(
                 .iter_mut()
                 .enumerate()
                 .filter(|(_partition, info)| info.is_none())
-                .take(total_slots as usize)
+                .take(total_vcores as usize)
                 .collect::<Vec<_>>();
             for (partition_id, task_info) in runnable_tasks {
-                // Move to the index which has available slots
-                if idx_slot >= slots.len() {
-                    idx_slot = 0;
+                // Wrap around and skip exhausted budgets.
+                if idx >= budgets.len() {
+                    idx = 0;
                 }
-                if slots[idx_slot].slots == 0 {
-                    idx_slot = 0;
+                if budgets[idx].vcores == 0 {
+                    idx = 0;
                 }
-                // Since the slots is a vector with descending order, and the total available slots is larger than 0,
-                // we are sure the available slot number at idx_slot is larger than 1
-                let slot = &mut slots[idx_slot];
-                let executor_id = slot.executor_id.clone();
+                // Budgets are sorted descending and total_vcores > 0, so
+                // budgets[idx].vcores is guaranteed > 0 here.
+                let current = &mut budgets[idx];
+                let executor_id = current.executor_id.clone();
                 let task_id = *task_id_gen;
                 *task_id_gen += 1;
                 *task_info = Some(create_task_info(executor_id.clone(), task_id));
@@ -513,10 +513,10 @@ pub(crate) async fn bind_task_round_robin(
                 };
                 schedulable_tasks.push((executor_id, task_desc));
 
-                idx_slot += 1;
-                slot.slots -= 1;
-                total_slots -= 1;
-                if total_slots == 0 {
+                idx += 1;
+                current.vcores -= 1;
+                total_vcores -= 1;
+                if total_vcores == 0 {
                     return schedulable_tasks;
                 }
             }
@@ -541,7 +541,7 @@ pub trait DistributionPolicy: std::fmt::Debug + Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `slots` - vector of available executor slots, there may not be available slots
+    /// * `budgets` - per-executor free-vcore budgets (may be empty)
     /// * `running_jobs` - (JobId -> JobInfoCache) cache must contain only running jobs
     ///
     /// # Returns
@@ -550,7 +550,7 @@ pub trait DistributionPolicy: std::fmt::Debug + Send + Sync {
     ///
     async fn bind_tasks(
         &self,
-        mut slots: Vec<&mut AvailableTaskSlots>,
+        mut budgets: Vec<&mut AvailableVcores>,
         running_jobs: Arc<HashMap<JobId, JobInfoCache>>,
     ) -> datafusion::error::Result<Vec<BoundTask>>;
 
@@ -565,7 +565,7 @@ mod test {
 
     use ballista_core::JobId;
     use ballista_core::error::Result;
-    use ballista_core::serde::protobuf::AvailableTaskSlots;
+    use ballista_core::serde::protobuf::AvailableVcores;
     use ballista_core::serde::scheduler::{
         ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
     };
@@ -582,11 +582,10 @@ mod test {
     async fn test_bind_task_bias() -> Result<()> {
         let num_partition = 8usize;
         let active_jobs = mock_active_jobs(num_partition).await?;
-        let mut available_slots = mock_available_slots();
-        let available_slots_ref: Vec<&mut AvailableTaskSlots> =
-            available_slots.iter_mut().collect();
+        let mut budgets = mock_budgets();
+        let budgets_ref: Vec<&mut AvailableVcores> = budgets.iter_mut().collect();
         let bound_tasks =
-            bind_task_bias(available_slots_ref, Arc::new(active_jobs), |_| false).await;
+            bind_task_bias(budgets_ref, Arc::new(active_jobs), |_| false).await;
         assert_eq!(9, bound_tasks.len());
 
         let result = get_result(bound_tasks);
@@ -632,12 +631,10 @@ mod test {
     async fn test_bind_task_round_robin() -> Result<()> {
         let num_partition = 8usize;
         let active_jobs = mock_active_jobs(num_partition).await?;
-        let mut available_slots = mock_available_slots();
-        let available_slots_ref: Vec<&mut AvailableTaskSlots> =
-            available_slots.iter_mut().collect();
+        let mut budgets = mock_budgets();
+        let budgets_ref: Vec<&mut AvailableVcores> = budgets.iter_mut().collect();
         let bound_tasks =
-            bind_task_round_robin(available_slots_ref, Arc::new(active_jobs), |_| false)
-                .await;
+            bind_task_round_robin(budgets_ref, Arc::new(active_jobs), |_| false).await;
         assert_eq!(9, bound_tasks.len());
 
         let result = get_result(bound_tasks);
@@ -730,7 +727,7 @@ mod test {
             host: "localhost".to_string(),
             port: 50051,
             grpc_port: 50052,
-            specification: ExecutorSpecification::default().with_task_slots(32),
+            specification: ExecutorSpecification::default().with_vcores(32),
             os_info: ExecutorOperatingSystemSpecification::default(),
         };
 
@@ -747,19 +744,19 @@ mod test {
         Ok(graph)
     }
 
-    fn mock_available_slots() -> Vec<AvailableTaskSlots> {
+    fn mock_budgets() -> Vec<AvailableVcores> {
         vec![
-            AvailableTaskSlots {
+            AvailableVcores {
                 executor_id: "executor_1".to_string(),
-                slots: 3,
+                vcores: 3,
             },
-            AvailableTaskSlots {
+            AvailableVcores {
                 executor_id: "executor_2".to_string(),
-                slots: 5,
+                vcores: 5,
             },
-            AvailableTaskSlots {
+            AvailableVcores {
                 executor_id: "executor_3".to_string(),
-                slots: 7,
+                vcores: 7,
             },
         ]
     }

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -456,7 +456,7 @@ impl SchedulerConfig {
 #[derive(Clone, Copy, Debug, serde::Deserialize, Default)]
 #[cfg_attr(feature = "build-binary", derive(clap::ValueEnum))]
 pub enum TaskDistribution {
-    /// Eagerly assign tasks to executor slots. This will assign as many task slots per executor
+    /// Eagerly assign tasks to executor slots. This will assign as many vcores per executor
     /// as are currently available
     #[default]
     Bias,
@@ -486,7 +486,7 @@ impl std::str::FromStr for TaskDistribution {
 /// Policy for distributing tasks to available executor slots.
 #[derive(Debug, Clone, Default)]
 pub enum TaskDistributionPolicy {
-    /// Eagerly assign tasks to executor slots. This will assign as many task slots per executor
+    /// Eagerly assign tasks to executor slots. This will assign as many vcores per executor
     /// as are currently available
     #[default]
     Bias,

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -1534,7 +1534,7 @@ order by
                 host: "localhost".to_string(),
                 port: 50050,
                 grpc_port: 50051,
-                specification: ExecutorSpecification::default().with_task_slots(1),
+                specification: ExecutorSpecification::default().with_vcores(1),
                 os_info: ExecutorOperatingSystemSpecification::default(),
             },
             partition_stats: PartitionStats::new(Some(10), None, Some(1)),

--- a/ballista/scheduler/src/scheduler_server/grpc.rs
+++ b/ballista/scheduler/src/scheduler_server/grpc.rs
@@ -22,7 +22,7 @@ use ballista_core::extension::SessionConfigHelperExt;
 use ballista_core::serde::protobuf::execute_query_params::Query;
 use ballista_core::serde::protobuf::scheduler_grpc_server::SchedulerGrpc;
 use ballista_core::serde::protobuf::{
-    AvailableTaskSlots, CancelJobParams, CancelJobResult, CleanJobDataParams,
+    AvailableVcores, CancelJobParams, CancelJobResult, CleanJobDataParams,
     CleanJobDataResult, CreateUpdateSessionParams, CreateUpdateSessionResult,
     ExecuteQueryFailureResult, ExecuteQueryParams, ExecuteQueryResult,
     ExecuteQuerySuccessResult, ExecutorHeartbeat, ExecutorStoppedParams,
@@ -82,7 +82,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
         let remote_addr = extract_connect_info(&request);
         if let PollWorkParams {
             metadata: Some(metadata),
-            num_free_slots,
+            num_free_vcores,
             task_status,
         } = request.into_inner()
         {
@@ -123,22 +123,22 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerGrpc
                     Status::internal(msg)
                 })?;
 
-            let mut available_slots = [AvailableTaskSlots {
+            let mut budgets = [AvailableVcores {
                 executor_id: executor_id.clone(),
-                slots: num_free_slots,
+                vcores: num_free_vcores,
             }];
-            let available_slots = available_slots.iter_mut().collect();
+            let budgets = budgets.iter_mut().collect();
             let running_jobs = self.state.task_manager.get_running_job_cache();
             let schedulable_tasks = match self.state.config.task_distribution {
                 TaskDistributionPolicy::Bias => {
-                    bind_task_bias(available_slots, running_jobs, |_| false).await
+                    bind_task_bias(budgets, running_jobs, |_| false).await
                 }
                 TaskDistributionPolicy::RoundRobin => {
-                    bind_task_round_robin(available_slots, running_jobs, |_| false).await
+                    bind_task_round_robin(budgets, running_jobs, |_| false).await
                 }
 
                 TaskDistributionPolicy::Custom(ref policy) => policy
-                    .bind_tasks(available_slots, running_jobs)
+                    .bind_tasks(budgets, running_jobs)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?,
             };
@@ -907,14 +907,12 @@ mod test {
             host: Some("http://localhost:8080".to_owned()),
             port: 0,
             grpc_port: 0,
-            specification: Some(
-                ExecutorSpecification::default().with_task_slots(2).into(),
-            ),
+            specification: Some(ExecutorSpecification::default().with_vcores(2).into()),
             os_info: Some(ExecutorOperatingSystemSpecification::default().into()),
         };
         let request: Request<PollWorkParams> = Request::new(PollWorkParams {
             metadata: Some(exec_meta.clone()),
-            num_free_slots: 0,
+            num_free_vcores: 0,
             task_status: vec![],
         });
         let response = scheduler
@@ -940,12 +938,12 @@ mod test {
 
         assert_eq!(stored_executor.grpc_port, 0);
         assert_eq!(stored_executor.port, 0);
-        assert_eq!(stored_executor.specification.task_slots, 2);
+        assert_eq!(stored_executor.specification.vcores, 2);
         assert_eq!(stored_executor.host, "http://localhost:8080".to_owned());
 
         let request: Request<PollWorkParams> = Request::new(PollWorkParams {
             metadata: Some(exec_meta.clone()),
-            num_free_slots: 1,
+            num_free_vcores: 1,
             task_status: vec![],
         });
         let response = scheduler
@@ -972,7 +970,7 @@ mod test {
 
         assert_eq!(stored_executor.grpc_port, 0);
         assert_eq!(stored_executor.port, 0);
-        assert_eq!(stored_executor.specification.task_slots, 2);
+        assert_eq!(stored_executor.specification.vcores, 2);
         assert_eq!(stored_executor.host, "http://localhost:8080".to_owned());
 
         Ok(())
@@ -998,9 +996,7 @@ mod test {
             host: Some("http://localhost:8080".to_owned()),
             port: 0,
             grpc_port: 0,
-            specification: Some(
-                ExecutorSpecification::default().with_task_slots(2).into(),
-            ),
+            specification: Some(ExecutorSpecification::default().with_vcores(2).into()),
             os_info: Some(ExecutorOperatingSystemSpecification::default().into()),
         };
 
@@ -1027,7 +1023,7 @@ mod test {
 
         assert_eq!(stored_executor.grpc_port, 0);
         assert_eq!(stored_executor.port, 0);
-        assert_eq!(stored_executor.specification.task_slots, 2);
+        assert_eq!(stored_executor.specification.vcores, 2);
         assert_eq!(stored_executor.host, "http://localhost:8080".to_owned());
 
         let request: Request<ExecutorStoppedParams> =
@@ -1086,9 +1082,7 @@ mod test {
             host: Some("http://localhost:8080".to_owned()),
             port: 0,
             grpc_port: 0,
-            specification: Some(
-                ExecutorSpecification::default().with_task_slots(2).into(),
-            ),
+            specification: Some(ExecutorSpecification::default().with_vcores(2).into()),
             os_info: Some(ExecutorOperatingSystemSpecification::default().into()),
         };
 
@@ -1115,7 +1109,7 @@ mod test {
 
         assert_eq!(stored_executor.grpc_port, 0);
         assert_eq!(stored_executor.port, 0);
-        assert_eq!(stored_executor.specification.task_slots, 2);
+        assert_eq!(stored_executor.specification.vcores, 2);
         assert_eq!(stored_executor.host, "http://localhost:8080".to_owned());
 
         Ok(())
@@ -1142,9 +1136,7 @@ mod test {
             host: Some("http://localhost:8080".to_owned()),
             port: 0,
             grpc_port: 0,
-            specification: Some(
-                ExecutorSpecification::default().with_task_slots(2).into(),
-            ),
+            specification: Some(ExecutorSpecification::default().with_vcores(2).into()),
             os_info: Some(ExecutorOperatingSystemSpecification::default().into()),
         };
 
@@ -1171,7 +1163,7 @@ mod test {
 
         assert_eq!(stored_executor.grpc_port, 0);
         assert_eq!(stored_executor.port, 0);
-        assert_eq!(stored_executor.specification.task_slots, 2);
+        assert_eq!(stored_executor.specification.vcores, 2);
         assert_eq!(stored_executor.host, "http://localhost:8080".to_owned());
 
         // heartbeat from the executor
@@ -1231,9 +1223,7 @@ mod test {
             host: Some("http://localhost:8080".to_owned()),
             port: 0,
             grpc_port: 0,
-            specification: Some(
-                ExecutorSpecification::default().with_task_slots(2).into(),
-            ),
+            specification: Some(ExecutorSpecification::default().with_vcores(2).into()),
             os_info: Some(ExecutorOperatingSystemSpecification::default().into()),
         };
 
@@ -1260,7 +1250,7 @@ mod test {
 
         assert_eq!(stored_executor.grpc_port, 0);
         assert_eq!(stored_executor.port, 0);
-        assert_eq!(stored_executor.specification.task_slots, 2);
+        assert_eq!(stored_executor.specification.vcores, 2);
         assert_eq!(stored_executor.host, "http://localhost:8080".to_owned());
 
         // Context strictly used for values-based query serialization to avoid

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -403,8 +403,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
     async fn do_register_executor(&self, metadata: ExecutorMetadata) -> Result<()> {
         let executor_data = ExecutorData {
             executor_id: metadata.id.clone(),
-            total_task_slots: metadata.specification.task_slots,
-            available_task_slots: metadata.specification.task_slots,
+            total_vcores: metadata.specification.vcores,
+            available_vcores: metadata.specification.vcores,
         };
 
         // Save the executor to state
@@ -483,11 +483,11 @@ mod test {
         let plan = test_plan();
         // this test will fail when AQE scheduling is used.
         // as AQE will fold plan due to empty scan
-        let task_slots = 4;
+        let total_vcores = 4;
 
         let scheduler = test_scheduler(TaskSchedulingPolicy::PullStaged).await?;
 
-        let executors = test_executors(task_slots);
+        let executors = test_executors(total_vcores);
         for (executor_metadata, executor_data) in executors {
             scheduler
                 .state
@@ -497,7 +497,7 @@ mod test {
         }
 
         let config =
-            SessionConfig::new_with_ballista().with_target_partitions(task_slots);
+            SessionConfig::new_with_ballista().with_target_partitions(total_vcores);
 
         let ctx = scheduler
             .state
@@ -594,11 +594,11 @@ mod test {
     #[tokio::test]
     async fn test_submit_physical_plan() -> Result<()> {
         let logical_plan = test_plan();
-        let task_slots = 4;
+        let total_vcores = 4;
 
         let scheduler = test_scheduler(TaskSchedulingPolicy::PullStaged).await?;
 
-        let executors = test_executors(task_slots);
+        let executors = test_executors(total_vcores);
         for (executor_metadata, executor_data) in executors {
             scheduler
                 .state
@@ -608,7 +608,7 @@ mod test {
         }
 
         let config =
-            SessionConfig::new_with_ballista().with_target_partitions(task_slots);
+            SessionConfig::new_with_ballista().with_target_partitions(total_vcores);
 
         let ctx = scheduler
             .state
@@ -1037,7 +1037,7 @@ mod test {
     }
 
     fn test_executors(num_partitions: usize) -> Vec<(ExecutorMetadata, ExecutorData)> {
-        let task_slots = (num_partitions as u32).div_ceil(2);
+        let vcores = (num_partitions as u32).div_ceil(2);
 
         vec![
             (
@@ -1046,14 +1046,13 @@ mod test {
                     host: "localhost1".to_string(),
                     port: 8080,
                     grpc_port: 9090,
-                    specification: ExecutorSpecification::default()
-                        .with_task_slots(task_slots),
+                    specification: ExecutorSpecification::default().with_vcores(vcores),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 ExecutorData {
                     executor_id: "executor-1".to_owned(),
-                    total_task_slots: task_slots,
-                    available_task_slots: task_slots,
+                    total_vcores: vcores,
+                    available_vcores: vcores,
                 },
             ),
             (
@@ -1063,13 +1062,13 @@ mod test {
                     port: 8080,
                     grpc_port: 9090,
                     specification: ExecutorSpecification::default()
-                        .with_task_slots(num_partitions as u32 - task_slots),
+                        .with_vcores(num_partitions as u32 - vcores),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 ExecutorData {
                     executor_id: "executor-2".to_owned(),
-                    total_task_slots: num_partitions as u32 - task_slots,
-                    available_task_slots: num_partitions as u32 - task_slots,
+                    total_vcores: num_partitions as u32 - vcores,
+                    available_vcores: num_partitions as u32 - vcores,
                 },
             ),
         ]

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -520,7 +520,7 @@ fn small_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             host: "".to_string(),
             port: 0,
             grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
+            specification: ExecutorSpecification::default().with_vcores(0),
             os_info: ExecutorOperatingSystemSpecification::default(),
         },
         // next few properties are needed
@@ -552,7 +552,7 @@ fn big_statistics_exchange() -> Vec<Vec<PartitionLocation>> {
             host: "".to_string(),
             port: 0,
             grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
+            specification: ExecutorSpecification::default().with_vcores(0),
             os_info: ExecutorOperatingSystemSpecification::default(),
         },
 

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -106,7 +106,7 @@ fn partitions_with_byte_sizes(
                     host: "".to_string(),
                     port: 0,
                     grpc_port: 0,
-                    specification: ExecutorSpecification::default().with_task_slots(0),
+                    specification: ExecutorSpecification::default().with_vcores(0),
                     os_info: ExecutorOperatingSystemSpecification::default(),
                 },
                 partition_stats: PartitionStats::new(Some(1), None, Some(bytes)),

--- a/ballista/scheduler/src/state/aqe/test/mod.rs
+++ b/ballista/scheduler/src/state/aqe/test/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn mock_partitions_with_statistics() -> Vec<Vec<PartitionLocation>> {
             host: "".to_string(),
             port: 0,
             grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
+            specification: ExecutorSpecification::default().with_vcores(0),
             os_info: ExecutorOperatingSystemSpecification::default(),
         },
         // next few properties are needed
@@ -79,7 +79,7 @@ pub(crate) fn mock_partitions_with_statistics_no_data() -> Vec<Vec<PartitionLoca
             host: "".to_string(),
             port: 0,
             grpc_port: 0,
-            specification: ExecutorSpecification::default().with_task_slots(0),
+            specification: ExecutorSpecification::default().with_vcores(0),
             os_info: ExecutorOperatingSystemSpecification::default(),
         },
         // next few properties are needed

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -60,7 +60,7 @@ type ExecutorClients = Arc<DashMap<String, ExecutorGrpcClient<Channel>>>;
 /// - Cleaning up job data on executors
 #[derive(Clone)]
 pub struct ExecutorManager {
-    /// Cluster state for tracking executor registration and task slots.
+    /// Cluster state for tracking executor registration and vcores.
     cluster_state: Arc<dyn ClusterState>,
     /// Scheduler configuration.
     config: Arc<SchedulerConfig>,
@@ -128,7 +128,7 @@ impl ExecutorManager {
             .await
     }
 
-    /// Returns reserved task slots to the pool of available slots.
+    /// Returns reserved vcores to the pool of available slots.
     ///
     /// This operation is atomic: either all slots are returned or none are.
     pub async fn unbind_tasks(&self, executor_slots: Vec<ExecutorSlot>) -> Result<()> {
@@ -332,15 +332,15 @@ impl ExecutorManager {
     /// For push-based scheduling, use [`Self::register_executor`] instead.
     pub async fn save_executor_metadata(&self, metadata: ExecutorMetadata) -> Result<()> {
         trace!(
-            "save executor metadata {} with {} task slots (pull-based registration)",
-            metadata.id, metadata.specification.task_slots
+            "save executor metadata {} with {} vcores (pull-based registration)",
+            metadata.id, metadata.specification.vcores
         );
         self.cluster_state.save_executor_metadata(metadata).await
     }
 
     /// Registers the executor with the scheduler for push-based task scheduling.
     ///
-    /// This saves both the executor metadata and available task slots to persistent state.
+    /// This saves both the executor metadata and vcore inventory to persistent state.
     /// For pull-based scheduling, use [`Self::save_executor_metadata`] instead.
     pub async fn register_executor(
         &self,
@@ -348,8 +348,8 @@ impl ExecutorManager {
         specification: ExecutorData,
     ) -> Result<()> {
         debug!(
-            "registering executor {} with {} task slots (push-based registration)",
-            metadata.id, specification.total_task_slots
+            "registering executor {} with {} vcores (push-based registration)",
+            metadata.id, specification.total_vcores
         );
 
         ExecutorManager::test_connectivity(&metadata).await?;

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -325,7 +325,7 @@ pub fn default_task_runner() -> impl TaskRunner {
 #[derive(Clone)]
 struct VirtualExecutor {
     executor_id: String,
-    task_slots: usize,
+    vcores: usize,
     runner: Arc<dyn TaskRunner>,
 }
 
@@ -399,14 +399,14 @@ impl SchedulerTest {
         config: SchedulerConfig,
         metrics_collector: Arc<dyn SchedulerMetricsCollector>,
         num_executors: usize,
-        task_slots_per_executor: usize,
+        vcores_per_executor: usize,
         runner: Option<Arc<dyn TaskRunner>>,
     ) -> Result<Self> {
         let cluster = BallistaCluster::new_from_config(&config).await?;
 
-        let session_config = if num_executors > 0 && task_slots_per_executor > 0 {
+        let session_config = if num_executors > 0 && vcores_per_executor > 0 {
             SessionConfig::new_with_ballista()
-                .with_target_partitions(num_executors * task_slots_per_executor)
+                .with_target_partitions(num_executors * vcores_per_executor)
         } else {
             SessionConfig::new_with_ballista()
         };
@@ -418,7 +418,7 @@ impl SchedulerTest {
                 let id = format!("virtual-executor-{i}");
                 let executor = VirtualExecutor {
                     executor_id: id.clone(),
-                    task_slots: task_slots_per_executor,
+                    vcores: vcores_per_executor,
                     runner: runner.clone(),
                 };
                 (id, executor)
@@ -443,21 +443,21 @@ impl SchedulerTest {
             );
         scheduler.init().await?;
 
-        for (executor_id, VirtualExecutor { task_slots, .. }) in executors {
+        for (executor_id, VirtualExecutor { vcores, .. }) in executors {
             let metadata = ExecutorMetadata {
                 id: executor_id.clone(),
                 host: String::default(),
                 port: 0,
                 grpc_port: 0,
                 specification: ExecutorSpecification::default()
-                    .with_task_slots(task_slots as u32),
+                    .with_vcores(vcores as u32),
                 os_info: ExecutorOperatingSystemSpecification::default(),
             };
 
             let executor_data = ExecutorData {
                 executor_id,
-                total_task_slots: task_slots as u32,
-                available_task_slots: task_slots as u32,
+                total_vcores: vcores as u32,
+                available_vcores: vcores as u32,
             };
 
             scheduler
@@ -1167,7 +1167,7 @@ pub fn mock_executor(executor_id: String) -> ExecutorMetadata {
         host: "localhost2".to_string(),
         port: 8080,
         grpc_port: 9090,
-        specification: ExecutorSpecification::default().with_task_slots(1),
+        specification: ExecutorSpecification::default().with_vcores(1),
         os_info: ExecutorOperatingSystemSpecification::default(),
     }
 }

--- a/benchmarks/src/bin/shuffle_bench.rs
+++ b/benchmarks/src/bin/shuffle_bench.rs
@@ -115,7 +115,7 @@ struct Args {
 
     /// Concurrent shuffle tasks to simulate executor parallelism.
     #[arg(long, default_value_t = 1)]
-    concurrent_tasks: usize,
+    vcores: usize,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -315,7 +315,7 @@ fn run_iteration(
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
         let start = Instant::now();
-        if args.concurrent_tasks <= 1 {
+        if args.vcores <= 1 {
             let work_dir = args.output_dir.join("task_0");
             let metrics = execute_shuffle_write(
                 args,
@@ -331,8 +331,8 @@ fn run_iteration(
             let _ = fs::remove_dir_all(&work_dir);
             (elapsed, Some(metrics))
         } else {
-            let mut handles = Vec::with_capacity(args.concurrent_tasks);
-            for task_id in 0..args.concurrent_tasks {
+            let mut handles = Vec::with_capacity(args.vcores);
+            for task_id in 0..args.vcores {
                 let args = args.clone();
                 let hash_col_indices = hash_col_indices.to_vec();
                 let work_dir = args.output_dir.join(format!("task_{task_id}"));
@@ -464,8 +464,8 @@ fn main() {
     if let Some(m) = args.memory_limit {
         println!("Memory limit:   {m} bytes");
     }
-    if args.concurrent_tasks > 1 {
-        println!("Concurrent:     {} tasks", args.concurrent_tasks);
+    if args.vcores > 1 {
+        println!("Concurrent:     {} tasks", args.vcores);
     }
     println!(
         "Iterations:     {} (warmup {})",
@@ -497,7 +497,7 @@ fn main() {
 
     if !times.is_empty() {
         let avg = times.iter().sum::<f64>() / times.len() as f64;
-        let total_writer_rows = total_rows * args.concurrent_tasks as u64;
+        let total_writer_rows = total_rows * args.vcores as u64;
         println!();
         println!("=== Results ===");
         println!("avg time: {avg:.3}s");
@@ -509,7 +509,7 @@ fn main() {
         println!(
             "throughput: {} rows/s (total across {} tasks)",
             (total_writer_rows as f64 / avg) as u64,
-            args.concurrent_tasks
+            args.vcores
         );
         if let Some(metrics) = last_metrics {
             println!();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     build:
       dockerfile: dev/docker/ballista-executor.Dockerfile
       context: .
-    command: "--bind-host 0.0.0.0 --scheduler-host ballista-scheduler --concurrent-tasks 4 --memory-pool-size 8GB --work-dir /work"
+    command: "--bind-host 0.0.0.0 --scheduler-host ballista-scheduler --vcores 4 --memory-pool-size 8GB --work-dir /work"
     deploy:
       replicas: 2
       resources:

--- a/docs/source/contributors-guide/user-personas.md
+++ b/docs/source/contributors-guide/user-personas.md
@@ -83,7 +83,7 @@ to make sure a change that delights one audience does not quietly break another.
 - **Coming from**: Apache Spark.
 - **Why Ballista**: Keep the Spark mental model — plans split into **stages** at
   shuffle boundaries, one **task** per partition, shuffle files, executors with
-  task slots, and adaptive query execution (**AQE**) for runtime adaptivity — on
+  vcores, and adaptive query execution (**AQE**) for runtime adaptivity — on
   top of DataFusion and Arrow.
 - **Depends on** (must not regress):
   - The stage/task execution model at shuffle boundaries.
@@ -92,7 +92,7 @@ to make sure a change that delights one audience does not quietly break another.
   - Broadcast joins for small build sides, to avoid shuffles and skew (the
     equivalent of Spark's broadcast hash join).
   - The operational surface Spark users expect: a scheduler plus executors,
-    task-slot concurrency, a tunable `target_partitions`, and stage/task
+    vcore concurrency, a tunable `target_partitions`, and stage/task
     observability (task timings, a history server / UI) for debugging skew.
   - Behavior driven by configuration and `SET`, not hard-coded planner choices.
 - **Red flags in a pull request**:

--- a/docs/source/contributors-guide/user-personas.md
+++ b/docs/source/contributors-guide/user-personas.md
@@ -83,7 +83,7 @@ to make sure a change that delights one audience does not quietly break another.
 - **Coming from**: Apache Spark.
 - **Why Ballista**: Keep the Spark mental model — plans split into **stages** at
   shuffle boundaries, one **task** per partition, shuffle files, executors with
-  vcores, and adaptive query execution (**AQE**) for runtime adaptivity — on
+  task slots, and adaptive query execution (**AQE**) for runtime adaptivity — on
   top of DataFusion and Arrow.
 - **Depends on** (must not regress):
   - The stage/task execution model at shuffle boundaries.
@@ -92,7 +92,7 @@ to make sure a change that delights one audience does not quietly break another.
   - Broadcast joins for small build sides, to avoid shuffles and skew (the
     equivalent of Spark's broadcast hash join).
   - The operational surface Spark users expect: a scheduler plus executors,
-    vcore concurrency, a tunable `target_partitions`, and stage/task
+    task-slot concurrency, a tunable `target_partitions`, and stage/task
     observability (task timings, a history server / UI) for debugging skew.
   - Behavior driven by configuration and `SET`, not hard-coded planner choices.
 - **Red flags in a pull request**:

--- a/docs/source/user-guide/cli.md
+++ b/docs/source/user-guide/cli.md
@@ -158,7 +158,7 @@ ballista-cli
 
 The TUI provides the following views:
 
-- **Executors**: Lists all registered executors with their host, port, task slots, memory usage, and last seen time.
+- **Executors**: Lists all registered executors with their host, port, vcores, memory usage, and last seen time.
   Supports sorting by any column.
 - **Executor details**: Select an executor and press `Enter` to show extra details about it.
 - **Jobs**: Displays active and completed jobs with their status, start time, and duration. Supports sorting, job

--- a/docs/source/user-guide/deployment/docker.md
+++ b/docs/source/user-guide/deployment/docker.md
@@ -98,7 +98,7 @@ Use `docker logs CONTAINER_ID` to check the output from the executor(s):
 $ docker logs fb8b530cee6d
 INFO ballista_executor::executor_process: Running with config:
 INFO ballista_executor::executor_process: work_dir: /tmp/.tmpAkP3pZ
-INFO ballista_executor::executor_process: concurrent_tasks: 48
+INFO ballista_executor::executor_process: Executor vcores (default: available CPU cores): 48
 INFO ballista_executor::executor_process: Ballista v52.0.0 Rust Executor Flight Server listening on 0.0.0.0:50051
 INFO ballista_executor::execution_loop: Starting poll work loop with scheduler
 ```

--- a/docs/source/user-guide/python/quickstart.md
+++ b/docs/source/user-guide/python/quickstart.md
@@ -51,7 +51,7 @@ ctx = BallistaSessionContext(f"df://{host}:{port}")
 ### Target Partitions
 
 Set `datafusion.execution.target_partitions` to match your cluster capacity
-(`executors × concurrent_tasks_per_executor`) by passing `cluster_config` to the
+(`executors × vcores_per_executor`) by passing `cluster_config` to the
 constructor. The default inherits from DataFusion and is based on the client's CPU
 count, which is far too low for distributed execution:
 
@@ -59,8 +59,8 @@ count, which is far too low for distributed execution:
 from ballista import BallistaSessionContext
 
 executors = 4
-concurrent_tasks = 8
-target_partitions = executors * concurrent_tasks
+vcores = 8
+target_partitions = executors * vcores
 
 ctx = BallistaSessionContext(
     "df://localhost:50050",

--- a/docs/source/user-guide/tuning-guide.md
+++ b/docs/source/user-guide/tuning-guide.md
@@ -56,12 +56,12 @@ let ctx: SessionContext = SessionContext::remote_with_state(&url,state).await?;
 
 ## Configuring Executor Concurrency Levels
 
-Each executor instance has a fixed number of tasks that it can process concurrently. This is specified by passing a
-`concurrent_tasks` command-line parameter. The default setting is to use all available CPU cores.
+Each executor instance advertises a fixed number of virtual cores (vcores) to the scheduler. This is specified by
+passing a `--vcores` command-line parameter. The default setting is to use all available CPU cores.
 
 Increasing this configuration setting will increase the number of tasks that each executor can run concurrently but
 this will also mean that the executor will use more memory. If executors are failing due to out-of-memory errors then
-decreasing the number of concurrent tasks may help.
+decreasing the vcore count may help.
 
 ## Configuring Executor Memory Pool
 
@@ -71,22 +71,22 @@ memory. To bound executor memory and let those operators spill to disk under
 pressure, pass `--memory-pool-size` when starting the executor:
 
 ```sh
-ballista-executor --memory-pool-size 8GB --concurrent-tasks 8
+ballista-executor --memory-pool-size 8GB --vcores 8
 ```
 
 The argument accepts human-readable sizes (`8GB`, `512MiB`) or a plain byte
 count. SI suffixes (`KB`/`MB`/`GB`) are powers of 10; IEC suffixes
 (`KiB`/`MiB`/`GiB`) are powers of 2.
 
-The total budget is divided equally across concurrent task slots: each task
-receives its own `FairSpillPool` of size `memory_pool_size / concurrent_tasks`.
-With `--memory-pool-size 8GB --concurrent-tasks 8`, every task sees a 1 GB
+The total budget is divided equally across the executor's vcores: each task
+receives its own `FairSpillPool` of size `memory_pool_size / vcores`.
+With `--memory-pool-size 8GB --vcores 8`, every task sees a 1 GB
 pool, fully isolated from other tasks. Idle slots do not lend their share to
 busy ones, which keeps task memory predictable at the cost of some unused
 capacity when the executor is under-utilized.
 
 The executor refuses to start if the per-task share would round to zero (i.e.
-`memory_pool_size < concurrent_tasks`).
+`memory_pool_size < vcores`).
 
 When `--memory-pool-size` is not set, the executor behaves as before with no
 memory pool installed.

--- a/examples/examples/mtls-cluster.rs
+++ b/examples/examples/mtls-cluster.rs
@@ -363,7 +363,7 @@ async fn run_executor() -> Result<(), Box<dyn std::error::Error>> {
         grpc_port: 0, // Not used in pull-based scheduling
         specification: Some(ExecutorSpecification {
             resources: vec![ExecutorResource {
-                resource: Some(Resource::TaskSlots(4)),
+                resource: Some(Resource::Vcores(4)),
             }],
         }),
         os_info: None,
@@ -388,7 +388,7 @@ async fn run_executor() -> Result<(), Box<dyn std::error::Error>> {
         config_producer,
         Default::default(), // function_registry
         Arc::new(LoggingMetricsCollector::default()), // metrics_collector
-        4,                  // concurrent_tasks
+        4,                  // vcores
     ));
 
     // Start Flight service with mTLS for serving shuffle data

--- a/examples/examples/standalone-substrait.rs
+++ b/examples/examples/standalone-substrait.rs
@@ -578,13 +578,13 @@ pub async fn setup_standalone(session_state: Option<&SessionState>) -> Result<St
         }
     };
 
-    let concurrent_tasks = config.ballista_standalone_parallelism();
+    let vcores = config.ballista_standalone_parallelism();
 
     match session_state {
         None => {
             ballista_executor::new_standalone_executor(
                 scheduler,
-                concurrent_tasks,
+                vcores,
                 BallistaCodec::default(),
             )
             .await
@@ -593,7 +593,7 @@ pub async fn setup_standalone(session_state: Option<&SessionState>) -> Result<St
         Some(session_state) => {
             ballista_executor::new_standalone_executor_from_state(
                 scheduler,
-                concurrent_tasks,
+                vcores,
                 session_state,
             )
             .await

--- a/python/src/cluster.rs
+++ b/python/src/cluster.rs
@@ -141,7 +141,7 @@ pub struct PyExecutor {
 //        which forked it. This will be investigated further
 #[pymethods]
 impl PyExecutor {
-    #[pyo3(signature = (bind_port=None, bind_host =None, scheduler_host = None, scheduler_port = None, concurrent_tasks = None))]
+    #[pyo3(signature = (bind_port=None, bind_host =None, scheduler_host = None, scheduler_port = None, vcores = None))]
     #[new]
     pub fn new(
         _py: Python,
@@ -149,7 +149,7 @@ impl PyExecutor {
         bind_host: Option<String>,
         scheduler_host: Option<String>,
         scheduler_port: Option<u16>,
-        concurrent_tasks: Option<u16>,
+        vcores: Option<u16>,
     ) -> PyResult<Self> {
         let mut config = ExecutorProcessConfig::default();
         if let Some(port) = bind_port {
@@ -168,8 +168,8 @@ impl PyExecutor {
             config.scheduler_host = host;
         }
 
-        if let Some(concurrent_tasks) = concurrent_tasks {
-            config.concurrent_tasks = concurrent_tasks as usize
+        if let Some(vcores) = vcores {
+            config.vcores = vcores as usize
         }
 
         let config = Arc::new(config);
@@ -248,12 +248,12 @@ impl PyExecutor {
 
     pub fn __repr__(&self) -> String {
         format!(
-            "BallistaExecutor(address={}:{}, scheduler={}:{}, concurrent_tasks={} listening={})",
+            "BallistaExecutor(address={}:{}, scheduler={}:{}, vcores={} listening={})",
             self.config.bind_host,
             self.config.port,
             self.config.scheduler_host,
             self.config.scheduler_port,
-            self.config.concurrent_tasks,
+            self.config.vcores,
             self.handle.is_some()
         )
     }


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #2038: split the `task_slots` → `vcores` rename into its own PR so it can land independently.

Mechanical rename, no behavior change. Follows the YARN precedent (`yarn.nodemanager.resource.cpu-vcores`) and Spark's `spark.executor.cores`. The `v` prefix is self-documenting — readers grepping in a year don't have to hunt for a doc comment to know these aren't physical `nproc`. It also leaves room for future execution models that decouple "how many tasks" from "how many cores per task."

## What changed

- `ExecutorSpecification.task_slots` → `vcores` (u32), with a YARN/Spark doc comment
- Proto: `ExecutorResource.task_slots` → `vcores`, `AvailableTaskSlots` → `AvailableVcores`, `ExecutorTaskSlots` → `ExecutorVcores`, `PollWorkParams.num_free_slots` → `num_free_vcores`. Field numbers preserved for wire compat.
- CLI: `--concurrent-tasks` → `--vcores` on both `ballista-executor` and `ballista-cli`
- Cluster bookkeeping: `InMemoryClusterState.task_slots` → `available_vcores`
- TUI: "Task Slots" column → "vCores"
- Docs, `docker-compose.yml`, tpch workflow, and CLI README updated so `--concurrent-tasks` invocations don't fail at boot under the new flag name
- Historical changelogs left untouched

## Test plan

- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p ballista-scheduler --lib\` (224 tests)
- [x] \`cargo test -p ballista-core --lib\` (116 tests)
- [x] Proto codegen produces no diff after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)