### PR TITLE
fix: keep EmptyExec partition count intact across stage serialization [AQE]

### DIFF
--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -855,6 +855,45 @@ mod test {
         );
     }
 
+    // `datafusion-proto` encodes an `EmptyExec` as its schema alone, so a
+    // multi-partition `EmptyExec` decodes with a single partition (apache/datafusion
+    // #23642). `make_empty_exec_serde_safe` in the scheduler works around this by
+    // rewriting such nodes into a round-robin `RepartitionExec` before a stage plan
+    // goes on the wire.
+    //
+    // This test pins the upstream behaviour that makes the workaround necessary: when
+    // it starts failing, DataFusion preserves the partition count and the workaround
+    // can be deleted.
+    #[tokio::test]
+    async fn empty_exec_partition_count_is_lost_by_datafusion_proto() {
+        use datafusion::physical_plan::ExecutionPlanProperties;
+        use datafusion::physical_plan::empty::EmptyExec;
+        use datafusion_proto::physical_plan::{
+            AsExecutionPlan, DefaultPhysicalExtensionCodec,
+        };
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> =
+            Arc::new(EmptyExec::new(schema).with_partitions(4));
+        assert_eq!(
+            plan.output_partitioning().partition_count(),
+            4,
+            "precondition: EmptyExec reports 4 partitions"
+        );
+
+        let codec = DefaultPhysicalExtensionCodec {};
+        let proto = PhysicalPlanNode::try_from_physical_plan(plan, &codec).unwrap();
+        let ctx = SessionContext::new().task_ctx();
+        let decoded = proto.try_into_physical_plan(&ctx, &codec).unwrap();
+
+        assert_eq!(
+            decoded.output_partitioning().partition_count(),
+            1,
+            "EmptyExec partition count is dropped on the wire; if this now decodes as \
+             4, apache/datafusion#23642 is fixed and make_empty_exec_serde_safe can go"
+        );
+    }
+
     #[tokio::test]
     async fn test_unresolved_shuffle_exec_roundtrip() {
         let schema = create_test_schema();

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -33,10 +33,12 @@ use ballista_core::{
     serde::scheduler::PartitionLocation,
 };
 use datafusion::arrow::datatypes::DataType;
+use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_optimizer::enforce_sorting::EnforceSorting;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::joins::{
     HashJoinExec, HashJoinExecBuilder, PartitionMode, SortMergeJoinExec,
 };
@@ -672,6 +674,42 @@ pub fn rollback_resolved_shuffles(
     Ok(with_new_children_if_necessary(stage, new_children)?)
 }
 
+/// Rewrites every multi-partition [`EmptyExec`] into a round-robin [`RepartitionExec`]
+/// over a single-partition [`EmptyExec`], which is an equivalent plan whose partition
+/// count survives serialization.
+///
+/// `datafusion-proto` encodes an `EmptyExec` as its schema alone, so a multi-partition
+/// `EmptyExec` decodes on the executor with a single partition
+/// (<https://github.com/apache/datafusion/issues/23642>). A stage is sized from the
+/// scheduler-side partition count, so every task above partition 0 would then fail with
+/// `EmptyExec invalid partition N (expected less than 1)`. A `RepartitionExec` carries
+/// its partitioning on the wire, so the count arrives intact.
+///
+/// This runs at the point the stage plan is built for the wire, after all physical
+/// optimizer rules, so no later rule can collapse the rewrite. It can be removed once
+/// the partition count survives `EmptyExec` serialization upstream.
+fn make_empty_exec_serde_safe(
+    plan: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    Ok(plan
+        .transform_up(|node| {
+            let Some(empty) = node.downcast_ref::<EmptyExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            let partition_count =
+                empty.properties().output_partitioning().partition_count();
+            if partition_count <= 1 {
+                return Ok(Transformed::no(node));
+            }
+            let single: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(empty.schema()));
+            Ok(Transformed::yes(Arc::new(RepartitionExec::try_new(
+                single,
+                Partitioning::RoundRobinBatch(partition_count),
+            )?)))
+        })?
+        .data)
+}
+
 pub(crate) fn create_shuffle_writer_with_config(
     job_id: &JobId,
     stage_id: usize,
@@ -679,6 +717,8 @@ pub(crate) fn create_shuffle_writer_with_config(
     partitioning: Option<Partitioning>,
     config: &ConfigOptions,
 ) -> Result<Arc<dyn ShuffleWriter>> {
+    let plan = make_empty_exec_serde_safe(plan)?;
+
     // Check if sort-based shuffle is enabled
     let ballista_config = config
         .extensions
@@ -746,6 +786,41 @@ mod test {
     use datafusion_proto::protobuf::PhysicalPlanNode;
     use std::sync::Arc;
     use uuid::Uuid;
+
+    #[test]
+    fn multi_partition_empty_exec_is_rewritten_for_the_wire() {
+        use super::make_empty_exec_serde_safe;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> =
+            Arc::new(EmptyExec::new(schema).with_partitions(4));
+
+        let rewritten = make_empty_exec_serde_safe(plan).unwrap();
+
+        assert_eq!(
+            displayable(rewritten.as_ref()).indent(false).to_string(),
+            "RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1\n  EmptyExec\n"
+        );
+    }
+
+    #[test]
+    fn single_partition_empty_exec_is_left_alone() {
+        use super::make_empty_exec_serde_safe;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+
+        let rewritten = make_empty_exec_serde_safe(plan).unwrap();
+
+        assert_eq!(
+            displayable(rewritten.as_ref()).indent(false).to_string(),
+            "EmptyExec\n"
+        );
+    }
 
     macro_rules! downcast_exec {
         ($exec: expr, $ty: ty) => {

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -72,7 +72,8 @@ async fn should_propagate_empty_stage() -> datafusion::error::Result<()> {
     assert_eq!(1, stages.len());
     assert_plan!(stages.first().unwrap().plan.as_ref(),  @ r"
     ShuffleWriterExec: partitioning: None
-      EmptyExec
+      RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+        EmptyExec
     ");
     planner.finalise_stage_internal(1, mock_partitions_with_statistics_no_data())?;
 
@@ -146,7 +147,8 @@ async fn should_propagate_empty_stage_and_remove() -> datafusion::error::Result<
     assert_eq!(1, stages.len());
     assert_plan!(stages.first().unwrap().plan.as_ref(),  @ r"
     ShuffleWriterExec: partitioning: None
-      EmptyExec
+      RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
+        EmptyExec
     ");
     planner.finalise_stage_internal(1, mock_partitions_with_statistics_no_data())?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2047.

# Rationale for this change

With adaptive execution enabled (`ballista.planner.adaptive.enabled=true`), 15 TPC-DS queries fail with:

```
Internal("Assertion failed: partition < self.partitions:
  EmptyExec invalid partition 1 (expected less than 1)")
```

The adaptive planner's `PropagateEmptyExecRule` collapses a provably empty sub-plan into an `EmptyExec` that inherits the partition count of the node it replaced, and the scheduler sizes a stage's task count from that count.

`datafusion-proto` encodes an `EmptyExec` as its schema alone — `EmptyExecNode` has no partitions field, and the decoder rebuilds the node with `EmptyExec::new(schema)`, which defaults to one partition. So a stage built from an `EmptyExec` with N partitions launches N tasks against a plan that, once it reaches the executor, can only execute partition 0. Every task above partition 0 then trips the assertion.

The static planner is unaffected because it never produces a multi-partition `EmptyExec`: its only `EmptyExec` comes from `LogicalPlan::EmptyRelation`, which has a single partition.

I filed the underlying serialization gap upstream as [apache/datafusion#23642](https://github.com/apache/datafusion/issues/23642).

# What changes are included in this PR?

- `make_empty_exec_serde_safe` in `ballista/scheduler/src/planner.rs` rewrites every multi-partition `EmptyExec` into a round-robin `RepartitionExec` over a single-partition `EmptyExec`. The plan is equivalent, and a `RepartitionExec` carries its partitioning through serialization, so the count arrives on the executor intact.

  It is applied in `create_shuffle_writer_with_config`, the single point where a stage plan is built for the wire. That is after all physical optimizer rules, so no later rule can collapse the rewrite, and it is a no-op for the static planner.

- A unit test for the rewrite and for the single-partition case, asserted on the rendered plan string.

- A test in `ballista-core` pinning the upstream `datafusion-proto` behaviour that makes the workaround necessary. When that test starts failing, the partition count survives serialization upstream and `make_empty_exec_serde_safe` can be deleted.

- Two AQE stage-plan snapshots updated. Both cover a stage plan carrying a 2-partition `EmptyExec` — exactly the shape that fails on the wire today.

# How are these changes tested?

`cargo test --workspace` and `cargo clippy --all-targets --workspace -- -D warnings` are clean.

Verified end-to-end against SF1 TPC-DS on a native 1-scheduler / 1-executor cluster (8 slots), with `ballista.planner.adaptive.enabled=true` and `datafusion.optimizer.prefer_hash_join=false`, running each of the 15 queries listed in #2047. The assertion no longer occurs on any of them.

13 of the 15 (q8, q16, q24, q29, q34, q37, q41, q43, q46, q54, q61, q68, q73) now run to completion. q1 and q44 no longer hit the assertion but do not complete: they hang on a **separate, pre-existing** defect that the assertion was previously masking. Once the residual plan collapses to empty, the replan removes an in-flight stage's exchange and cancels the stage; the tasks already running then complete, and the late status update fails `finalise_stage` with `Execution("Can't find active cache resolve")`, so the job never finishes. That error is visible in the scheduler log on `main` today, before this change. It is unrelated to serialization and is tracked separately in #2063.

Also unchanged by this PR, and tracked separately: the empty results themselves fall under the AQE correctness divergences in #2046.
