### PR TITLE
fix: remove the static planner SortMergeJoinExec broadcast conversion

### DIFF
--- a/ballista/client/tests/context_checks.rs
+++ b/ballista/client/tests/context_checks.rs
@@ -960,14 +960,6 @@ mod supported {
         ctx: SessionContext,
         test_data: String,
     ) -> datafusion::error::Result<()> {
-        // Exercise the plain sort-merge-join execution path: disable the
-        // default SortMergeJoinExec broadcast conversion so the join stays a
-        // SortMergeJoinExec in the distributed plan.
-        ctx.sql("SET ballista.optimizer.broadcast_sort_merge_join_enabled = false")
-            .await?
-            .collect()
-            .await?;
-
         ctx.register_parquet(
             "t0",
             &format!("{test_data}/alltypes_plain.parquet"),

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -103,12 +103,6 @@ pub const BALLISTA_SHUFFLE_SORT_BASED_MEMORY_LIMIT_PER_TASK_BYTES: &str =
 pub const BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES: &str =
     "ballista.optimizer.broadcast_join_threshold_bytes";
 
-/// Configuration key to enable broadcasting a small build side of a
-/// `SortMergeJoinExec` by converting it to a `CollectLeft` hash join in the
-/// static distributed planner. Enabled by default.
-pub const BALLISTA_BROADCAST_SORT_MERGE_JOIN_ENABLED: &str =
-    "ballista.optimizer.broadcast_sort_merge_join_enabled";
-
 /// Configuration key to enable AQE coalesce-shuffle-partitions rule.
 /// Disabled by default — opt in when the workload benefits from larger
 /// downstream tasks more than from preserved parallelism.
@@ -245,12 +239,6 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
                           Set to 0 to disable promotion.".to_string(),
                          DataType::UInt64,
                          Some((10 * 1024 * 1024).to_string())),
-        ConfigEntry::new(BALLISTA_BROADCAST_SORT_MERGE_JOIN_ENABLED.to_string(),
-                         "Broadcast a small build side of a SortMergeJoinExec by converting it \
-                          to a CollectLeft hash join in the static distributed planner. \
-                          The build side must also fit under broadcast_join_threshold_bytes.".to_string(),
-                         DataType::Boolean,
-                         Some(true.to_string())),
         ConfigEntry::new(BALLISTA_CLIENT_PULL.to_string(),
                          "Should client employ pull or push job tracking. In pull mode client will make a request to server in the loop, until job finishes. Pull mode is kept for legacy clients.".to_string(),
                          DataType::Boolean,
@@ -581,13 +569,6 @@ impl BallistaConfig {
         self.get_usize_setting(BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES)
     }
 
-    /// Returns whether broadcasting a small build side of a `SortMergeJoinExec`
-    /// (by converting it to a `CollectLeft` hash join) is enabled in the static
-    /// distributed planner.
-    pub fn broadcast_sort_merge_join_enabled(&self) -> bool {
-        self.get_bool_setting(BALLISTA_BROADCAST_SORT_MERGE_JOIN_ENABLED)
-    }
-
     /// Returns whether the AQE coalesce-shuffle-partitions rule is enabled.
     pub fn coalesce_enabled(&self) -> bool {
         self.get_bool_setting(BALLISTA_COALESCE_ENABLED)
@@ -851,11 +832,5 @@ mod tests {
         let config = BallistaConfig::default();
         assert_eq!(16777216, config.grpc_client_max_message_size());
         Ok(())
-    }
-
-    #[test]
-    fn broadcast_sort_merge_join_enabled_by_default() {
-        let config = BallistaConfig::default();
-        assert!(config.broadcast_sort_merge_join_enabled());
     }
 }

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -39,12 +39,9 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_optimizer::enforce_sorting::EnforceSorting;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::joins::{
-    HashJoinExec, HashJoinExecBuilder, PartitionMode, SortMergeJoinExec,
-};
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
-use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::{
     ExecutionPlan, Partitioning, with_new_children_if_necessary,
@@ -285,8 +282,7 @@ impl DefaultDistributedPlanner {
         // side to every probe task, which is only correct for probe-driven join
         // types. If the join type is not broadcast-safe, demote it back to a
         // partitioned (shuffle) join. This is a correctness guard, so it runs
-        // regardless of the Ballista broadcast threshold below. A
-        // `SortMergeJoinExec` falls through to the SMJ-broadcast path below.
+        // regardless of the Ballista broadcast threshold below.
         if let Some(hash_join) = plan.downcast_ref::<HashJoinExec>()
             && *hash_join.partition_mode() == PartitionMode::CollectLeft
         {
@@ -312,30 +308,11 @@ impl DefaultDistributedPlanner {
             return Ok(plan);
         }
 
-        // The candidate is a `HashJoinExec(Partitioned)`: either the plan itself,
-        // or a `SortMergeJoinExec` converted to one when SMJ broadcast is enabled.
-        // `converted` owns the converted join so `hash_join` can borrow from it,
-        // and the original `plan` is returned unchanged when no promotion happens.
-        let smj_broadcast_enabled = config
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.broadcast_sort_merge_join_enabled())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().broadcast_sort_merge_join_enabled()
-            });
-        let converted: Option<Arc<HashJoinExec>> =
-            match plan.downcast_ref::<SortMergeJoinExec>() {
-                Some(smj) if smj_broadcast_enabled => {
-                    Some(convert_sort_merge_to_hash_join(smj)?)
-                }
-                _ => None,
-            };
-        let hash_join: &HashJoinExec =
-            match (plan.downcast_ref::<HashJoinExec>(), &converted) {
-                (Some(hj), _) => hj,
-                (None, Some(hj)) => hj.as_ref(),
-                (None, None) => return Ok(plan),
-            };
+        // The candidate must already be a `HashJoinExec(Partitioned)`. A
+        // `SortMergeJoinExec` is never a broadcast candidate.
+        let Some(hash_join) = plan.downcast_ref::<HashJoinExec>() else {
+            return Ok(plan);
+        };
         debug!(
             "broadcast check: evaluating HashJoinExec mode={:?} join_type={:?} threshold={threshold_bytes}",
             hash_join.partition_mode(),
@@ -522,33 +499,6 @@ impl DefaultDistributedPlanner {
             .with_new_children(vec![new_left, new_right])?
             .build_exec()?)
     }
-}
-
-/// Strips a top-level `SortExec`, returning its input. A `SortMergeJoinExec`
-/// requires sorted inputs, but the broadcast `CollectLeft` hash join converted
-/// from it does not, so the sort is dropped during conversion.
-fn strip_sort(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-    if let Some(sort) = plan.downcast_ref::<SortExec>() {
-        sort.input().clone()
-    } else {
-        plan
-    }
-}
-
-/// Converts a `SortMergeJoinExec` into an equivalent `HashJoinExec(Partitioned)`,
-/// dropping the now-redundant input sorts. The result is then evaluated by the
-/// normal hash-join broadcast path, which promotes it to `CollectLeft` when a
-/// side fits under the threshold.
-fn convert_sort_merge_to_hash_join(smj: &SortMergeJoinExec) -> Result<Arc<HashJoinExec>> {
-    let left = strip_sort(smj.left().clone());
-    let right = strip_sort(smj.right().clone());
-    let hash_join =
-        HashJoinExecBuilder::new(left, right, smj.on().to_vec(), smj.join_type())
-            .with_filter(smj.filter().clone())
-            .with_partition_mode(PartitionMode::Partitioned)
-            .with_null_equality(smj.null_equality)
-            .build()?;
-    Ok(Arc::new(hash_join))
 }
 
 fn create_unresolved_shuffle(
@@ -1107,7 +1057,7 @@ order by
     async fn distributed_broadcast_join_plan() -> Result<(), BallistaError> {
         use datafusion::physical_plan::joins::PartitionMode;
 
-        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, true, false)?;
+        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, true)?;
 
         let df = ctx
             .sql("select count(*) from big join small on big.k = small.k")
@@ -1151,81 +1101,12 @@ order by
     }
 
     #[tokio::test]
-    async fn distributed_broadcast_sort_merge_join_plan() -> Result<(), BallistaError> {
-        // prefer_hash_join=false -> DataFusion plans a SortMergeJoinExec.
-        // broadcast_sort_merge_join_enabled=true -> the small build side is
-        // converted to a broadcast CollectLeft hash join: the SortMergeJoinExec
-        // and its input SortExecs are gone, and the build input is an
-        // UnresolvedShuffleExec with broadcast=true.
-        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, false, true)?;
-
-        let df = ctx
-            .sql("select count(*) from big join small on big.k = small.k")
-            .await?;
-
-        let plan = df.into_optimized_plan()?;
-        let plan = ctx.state().create_physical_plan(&plan).await?;
-
-        let mut planner = DefaultDistributedPlanner::new();
-        let job_uuid = Uuid::new_v4();
-        let stages =
-            planner.plan_query_stages(&job_uuid.to_string().into(), plan, &options)?;
-
-        // Stage 1 holds the join: a broadcast CollectLeft hash join, no
-        // SortMergeJoinExec and no SortExec.
-        assert_plan!(stages[1].as_ref(), @"
-        ShuffleWriterExec: partitioning: None
-          AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]
-            ProjectionExec: expr=[]
-              ProjectionExec: expr=[k@1 as k, k@0 as k]
-                HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(k@0, k@0)]
-                  UnresolvedShuffleExec: stage=1, broadcast=true, upstream_partitions: 1
-                  DataSourceExec: partitions=1, partition_sizes=[1]
-        ");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn distributed_sort_merge_join_unchanged_when_flag_disabled()
-    -> Result<(), BallistaError> {
-        // SMJ planned (prefer_hash_join=false), flag OFF -> no conversion: the
-        // join stays a SortMergeJoinExec over sorted inputs.
-        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, false, false)?;
-
-        let df = ctx
-            .sql("select count(*) from big join small on big.k = small.k")
-            .await?;
-        let plan = df.into_optimized_plan()?;
-        let plan = ctx.state().create_physical_plan(&plan).await?;
-
-        let mut planner = DefaultDistributedPlanner::new();
-        let job_uuid = Uuid::new_v4();
-        let stages =
-            planner.plan_query_stages(&job_uuid.to_string().into(), plan, &options)?;
-
-        // Stage 0 holds the join, still a SortMergeJoinExec over sorted inputs
-        // (no HashJoinExec, no broadcast UnresolvedShuffleExec).
-        assert_plan!(stages[0].as_ref(), @r"
-        ShuffleWriterExec: partitioning: None
-          AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]
-            ProjectionExec: expr=[]
-              SortMergeJoinExec: join_type=Inner, on=[(k@0, k@0)]
-                SortExec: expr=[k@0 ASC], preserve_partitioning=[false]
-                  DataSourceExec: partitions=1, partition_sizes=[1]
-                SortExec: expr=[k@0 ASC], preserve_partitioning=[false]
-                  DataSourceExec: partitions=1, partition_sizes=[1]
-        ");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn distributed_sort_merge_join_unchanged_when_sides_too_large()
-    -> Result<(), BallistaError> {
-        // Flag ON but threshold tiny (1 byte) -> neither side qualifies, so the
-        // join stays a SortMergeJoinExec over sorted inputs.
-        let (ctx, options) = make_broadcast_test_ctx(1, 1, false, true)?;
+    async fn distributed_sort_merge_join_is_never_broadcast() -> Result<(), BallistaError>
+    {
+        // SMJ planned (prefer_hash_join=false). A SortMergeJoinExec is never a
+        // broadcast candidate, so it stays a SortMergeJoinExec over sorted
+        // inputs even though the small side is well under the threshold.
+        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, false)?;
 
         let df = ctx
             .sql("select count(*) from big join small on big.k = small.k")
@@ -1259,7 +1140,7 @@ order by
     -> Result<(), BallistaError> {
         use datafusion::physical_plan::joins::PartitionMode;
 
-        let (ctx, options) = make_broadcast_test_ctx(0, 1, true, false)?;
+        let (ctx, options) = make_broadcast_test_ctx(0, 1, true)?;
 
         let df = ctx
             .sql("select count(*) from big join small on big.k = small.k")
@@ -1320,8 +1201,7 @@ order by
         ];
 
         for sql in sqls {
-            let (ctx, options) =
-                make_broadcast_test_ctx(10 * 1024 * 1024, 1, true, false)?;
+            let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, true)?;
             let plan = ctx.sql(sql).await?.into_optimized_plan()?;
             let plan = ctx.state().create_physical_plan(&plan).await?;
 
@@ -1453,7 +1333,7 @@ order by
     {
         use datafusion::physical_plan::joins::PartitionMode;
 
-        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, true, false)?;
+        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, true)?;
 
         let df = ctx
             .sql("select * from small left join big on small.k = big.k")
@@ -1498,7 +1378,7 @@ order by
     {
         use datafusion::physical_plan::joins::PartitionMode;
 
-        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, false, false)?;
+        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024, 1, false)?;
 
         let df = ctx
             .sql("select count(*) from big join small on big.k = small.k")
@@ -1542,8 +1422,7 @@ order by
         // broadcast build stage has 3 input partitions and writes 3 shuffle
         // files. The broadcast UnresolvedShuffleExec must report
         // upstream_partition_count = 3.
-        let (ctx, options) =
-            make_broadcast_test_ctx(10 * 1024 * 1024 * 1024, 3, true, false)?;
+        let (ctx, options) = make_broadcast_test_ctx(10 * 1024 * 1024 * 1024, 3, true)?;
 
         let df = ctx
             .sql("select count(*) from big join small on big.k = small.k")
@@ -1836,7 +1715,6 @@ order by
         threshold_bytes: usize,
         small_partitions: usize,
         prefer_hash_join: bool,
-        smj_broadcast_enabled: bool,
     ) -> Result<
         (
             datafusion::prelude::SessionContext,
@@ -1889,11 +1767,7 @@ order by
                 "datafusion.optimizer.hash_join_single_partition_threshold",
                 0,
             )
-            .set_bool("datafusion.optimizer.prefer_hash_join", prefer_hash_join)
-            .set_bool(
-                "ballista.optimizer.broadcast_sort_merge_join_enabled",
-                smj_broadcast_enabled,
-            );
+            .set_bool("datafusion.optimizer.prefer_hash_join", prefer_hash_join);
         let ctx = datafusion::prelude::SessionContext::new_with_config(session_config);
         ctx.register_batch("big", big_batch)?;
 

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q10.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q10.txt
@@ -1,60 +1,57 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  StatsExec: rows=25
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([c_custkey@0], 16)
   StatsExec: rows=15000000
 
-=== Stage 4 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([o_custkey@1], 16)
   FilterExec: o_orderdate@2 >= 1993-10-01 AND o_orderdate@2 < 1994-01-01, projection=[o_orderkey@0, o_custkey@1]
     StatsExec: rows=150000000
 
-=== Stage 5 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([o_orderkey@7], 16)
   ProjectionExec: expr=[c_custkey@0 as c_custkey, c_name@1 as c_name, c_address@2 as c_address, c_nationkey@3 as c_nationkey, c_phone@4 as c_phone, c_acctbal@5 as c_acctbal, c_comment@6 as c_comment, o_orderkey@7 as o_orderkey]
     SortMergeJoinExec: join_type=Inner, on=[(c_custkey@0, o_custkey@1)]
       SortExec: expr=[c_custkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([c_custkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([c_custkey@0], 16)
       SortExec: expr=[o_custkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=4, partitioning: Hash([o_custkey@1], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([o_custkey@1], 16)
 
-=== Stage 6 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@0], 16)
   FilterExec: l_returnflag@3 = R, projection=[l_orderkey@0, l_extendedprice@1, l_discount@2]
     StatsExec: rows=600037902
 
-=== Stage 7 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([c_nationkey@3], 16)
   ProjectionExec: expr=[c_custkey@0 as c_custkey, c_name@1 as c_name, c_address@2 as c_address, c_nationkey@3 as c_nationkey, c_phone@4 as c_phone, c_acctbal@5 as c_acctbal, c_comment@6 as c_comment, l_extendedprice@9 as l_extendedprice, l_discount@10 as l_discount]
     SortMergeJoinExec: join_type=Inner, on=[(o_orderkey@7, l_orderkey@0)]
       SortExec: expr=[o_orderkey@7 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([o_orderkey@7], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([o_orderkey@7], 16)
       SortExec: expr=[l_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([l_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([l_orderkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 6 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  StatsExec: rows=25
+
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([c_custkey@0, c_name@1, c_acctbal@2, c_phone@3, n_name@4, c_address@5, c_comment@6], 16)
   AggregateExec: mode=Partial, gby=[c_custkey@0 as c_custkey, c_name@1 as c_name, c_acctbal@4 as c_acctbal, c_phone@3 as c_phone, n_name@8 as n_name, c_address@2 as c_address, c_comment@5 as c_comment], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
     ProjectionExec: expr=[c_custkey@0 as c_custkey, c_name@1 as c_name, c_address@2 as c_address, c_phone@4 as c_phone, c_acctbal@5 as c_acctbal, c_comment@6 as c_comment, l_extendedprice@7 as l_extendedprice, l_discount@8 as l_discount, n_name@10 as n_name]
-      ProjectionExec: expr=[c_custkey@2 as c_custkey, c_name@3 as c_name, c_address@4 as c_address, c_nationkey@5 as c_nationkey, c_phone@6 as c_phone, c_acctbal@7 as c_acctbal, c_comment@8 as c_comment, l_extendedprice@9 as l_extendedprice, l_discount@10 as l_discount, n_nationkey@0 as n_nationkey, n_name@1 as n_name]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, c_nationkey@3)]
-          UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=7, partitioning: Hash([c_nationkey@3], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(c_nationkey@3, n_nationkey@0)]
+        SortExec: expr=[c_nationkey@3 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=5, partitioning: Hash([c_nationkey@3], 16)
+        SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=6, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 9 ===
+=== Stage 8 ===
 ShuffleWriterExec: partitioning: None
   SortExec: TopK(fetch=20), expr=[revenue@2 DESC], preserve_partitioning=[true]
     ProjectionExec: expr=[c_custkey@0 as c_custkey, c_name@1 as c_name, sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)@7 as revenue, c_acctbal@2 as c_acctbal, n_name@4 as n_name, c_address@5 as c_address, c_phone@3 as c_phone, c_comment@6 as c_comment]
       AggregateExec: mode=FinalPartitioned, gby=[c_custkey@0 as c_custkey, c_name@1 as c_name, c_acctbal@2 as c_acctbal, c_phone@3 as c_phone, n_name@4 as n_name, c_address@5 as c_address, c_comment@6 as c_comment], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
-        UnresolvedShuffleExec: stage=8, partitioning: Hash([c_custkey@0, c_name@1, c_acctbal@2, c_phone@3, n_name@4, c_address@5, c_comment@6], 16)
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([c_custkey@0, c_name@1, c_acctbal@2, c_phone@3, n_name@4, c_address@5, c_comment@6], 16)
 
-=== Stage 10 ===
+=== Stage 9 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [revenue@2 DESC], fetch=20
-    UnresolvedShuffleExec: stage=9, partitioning: Hash([c_custkey@0, c_name@1, c_acctbal@3, c_phone@6, n_name@4, c_address@5, c_comment@7], 16)
+    UnresolvedShuffleExec: stage=8, partitioning: Hash([c_custkey@0, c_name@1, c_acctbal@3, c_phone@6, n_name@4, c_address@5, c_comment@7], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q11.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q11.txt
@@ -1,74 +1,68 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  FilterExec: n_name@1 = GERMANY, projection=[n_nationkey@0]
-    StatsExec: rows=25
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@0], 16)
   StatsExec: rows=80000000
 
-=== Stage 4 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 5 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@2], 16)
   ProjectionExec: expr=[ps_availqty@1 as ps_availqty, ps_supplycost@2 as ps_supplycost, s_nationkey@4 as s_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(ps_suppkey@0, s_suppkey@0)]
       SortExec: expr=[ps_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([ps_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([ps_suppkey@0], 16)
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=4, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 6 ===
-ShuffleWriterExec: partitioning: None
-  AggregateExec: mode=Partial, gby=[], aggr=[sum(partsupp.ps_supplycost * partsupp.ps_availqty)]
-    ProjectionExec: expr=[ps_availqty@0 as ps_availqty, ps_supplycost@1 as ps_supplycost]
-      ProjectionExec: expr=[ps_availqty@1 as ps_availqty, ps_supplycost@2 as ps_supplycost, s_nationkey@3 as s_nationkey, n_nationkey@0 as n_nationkey]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@2)]
-          UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=5, partitioning: Hash([s_nationkey@2], 16)
-
-=== Stage 7 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
   FilterExec: n_name@1 = GERMANY, projection=[n_nationkey@0]
     StatsExec: rows=25
 
-=== Stage 8 ===
+=== Stage 5 ===
 ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=7, partitioning: Hash([n_nationkey@0], 16)
+  AggregateExec: mode=Partial, gby=[], aggr=[sum(partsupp.ps_supplycost * partsupp.ps_availqty)]
+    ProjectionExec: expr=[ps_availqty@0 as ps_availqty, ps_supplycost@1 as ps_supplycost]
+      SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@2, n_nationkey@0)]
+        SortExec: expr=[s_nationkey@2 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=3, partitioning: Hash([s_nationkey@2], 16)
+        SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=4, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 9 ===
+=== Stage 6 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@1], 16)
   StatsExec: rows=80000000
 
-=== Stage 10 ===
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 11 ===
+=== Stage 8 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@3], 16)
   ProjectionExec: expr=[ps_partkey@0 as ps_partkey, ps_availqty@2 as ps_availqty, ps_supplycost@3 as ps_supplycost, s_nationkey@5 as s_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(ps_suppkey@1, s_suppkey@0)]
       SortExec: expr=[ps_suppkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=9, partitioning: Hash([ps_suppkey@1], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([ps_suppkey@1], 16)
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=10, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 12 ===
+=== Stage 9 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  FilterExec: n_name@1 = GERMANY, projection=[n_nationkey@0]
+    StatsExec: rows=25
+
+=== Stage 10 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@0], 16)
   AggregateExec: mode=Partial, gby=[ps_partkey@0 as ps_partkey], aggr=[sum(partsupp.ps_supplycost * partsupp.ps_availqty)]
     ProjectionExec: expr=[ps_partkey@0 as ps_partkey, ps_availqty@1 as ps_availqty, ps_supplycost@2 as ps_supplycost]
-      ProjectionExec: expr=[ps_partkey@1 as ps_partkey, ps_availqty@2 as ps_availqty, ps_supplycost@3 as ps_supplycost, s_nationkey@4 as s_nationkey, n_nationkey@0 as n_nationkey]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@3)]
-          UnresolvedShuffleExec: stage=8, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=11, partitioning: Hash([s_nationkey@3], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@3, n_nationkey@0)]
+        SortExec: expr=[s_nationkey@3 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=8, partitioning: Hash([s_nationkey@3], 16)
+        SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=9, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 13 ===
+=== Stage 11 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[value@1 DESC], preserve_partitioning=[true]
     ProjectionExec: expr=[ps_partkey@1 as ps_partkey, sum(partsupp.ps_supplycost * partsupp.ps_availqty)@2 as value]
@@ -76,12 +70,12 @@ ShuffleWriterExec: partitioning: None
         ProjectionExec: expr=[CAST(CAST(sum(partsupp.ps_supplycost * partsupp.ps_availqty)@0 AS Float64) * 0.0001 AS Decimal128(38, 15)) as sum(partsupp.ps_supplycost * partsupp.ps_availqty) * Float64(0.0001)]
           AggregateExec: mode=Final, gby=[], aggr=[sum(partsupp.ps_supplycost * partsupp.ps_availqty)]
             CoalescePartitionsExec
-              UnresolvedShuffleExec: stage=6, partitioning: Hash([s_nationkey@2], 16)
+              UnresolvedShuffleExec: stage=5, partitioning: Hash([n_nationkey@3], 16)
         ProjectionExec: expr=[ps_partkey@0 as ps_partkey, sum(partsupp.ps_supplycost * partsupp.ps_availqty)@1 as sum(partsupp.ps_supplycost * partsupp.ps_availqty), CAST(sum(partsupp.ps_supplycost * partsupp.ps_availqty)@1 AS Decimal128(38, 15)) as join_proj_push_down_1]
           AggregateExec: mode=FinalPartitioned, gby=[ps_partkey@0 as ps_partkey], aggr=[sum(partsupp.ps_supplycost * partsupp.ps_availqty)]
-            UnresolvedShuffleExec: stage=12, partitioning: Hash([ps_partkey@0], 16)
+            UnresolvedShuffleExec: stage=10, partitioning: Hash([ps_partkey@0], 16)
 
-=== Stage 14 ===
+=== Stage 12 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [value@1 DESC]
-    UnresolvedShuffleExec: stage=13, partitioning: Hash([ps_partkey@0], 16)
+    UnresolvedShuffleExec: stage=11, partitioning: Hash([ps_partkey@0], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q15.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q15.txt
@@ -1,57 +1,53 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([l_suppkey@0], 16)
-  AggregateExec: mode=Partial, gby=[l_suppkey@0 as l_suppkey], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
-    FilterExec: l_shipdate@3 >= 1996-01-01 AND l_shipdate@3 < 1996-04-01, projection=[l_suppkey@0, l_extendedprice@1, l_discount@2]
-      StatsExec: rows=600037902
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  AggregateExec: mode=Partial, gby=[], aggr=[max(revenue0.total_revenue)]
-    ProjectionExec: expr=[sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)@1 as total_revenue]
-      AggregateExec: mode=FinalPartitioned, gby=[l_suppkey@0 as l_suppkey], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
-        UnresolvedShuffleExec: stage=1, partitioning: Hash([l_suppkey@0], 16)
-
-=== Stage 3 ===
-SortShuffleWriterExec: partitioning=Hash([max(revenue0.total_revenue)@0], 16)
-  AggregateExec: mode=Final, gby=[], aggr=[max(revenue0.total_revenue)]
-    CoalescePartitionsExec
-      UnresolvedShuffleExec: stage=2, partitioning: Hash([l_suppkey@0], 16)
-
-=== Stage 4 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=3, partitioning: Hash([max(revenue0.total_revenue)@0], 16)
-
-=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 6 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@0], 16)
   AggregateExec: mode=Partial, gby=[l_suppkey@0 as l_suppkey], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
     FilterExec: l_shipdate@3 >= 1996-01-01 AND l_shipdate@3 < 1996-04-01, projection=[l_suppkey@0, l_extendedprice@1, l_discount@2]
       StatsExec: rows=600037902
 
-=== Stage 7 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([total_revenue@4], 16)
   ProjectionExec: expr=[s_suppkey@0 as s_suppkey, s_name@1 as s_name, s_address@2 as s_address, s_phone@3 as s_phone, total_revenue@5 as total_revenue]
     SortMergeJoinExec: join_type=Inner, on=[(s_suppkey@0, supplier_no@0)]
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([s_suppkey@0], 16)
       SortExec: expr=[supplier_no@0 ASC], preserve_partitioning=[true]
         ProjectionExec: expr=[l_suppkey@0 as supplier_no, sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)@1 as total_revenue]
           AggregateExec: mode=FinalPartitioned, gby=[l_suppkey@0 as l_suppkey], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
-            UnresolvedShuffleExec: stage=6, partitioning: Hash([l_suppkey@0], 16)
+            UnresolvedShuffleExec: stage=2, partitioning: Hash([l_suppkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 4 ===
+SortShuffleWriterExec: partitioning=Hash([l_suppkey@0], 16)
+  AggregateExec: mode=Partial, gby=[l_suppkey@0 as l_suppkey], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
+    FilterExec: l_shipdate@3 >= 1996-01-01 AND l_shipdate@3 < 1996-04-01, projection=[l_suppkey@0, l_extendedprice@1, l_discount@2]
+      StatsExec: rows=600037902
+
+=== Stage 5 ===
+ShuffleWriterExec: partitioning: None
+  AggregateExec: mode=Partial, gby=[], aggr=[max(revenue0.total_revenue)]
+    ProjectionExec: expr=[sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)@1 as total_revenue]
+      AggregateExec: mode=FinalPartitioned, gby=[l_suppkey@0 as l_suppkey], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([l_suppkey@0], 16)
+
+=== Stage 6 ===
+SortShuffleWriterExec: partitioning=Hash([max(revenue0.total_revenue)@0], 16)
+  AggregateExec: mode=Final, gby=[], aggr=[max(revenue0.total_revenue)]
+    CoalescePartitionsExec
+      UnresolvedShuffleExec: stage=5, partitioning: Hash([l_suppkey@0], 16)
+
+=== Stage 7 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[s_suppkey@0 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[s_suppkey@0 as s_suppkey, s_name@1 as s_name, s_address@2 as s_address, s_phone@3 as s_phone, total_revenue@4 as total_revenue]
-      ProjectionExec: expr=[s_suppkey@1 as s_suppkey, s_name@2 as s_name, s_address@3 as s_address, s_phone@4 as s_phone, total_revenue@5 as total_revenue, max(revenue0.total_revenue)@0 as max(revenue0.total_revenue)]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(max(revenue0.total_revenue)@0, total_revenue@4)]
-          UnresolvedShuffleExec: stage=4, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=7, partitioning: Hash([total_revenue@4], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(total_revenue@4, max(revenue0.total_revenue)@0)]
+        SortExec: expr=[total_revenue@4 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=3, partitioning: Hash([total_revenue@4], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([max(revenue0.total_revenue)@0], 16)
 
-=== Stage 9 ===
+=== Stage 8 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [s_suppkey@0 ASC NULLS LAST]
-    UnresolvedShuffleExec: stage=8, partitioning: Hash([total_revenue@4], 16)
+    UnresolvedShuffleExec: stage=7, partitioning: Hash([total_revenue@4], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q16.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q16.txt
@@ -1,46 +1,44 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
-  FilterExec: s_comment@1 LIKE %Customer%Complaints%, projection=[s_suppkey@0]
-    StatsExec: rows=1000000
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([s_suppkey@0], 16)
-
-=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@0], 16)
   StatsExec: rows=80000000
 
-=== Stage 4 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([p_partkey@0], 16)
   FilterExec: p_brand@1 != Brand#45 AND p_type@2 NOT LIKE MEDIUM POLISHED% AND p_size@3 IN (SET) ([49, 14, 23, 45, 19, 3, 36, 9])
     StatsExec: rows=20000000
 
-=== Stage 5 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@0], 16)
   ProjectionExec: expr=[ps_suppkey@1 as ps_suppkey, p_brand@3 as p_brand, p_type@4 as p_type, p_size@5 as p_size]
     SortMergeJoinExec: join_type=Inner, on=[(ps_partkey@0, p_partkey@0)]
       SortExec: expr=[ps_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([ps_partkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([ps_partkey@0], 16)
       SortExec: expr=[p_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=4, partitioning: Hash([p_partkey@0], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([p_partkey@0], 16)
 
-=== Stage 6 ===
+=== Stage 4 ===
+SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
+  FilterExec: s_comment@1 LIKE %Customer%Complaints%, projection=[s_suppkey@0]
+    StatsExec: rows=1000000
+
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([p_brand@0, p_type@1, p_size@2], 16)
   AggregateExec: mode=Partial, gby=[p_brand@0 as p_brand, p_type@1 as p_type, p_size@2 as p_size], aggr=[count(alias1)]
-    AggregateExec: mode=SinglePartitioned, gby=[p_brand@1 as p_brand, p_type@2 as p_type, p_size@3 as p_size, ps_suppkey@0 as alias1], aggr=[]
-      HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(s_suppkey@0, ps_suppkey@0)]
-        UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([ps_suppkey@0], 16)
+    AggregateExec: mode=SinglePartitioned, gby=[p_brand@1 as p_brand, p_type@2 as p_type, p_size@3 as p_size, ps_suppkey@0 as alias1], aggr=[], ordering_mode=PartiallySorted([3])
+      SortMergeJoinExec: join_type=LeftAnti, on=[(ps_suppkey@0, s_suppkey@0)]
+        SortExec: expr=[ps_suppkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=3, partitioning: Hash([ps_suppkey@0], 16)
+        SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=4, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 7 ===
+=== Stage 6 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[supplier_cnt@3 DESC, p_brand@0 ASC NULLS LAST, p_type@1 ASC NULLS LAST, p_size@2 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[p_brand@0 as p_brand, p_type@1 as p_type, p_size@2 as p_size, count(alias1)@3 as supplier_cnt]
       AggregateExec: mode=FinalPartitioned, gby=[p_brand@0 as p_brand, p_type@1 as p_type, p_size@2 as p_size], aggr=[count(alias1)]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([p_brand@0, p_type@1, p_size@2], 16)
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([p_brand@0, p_type@1, p_size@2], 16)
 
-=== Stage 8 ===
+=== Stage 7 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [supplier_cnt@3 DESC, p_brand@0 ASC NULLS LAST, p_type@1 ASC NULLS LAST, p_size@2 ASC NULLS LAST]
-    UnresolvedShuffleExec: stage=7, partitioning: Hash([p_brand@0, p_type@1, p_size@2], 16)
+    UnresolvedShuffleExec: stage=6, partitioning: Hash([p_brand@0, p_type@1, p_size@2], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q2.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q2.txt
@@ -1,137 +1,123 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
-  FilterExec: r_name@1 = EUROPE, projection=[r_regionkey@0]
-    StatsExec: rows=5
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([r_regionkey@0], 16)
-
-=== Stage 3 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  StatsExec: rows=25
-
-=== Stage 4 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=3, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([p_partkey@0], 16)
   FilterExec: p_size@3 = 15 AND p_type@2 LIKE %BRASS, projection=[p_partkey@0, p_mfgr@1]
     StatsExec: rows=20000000
 
-=== Stage 6 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@0], 16)
   StatsExec: rows=80000000
 
-=== Stage 7 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@2], 16)
   ProjectionExec: expr=[p_partkey@0 as p_partkey, p_mfgr@1 as p_mfgr, ps_suppkey@3 as ps_suppkey, ps_supplycost@4 as ps_supplycost]
     SortMergeJoinExec: join_type=Inner, on=[(p_partkey@0, ps_partkey@0)]
       SortExec: expr=[p_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([p_partkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([p_partkey@0], 16)
       SortExec: expr=[ps_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([ps_partkey@0], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([ps_partkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 9 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@4], 16)
   ProjectionExec: expr=[p_partkey@0 as p_partkey, p_mfgr@1 as p_mfgr, s_name@5 as s_name, s_address@6 as s_address, s_nationkey@7 as s_nationkey, s_phone@8 as s_phone, s_acctbal@9 as s_acctbal, s_comment@10 as s_comment, ps_supplycost@3 as ps_supplycost]
     SortMergeJoinExec: join_type=Inner, on=[(ps_suppkey@2, s_suppkey@0)]
       SortExec: expr=[ps_suppkey@2 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([ps_suppkey@2], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([ps_suppkey@2], 16)
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=8, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 10 ===
+=== Stage 6 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  StatsExec: rows=25
+
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([n_regionkey@9], 16)
   ProjectionExec: expr=[p_partkey@0 as p_partkey, p_mfgr@1 as p_mfgr, s_name@2 as s_name, s_address@3 as s_address, s_phone@5 as s_phone, s_acctbal@6 as s_acctbal, s_comment@7 as s_comment, ps_supplycost@8 as ps_supplycost, n_name@10 as n_name, n_regionkey@11 as n_regionkey]
-    ProjectionExec: expr=[p_partkey@3 as p_partkey, p_mfgr@4 as p_mfgr, s_name@5 as s_name, s_address@6 as s_address, s_nationkey@7 as s_nationkey, s_phone@8 as s_phone, s_acctbal@9 as s_acctbal, s_comment@10 as s_comment, ps_supplycost@11 as ps_supplycost, n_nationkey@0 as n_nationkey, n_name@1 as n_name, n_regionkey@2 as n_regionkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@4)]
-        UnresolvedShuffleExec: stage=4, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=9, partitioning: Hash([s_nationkey@4], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@4, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@4 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([s_nationkey@4], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 11 ===
-SortShuffleWriterExec: partitioning=Hash([p_partkey@0, ps_supplycost@7], 16)
-  ProjectionExec: expr=[p_partkey@0 as p_partkey, p_mfgr@1 as p_mfgr, s_name@2 as s_name, s_address@3 as s_address, s_phone@4 as s_phone, s_acctbal@5 as s_acctbal, s_comment@6 as s_comment, ps_supplycost@7 as ps_supplycost, n_name@8 as n_name]
-    ProjectionExec: expr=[p_partkey@1 as p_partkey, p_mfgr@2 as p_mfgr, s_name@3 as s_name, s_address@4 as s_address, s_phone@5 as s_phone, s_acctbal@6 as s_acctbal, s_comment@7 as s_comment, ps_supplycost@8 as ps_supplycost, n_name@9 as n_name, n_regionkey@10 as n_regionkey, r_regionkey@0 as r_regionkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(r_regionkey@0, n_regionkey@9)]
-        UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=10, partitioning: Hash([n_regionkey@9], 16)
-
-=== Stage 12 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=11, partitioning: Hash([p_partkey@0, ps_supplycost@7], 16)
-
-=== Stage 13 ===
+=== Stage 8 ===
 SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
   FilterExec: r_name@1 = EUROPE, projection=[r_regionkey@0]
     StatsExec: rows=5
 
-=== Stage 14 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=13, partitioning: Hash([r_regionkey@0], 16)
+=== Stage 9 ===
+SortShuffleWriterExec: partitioning=Hash([p_partkey@0, ps_supplycost@7], 16)
+  ProjectionExec: expr=[p_partkey@0 as p_partkey, p_mfgr@1 as p_mfgr, s_name@2 as s_name, s_address@3 as s_address, s_phone@4 as s_phone, s_acctbal@5 as s_acctbal, s_comment@6 as s_comment, ps_supplycost@7 as ps_supplycost, n_name@8 as n_name]
+    SortMergeJoinExec: join_type=Inner, on=[(n_regionkey@9, r_regionkey@0)]
+      SortExec: expr=[n_regionkey@9 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([n_regionkey@9], 16)
+      SortExec: expr=[r_regionkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=8, partitioning: Hash([r_regionkey@0], 16)
 
-=== Stage 15 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  StatsExec: rows=25
-
-=== Stage 16 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=15, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 17 ===
+=== Stage 10 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@1], 16)
   StatsExec: rows=80000000
 
-=== Stage 18 ===
+=== Stage 11 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 19 ===
+=== Stage 12 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@2], 16)
   ProjectionExec: expr=[ps_partkey@0 as ps_partkey, ps_supplycost@2 as ps_supplycost, s_nationkey@4 as s_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(ps_suppkey@1, s_suppkey@0)]
       SortExec: expr=[ps_suppkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=17, partitioning: Hash([ps_suppkey@1], 16)
+        UnresolvedShuffleExec: stage=10, partitioning: Hash([ps_suppkey@1], 16)
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=18, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=11, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 20 ===
+=== Stage 13 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  StatsExec: rows=25
+
+=== Stage 14 ===
 SortShuffleWriterExec: partitioning=Hash([n_regionkey@2], 16)
   ProjectionExec: expr=[ps_partkey@0 as ps_partkey, ps_supplycost@1 as ps_supplycost, n_regionkey@4 as n_regionkey]
-    ProjectionExec: expr=[ps_partkey@2 as ps_partkey, ps_supplycost@3 as ps_supplycost, s_nationkey@4 as s_nationkey, n_nationkey@0 as n_nationkey, n_regionkey@1 as n_regionkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@2)]
-        UnresolvedShuffleExec: stage=16, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=19, partitioning: Hash([s_nationkey@2], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@2, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@2 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=12, partitioning: Hash([s_nationkey@2], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=13, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 21 ===
+=== Stage 15 ===
+SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
+  FilterExec: r_name@1 = EUROPE, projection=[r_regionkey@0]
+    StatsExec: rows=5
+
+=== Stage 16 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@0], 16)
   AggregateExec: mode=Partial, gby=[ps_partkey@0 as ps_partkey], aggr=[min(partsupp.ps_supplycost)]
     ProjectionExec: expr=[ps_partkey@0 as ps_partkey, ps_supplycost@1 as ps_supplycost]
-      ProjectionExec: expr=[ps_partkey@1 as ps_partkey, ps_supplycost@2 as ps_supplycost, n_regionkey@3 as n_regionkey, r_regionkey@0 as r_regionkey]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(r_regionkey@0, n_regionkey@2)]
-          UnresolvedShuffleExec: stage=14, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=20, partitioning: Hash([n_regionkey@2], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(n_regionkey@2, r_regionkey@0)]
+        SortExec: expr=[n_regionkey@2 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=14, partitioning: Hash([n_regionkey@2], 16)
+        SortExec: expr=[r_regionkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=15, partitioning: Hash([r_regionkey@0], 16)
 
-=== Stage 22 ===
+=== Stage 17 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@1, min(partsupp.ps_supplycost)@0], 16)
   ProjectionExec: expr=[min(partsupp.ps_supplycost)@1 as min(partsupp.ps_supplycost), ps_partkey@0 as ps_partkey]
     AggregateExec: mode=FinalPartitioned, gby=[ps_partkey@0 as ps_partkey], aggr=[min(partsupp.ps_supplycost)]
-      UnresolvedShuffleExec: stage=21, partitioning: Hash([ps_partkey@0], 16)
+      UnresolvedShuffleExec: stage=16, partitioning: Hash([ps_partkey@0], 16)
 
-=== Stage 23 ===
+=== Stage 18 ===
 ShuffleWriterExec: partitioning: None
   SortExec: TopK(fetch=100), expr=[s_acctbal@0 DESC, n_name@2 ASC NULLS LAST, s_name@1 ASC NULLS LAST, p_partkey@3 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[s_acctbal@5 as s_acctbal, s_name@2 as s_name, n_name@8 as n_name, p_partkey@0 as p_partkey, p_mfgr@1 as p_mfgr, s_address@3 as s_address, s_phone@4 as s_phone, s_comment@6 as s_comment]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(p_partkey@0, ps_partkey@1), (ps_supplycost@7, min(partsupp.ps_supplycost)@0)]
-        UnresolvedShuffleExec: stage=12, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=22, partitioning: Hash([ps_partkey@1, min(partsupp.ps_supplycost)@0], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(p_partkey@0, ps_partkey@1), (ps_supplycost@7, min(partsupp.ps_supplycost)@0)]
+        SortExec: expr=[p_partkey@0 ASC, ps_supplycost@7 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=9, partitioning: Hash([p_partkey@0, ps_supplycost@7], 16)
+        SortExec: expr=[ps_partkey@1 ASC, min(partsupp.ps_supplycost)@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=17, partitioning: Hash([ps_partkey@1, min(partsupp.ps_supplycost)@0], 16)
 
-=== Stage 24 ===
+=== Stage 19 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [s_acctbal@0 DESC, n_name@2 ASC NULLS LAST, s_name@1 ASC NULLS LAST, p_partkey@3 ASC NULLS LAST], fetch=100
-    UnresolvedShuffleExec: stage=23, partitioning: Hash([p_partkey@3, min(partsupp.ps_supplycost)@9], 16)
+    UnresolvedShuffleExec: stage=18, partitioning: Hash([p_partkey@3, min(partsupp.ps_supplycost)@9], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q20.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q20.txt
@@ -1,69 +1,66 @@
 === Stage 1 ===
+SortShuffleWriterExec: partitioning=Hash([s_nationkey@3], 16)
+  StatsExec: rows=1000000
+
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
   FilterExec: n_name@1 = CANADA, projection=[n_nationkey@0]
     StatsExec: rows=25
 
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([n_nationkey@0], 16)
-
 === Stage 3 ===
-SortShuffleWriterExec: partitioning=Hash([s_nationkey@3], 16)
-  StatsExec: rows=1000000
-
-=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   ProjectionExec: expr=[s_suppkey@0 as s_suppkey, s_name@1 as s_name, s_address@2 as s_address]
-    ProjectionExec: expr=[s_suppkey@1 as s_suppkey, s_name@2 as s_name, s_address@3 as s_address, s_nationkey@4 as s_nationkey, n_nationkey@0 as n_nationkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@3)]
-        UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([s_nationkey@3], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@3, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@3 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([s_nationkey@3], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 5 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@0], 16)
   StatsExec: rows=80000000
 
-=== Stage 6 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([p_partkey@0], 16)
   FilterExec: p_name@1 LIKE forest%, projection=[p_partkey@0]
     StatsExec: rows=20000000
 
-=== Stage 7 ===
+=== Stage 6 ===
 SortShuffleWriterExec: partitioning=Hash([ps_partkey@0, ps_suppkey@1], 16)
   SortMergeJoinExec: join_type=LeftSemi, on=[(ps_partkey@0, p_partkey@0)]
     SortExec: expr=[ps_partkey@0 ASC], preserve_partitioning=[true]
-      UnresolvedShuffleExec: stage=5, partitioning: Hash([ps_partkey@0], 16)
+      UnresolvedShuffleExec: stage=4, partitioning: Hash([ps_partkey@0], 16)
     SortExec: expr=[p_partkey@0 ASC], preserve_partitioning=[true]
-      UnresolvedShuffleExec: stage=6, partitioning: Hash([p_partkey@0], 16)
+      UnresolvedShuffleExec: stage=5, partitioning: Hash([p_partkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([l_partkey@0, l_suppkey@1], 16)
   AggregateExec: mode=Partial, gby=[l_partkey@0 as l_partkey, l_suppkey@1 as l_suppkey], aggr=[sum(lineitem.l_quantity)]
     FilterExec: l_shipdate@3 >= 1994-01-01 AND l_shipdate@3 < 1995-01-01, projection=[l_partkey@0, l_suppkey@1, l_quantity@2]
       StatsExec: rows=600037902
 
-=== Stage 9 ===
+=== Stage 8 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@0], 16)
   ProjectionExec: expr=[ps_suppkey@1 as ps_suppkey]
     SortMergeJoinExec: join_type=Inner, on=[(ps_partkey@0, l_partkey@1), (ps_suppkey@1, l_suppkey@2)], filter=CAST(ps_availqty@0 AS Float64) > Float64(0.5) * sum(lineitem.l_quantity)@1
       SortExec: expr=[ps_partkey@0 ASC, ps_suppkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([ps_partkey@0, ps_suppkey@1], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([ps_partkey@0, ps_suppkey@1], 16)
       SortExec: expr=[l_partkey@1 ASC, l_suppkey@2 ASC], preserve_partitioning=[true]
         ProjectionExec: expr=[0.5 * CAST(sum(lineitem.l_quantity)@2 AS Float64) as Float64(0.5) * sum(lineitem.l_quantity), l_partkey@0 as l_partkey, l_suppkey@1 as l_suppkey]
           AggregateExec: mode=FinalPartitioned, gby=[l_partkey@0 as l_partkey, l_suppkey@1 as l_suppkey], aggr=[sum(lineitem.l_quantity)]
-            UnresolvedShuffleExec: stage=8, partitioning: Hash([l_partkey@0, l_suppkey@1], 16)
+            UnresolvedShuffleExec: stage=7, partitioning: Hash([l_partkey@0, l_suppkey@1], 16)
 
-=== Stage 10 ===
+=== Stage 9 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[s_name@0 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[s_name@1 as s_name, s_address@2 as s_address]
       SortMergeJoinExec: join_type=LeftSemi, on=[(s_suppkey@0, ps_suppkey@0)]
         SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-          UnresolvedShuffleExec: stage=4, partitioning: Hash([s_suppkey@0], 16)
+          UnresolvedShuffleExec: stage=3, partitioning: Hash([s_suppkey@0], 16)
         SortExec: expr=[ps_suppkey@0 ASC], preserve_partitioning=[true]
-          UnresolvedShuffleExec: stage=9, partitioning: Hash([ps_suppkey@0], 16)
+          UnresolvedShuffleExec: stage=8, partitioning: Hash([ps_suppkey@0], 16)
 
-=== Stage 11 ===
+=== Stage 10 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [s_name@0 ASC NULLS LAST]
-    UnresolvedShuffleExec: stage=10, partitioning: Hash([s_suppkey@0], 16)
+    UnresolvedShuffleExec: stage=9, partitioning: Hash([s_suppkey@0], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q21.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q21.txt
@@ -1,82 +1,79 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  FilterExec: n_name@1 = SAUDI ARABIA, projection=[n_nationkey@0]
-    StatsExec: rows=25
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 4 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@1], 16)
   FilterExec: l_receiptdate@3 > l_commitdate@2, projection=[l_orderkey@0, l_suppkey@1]
     StatsExec: rows=600037902
 
-=== Stage 5 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@2], 16)
   ProjectionExec: expr=[s_name@1 as s_name, s_nationkey@2 as s_nationkey, l_orderkey@3 as l_orderkey, l_suppkey@4 as l_suppkey]
     SortMergeJoinExec: join_type=Inner, on=[(s_suppkey@0, l_suppkey@1)]
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([s_suppkey@0], 16)
       SortExec: expr=[l_suppkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=4, partitioning: Hash([l_suppkey@1], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([l_suppkey@1], 16)
 
-=== Stage 6 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([o_orderkey@0], 16)
   FilterExec: o_orderstatus@1 = F, projection=[o_orderkey@0]
     StatsExec: rows=150000000
 
-=== Stage 7 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@1], 16)
   ProjectionExec: expr=[s_name@0 as s_name, s_nationkey@1 as s_nationkey, l_orderkey@2 as l_orderkey, l_suppkey@3 as l_suppkey]
     SortMergeJoinExec: join_type=Inner, on=[(l_orderkey@2, o_orderkey@0)]
       SortExec: expr=[l_orderkey@2 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([l_orderkey@2], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([l_orderkey@2], 16)
       SortExec: expr=[o_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([o_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([o_orderkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 6 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  FilterExec: n_name@1 = SAUDI ARABIA, projection=[n_nationkey@0]
+    StatsExec: rows=25
+
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@1], 16)
   ProjectionExec: expr=[s_name@0 as s_name, l_orderkey@2 as l_orderkey, l_suppkey@3 as l_suppkey]
-    ProjectionExec: expr=[s_name@1 as s_name, s_nationkey@2 as s_nationkey, l_orderkey@3 as l_orderkey, l_suppkey@4 as l_suppkey, n_nationkey@0 as n_nationkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@1)]
-        UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([s_nationkey@1], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@1, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@1 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([s_nationkey@1], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 9 ===
+=== Stage 8 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@0], 16)
   StatsExec: rows=600037902
 
-=== Stage 10 ===
+=== Stage 9 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@0], 16)
   FilterExec: l_receiptdate@3 > l_commitdate@2, projection=[l_orderkey@0, l_suppkey@1]
     StatsExec: rows=600037902
 
-=== Stage 11 ===
+=== Stage 10 ===
 SortShuffleWriterExec: partitioning=Hash([s_name@0], 16)
   AggregateExec: mode=Partial, gby=[s_name@0 as s_name], aggr=[count(Int64(1))]
     ProjectionExec: expr=[s_name@0 as s_name]
       SortMergeJoinExec: join_type=LeftAnti, on=[(l_orderkey@1, l_orderkey@0)], filter=l_suppkey@1 != l_suppkey@0
         SortMergeJoinExec: join_type=LeftSemi, on=[(l_orderkey@1, l_orderkey@0)], filter=l_suppkey@1 != l_suppkey@0
           SortExec: expr=[l_orderkey@1 ASC], preserve_partitioning=[true]
-            UnresolvedShuffleExec: stage=8, partitioning: Hash([l_orderkey@1], 16)
+            UnresolvedShuffleExec: stage=7, partitioning: Hash([l_orderkey@1], 16)
           SortExec: expr=[l_orderkey@0 ASC], preserve_partitioning=[true]
-            UnresolvedShuffleExec: stage=9, partitioning: Hash([l_orderkey@0], 16)
+            UnresolvedShuffleExec: stage=8, partitioning: Hash([l_orderkey@0], 16)
         SortExec: expr=[l_orderkey@0 ASC], preserve_partitioning=[true]
-          UnresolvedShuffleExec: stage=10, partitioning: Hash([l_orderkey@0], 16)
+          UnresolvedShuffleExec: stage=9, partitioning: Hash([l_orderkey@0], 16)
 
-=== Stage 12 ===
+=== Stage 11 ===
 ShuffleWriterExec: partitioning: None
   SortExec: TopK(fetch=100), expr=[numwait@1 DESC, s_name@0 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[s_name@0 as s_name, count(Int64(1))@1 as numwait]
       AggregateExec: mode=FinalPartitioned, gby=[s_name@0 as s_name], aggr=[count(Int64(1))]
-        UnresolvedShuffleExec: stage=11, partitioning: Hash([s_name@0], 16)
+        UnresolvedShuffleExec: stage=10, partitioning: Hash([s_name@0], 16)
 
-=== Stage 13 ===
+=== Stage 12 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [numwait@1 DESC, s_name@0 ASC NULLS LAST], fetch=100
-    UnresolvedShuffleExec: stage=12, partitioning: Hash([s_name@0], 16)
+    UnresolvedShuffleExec: stage=11, partitioning: Hash([s_name@0], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q5.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q5.txt
@@ -1,89 +1,83 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
-  FilterExec: r_name@1 = ASIA, projection=[r_regionkey@0]
-    StatsExec: rows=5
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([r_regionkey@0], 16)
-
-=== Stage 3 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  StatsExec: rows=25
-
-=== Stage 4 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=3, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([c_custkey@0], 16)
   StatsExec: rows=15000000
 
-=== Stage 6 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([o_custkey@1], 16)
   FilterExec: o_orderdate@2 >= 1994-01-01 AND o_orderdate@2 < 1995-01-01, projection=[o_orderkey@0, o_custkey@1]
     StatsExec: rows=150000000
 
-=== Stage 7 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([o_orderkey@1], 16)
   ProjectionExec: expr=[c_nationkey@1 as c_nationkey, o_orderkey@2 as o_orderkey]
     SortMergeJoinExec: join_type=Inner, on=[(c_custkey@0, o_custkey@1)]
       SortExec: expr=[c_custkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([c_custkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([c_custkey@0], 16)
       SortExec: expr=[o_custkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([o_custkey@1], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([o_custkey@1], 16)
 
-=== Stage 8 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@0], 16)
   StatsExec: rows=600037902
 
-=== Stage 9 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@1, c_nationkey@0], 16)
   ProjectionExec: expr=[c_nationkey@0 as c_nationkey, l_suppkey@3 as l_suppkey, l_extendedprice@4 as l_extendedprice, l_discount@5 as l_discount]
     SortMergeJoinExec: join_type=Inner, on=[(o_orderkey@1, l_orderkey@0)]
       SortExec: expr=[o_orderkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([o_orderkey@1], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([o_orderkey@1], 16)
       SortExec: expr=[l_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=8, partitioning: Hash([l_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([l_orderkey@0], 16)
 
-=== Stage 10 ===
+=== Stage 6 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0, s_nationkey@1], 16)
   StatsExec: rows=1000000
 
-=== Stage 11 ===
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@2], 16)
   ProjectionExec: expr=[l_extendedprice@2 as l_extendedprice, l_discount@3 as l_discount, s_nationkey@5 as s_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(l_suppkey@1, s_suppkey@0), (c_nationkey@0, s_nationkey@1)]
       SortExec: expr=[l_suppkey@1 ASC, c_nationkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=9, partitioning: Hash([l_suppkey@1, c_nationkey@0], 16)
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([l_suppkey@1, c_nationkey@0], 16)
       SortExec: expr=[s_suppkey@0 ASC, s_nationkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=10, partitioning: Hash([s_suppkey@0, s_nationkey@1], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([s_suppkey@0, s_nationkey@1], 16)
 
-=== Stage 12 ===
+=== Stage 8 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  StatsExec: rows=25
+
+=== Stage 9 ===
 SortShuffleWriterExec: partitioning=Hash([n_regionkey@3], 16)
   ProjectionExec: expr=[l_extendedprice@0 as l_extendedprice, l_discount@1 as l_discount, n_name@4 as n_name, n_regionkey@5 as n_regionkey]
-    ProjectionExec: expr=[l_extendedprice@3 as l_extendedprice, l_discount@4 as l_discount, s_nationkey@5 as s_nationkey, n_nationkey@0 as n_nationkey, n_name@1 as n_name, n_regionkey@2 as n_regionkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@2)]
-        UnresolvedShuffleExec: stage=4, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=11, partitioning: Hash([s_nationkey@2], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@2, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@2 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([s_nationkey@2], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=8, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 13 ===
+=== Stage 10 ===
+SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
+  FilterExec: r_name@1 = ASIA, projection=[r_regionkey@0]
+    StatsExec: rows=5
+
+=== Stage 11 ===
 SortShuffleWriterExec: partitioning=Hash([n_name@0], 16)
   AggregateExec: mode=Partial, gby=[n_name@2 as n_name], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
     ProjectionExec: expr=[l_extendedprice@0 as l_extendedprice, l_discount@1 as l_discount, n_name@2 as n_name]
-      ProjectionExec: expr=[l_extendedprice@1 as l_extendedprice, l_discount@2 as l_discount, n_name@3 as n_name, n_regionkey@4 as n_regionkey, r_regionkey@0 as r_regionkey]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(r_regionkey@0, n_regionkey@3)]
-          UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=12, partitioning: Hash([n_regionkey@3], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(n_regionkey@3, r_regionkey@0)]
+        SortExec: expr=[n_regionkey@3 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=9, partitioning: Hash([n_regionkey@3], 16)
+        SortExec: expr=[r_regionkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=10, partitioning: Hash([r_regionkey@0], 16)
 
-=== Stage 14 ===
+=== Stage 12 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[revenue@1 DESC], preserve_partitioning=[true]
     ProjectionExec: expr=[n_name@0 as n_name, sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)@1 as revenue]
       AggregateExec: mode=FinalPartitioned, gby=[n_name@0 as n_name], aggr=[sum(lineitem.l_extendedprice * Some(1),20,0 - lineitem.l_discount) as sum(lineitem.l_extendedprice * Int64(1) - lineitem.l_discount)]
-        UnresolvedShuffleExec: stage=13, partitioning: Hash([n_name@0], 16)
+        UnresolvedShuffleExec: stage=11, partitioning: Hash([n_name@0], 16)
 
-=== Stage 15 ===
+=== Stage 13 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [revenue@1 DESC]
-    UnresolvedShuffleExec: stage=14, partitioning: Hash([n_name@0], 16)
+    UnresolvedShuffleExec: stage=12, partitioning: Hash([n_name@0], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q7.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q7.txt
@@ -1,89 +1,84 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  FilterExec: n_name@1 = FRANCE OR n_name@1 = GERMANY
-    StatsExec: rows=25
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 4 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@1], 16)
   FilterExec: l_shipdate@4 >= 1995-01-01 AND l_shipdate@4 <= 1996-12-31
     StatsExec: rows=600037902
 
-=== Stage 5 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@1], 16)
   ProjectionExec: expr=[s_nationkey@1 as s_nationkey, l_orderkey@2 as l_orderkey, l_extendedprice@4 as l_extendedprice, l_discount@5 as l_discount, l_shipdate@6 as l_shipdate]
     SortMergeJoinExec: join_type=Inner, on=[(s_suppkey@0, l_suppkey@1)]
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([s_suppkey@0], 16)
       SortExec: expr=[l_suppkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=4, partitioning: Hash([l_suppkey@1], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([l_suppkey@1], 16)
 
-=== Stage 6 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([o_orderkey@0], 16)
   StatsExec: rows=150000000
 
-=== Stage 7 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([o_custkey@4], 16)
   ProjectionExec: expr=[s_nationkey@0 as s_nationkey, l_extendedprice@2 as l_extendedprice, l_discount@3 as l_discount, l_shipdate@4 as l_shipdate, o_custkey@6 as o_custkey]
     SortMergeJoinExec: join_type=Inner, on=[(l_orderkey@1, o_orderkey@0)]
       SortExec: expr=[l_orderkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([l_orderkey@1], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([l_orderkey@1], 16)
       SortExec: expr=[o_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([o_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([o_orderkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 6 ===
 SortShuffleWriterExec: partitioning=Hash([c_custkey@0], 16)
   StatsExec: rows=15000000
 
-=== Stage 9 ===
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@0], 16)
   ProjectionExec: expr=[s_nationkey@0 as s_nationkey, l_extendedprice@1 as l_extendedprice, l_discount@2 as l_discount, l_shipdate@3 as l_shipdate, c_nationkey@6 as c_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(o_custkey@4, c_custkey@0)]
       SortExec: expr=[o_custkey@4 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([o_custkey@4], 16)
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([o_custkey@4], 16)
       SortExec: expr=[c_custkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=8, partitioning: Hash([c_custkey@0], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([c_custkey@0], 16)
 
-=== Stage 10 ===
+=== Stage 8 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  FilterExec: n_name@1 = FRANCE OR n_name@1 = GERMANY
+    StatsExec: rows=25
+
+=== Stage 9 ===
 SortShuffleWriterExec: partitioning=Hash([c_nationkey@3], 16)
   ProjectionExec: expr=[l_extendedprice@1 as l_extendedprice, l_discount@2 as l_discount, l_shipdate@3 as l_shipdate, c_nationkey@4 as c_nationkey, n_name@6 as n_name]
-    ProjectionExec: expr=[s_nationkey@2 as s_nationkey, l_extendedprice@3 as l_extendedprice, l_discount@4 as l_discount, l_shipdate@5 as l_shipdate, c_nationkey@6 as c_nationkey, n_nationkey@0 as n_nationkey, n_name@1 as n_name]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@0)]
-        UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=9, partitioning: Hash([s_nationkey@0], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@0, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([s_nationkey@0], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=8, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 11 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=10, partitioning: Hash([c_nationkey@3], 16)
-
-=== Stage 12 ===
+=== Stage 10 ===
 SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
   FilterExec: n_name@1 = GERMANY OR n_name@1 = FRANCE
     StatsExec: rows=25
 
-=== Stage 13 ===
+=== Stage 11 ===
 SortShuffleWriterExec: partitioning=Hash([supp_nation@0, cust_nation@1, l_year@2], 16)
   AggregateExec: mode=Partial, gby=[supp_nation@0 as supp_nation, cust_nation@1 as cust_nation, l_year@2 as l_year], aggr=[sum(shipping.volume)]
     ProjectionExec: expr=[n_name@4 as supp_nation, n_name@6 as cust_nation, date_part(YEAR, l_shipdate@2) as l_year, l_extendedprice@0 * (Some(1),20,0 - l_discount@1) as volume]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(c_nationkey@3, n_nationkey@0)], filter=n_name@0 = FRANCE AND n_name@1 = GERMANY OR n_name@0 = GERMANY AND n_name@1 = FRANCE
-        UnresolvedShuffleExec: stage=11, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=12, partitioning: Hash([n_nationkey@0], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(c_nationkey@3, n_nationkey@0)], filter=n_name@0 = FRANCE AND n_name@1 = GERMANY OR n_name@0 = GERMANY AND n_name@1 = FRANCE
+        SortExec: expr=[c_nationkey@3 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=9, partitioning: Hash([c_nationkey@3], 16)
+        SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=10, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 14 ===
+=== Stage 12 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[supp_nation@0 ASC NULLS LAST, cust_nation@1 ASC NULLS LAST, l_year@2 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[supp_nation@0 as supp_nation, cust_nation@1 as cust_nation, l_year@2 as l_year, sum(shipping.volume)@3 as revenue]
       AggregateExec: mode=FinalPartitioned, gby=[supp_nation@0 as supp_nation, cust_nation@1 as cust_nation, l_year@2 as l_year], aggr=[sum(shipping.volume)]
-        UnresolvedShuffleExec: stage=13, partitioning: Hash([supp_nation@0, cust_nation@1, l_year@2], 16)
+        UnresolvedShuffleExec: stage=11, partitioning: Hash([supp_nation@0, cust_nation@1, l_year@2], 16)
 
-=== Stage 15 ===
+=== Stage 13 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [supp_nation@0 ASC NULLS LAST, cust_nation@1 ASC NULLS LAST, l_year@2 ASC NULLS LAST]
-    UnresolvedShuffleExec: stage=14, partitioning: Hash([supp_nation@0, cust_nation@1, l_year@2], 16)
+    UnresolvedShuffleExec: stage=12, partitioning: Hash([supp_nation@0, cust_nation@1, l_year@2], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q8.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q8.txt
@@ -1,118 +1,110 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
-  FilterExec: r_name@1 = AMERICA, projection=[r_regionkey@0]
-    StatsExec: rows=5
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([r_regionkey@0], 16)
-
-=== Stage 3 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  StatsExec: rows=25
-
-=== Stage 4 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=3, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([p_partkey@0], 16)
   FilterExec: p_type@1 = ECONOMY ANODIZED STEEL, projection=[p_partkey@0]
     StatsExec: rows=20000000
 
-=== Stage 6 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([l_partkey@1], 16)
   StatsExec: rows=600037902
 
-=== Stage 7 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@1], 16)
   ProjectionExec: expr=[l_orderkey@1 as l_orderkey, l_suppkey@3 as l_suppkey, l_extendedprice@4 as l_extendedprice, l_discount@5 as l_discount]
     SortMergeJoinExec: join_type=Inner, on=[(p_partkey@0, l_partkey@1)]
       SortExec: expr=[p_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([p_partkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([p_partkey@0], 16)
       SortExec: expr=[l_partkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([l_partkey@1], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([l_partkey@1], 16)
 
-=== Stage 8 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 9 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@0], 16)
   ProjectionExec: expr=[l_orderkey@0 as l_orderkey, l_extendedprice@2 as l_extendedprice, l_discount@3 as l_discount, s_nationkey@5 as s_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(l_suppkey@1, s_suppkey@0)]
       SortExec: expr=[l_suppkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([l_suppkey@1], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([l_suppkey@1], 16)
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=8, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 10 ===
+=== Stage 6 ===
 SortShuffleWriterExec: partitioning=Hash([o_orderkey@0], 16)
   FilterExec: o_orderdate@2 >= 1995-01-01 AND o_orderdate@2 <= 1996-12-31
     StatsExec: rows=150000000
 
-=== Stage 11 ===
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([o_custkey@3], 16)
   ProjectionExec: expr=[l_extendedprice@1 as l_extendedprice, l_discount@2 as l_discount, s_nationkey@3 as s_nationkey, o_custkey@5 as o_custkey, o_orderdate@6 as o_orderdate]
     SortMergeJoinExec: join_type=Inner, on=[(l_orderkey@0, o_orderkey@0)]
       SortExec: expr=[l_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=9, partitioning: Hash([l_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([l_orderkey@0], 16)
       SortExec: expr=[o_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=10, partitioning: Hash([o_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([o_orderkey@0], 16)
 
-=== Stage 12 ===
+=== Stage 8 ===
 SortShuffleWriterExec: partitioning=Hash([c_custkey@0], 16)
   StatsExec: rows=15000000
 
-=== Stage 13 ===
+=== Stage 9 ===
 SortShuffleWriterExec: partitioning=Hash([c_nationkey@4], 16)
   ProjectionExec: expr=[l_extendedprice@0 as l_extendedprice, l_discount@1 as l_discount, s_nationkey@2 as s_nationkey, o_orderdate@4 as o_orderdate, c_nationkey@6 as c_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(o_custkey@3, c_custkey@0)]
       SortExec: expr=[o_custkey@3 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=11, partitioning: Hash([o_custkey@3], 16)
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([o_custkey@3], 16)
       SortExec: expr=[c_custkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=12, partitioning: Hash([c_custkey@0], 16)
+        UnresolvedShuffleExec: stage=8, partitioning: Hash([c_custkey@0], 16)
 
-=== Stage 14 ===
-SortShuffleWriterExec: partitioning=Hash([s_nationkey@2], 16)
-  ProjectionExec: expr=[l_extendedprice@0 as l_extendedprice, l_discount@1 as l_discount, s_nationkey@2 as s_nationkey, o_orderdate@3 as o_orderdate, n_regionkey@6 as n_regionkey]
-    ProjectionExec: expr=[l_extendedprice@2 as l_extendedprice, l_discount@3 as l_discount, s_nationkey@4 as s_nationkey, o_orderdate@5 as o_orderdate, c_nationkey@6 as c_nationkey, n_nationkey@0 as n_nationkey, n_regionkey@1 as n_regionkey]
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, c_nationkey@4)]
-        UnresolvedShuffleExec: stage=4, broadcast=true, upstream_partitions: 16
-        UnresolvedShuffleExec: stage=13, partitioning: Hash([c_nationkey@4], 16)
-
-=== Stage 15 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=14, partitioning: Hash([s_nationkey@2], 16)
-
-=== Stage 16 ===
+=== Stage 10 ===
 SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
   StatsExec: rows=25
 
-=== Stage 17 ===
+=== Stage 11 ===
+SortShuffleWriterExec: partitioning=Hash([s_nationkey@2], 16)
+  ProjectionExec: expr=[l_extendedprice@0 as l_extendedprice, l_discount@1 as l_discount, s_nationkey@2 as s_nationkey, o_orderdate@3 as o_orderdate, n_regionkey@6 as n_regionkey]
+    SortMergeJoinExec: join_type=Inner, on=[(c_nationkey@4, n_nationkey@0)]
+      SortExec: expr=[c_nationkey@4 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=9, partitioning: Hash([c_nationkey@4], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=10, partitioning: Hash([n_nationkey@0], 16)
+
+=== Stage 12 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  StatsExec: rows=25
+
+=== Stage 13 ===
 SortShuffleWriterExec: partitioning=Hash([n_regionkey@3], 16)
   ProjectionExec: expr=[l_extendedprice@0 as l_extendedprice, l_discount@1 as l_discount, o_orderdate@3 as o_orderdate, n_regionkey@4 as n_regionkey, n_name@6 as n_name]
-    HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(s_nationkey@2, n_nationkey@0)]
-      UnresolvedShuffleExec: stage=15, broadcast=true, upstream_partitions: 16
-      UnresolvedShuffleExec: stage=16, partitioning: Hash([n_nationkey@0], 16)
+    SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@2, n_nationkey@0)]
+      SortExec: expr=[s_nationkey@2 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=11, partitioning: Hash([s_nationkey@2], 16)
+      SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+        UnresolvedShuffleExec: stage=12, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 18 ===
+=== Stage 14 ===
+SortShuffleWriterExec: partitioning=Hash([r_regionkey@0], 16)
+  FilterExec: r_name@1 = AMERICA, projection=[r_regionkey@0]
+    StatsExec: rows=5
+
+=== Stage 15 ===
 SortShuffleWriterExec: partitioning=Hash([o_year@0], 16)
   AggregateExec: mode=Partial, gby=[o_year@0 as o_year], aggr=[sum(CASE WHEN all_nations.nation = BRAZIL THEN all_nations.volume ELSE Some(0),38,4 END) as sum(CASE WHEN all_nations.nation = Utf8("BRAZIL") THEN all_nations.volume ELSE Int64(0) END), sum(all_nations.volume)]
     ProjectionExec: expr=[date_part(YEAR, o_orderdate@2) as o_year, l_extendedprice@0 * (Some(1),20,0 - l_discount@1) as volume, n_name@4 as nation]
-      ProjectionExec: expr=[l_extendedprice@1 as l_extendedprice, l_discount@2 as l_discount, o_orderdate@3 as o_orderdate, n_regionkey@4 as n_regionkey, n_name@5 as n_name, r_regionkey@0 as r_regionkey]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(r_regionkey@0, n_regionkey@3)]
-          UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=17, partitioning: Hash([n_regionkey@3], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(n_regionkey@3, r_regionkey@0)]
+        SortExec: expr=[n_regionkey@3 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=13, partitioning: Hash([n_regionkey@3], 16)
+        SortExec: expr=[r_regionkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=14, partitioning: Hash([r_regionkey@0], 16)
 
-=== Stage 19 ===
+=== Stage 16 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[o_year@0 ASC NULLS LAST], preserve_partitioning=[true]
     ProjectionExec: expr=[o_year@0 as o_year, sum(CASE WHEN all_nations.nation = Utf8("BRAZIL") THEN all_nations.volume ELSE Int64(0) END)@1 / sum(all_nations.volume)@2 as mkt_share]
       AggregateExec: mode=FinalPartitioned, gby=[o_year@0 as o_year], aggr=[sum(CASE WHEN all_nations.nation = BRAZIL THEN all_nations.volume ELSE Some(0),38,4 END) as sum(CASE WHEN all_nations.nation = Utf8("BRAZIL") THEN all_nations.volume ELSE Int64(0) END), sum(all_nations.volume)]
-        UnresolvedShuffleExec: stage=18, partitioning: Hash([o_year@0], 16)
+        UnresolvedShuffleExec: stage=15, partitioning: Hash([o_year@0], 16)
 
-=== Stage 20 ===
+=== Stage 17 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [o_year@0 ASC NULLS LAST]
-    UnresolvedShuffleExec: stage=19, partitioning: Hash([o_year@0], 16)
+    UnresolvedShuffleExec: stage=16, partitioning: Hash([o_year@0], 16)

--- a/ballista/scheduler/tests/tpch_plan_stability/approved/q9.txt
+++ b/ballista/scheduler/tests/tpch_plan_stability/approved/q9.txt
@@ -1,85 +1,82 @@
 === Stage 1 ===
-SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
-  StatsExec: rows=25
-
-=== Stage 2 ===
-ShuffleWriterExec: partitioning: None
-  UnresolvedShuffleExec: stage=1, partitioning: Hash([n_nationkey@0], 16)
-
-=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([p_partkey@0], 16)
   FilterExec: p_name@1 LIKE %green%, projection=[p_partkey@0]
     StatsExec: rows=20000000
 
-=== Stage 4 ===
+=== Stage 2 ===
 SortShuffleWriterExec: partitioning=Hash([l_partkey@1], 16)
   StatsExec: rows=600037902
 
-=== Stage 5 ===
+=== Stage 3 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@2], 16)
   ProjectionExec: expr=[l_orderkey@1 as l_orderkey, l_partkey@2 as l_partkey, l_suppkey@3 as l_suppkey, l_quantity@4 as l_quantity, l_extendedprice@5 as l_extendedprice, l_discount@6 as l_discount]
     SortMergeJoinExec: join_type=Inner, on=[(p_partkey@0, l_partkey@1)]
       SortExec: expr=[p_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=3, partitioning: Hash([p_partkey@0], 16)
+        UnresolvedShuffleExec: stage=1, partitioning: Hash([p_partkey@0], 16)
       SortExec: expr=[l_partkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=4, partitioning: Hash([l_partkey@1], 16)
+        UnresolvedShuffleExec: stage=2, partitioning: Hash([l_partkey@1], 16)
 
-=== Stage 6 ===
+=== Stage 4 ===
 SortShuffleWriterExec: partitioning=Hash([s_suppkey@0], 16)
   StatsExec: rows=1000000
 
-=== Stage 7 ===
+=== Stage 5 ===
 SortShuffleWriterExec: partitioning=Hash([l_suppkey@2, l_partkey@1], 16)
   ProjectionExec: expr=[l_orderkey@0 as l_orderkey, l_partkey@1 as l_partkey, l_suppkey@2 as l_suppkey, l_quantity@3 as l_quantity, l_extendedprice@4 as l_extendedprice, l_discount@5 as l_discount, s_nationkey@7 as s_nationkey]
     SortMergeJoinExec: join_type=Inner, on=[(l_suppkey@2, s_suppkey@0)]
       SortExec: expr=[l_suppkey@2 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=5, partitioning: Hash([l_suppkey@2], 16)
+        UnresolvedShuffleExec: stage=3, partitioning: Hash([l_suppkey@2], 16)
       SortExec: expr=[s_suppkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=6, partitioning: Hash([s_suppkey@0], 16)
+        UnresolvedShuffleExec: stage=4, partitioning: Hash([s_suppkey@0], 16)
 
-=== Stage 8 ===
+=== Stage 6 ===
 SortShuffleWriterExec: partitioning=Hash([ps_suppkey@1, ps_partkey@0], 16)
   StatsExec: rows=80000000
 
-=== Stage 9 ===
+=== Stage 7 ===
 SortShuffleWriterExec: partitioning=Hash([l_orderkey@0], 16)
   ProjectionExec: expr=[l_orderkey@0 as l_orderkey, l_quantity@3 as l_quantity, l_extendedprice@4 as l_extendedprice, l_discount@5 as l_discount, s_nationkey@6 as s_nationkey, ps_supplycost@9 as ps_supplycost]
     SortMergeJoinExec: join_type=Inner, on=[(l_suppkey@2, ps_suppkey@1), (l_partkey@1, ps_partkey@0)]
       SortExec: expr=[l_suppkey@2 ASC, l_partkey@1 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=7, partitioning: Hash([l_suppkey@2, l_partkey@1], 16)
+        UnresolvedShuffleExec: stage=5, partitioning: Hash([l_suppkey@2, l_partkey@1], 16)
       SortExec: expr=[ps_suppkey@1 ASC, ps_partkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=8, partitioning: Hash([ps_suppkey@1, ps_partkey@0], 16)
+        UnresolvedShuffleExec: stage=6, partitioning: Hash([ps_suppkey@1, ps_partkey@0], 16)
 
-=== Stage 10 ===
+=== Stage 8 ===
 SortShuffleWriterExec: partitioning=Hash([o_orderkey@0], 16)
   StatsExec: rows=150000000
 
-=== Stage 11 ===
+=== Stage 9 ===
 SortShuffleWriterExec: partitioning=Hash([s_nationkey@3], 16)
   ProjectionExec: expr=[l_quantity@1 as l_quantity, l_extendedprice@2 as l_extendedprice, l_discount@3 as l_discount, s_nationkey@4 as s_nationkey, ps_supplycost@5 as ps_supplycost, o_orderdate@7 as o_orderdate]
     SortMergeJoinExec: join_type=Inner, on=[(l_orderkey@0, o_orderkey@0)]
       SortExec: expr=[l_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=9, partitioning: Hash([l_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=7, partitioning: Hash([l_orderkey@0], 16)
       SortExec: expr=[o_orderkey@0 ASC], preserve_partitioning=[true]
-        UnresolvedShuffleExec: stage=10, partitioning: Hash([o_orderkey@0], 16)
+        UnresolvedShuffleExec: stage=8, partitioning: Hash([o_orderkey@0], 16)
 
-=== Stage 12 ===
+=== Stage 10 ===
+SortShuffleWriterExec: partitioning=Hash([n_nationkey@0], 16)
+  StatsExec: rows=25
+
+=== Stage 11 ===
 SortShuffleWriterExec: partitioning=Hash([nation@0, o_year@1], 16)
   AggregateExec: mode=Partial, gby=[nation@0 as nation, o_year@1 as o_year], aggr=[sum(profit.amount)]
     ProjectionExec: expr=[n_name@7 as nation, date_part(YEAR, o_orderdate@5) as o_year, l_extendedprice@1 * (Some(1),20,0 - l_discount@2) - ps_supplycost@4 * l_quantity@0 as amount]
-      ProjectionExec: expr=[l_quantity@2 as l_quantity, l_extendedprice@3 as l_extendedprice, l_discount@4 as l_discount, s_nationkey@5 as s_nationkey, ps_supplycost@6 as ps_supplycost, o_orderdate@7 as o_orderdate, n_nationkey@0 as n_nationkey, n_name@1 as n_name]
-        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(n_nationkey@0, s_nationkey@3)]
-          UnresolvedShuffleExec: stage=2, broadcast=true, upstream_partitions: 16
-          UnresolvedShuffleExec: stage=11, partitioning: Hash([s_nationkey@3], 16)
+      SortMergeJoinExec: join_type=Inner, on=[(s_nationkey@3, n_nationkey@0)]
+        SortExec: expr=[s_nationkey@3 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=9, partitioning: Hash([s_nationkey@3], 16)
+        SortExec: expr=[n_nationkey@0 ASC], preserve_partitioning=[true]
+          UnresolvedShuffleExec: stage=10, partitioning: Hash([n_nationkey@0], 16)
 
-=== Stage 13 ===
+=== Stage 12 ===
 ShuffleWriterExec: partitioning: None
   SortExec: expr=[nation@0 ASC NULLS LAST, o_year@1 DESC], preserve_partitioning=[true]
     ProjectionExec: expr=[nation@0 as nation, o_year@1 as o_year, sum(profit.amount)@2 as sum_profit]
       AggregateExec: mode=FinalPartitioned, gby=[nation@0 as nation, o_year@1 as o_year], aggr=[sum(profit.amount)]
-        UnresolvedShuffleExec: stage=12, partitioning: Hash([nation@0, o_year@1], 16)
+        UnresolvedShuffleExec: stage=11, partitioning: Hash([nation@0, o_year@1], 16)
 
-=== Stage 14 ===
+=== Stage 13 ===
 ShuffleWriterExec: partitioning: None
   SortPreservingMergeExec: [nation@0 ASC NULLS LAST, o_year@1 DESC]
-    UnresolvedShuffleExec: stage=13, partitioning: Hash([nation@0, o_year@1], 16)
+    UnresolvedShuffleExec: stage=12, partitioning: Hash([nation@0, o_year@1], 16)

--- a/benchmarks/src/bin/tpcds.rs
+++ b/benchmarks/src/bin/tpcds.rs
@@ -66,16 +66,8 @@ const SKIP: &[(usize, &str)] = &[
     // data (confirmed reproducible; DataFusion is correct under both join modes).
     // See https://github.com/apache/datafusion-ballista/issues/2046
     (
-        4,
-        "distributed result diverges from DataFusion (issue #2046)",
-    ),
-    (
         38,
         "distributed INTERSECT diverges from DataFusion (issue #2046)",
-    ),
-    (
-        78,
-        "distributed LIMIT drops rows vs DataFusion (issue #2046)",
     ),
     (
         87,

--- a/docs/source/upgrading/54.0.0.md
+++ b/docs/source/upgrading/54.0.0.md
@@ -21,10 +21,6 @@
 
 ## Ballista 54.0.0
 
-**Note:** Ballista `54.0.0` has not been released yet. The information provided
-in this section pertains to features and changes that have already been merged
-to the main branch and are awaiting release in this version.
-
 ### For library and embedding users
 
 #### Upgrade to DataFusion 54

--- a/docs/source/upgrading/55.0.0.md
+++ b/docs/source/upgrading/55.0.0.md
@@ -1,0 +1,73 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Upgrade Guides
+
+## Ballista 55.0.0
+
+**Note:** Ballista `55.0.0` has not been released yet. The information provided
+in this section pertains to features and changes that have already been merged
+to the main branch and are awaiting release in this version.
+
+### Planner and execution behavior changes
+
+#### `SortMergeJoinExec` is no longer converted to a broadcast join
+
+`54.0.0` added a static-planner rewrite that converted a `SortMergeJoinExec`
+with a small build side into a broadcast `CollectLeft` hash join, governed by
+`ballista.optimizer.broadcast_sort_merge_join_enabled` (default `true`). That
+rewrite produced incorrect results for some plans, so both the rewrite and its
+config key are removed in `55.0.0`.
+
+A `SortMergeJoinExec` now always executes as a sort-merge join over
+repartitioned inputs. Broadcast promotion still applies to a `HashJoinExec`
+whose smaller side fits under `ballista.optimizer.broadcast_join_threshold_bytes`
+(default `10 MB`), which is unchanged.
+
+**This affects the default configuration.** Ballista sets
+`datafusion.optimizer.prefer_hash_join = false` by default (see
+[#1648](https://github.com/apache/datafusion-ballista/issues/1648)), so joins are
+planned as `SortMergeJoinExec` unless you opt out. Under `54.0.0` those joins were
+then silently converted to broadcast hash joins whenever one side fit under the
+threshold, so expect join plan shape — and therefore performance and shuffle
+behavior — to change on upgrade for any query with a join whose smaller side is
+under `10 MB`.
+
+Alongside the incorrect results, the conversion also worked against the reason
+sort-merge join is the default. DataFusion's hash join has no spill support, so a
+`CollectLeft` build side must fit in memory in every parallel task on an executor;
+sort-merge join spills. Converting a sort-merge join into a broadcast hash join
+reintroduced exactly the memory behavior that the `prefer_hash_join = false`
+default exists to avoid.
+
+**Action required:** the key `ballista.optimizer.broadcast_sort_merge_join_enabled`
+no longer exists, and Ballista rejects unknown configuration keys. If you set it
+(including to `false`, which was the workaround for the incorrect results), remove
+it — otherwise the session fails with:
+
+```text
+configuration key `optimizer.broadcast_sort_merge_join_enabled` does not exist
+```
+
+If you relied on it being `false`, no replacement is needed: that is now the only
+behavior. If you relied on it being `true` and want small joins to broadcast, set
+`datafusion.optimizer.prefer_hash_join = true` so joins are planned as a
+`HashJoinExec`, which remains eligible for broadcast promotion. Note this opts you
+into the non-spilling hash join for _all_ joins in the session, not only the small
+ones.

--- a/docs/source/upgrading/index.rst
+++ b/docs/source/upgrading/index.rst
@@ -21,4 +21,5 @@ Upgrade Guides
 .. toctree::
    :maxdepth: 1
 
+   Ballista 55.0.0 <55.0.0>
    Ballista 54.0.0 <54.0.0>


### PR DESCRIPTION
# Which issue does this PR close?

Partially addresses #2046 (q4 and q78 only).

# Rationale for this change

TL;DR. The SMJ "broadcast join" optimization in the static planner was poorly thought out. TPC-DS tests exposed that it caused correctness issues. Let's remove it.

This PR does not make any changes to AQE join selection.

# AI description of changes

`54.0.0` added a static-planner rewrite that converted a `SortMergeJoinExec` with a small build side into a broadcast `CollectLeft` hash join, gated by `ballista.optimizer.broadcast_sort_merge_join_enabled` (default `true`). The rewrite produces incorrect results, so the only safe value for the key is `false`. A config knob whose correct setting is always "off" is better removed along with the code it gates.

This is not an edge-case path. Ballista sets `datafusion.optimizer.prefer_hash_join = false` by default (#1648), so joins are planned as `SortMergeJoinExec` unless a user opts out, and the conversion then fired on any join with a side under the threshold.

# What changes are included in this PR?

- Remove `convert_sort_merge_to_hash_join` and its `strip_sort` helper from `DefaultDistributedPlanner`. A `SortMergeJoinExec` is no longer a broadcast candidate; only a `HashJoinExec(Partitioned)` is.
- Remove the `ballista.optimizer.broadcast_sort_merge_join_enabled` config key and its `BallistaConfig` accessor.
- Drop the test asserting the conversion happens, and the test asserting the threshold gated it (now vacuous). `distributed_sort_merge_join_unchanged_when_flag_disabled` becomes `distributed_sort_merge_join_is_never_broadcast`, since that is now unconditional behavior.
- Re-enable TPC-DS q4 and q78 in the correctness gate.
- Add a `55.0.0` upgrade guide; drop the stale "not been released yet" note from the `54.0.0` guide.

Broadcast promotion of a `HashJoinExec` under `ballista.optimizer.broadcast_join_threshold_bytes` is unchanged, as is the correctness guard that demotes a DataFusion-promoted `CollectLeft` join with an unsafe join type.

# Are there any user-facing changes?

Yes, two, both documented in `docs/source/upgrading/55.0.0.md`:

1. `ballista.optimizer.broadcast_sort_merge_join_enabled` no longer exists. Ballista rejects unknown configuration keys, so a session that still sets it now fails with ``configuration key `optimizer.broadcast_sort_merge_join_enabled` does not exist``. This is a breaking config change against `54.0.0`.
2. A `SortMergeJoinExec` is never converted to a broadcast join. Because sort-merge is Ballista's default join strategy, join plan shape — and therefore performance and shuffle behavior — changes on upgrade for any query with a join whose smaller side is under `10 MB`. Users who want the broadcast can set `datafusion.optimizer.prefer_hash_join = true`, at the cost of opting into the non-spilling hash join for all joins in the session.

## Verification

Locally: `cargo clippy --all-targets --workspace --all-features -- -D warnings` passes, and the `ballista-scheduler` planner, `ballista-core` config, and `tpcds` bin tests pass.

The q4/q78 fix itself is **not** verified locally — it needs SF1 TPC-DS data and a live cluster. The TPC-DS SF1 workflow runs on this PR and is the real check; if q4 or q78 still diverge, those skip entries should go back with an updated reason.

Given the default-plan-shape change, TPC-H benchmark numbers before/after would be worth having before this merges.