### PR TITLE
ci: skip expensive workflows for docs-only changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,8 @@ on:
       - "dev/docker/**"
       - "dev/build-ballista-docker.sh"
       - ".github/workflows/docker.yml"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   push:
     branches: [ "main" ]
     paths:
@@ -40,6 +42,8 @@ on:
       - "dev/docker/**"
       - "dev/build-ballista-docker.sh"
       - ".github/workflows/docker.yml"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,8 @@ on:
       - ".github/actions/setup-windows-builder/**"
       - ".github/actions/setup-rust-runtime/**"
       - ".github/workflows/rust.yml"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   pull_request:
     paths:
       - "ballista/**"
@@ -53,6 +55,8 @@ on:
       - ".github/actions/setup-windows-builder/**"
       - ".github/actions/setup-rust-runtime/**"
       - ".github/workflows/rust.yml"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -35,6 +35,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpcds.yml"
       - ".github/actions/setup-builder/**"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   pull_request:
     paths:
       - "ballista/**"
@@ -44,6 +46,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpcds.yml"
       - ".github/actions/setup-builder/**"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -35,6 +35,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpch.yml"
       - ".github/actions/setup-builder/**"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   pull_request:
     paths:
       - "ballista/**"
@@ -44,6 +46,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpch.yml"
       - ".github/actions/setup-builder/**"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/web-tui.yml
+++ b/.github/workflows/web-tui.yml
@@ -35,6 +35,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/web-tui.yml"
       - ".github/actions/setup-builder/**"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   pull_request:
     paths:
       - "ballista/**"
@@ -44,6 +46,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/web-tui.yml"
       - ".github/actions/setup-builder/**"
+      # docs-only changes cannot affect this job; exclusions are applied last
+      - "!**/*.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Which issue does this PR close?

N/A - CI-only change, no issue filed.

 # Rationale for this change

The TPC-H, TPC-DS, Rust, Docker, and Web TUI workflows are all already gated on path allowlists, so changes under `docs/**` or to the root `README.md` correctly skip them. However, those allowlists use whole-directory globs (`ballista/**`, `benchmarks/**`, `examples/**`, `ballista-cli/**`), and there are ten markdown files living inside those directories:

```
ballista-cli/README.md
benchmarks/README.md
examples/README.md
ballista/core/README.md
ballista/scheduler/README.md
ballista/executor/README.md
ballista/client/README.md
benchmarks/db-benchmark/README.md
benchmarks/spark/README.md
ballista/scheduler/tests/tpch_plan_stability/README.md
```

As a result, editing only `benchmarks/README.md` currently triggers TPC-H SF10 and TPC-DS SF1 along with the Rust, Docker, and Web TUI builds. This is not hypothetical: #2015 ("docs: remove outdated TPC-H benchmark results from READMEs") touched only `ballista/client/README.md` and ran the full expensive matrix for no reason.

# What changes are included in this PR?

Appends `- "!**/*.md"` to the `paths` list of both the `push` and `pull_request` triggers in `tpch.yml`, `tpcds.yml`, `rust.yml`, `docker.yml`, and `web-tui.yml`. GitHub evaluates path patterns in order and the last match wins, so the exclusion has to be the final entry.

Two workflows are deliberately left alone:

- `dev.yml` (RAT and prettier) has no path filter and should keep running on everything, since prettier lints the markdown itself.
- `docs.yaml` still deploys the site on `docs/**`.

Verification, beyond confirming the YAML still parses, simulated the GitHub path-filter semantics against representative change sets to check both directions. Docs-only sets now skip all five workflows, while a `.rs` edit, a `Cargo.toml` bump, and a mixed code-plus-markdown change each still trigger all five. The mixed case matters most: a PR that touches both code and a README is not docs-only and must still build.

# Are there any user-facing changes?

No. CI configuration only, with no public API impact.