### PR TITLE
docs(config): rewrite max_partitions_per_task description to be timeless

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -359,13 +359,12 @@ static CONFIG_ENTRIES: LazyLock<HashMap<String, ConfigEntry>> = LazyLock::new(||
         ConfigEntry::new(
             BALLISTA_SCHEDULER_MAX_PARTITIONS_PER_TASK.to_string(),
             "Upper bound on the number of input partitions packed into a single \
-             task's `partition_slice`. `1` (default) is the pre-multi-partition-tasks \
-             execution model — one task per partition, matching the Spark user \
-             persona and preserving master's behaviour on merge. Raise to enable \
-             multi-partition tasks (fewer tasks, parallel-sort / parallel-join wins); \
-             `0` means unbounded — the scheduler fills each task up to the executor's \
-             free vcore count. Does not apply to collapse stages, which must pack \
-             their full pending queue into a single task for correctness."
+             task's `partition_slice`. `1` (default) means one task per input \
+             partition. Raise to enable multi-partition tasks (fewer tasks, \
+             parallel-sort / parallel-join wins); `0` means unbounded — the \
+             scheduler fills each task up to the executor's free vcore count. \
+             Does not apply to collapse stages, which must pack their full \
+             pending queue into a single task for correctness."
                 .to_string(),
             DataType::UInt64,
             Some(1.to_string()),


### PR DESCRIPTION
## Summary
- Drop PR-relative phrasing (\"pre-multi-partition-tasks execution model\", \"preserving master's behaviour on merge\") and the \"Spark user persona\" jargon from `BALLISTA_SCHEDULER_MAX_PARTITIONS_PER_TASK`'s description.
- Describe what the setting does in terms a config-doc reader can act on today.

Addresses @andygrove's review comment on #2038: https://github.com/apache/datafusion-ballista/pull/2038#discussion_r3611238937

## Test plan
- [x] Docs-only change; existing `cargo check` covers that the string still compiles as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)