### PR TITLE
chore(scheduler,executor): downgrade #2038 per-task traces to debug

### DIFF
--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -38,7 +38,7 @@ use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::metrics::MetricsSet;
 use datafusion::prelude::SessionConfig;
 use futures::stream::TryStreamExt;
-use log::info;
+use log::debug;
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
@@ -260,7 +260,7 @@ impl QueryStageExecutor for DefaultQueryStageExec {
                 ShuffleWriterVariant::Hash(writer) => (Arc::new(writer.clone()), false),
                 ShuffleWriterVariant::Sort(writer) => (Arc::new(writer.clone()), true),
             };
-        info!(
+        debug!(
             "executor plan pre-run (task_id={task_id}):\n{}",
             DisplayableExecutionPlan::new(plan_arc.as_ref()).indent(true)
         );
@@ -272,7 +272,7 @@ impl QueryStageExecutor for DefaultQueryStageExec {
         let result =
             drive_shuffle_writer_stage(plan_arc.clone(), context, is_sort_shuffle).await;
 
-        info!(
+        debug!(
             "executor plan post-run (task_id={task_id}, ok={}):\n{}",
             result.is_ok(),
             DisplayableExecutionPlan::with_metrics(plan_arc.as_ref()).indent(true)

--- a/ballista/scheduler/src/cluster/mod.rs
+++ b/ballista/scheduler/src/cluster/mod.rs
@@ -34,7 +34,7 @@ use ballista_core::{ConfigProducer, JobId, JobStatusSubscriber};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::Stream;
-use log::{debug, info};
+use log::debug;
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -392,8 +392,8 @@ fn stage_has_input_collapse(plan_root: &Arc<dyn ExecutionPlan>) -> bool {
         [child] => walk(child),
         _ => false,
     };
-    info!(
-        "DIAG stage_has_input_collapse: root={} root_partitions={} → {result}",
+    debug!(
+        "stage_has_input_collapse: root={} root_partitions={} → {result}",
         plan_root.name(),
         plan_root
             .properties()
@@ -461,8 +461,8 @@ fn bind_one(
     } else {
         input_partition_ids.len() as u32
     };
-    info!(
-        "DIAG bind_one: job={} stage={} exec={} vcores={} max={} slice_len={} consumed={} partitions={:?} collapse={}",
+    debug!(
+        "bind_one: job={} stage={} exec={} vcores={} max={} slice_len={} consumed={} partitions={:?} collapse={}",
         job_id,
         running_stage.stage_id,
         budget.executor_id,


### PR DESCRIPTION
## Summary

Follow-up to #2038 (multi-partition tasks). Four log sites introduced by that PR fire on every scheduling/execution decision and flood scheduler + executor logs at INFO. This PR moves all four to `debug!` and drops the ad-hoc `DIAG ` prefix.

- `ballista/scheduler/src/cluster/mod.rs`: `stage_has_input_collapse` + `bind_one` — per-bind decision traces.
- `ballista/executor/src/execution_engine.rs`: `executor plan pre-run` + `executor plan post-run` — per-task `DisplayableExecutionPlan` dumps. Pre-#2038 this function had no logging; both dumps are noise for anyone not actively debugging.

Turn them back on locally with:

```
RUST_LOG=ballista_scheduler=debug,ballista_executor=debug
```

Closes #2103.

## Test plan

- [x] `cargo clippy --all-targets -p ballista-scheduler -p ballista-executor` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)