### PR TITLE
fix: executor hanging on ctrl+c

### DIFF
--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -670,6 +670,7 @@ pub async fn start_executor_process(
 
     // When `notify_shutdown` is dropped, all components which have `subscribe`d will
     // receive the shutdown signal and can exit
+    let _ = notify_shutdown.send(());
     drop(notify_shutdown);
     // Drop final `Sender` so the `Receiver` below can complete
     drop(shutdown_complete_tx);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2105.

 # Rationale for this change
Before this fix, `Executor` process would hang indefinitely, though sending a stoppage signal to the Scheduler.
It was due to the fact that there were pending cloned instances of `notify_shutdown` field of the `ShutdownNotifier` struct

# What changes are included in this PR?
This fix introduces an explicit `.send() `call of the `notify_shutdown` field, which is essentially a `broadcast::Sender(),` which is used by `Shutdown` struct

# Are there any user-facing changes?
No

