### PR TITLE
Retryable IO errors misclassified when wrapped in DataFusionError::Shared

### DIFF
--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -235,7 +235,7 @@ impl From<BallistaError> for FailedTask {
                 }
             }
             BallistaError::DataFusionError(e)
-                if matches!(*e, DataFusionError::IoError(_)) =>
+                if matches!(e.find_root(), DataFusionError::IoError(_)) =>
             {
                 FailedTask {
                     error: format!("Task failed due to DataFusion IO error: {e:?}"),
@@ -256,3 +256,76 @@ impl From<BallistaError> for FailedTask {
 }
 
 impl Error for BallistaError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn io_failed_task(e: BallistaError) -> FailedTask {
+        FailedTask::from(e)
+    }
+
+    #[test]
+    fn bare_datafusion_io_error_is_retryable() {
+        let e = BallistaError::DataFusionError(Box::new(DataFusionError::IoError(
+            io::Error::new(io::ErrorKind::ConnectionReset, "connection reset"),
+        )));
+        let task = io_failed_task(e);
+        assert!(task.retryable);
+        assert!(matches!(task.failed_reason, Some(FailedReason::IoError(_))));
+    }
+
+    #[test]
+    fn shared_wrapped_io_error_is_retryable() {
+        // Errors from a join's shared build side arrive as Shared(Arc<IoError>);
+        // the classifier must see through the wrapper or it will not retry a
+        // transient IO failure.
+        let inner = DataFusionError::IoError(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection reset",
+        ));
+        let shared = DataFusionError::Shared(Arc::new(inner));
+        let e = BallistaError::DataFusionError(Box::new(shared));
+        let task = io_failed_task(e);
+        assert!(task.retryable);
+        assert!(matches!(task.failed_reason, Some(FailedReason::IoError(_))));
+    }
+
+    #[test]
+    fn context_wrapped_shared_io_error_is_retryable() {
+        let inner = DataFusionError::IoError(io::Error::other("s3 timeout"));
+        let shared = DataFusionError::Shared(Arc::new(inner));
+        let ctx = shared.context("reading join build side");
+        let e = BallistaError::DataFusionError(Box::new(ctx));
+        let task = io_failed_task(e);
+        assert!(task.retryable);
+        assert!(matches!(task.failed_reason, Some(FailedReason::IoError(_))));
+    }
+
+    #[test]
+    fn non_io_datafusion_error_stays_non_retryable() {
+        let e = BallistaError::DataFusionError(Box::new(DataFusionError::Plan(
+            "bad plan".to_string(),
+        )));
+        let task = io_failed_task(e);
+        assert!(!task.retryable);
+        assert!(matches!(
+            task.failed_reason,
+            Some(FailedReason::ExecutionError(_))
+        ));
+    }
+
+    #[test]
+    fn shared_wrapped_non_io_error_stays_non_retryable() {
+        let inner = DataFusionError::Plan("bad plan".to_string());
+        let shared = DataFusionError::Shared(Arc::new(inner));
+        let e = BallistaError::DataFusionError(Box::new(shared));
+        let task = io_failed_task(e);
+        assert!(!task.retryable);
+        assert!(matches!(
+            task.failed_reason,
+            Some(FailedReason::ExecutionError(_))
+        ));
+    }
+}


### PR DESCRIPTION
Hit this while running queries with joins against flaky object storage: a transient IO error on the build side of a hash join kills the whole job instead of getting retried.

Turned out the retry classifier in `ballista/core/src/error.rs` does a shallow `matches!(*e, DataFusionError::IoError(_))` on the outermost variant. But errors coming off a join's shared build side get wrapped in `DataFusionError::Shared` (an `Arc` for sharing across consumers), so the `IoError` inside is never seen and the task falls through to the catch-all `retryable: false` arm. AQE off works fine because the error arrives unwrapped, which is how I narrowed it down to the wrapping.

DataFusion already has `find_root()` for exactly this, so the fix is to classify on the root error instead of the wrapper. One-line change plus unit tests covering bare, `Shared`-wrapped, `Context`-wrapped-`Shared`, and non-IO cases.

Closes #2028.

Tested with `cargo test -p ballista-core --lib error::` (5 new tests pass) and `cargo clippy -p ballista-core --lib` is clean. I couldn't run the full cluster chaos harness from #2026 locally, but the unit tests cover the classifier paths directly.
