### PR TITLE
docs: correct scan partitioning description in tuning guide

### DIFF
--- a/docs/source/user-guide/tuning-guide.md
+++ b/docs/source/user-guide/tuning-guide.md
@@ -26,14 +26,20 @@ by adding more compute resource.
 
 The basic unit of concurrency and parallelism in Ballista is the concept of a partition. The leaf nodes of a query
 are typically table scans that read files from object storage, and the number of partitions such a scan produces is
-driven by `datafusion.execution.target_partitions`. This is currently a global setting for the entire context. The
-default value for this setting is 16.
+driven by `datafusion.execution.target_partitions`. This is currently a global setting for the entire context.
+
+DataFusion's own default for this setting is the number of CPU cores available to the process. Ballista overrides it
+to 16 in `SessionConfig::new_with_ballista()`, so a context created with `SessionContext::remote()` or
+`SessionContext::standalone()` starts at 16. If you instead build your own `SessionConfig` and pass it to
+`remote_with_state()` or `standalone_with_state()`, Ballista leaves the setting alone and you get whatever that
+config carries, which is the client machine's core count for a plain `SessionConfig::new()`. Set it explicitly if
+you care about the value.
 
 A scan is partitioned in two steps:
 
 1. When the table is listed, its files are sorted by path and distributed into **at most** `target_partitions`
-   file groups. A "customer" table of 200 Parquet files read with the default `target_partitions = 16` therefore
-   produces 16 partitions of roughly 13 files each, not 200 partitions.
+   file groups. A "customer" table of 200 Parquet files read with `target_partitions = 16` therefore produces
+   16 partitions of roughly 13 files each, not 200 partitions.
 2. The physical optimizer then splits individual files by byte range, so a table with fewer files than
    `target_partitions` can still be read in parallel. A table consisting of a single large Parquet file is split
    into `target_partitions` byte ranges rather than being read by one task. This step is controlled by

--- a/docs/source/user-guide/tuning-guide.md
+++ b/docs/source/user-guide/tuning-guide.md
@@ -25,18 +25,25 @@ The goal of any distributed compute engine is to parallelize work as much as pos
 by adding more compute resource.
 
 The basic unit of concurrency and parallelism in Ballista is the concept of a partition. The leaf nodes of a query
-are typically table scans that read from files on disk and Ballista currently treats each file within a table as a
-single partition (in the future, Ballista will support splitting files into partitions but this is not implemented yet).
+are typically table scans that read files from object storage, and the number of partitions such a scan produces is
+driven by `datafusion.execution.target_partitions`. This is currently a global setting for the entire context. The
+default value for this setting is 16.
 
-For example, if there is a table "customer" that consists of 200 Parquet files, that table scan will naturally have
-200 partitions and the table scan and certain subsequent operations will also have 200 partitions. Conversely, if the
-table only has a single Parquet file then there will be a single partition and the work will not be able to scale even
-if the cluster has resource available. Ballista supports repartitioning within a query to improve parallelism.
-The configuration setting `datafusion.execution.target_partitions`can be set to the desired number of partitions. This is
-currently a global setting for the entire context. The default value for this setting is 16.
+A scan is partitioned in two steps:
 
-Note that Ballista will never decrease the number of partitions based on this setting and will only repartition if
-the source operation has fewer partitions than this setting.
+1. When the table is listed, its files are sorted by path and distributed into **at most** `target_partitions`
+   file groups. A "customer" table of 200 Parquet files read with the default `target_partitions = 16` therefore
+   produces 16 partitions of roughly 13 files each, not 200 partitions.
+2. The physical optimizer then splits individual files by byte range, so a table with fewer files than
+   `target_partitions` can still be read in parallel. A table consisting of a single large Parquet file is split
+   into `target_partitions` byte ranges rather than being read by one task. This step is controlled by
+   `datafusion.optimizer.repartition_file_scans` (default `true`) and only applies when the scan reads at least
+   `datafusion.optimizer.repartition_file_min_size` bytes (default 10 MB). Small tables below that threshold are
+   left as a single partition, since splitting them costs more than it saves.
+
+Ballista disables DataFusion's round-robin repartitioning, so this file-group splitting is the only source of
+parallelism for a scan stage. Raising `target_partitions` is the way to increase it, and lowering it is the way to
+reduce the number of partitions a large table is read with.
 
 Example: Setting the desired number of shuffle partitions when creating a context.
 
@@ -53,6 +60,30 @@ let state = SessionStateBuilder::new()
 
 let ctx: SessionContext = SessionContext::remote_with_state(&url,state).await?;
 ```
+
+### Partitions and Tasks
+
+A stage's partition count is not the same as its task count. The scheduler keeps a cursor over the stage's
+partitions and, each time an executor is assigned work, hands out a slice of those partitions to run as a single
+task. The size of that slice is bounded by both the executor's free vcores and
+`ballista.scheduler.max_partitions_per_task`.
+
+That setting still defaults to `1`, so out of the box a 16-partition scan stage runs as 16 single-partition tasks.
+Raising it lets the scheduler pack several partitions into one task, which reduces task count and scheduling
+overhead and allows operators such as sort and hash join to work across partitions within a task. Setting it to `0`
+removes the cap entirely, so each task is filled up to the assigned executor's free vcore count: a 16-partition
+stage then runs as one task on an idle 16-vcore executor, or as four 4-partition tasks across four 4-vcore
+executors.
+
+| key                                        | type   | default | description                                                                                                                                                                         |
+| ------------------------------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ballista.scheduler.max_partitions_per_task | UInt64 | 1       | Upper bound on the number of input partitions packed into a single task. `1` means one task per partition. `0` means unbounded, filling each task up to the executor's free vcores. |
+
+Stages whose plan collapses all input into a single partition (for example under a `CoalescePartitionsExec` or
+`SortPreservingMergeExec`) ignore this cap and always pack their full pending queue into one task, since splitting
+them would produce partial results that downstream stages cannot merge.
+
+Each task's plan is rewritten before dispatch so that its scan sees only the file groups belonging to its own slice.
 
 ## Configuring Executor Concurrency Levels
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A - documentation fix, no issue filed.

# Rationale for this change

The "Partitions and Parallelism" section of the tuning guide describes behavior that is no longer accurate, and the inaccuracy points users in the wrong direction when they size their clusters.

It states that "Ballista currently treats each file within a table as a single partition (in the future, Ballista will support splitting files into partitions but this is not implemented yet)", and that "Ballista will never decrease the number of partitions based on this setting". Neither is true today:

- File listing chunks the table's files into **at most** `target_partitions` file groups (`FileGroup::split_files`), so a 200 file table read with the default `target_partitions = 16` gives 16 partitions, not 200. The setting does decrease partition count.
- The physical optimizer then splits individual files by byte range (`datafusion.optimizer.repartition_file_scans`, gated on `datafusion.optimizer.repartition_file_min_size`), so a table consisting of one large Parquet file does scale across the cluster, contrary to what the guide warns.

The guide also never mentioned `ballista.scheduler.max_partitions_per_task`, which defaults to `1` and therefore determines the task count for every stage. Someone tuning `--vcores` without knowing about it cannot explain why a 16 partition stage produces 16 tasks.

# What changes are included in this PR?

- Rewrites the scan partitioning explanation to describe the two actual steps (file group chunking capped at `target_partitions`, then byte range splitting within files) and notes that Ballista disables round robin repartitioning, so file group splitting is the only source of scan parallelism.
- Adds a "Partitions and Tasks" subsection covering the partition to task binding, `ballista.scheduler.max_partitions_per_task` (default `1`, `0` for unbounded), and the collapse stage exemption.

# Are there any user-facing changes?

Documentation only. No code or API changes.
