### PR TITLE
feat(benchmarks): add --skip to omit queries from a tpch suite run

### DIFF
--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -80,6 +80,12 @@ struct BallistaBenchmarkOpt {
     #[structopt(short, long)]
     query: Option<usize>,
 
+    /// Query numbers to skip when running the whole suite. Can be specified
+    /// multiple times, e.g. `--skip 18 --skip 21`. Ignored when `--query` is
+    /// given.
+    #[structopt(long = "skip", number_of_values = 1)]
+    skip: Vec<usize>,
+
     /// Activate debug mode to see query results
     #[structopt(short, long)]
     debug: bool,
@@ -143,6 +149,12 @@ struct DataFusionBenchmarkOpt {
     /// Query number (1-22). If not specified, runs all queries.
     #[structopt(short, long)]
     query: Option<usize>,
+
+    /// Query numbers to skip when running the whole suite. Can be specified
+    /// multiple times, e.g. `--skip 18 --skip 21`. Ignored when `--query` is
+    /// given.
+    #[structopt(long = "skip", number_of_values = 1)]
+    skip: Vec<usize>,
 
     /// Activate debug mode to see query results
     #[structopt(short, long)]
@@ -312,6 +324,48 @@ async fn main() -> Result<()> {
     }
 }
 
+/// Resolves which TPC-H queries a benchmark run should execute.
+///
+/// A `--query` selects exactly that one and `--skip` is ignored, so asking for a
+/// query explicitly always runs it. Otherwise the full 1..=22 suite runs minus
+/// any `--skip` entries. Skip values outside 1..=22 are reported rather than
+/// silently ignored, since a typo would otherwise look like it took effect.
+fn select_queries(query: Option<usize>, skip: &[usize]) -> Result<Vec<usize>> {
+    if let Some(q) = query {
+        return Ok(vec![q]);
+    }
+
+    if let Some(bad) = skip.iter().find(|q| !(1..=22).contains(*q)) {
+        return Err(DataFusionError::Execution(format!(
+            "--skip {bad} is not a TPC-H query number (expected 1-22)"
+        )));
+    }
+
+    let selected: Vec<usize> = (1..=22).filter(|q| !skip.contains(q)).collect();
+    if selected.is_empty() {
+        return Err(DataFusionError::Execution(
+            "--skip excluded every query; nothing to run".to_string(),
+        ));
+    }
+
+    if !skip.is_empty() {
+        let mut skipped: Vec<usize> = skip.to_vec();
+        skipped.sort_unstable();
+        skipped.dedup();
+        println!(
+            "Skipping {} of 22 queries: {}",
+            skipped.len(),
+            skipped
+                .iter()
+                .map(|q| q.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    Ok(selected)
+}
+
 #[allow(clippy::await_holding_lock)]
 async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordBatch>> {
     println!("Running benchmarks with the following options: {opt:?}");
@@ -357,10 +411,7 @@ async fn benchmark_datafusion(opt: DataFusionBenchmarkOpt) -> Result<Vec<RecordB
     }
 
     // Determine which queries to run
-    let query_numbers: Vec<usize> = opt
-        .query
-        .map(|q| vec![q])
-        .unwrap_or_else(|| (1..=22).collect());
+    let query_numbers = select_queries(opt.query, &opt.skip)?;
 
     let mut benchmark_run = BenchmarkRun::new();
     let mut result: Vec<RecordBatch> = Vec::with_capacity(1);
@@ -496,10 +547,7 @@ async fn benchmark_ballista(opt: BallistaBenchmarkOpt) -> Result<()> {
     );
 
     // Determine which queries to run
-    let query_numbers: Vec<usize> = opt
-        .query
-        .map(|q| vec![q])
-        .unwrap_or_else(|| (1..=22).collect());
+    let query_numbers = select_queries(opt.query, &opt.skip)?;
 
     let oracle_ctx = if opt.verify {
         let cfg = SessionConfig::new()
@@ -1627,6 +1675,62 @@ mod tests {
     use std::env;
     use std::sync::Arc;
 
+    #[test]
+    fn select_queries_runs_whole_suite_by_default() {
+        assert_eq!(
+            select_queries(None, &[]).unwrap(),
+            (1..=22).collect::<Vec<_>>()
+        );
+    }
+
+    // The motivating case: run the full suite but leave out the query that
+    // exhausts the memory pool, without having to drive 21 single-query jobs.
+    #[test]
+    fn select_queries_omits_skipped() {
+        let selected = select_queries(None, &[18]).unwrap();
+        assert_eq!(selected.len(), 21);
+        assert!(!selected.contains(&18));
+        assert!(selected.contains(&17) && selected.contains(&19));
+    }
+
+    #[test]
+    fn select_queries_omits_several_skipped() {
+        let selected = select_queries(None, &[18, 21, 5]).unwrap();
+        assert_eq!(selected.len(), 19);
+        for q in [5, 18, 21] {
+            assert!(!selected.contains(&q), "query {q} should have been skipped");
+        }
+    }
+
+    // An explicit --query is a direct instruction, so it wins over --skip rather
+    // than silently producing an empty run.
+    #[test]
+    fn select_queries_prefers_explicit_query_over_skip() {
+        assert_eq!(select_queries(Some(18), &[18]).unwrap(), vec![18]);
+    }
+
+    // A repeated skip must not change the outcome.
+    #[test]
+    fn select_queries_tolerates_duplicate_skips() {
+        assert_eq!(select_queries(None, &[18, 18]).unwrap().len(), 21);
+    }
+
+    // A typo like `--skip 42` would otherwise look like it took effect.
+    #[test]
+    fn select_queries_rejects_out_of_range_skip() {
+        for bad in [0usize, 23, 100] {
+            assert!(
+                select_queries(None, &[bad]).is_err(),
+                "--skip {bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn select_queries_rejects_skipping_everything() {
+        assert!(select_queries(None, &(1..=22).collect::<Vec<_>>()).is_err());
+    }
+
     fn run_with(queries: Vec<QueryRun>) -> BenchmarkRun {
         BenchmarkRun {
             benchmark_version: "test".to_string(),
@@ -2054,6 +2158,7 @@ mod tests {
             // run the query to compute actual results of the query
             let opt = DataFusionBenchmarkOpt {
                 query: Some(n),
+                skip: vec![],
                 debug: false,
                 iterations: 1,
                 partitions: 2,


### PR DESCRIPTION
# Which issue does this PR close?

N/A — small benchmark tooling change, no issue filed.

# Rationale for this change

Sometimes one TPC-H query cannot complete on a given cluster and takes the rest of the suite down with it. At the moment the reference SF1000 cluster hits this on Q18, which exhausts the memory pool and OOM-kills the executors (#2025), wedging the queries that would have run after it.

The workaround has been to drive the remaining queries as individual single-query jobs. That measures something different: each job starts against a cold page cache, which on that cluster cost even the join-free queries (Q1, Q6) roughly 20 s apiece compared to the same query inside a continuous suite run. Mixing the two methods in one results column silently misattributes that penalty to the engine.

`--skip` lets the other 21 queries stay in a single run, so the column is internally consistent and the problem query can be investigated separately.

# What changes are included in this PR?

- Add `--skip <n>` to both the `ballista` and `datafusion` subcommands of the `tpch` benchmark binary. It is repeatable (`--skip 18 --skip 21`) and omits those queries from a whole-suite run.
- An explicit `--query` still wins over `--skip`, so asking for a query directly always runs it rather than silently producing an empty run.
- Skip values outside 1..=22, and a skip set that would exclude every query, are rejected with an error instead of being silently ignored — a typo like `--skip 42` would otherwise look like it took effect.
- When queries are skipped, the run prints which ones, so it is visible in the benchmark output that the suite was not complete.
- Both engine paths now share one `select_queries` helper instead of duplicating the "which queries do we run" logic.

# Are there any user-facing changes?

No library or API change. The `tpch` benchmark binary gains a `--skip` option; existing invocations behave exactly as before.

Tested by seven unit tests over `select_queries` covering the default full suite, single and multiple skips, `--query` precedence, duplicate skips, out-of-range values, and skipping everything.
