### PR TITLE
fix: [branch-54] map a task's partition through UnionExec when restricting file scans (backport of #2070)

### DIFF
--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -36,6 +36,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::metrics::MetricsSet;
+use datafusion::physical_plan::union::UnionExec;
 use datafusion::prelude::SessionConfig;
 use log::warn;
 use std::any::Any;
@@ -165,6 +166,65 @@ fn restrict_scan_to_partition(
     Some(DataSourceExec::from_data_source(config))
 }
 
+/// Restrict every file scan in `plan` to the file group the task running
+/// `partition` will actually poll.
+///
+/// A task executes exactly one partition of its stage, so each scan beneath it
+/// must be pinned to the one file group that partition reads (see
+/// [`restrict_scan_to_partition`]). Which group that is depends on the path from
+/// the stage root: most operators pass a partition straight through to their
+/// children, but a `UnionExec` concatenates its children's partitions, so its
+/// child `i` sees `partition` minus the partition counts of the children before
+/// it. Applying the stage's partition number directly to a scan under a union
+/// therefore addresses the wrong group, and for partitions past the scan's group
+/// count it addresses none at all — leaving that scan unrestricted and free to
+/// read the whole table.
+///
+/// Children a partition never reaches are left untouched: this task will not
+/// execute them.
+fn restrict_scans_for_partition(
+    plan: &Arc<dyn ExecutionPlan>,
+    partition: usize,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if plan.downcast_ref::<UnionExec>().is_some() {
+        // `UnionExec::execute(p)` walks its children subtracting each one's
+        // partition count until `p` lands inside a child, then executes that
+        // child alone. Mirror that walk so the scan under the serving child is
+        // pinned to the group that child's local partition reads.
+        let mut local = Some(partition);
+        let mut children = Vec::with_capacity(plan.children().len());
+        for child in plan.children() {
+            let count = child.properties().output_partitioning().partition_count();
+            match local {
+                Some(p) if p < count => {
+                    children.push(restrict_scans_for_partition(child, p)?);
+                    local = None;
+                }
+                Some(p) => {
+                    local = Some(p - count);
+                    children.push(Arc::clone(child));
+                }
+                None => children.push(Arc::clone(child)),
+            }
+        }
+        return Arc::clone(plan).with_new_children(children);
+    }
+
+    if let Some(rewritten) = restrict_scan_to_partition(plan, partition) {
+        return Ok(rewritten);
+    }
+
+    let children = plan
+        .children()
+        .into_iter()
+        .map(|child| restrict_scans_for_partition(child, partition))
+        .collect::<Result<Vec<_>>>()?;
+    if children.is_empty() {
+        return Ok(Arc::clone(plan));
+    }
+    Arc::clone(plan).with_new_children(children)
+}
+
 impl ExecutionEngine for DefaultExecutionEngine {
     fn create_query_stage_exec(
         &self,
@@ -188,15 +248,12 @@ impl ExecutionEngine for DefaultExecutionEngine {
                             reader.with_work_dir(work_dir.to_string()),
                         ))),
                     }
-                } else if let Some(rewritten) =
-                    restrict_scan_to_partition(&p, partition_id)
-                {
-                    Ok(Transformed::yes(rewritten))
                 } else {
                     Ok(Transformed::no(p))
                 }
             })?
             .data;
+        let plan = restrict_scans_for_partition(&plan, partition_id)?;
 
         // the query plan created by the scheduler always starts with a shuffle writer
         // (either ShuffleWriterExec or SortShuffleWriterExec)
@@ -382,5 +439,81 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
         assert!(restrict_scan_to_partition(&plan, 0).is_none());
+    }
+
+    /// Find the file-group layout of each scan under a union, left child first.
+    fn union_group_counts(plan: &Arc<dyn ExecutionPlan>) -> Vec<Vec<usize>> {
+        plan.children().into_iter().map(group_file_counts).collect()
+    }
+
+    /// A `UnionExec` concatenates its children's partitions, so stage partition
+    /// `left_count + k` is the right child's local partition `k`. The scan under
+    /// the serving child must be pinned to that local group.
+    #[test]
+    fn union_partition_maps_to_the_right_childs_local_group() {
+        let union: Arc<dyn ExecutionPlan> =
+            UnionExec::try_new(vec![scan_with_file_groups(4), scan_with_file_groups(4)])
+                .unwrap();
+        assert_eq!(
+            union.properties().output_partitioning().partition_count(),
+            8
+        );
+
+        // Partition 1 is served by the left child's local partition 1.
+        let restricted = restrict_scans_for_partition(&union, 1).unwrap();
+        assert_eq!(
+            union_group_counts(&restricted),
+            vec![vec![0, 1, 0, 0], vec![1, 1, 1, 1]],
+            "left scan pinned to group 1; right scan is never polled for this partition"
+        );
+
+        // Partition 6 is served by the right child's local partition 2 (6 - 4).
+        // Before the mapping existed this addressed no group at all and left the
+        // scan free to read the whole table.
+        let restricted = restrict_scans_for_partition(&union, 6).unwrap();
+        assert_eq!(
+            union_group_counts(&restricted),
+            vec![vec![1, 1, 1, 1], vec![0, 0, 1, 0]],
+            "right scan pinned to local group 2"
+        );
+    }
+
+    /// Every partition of a union must pin exactly one group in exactly one
+    /// child, so across the whole stage each file group is read exactly once.
+    #[test]
+    fn every_union_partition_pins_exactly_one_group() {
+        let union: Arc<dyn ExecutionPlan> =
+            UnionExec::try_new(vec![scan_with_file_groups(3), scan_with_file_groups(3)])
+                .unwrap();
+        for partition in 0..6 {
+            let restricted = restrict_scans_for_partition(&union, partition).unwrap();
+            let counts = union_group_counts(&restricted);
+            let (serving, idle) = if partition < 3 { (0, 1) } else { (1, 0) };
+            let expected_local = partition % 3;
+            assert_eq!(
+                counts[serving].iter().sum::<usize>(),
+                1,
+                "partition {partition}: serving child must keep exactly one group"
+            );
+            assert_eq!(
+                counts[serving][expected_local], 1,
+                "partition {partition}: expected local group {expected_local}, got {:?}",
+                counts[serving]
+            );
+            assert_eq!(
+                counts[idle],
+                vec![1, 1, 1],
+                "partition {partition}: the child it never polls is left untouched"
+            );
+        }
+    }
+
+    /// Without a union a partition passes straight through, so the behaviour is
+    /// unchanged from restricting the scan directly.
+    #[test]
+    fn scan_without_union_is_pinned_to_its_own_partition() {
+        let plan = scan_with_file_groups(4);
+        let restricted = restrict_scans_for_partition(&plan, 2).unwrap();
+        assert_eq!(group_file_counts(&restricted), vec![0, 0, 1, 0]);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Backport of #2070 to `branch-54`. The issue it fixes is #2067.

# Rationale for this change

A `UNION ALL` over file scans silently returns **inflated** results on `54.x` — no error, just several times too much data:

```sql
select round(sum(p),2) from
 (select ws_ext_sales_price p from web_sales
  union all
  select cs_ext_sales_price p from catalog_sales);
-- expected 5492796521.50
-- got     49389026433.70   (--partitions 16, executor -c 8; varied run to run)
```

A task executes one partition of its stage, so `restrict_scan_to_partition` pins each file scan beneath it to the single file group that partition reads. Without that, DataFusion 54's shared work-queue lets a lone `execute(p)` drain the queue and scan the whole table (#1907).

The pinning applied the stage's partition number directly to every scan, which is only correct when the partition passes straight through. A `UnionExec` concatenates its children's partitions: with N-partition children, stage partition `N + k` is the right child's local partition `k`. So for partitions `>= N`, `partition_id >= config.file_groups.len()` bailed out and returned `None`, leaving that scan unrestricted and free to read its entire table.

Silent wrong results are the worst failure mode to leave in a released line, which is why this is worth backporting.

# What changes are included in this PR?

A clean cherry-pick of 449e7b5e, confined to `ballista/executor/src/execution_engine.rs`. The plan is walked from the stage root, mirroring `UnionExec::execute`'s own partition arithmetic, so each scan is pinned to the group its local partition actually reads. Children a partition never reaches are left untouched, since this task does not execute them.

The upstream commit also removed two entries from the TPC-DS correctness gate's `SKIP` list (`benchmarks/src/bin/tpcds.rs`). That harness arrived with #2048 and does not exist on `branch-54`, so that hunk is dropped. It has no bearing on the fix.

All four regression tests from the original PR come across and pass on the `branch-54` base:

- `union_partition_maps_to_the_right_childs_local_group`
- `every_union_partition_pins_exactly_one_group`
- `scan_without_union_is_pinned_to_its_own_partition`
- `restrict_scan_partition_out_of_range_is_left_untouched`

# Are there any user-facing changes?

Queries with a `UNION ALL` over file scans now return correct results instead of inflated ones. No public API, config, or proto/wire changes, so this is not a breaking change.

`cargo fmt --check`, clippy on `ballista-executor` with `--all-targets --all-features`, and the full `ballista-executor` test suite are clean.