### PR TITLE
test(tpcds): bump TPC-DS test data to scale factor 10

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: TPC-DS SF1
+name: TPC-DS SF10
 
 permissions:
   contents: read
@@ -51,8 +51,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  tpcds-sf1:
-    name: TPC-DS SF1 (all queries, static planner)
+  tpcds-sf10:
+    name: TPC-DS SF10 (all queries, static planner)
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -85,11 +85,11 @@ jobs:
           cargo install --git https://github.com/clflushopt/tpchgen-rs \
             --rev 573fd0018dd1b41e52880162f615e9903418c397 --locked tpcgen-cli
 
-      - name: Generate TPC-DS SF1 data
+      - name: Generate TPC-DS SF10 data
         run: |
           mkdir -p "$RUNNER_TEMP/tpcds-data"
           tpcgen-cli tpcds parquet \
-            --scale-factor 1 \
+            --scale-factor 10 \
             --output-dir "$RUNNER_TEMP/tpcds-data"
 
       - name: Run TPC-DS queries against Ballista cluster
@@ -176,7 +176,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: tpcds-sf1-cluster-logs
+          name: tpcds-sf10-cluster-logs
           retention-days: 14
           path: |
             ${{ runner.temp }}/scheduler.log

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -351,10 +351,10 @@ yet published to crates.io, so the script installs `tpcgen-cli` from git,
 pinned to a fixed rev:
 
 ```bash
-SCALE_FACTOR=1 OUTPUT_DIR=./data-tpcds ./benchmarks/tpcds-gen.sh
+SCALE_FACTOR=10 OUTPUT_DIR=./data-tpcds ./benchmarks/tpcds-gen.sh
 ```
 
-`SCALE_FACTOR` (default `1`) and `OUTPUT_DIR` (default `benchmarks/data-tpcds`,
+`SCALE_FACTOR` (default `10`, matching CI) and `OUTPUT_DIR` (default `benchmarks/data-tpcds`,
 resolved relative to the script) are env overrides; `TPCGEN_REV` overrides the
 pinned `tpcgen-cli` git rev if needed. Note that, unlike the TPC-H generator, `tpcgen-cli tpcds` has no
 `--parts` flag — it writes a single `<table>.parquet` file per table for all
@@ -393,7 +393,7 @@ DataFusion query text. A default run (no `--query`) executes `1..=99` minus
 
 ### CI
 
-`.github/workflows/tpcds.yml` runs the SF1 suite against a local
+`.github/workflows/tpcds.yml` runs the SF10 suite against a local
 scheduler + executor on every push/PR touching `ballista/**` or
 `benchmarks/**`, under the default (static) planner. The adaptive planner
 (AQE on) is not gated yet — it currently fails many TPC-DS queries with an

--- a/benchmarks/tpcds-gen.sh
+++ b/benchmarks/tpcds-gen.sh
@@ -23,12 +23,12 @@
 # writes one Parquet file per table and has no --parts option.
 #
 # Env overrides:
-#   SCALE_FACTOR   TPC-DS scale factor (default: 1)
+#   SCALE_FACTOR   TPC-DS scale factor (default: 10, matching CI)
 #   OUTPUT_DIR     Where data is written (default: ./data-tpcds)
 #   TPCGEN_REV     tpcgen-cli git rev to install (default: pinned below)
 set -euo pipefail
 
-SCALE_FACTOR="${SCALE_FACTOR:-1}"
+SCALE_FACTOR="${SCALE_FACTOR:-10}"
 TPCGEN_REV="${TPCGEN_REV:-573fd0018dd1b41e52880162f615e9903418c397}"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change

The TPC-DS correctness gate has been running at SF1. At that size several
tables fit in a single batch, so the suite mostly exercises the planner and
barely touches the distributed execution paths that actually break: shuffle
writes/reads across multiple partitions, repartitioning, and spilling.

Running the same 99-query suite at SF10 keeps the exact same coverage in terms
of queries but puts real data volume behind it, which is where distributed
result divergence tends to show up.

# What changes are included in this PR?

- `.github/workflows/tpcds.yml`: generate the data with `--scale-factor 10`
  instead of `1`, and rename the workflow, job, and log artifact to match.
- `benchmarks/tpcds-gen.sh`: default `SCALE_FACTOR` to `10` so a local run
  reproduces CI without an env override. It is still overridable.
- `benchmarks/README.md`: update the SF references in the data generation and
  CI sections.

No change to the query set or the skip list.

# Are there any user-facing changes?

No. This only affects CI and the benchmark data generation script.