### PR TITLE
fix(executor): keep heartbeating while all task slots are busy

### DIFF
--- a/ballista/executor/src/execution_loop.rs
+++ b/ballista/executor/src/execution_loop.rs
@@ -49,6 +49,13 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tonic::codegen::{Body, Bytes, StdError};
 
+/// Maximum time the poll loop waits for a free vcore before polling the
+/// scheduler anyway. `poll_work` doubles as the executor's heartbeat under
+/// pull-based scheduling, so a fully-busy executor must keep polling (reporting
+/// zero free vcores) or the scheduler times it out and resets its tasks. Kept
+/// well below the scheduler's executor timeout.
+const HEARTBEAT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Main execution loop that polls the scheduler for available tasks.
 ///
 /// Runs indefinitely, periodically asking the scheduler for work. When tasks
@@ -114,13 +121,28 @@ where
         DedicatedExecutor::new("task_runner", executor_specification.vcores as usize);
 
     loop {
-        // Wait for a vcore permit before asking for new work.
-        let permit = free_vcores
-            .acquire()
-            .await
-            .map_err(|_| BallistaError::Internal("vcore semaphore closed".to_string()))?;
-        // Make the vcore available again for the actual bind below.
-        drop(permit);
+        // Wait for a vcore permit before asking for new work, but cap the wait
+        // so a fully-busy executor still polls the scheduler periodically.
+        // `poll_work` is the executor's ONLY heartbeat under pull-based
+        // scheduling (the scheduler records a heartbeat on every poll). If every
+        // vcore is held by a task running longer than the scheduler's executor
+        // timeout, blocking here indefinitely stops heartbeats, so the scheduler
+        // wrongly marks this healthy-but-busy executor dead and resets its
+        // in-flight tasks. On timeout we poll anyway below, reporting
+        // `num_free_vcores: 0`, so liveness no longer depends on vcore
+        // availability.
+        match tokio::time::timeout(HEARTBEAT_POLL_INTERVAL, free_vcores.acquire()).await {
+            // A vcore is free; release it so the bind below can claim it.
+            Ok(Ok(permit)) => drop(permit),
+            // Semaphore closed (executor shutting down).
+            Ok(Err(_)) => {
+                return Err(BallistaError::Internal(
+                    "vcore semaphore closed".to_string(),
+                ));
+            }
+            // No free vcore within the interval; poll anyway to stay alive.
+            Err(_) => {}
+        }
 
         // Keeps track of whether we received task in last iteration
         // to avoid going in sleep mode between polling


### PR DESCRIPTION
# Which issue does this PR close?

Part of #2158. Contributes toward #2144.

# Rationale for this change

Under pull-based scheduling the executor's only heartbeat to the scheduler is `poll_work` — the scheduler records a heartbeat on every poll. The poll loop, however, blocked on `free_vcores.acquire().await` *before* polling, waiting for a free vcore to bind new work.

When every vcore is held by a task running longer than the scheduler's `executor_timeout` (e.g. a long stage-1 scan on a wide TPC-H query such as q9/q18), the loop blocked on `acquire` indefinitely and never polled. The scheduler then stopped receiving heartbeats, marked the healthy-but-busy executor dead, and reset its in-flight (and completed) tasks. When a stage's tasks consistently exceed the timeout this livelocks: `reset -> re-dispatch -> reset`, never converging — the executor goes idle and the job hangs.

This is one of the root causes behind the fleet-wide heartbeat timeouts reported in #2144. It was originally found and fixed in the Spice AI fork; this ports the fix to current `main` (the loop has since been refactored to use `free_vcores`/`num_free_vcores`, so the fix is adapted accordingly).

# What changes are included in this PR?

- Cap the vcore wait at a new `HEARTBEAT_POLL_INTERVAL` (5s, well below the scheduler's executor timeout) using `tokio::time::timeout`.
- On timeout, poll the scheduler anyway, reporting `num_free_vcores: 0` (heartbeat only), so executor liveness no longer depends on vcore availability.
- A freed vcore still wakes the wait immediately, so scheduling responsiveness is unchanged; when fully busy the loop now polls roughly every 5s instead of never.
- Handle a closed semaphore (executor shutdown) explicitly.

# Are there any user-facing changes?

No. Behavior only changes for fully-busy executors, which now continue to heartbeat instead of being wrongly declared dead. No public API changes.
