### PR TITLE
feat(executor): log per-task memory pool peak usage

### DIFF
--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -70,6 +70,7 @@ use crate::execution_engine::{DefaultExecutionEngine, ExecutionEngine};
 use crate::executor::{Executor, TasksDrainedFuture};
 use crate::executor_server::TERMINATING;
 use crate::flight_service::BallistaFlightService;
+use crate::memory_pool::TrackedMemoryPool;
 use crate::metrics::ExecutorMetricCollectionPolicy;
 use crate::metrics::LoggingMetricsCollector;
 use crate::runtime_cache::{
@@ -106,7 +107,10 @@ fn memory_pool_policy(
             // single-vcore share it uses; a 4-partition task gets 4×,
             // matching the parallelism DataFusion will actually drive.
             let size = per_vcore.saturating_mul(vcores_consumed.max(1) as usize);
-            let pool: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(size));
+            // Wrap the per-task FairSpillPool in TrackedMemoryPool so peak
+            // usage is logged when the task's RuntimeEnv drops.
+            let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(size));
+            let pool: Arc<dyn MemoryPool> = Arc::new(TrackedMemoryPool::new(inner));
             RuntimeEnvBuilder::from_runtime_env(&base)
                 .with_memory_pool(pool)
                 .build_arc()

--- a/ballista/executor/src/lib.rs
+++ b/ballista/executor/src/lib.rs
@@ -39,6 +39,8 @@ pub mod executor_server;
 pub mod flight_service;
 /// HTTP server for Kubernetes-style /healthz and /readyz probes.
 pub mod health;
+/// Peak-usage tracking wrapper around a [`datafusion::execution::memory_pool::MemoryPool`].
+pub mod memory_pool;
 /// Metrics collection for executor runtime statistics.
 pub mod metrics;
 /// Session-scoped cache of shared executor runtime environments.

--- a/ballista/executor/src/memory_pool.rs
+++ b/ballista/executor/src/memory_pool.rs
@@ -18,14 +18,14 @@
 //! Peak-usage tracking wrapper around a [`MemoryPool`].
 //!
 //! [`TrackedMemoryPool`] wraps another [`MemoryPool`] and records the highest
-//! `reserved()` value it ever observed. It logs one `tracing` event on
-//! construction and one on drop, so a task's peak memory pool usage is
-//! visible in executor logs without any additional plumbing.
+//! `reserved()` value it ever observed. It logs one line on construction and
+//! one on drop, so a task's peak memory pool usage is visible in executor
+//! logs without any additional plumbing.
 //!
 //! Ballista builds one [`FairSpillPool`] per task (via
 //! [`memory_pool_policy`](crate::executor_process::ExecutorProcessConfig)),
 //! so wrapping the per-task pool gives per-task peak-memory logs. Correlate
-//! events by the `pool_id` field.
+//! the two log lines by matching `pool_id`.
 //!
 //! [`FairSpillPool`]: datafusion::execution::memory_pool::FairSpillPool
 
@@ -37,16 +37,16 @@ use datafusion::error::Result;
 use datafusion::execution::memory_pool::{
     MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
 };
-use tracing::info;
+use log::info;
 
 /// Monotonic pool identifier. Wraps around after `usize::MAX` pools, which is
 /// a non-concern in practice.
 static POOL_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Log target used for construction and drop events. Filter with
-/// `RUST_LOG=ballista_executor::memory_pool=info` (or `=debug`) to see only
-/// these events, or leave at the default `ballista=info` since the executor
-/// crate is `ballista_executor`.
+/// `RUST_LOG=ballista_executor::memory_pool=info` to see only these events,
+/// or leave at the default `ballista=info` — this crate is `ballista_executor`
+/// so it inherits the `ballista=*` filter.
 const LOG_TARGET: &str = "ballista_executor::memory_pool";
 
 /// A [`MemoryPool`] wrapper that records peak `reserved()` bytes and logs
@@ -69,9 +69,9 @@ impl TrackedMemoryPool {
         let id = POOL_ID.fetch_add(1, Ordering::Relaxed);
         info!(
             target: LOG_TARGET,
-            pool_id = id,
-            limit_bytes = memory_limit_bytes(inner.memory_limit()),
-            "memory pool created",
+            "memory pool created pool_id={} limit_bytes={}",
+            id,
+            memory_limit_bytes(inner.memory_limit()),
         );
         Self {
             inner,
@@ -183,10 +183,10 @@ impl Drop for TrackedMemoryPool {
     fn drop(&mut self) {
         info!(
             target: LOG_TARGET,
-            pool_id = self.id,
-            peak_bytes = self.peak.load(Ordering::Relaxed),
-            limit_bytes = memory_limit_bytes(self.inner.memory_limit()),
-            "memory pool dropped",
+            "memory pool dropped pool_id={} peak_bytes={} limit_bytes={}",
+            self.id,
+            self.peak.load(Ordering::Relaxed),
+            memory_limit_bytes(self.inner.memory_limit()),
         );
     }
 }

--- a/ballista/executor/src/memory_pool.rs
+++ b/ballista/executor/src/memory_pool.rs
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Peak-usage tracking wrapper around a [`MemoryPool`].
+//!
+//! [`TrackedMemoryPool`] wraps another [`MemoryPool`] and records the highest
+//! `reserved()` value it ever observed. It logs one `tracing` event on
+//! construction and one on drop, so a task's peak memory pool usage is
+//! visible in executor logs without any additional plumbing.
+//!
+//! Ballista builds one [`FairSpillPool`] per task (via
+//! [`memory_pool_policy`](crate::executor_process::ExecutorProcessConfig)),
+//! so wrapping the per-task pool gives per-task peak-memory logs. Correlate
+//! events by the `pool_id` field.
+//!
+//! [`FairSpillPool`]: datafusion::execution::memory_pool::FairSpillPool
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use datafusion::error::Result;
+use datafusion::execution::memory_pool::{
+    MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
+};
+use tracing::info;
+
+/// Monotonic pool identifier. Wraps around after `usize::MAX` pools, which is
+/// a non-concern in practice.
+static POOL_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// Log target used for construction and drop events. Filter with
+/// `RUST_LOG=ballista_executor::memory_pool=info` (or `=debug`) to see only
+/// these events, or leave at the default `ballista=info` since the executor
+/// crate is `ballista_executor`.
+const LOG_TARGET: &str = "ballista_executor::memory_pool";
+
+/// A [`MemoryPool`] wrapper that records peak `reserved()` bytes and logs
+/// them on `Drop`.
+///
+/// All trait methods delegate to `inner`; `grow` and successful `try_grow`
+/// additionally update the peak. Peak is inclusive of any concurrent activity
+/// on the wrapped pool — meaningful because Ballista's per-task pool is not
+/// shared across tasks (see the module docs).
+pub struct TrackedMemoryPool {
+    inner: Arc<dyn MemoryPool>,
+    peak: AtomicUsize,
+    id: usize,
+}
+
+impl TrackedMemoryPool {
+    /// Wraps `inner` and emits a "pool created" log line with a fresh
+    /// monotonic id.
+    pub fn new(inner: Arc<dyn MemoryPool>) -> Self {
+        let id = POOL_ID.fetch_add(1, Ordering::Relaxed);
+        info!(
+            target: LOG_TARGET,
+            pool_id = id,
+            limit_bytes = memory_limit_bytes(inner.memory_limit()),
+            "memory pool created",
+        );
+        Self {
+            inner,
+            peak: AtomicUsize::new(0),
+            id,
+        }
+    }
+
+    /// Highest `reserved()` observed since construction.
+    pub fn peak(&self) -> usize {
+        self.peak.load(Ordering::Relaxed)
+    }
+
+    /// Monotonic pool id, used as the correlation key in log events.
+    pub fn pool_id(&self) -> usize {
+        self.id
+    }
+
+    fn observe(&self, current: usize) {
+        // CAS-loop the peak forward. Contention is unlikely (per-task pool),
+        // and even under contention the loop terminates in bounded retries.
+        let mut peak = self.peak.load(Ordering::Relaxed);
+        while current > peak {
+            match self.peak.compare_exchange_weak(
+                peak,
+                current,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => peak = observed,
+            }
+        }
+    }
+}
+
+/// Renders `MemoryLimit` as either a byte count or a text tag (`unknown` /
+/// `infinite`) so structured log consumers see one field type.
+fn memory_limit_bytes(limit: MemoryLimit) -> String {
+    match limit {
+        MemoryLimit::Finite(bytes) => bytes.to_string(),
+        MemoryLimit::Infinite => "infinite".to_string(),
+        MemoryLimit::Unknown => "unknown".to_string(),
+    }
+}
+
+impl fmt::Debug for TrackedMemoryPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrackedMemoryPool")
+            .field("id", &self.id)
+            .field("peak", &self.peak.load(Ordering::Relaxed))
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl fmt::Display for TrackedMemoryPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "TrackedMemoryPool(id={} peak={} inner={})",
+            self.id,
+            self.peak.load(Ordering::Relaxed),
+            self.inner,
+        )
+    }
+}
+
+impl MemoryPool for TrackedMemoryPool {
+    fn name(&self) -> &str {
+        "TrackedMemoryPool"
+    }
+
+    fn register(&self, consumer: &MemoryConsumer) {
+        self.inner.register(consumer);
+    }
+
+    fn unregister(&self, consumer: &MemoryConsumer) {
+        self.inner.unregister(consumer);
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        self.inner.grow(reservation, additional);
+        self.observe(self.inner.reserved());
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        self.inner.shrink(reservation, shrink);
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
+        let result = self.inner.try_grow(reservation, additional);
+        if result.is_ok() {
+            self.observe(self.inner.reserved());
+        }
+        result
+    }
+
+    fn reserved(&self) -> usize {
+        self.inner.reserved()
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        self.inner.memory_limit()
+    }
+}
+
+impl Drop for TrackedMemoryPool {
+    fn drop(&mut self) {
+        info!(
+            target: LOG_TARGET,
+            pool_id = self.id,
+            peak_bytes = self.peak.load(Ordering::Relaxed),
+            limit_bytes = memory_limit_bytes(self.inner.memory_limit()),
+            "memory pool dropped",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::execution::memory_pool::FairSpillPool;
+
+    fn reserve(
+        pool: &Arc<dyn MemoryPool>,
+        name: &str,
+        bytes: usize,
+    ) -> MemoryReservation {
+        let consumer = MemoryConsumer::new(name);
+        let reservation = consumer.register(pool);
+        reservation.grow(bytes);
+        reservation
+    }
+
+    #[test]
+    fn tracks_peak_across_grow_and_shrink() {
+        let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(1024));
+        let tracked = Arc::new(TrackedMemoryPool::new(inner));
+        let pool: Arc<dyn MemoryPool> = tracked.clone();
+
+        let r = reserve(&pool, "t", 128);
+        assert_eq!(tracked.peak(), 128);
+        r.grow(256);
+        assert_eq!(tracked.peak(), 384);
+        r.shrink(128);
+        // Peak does not decrease when reservation shrinks.
+        assert_eq!(tracked.peak(), 384);
+        r.grow(100);
+        // Reservation now 356; still below prior peak of 384.
+        assert_eq!(tracked.peak(), 384);
+        r.grow(100);
+        // Reservation now 456; new peak.
+        assert_eq!(tracked.peak(), 456);
+    }
+
+    #[test]
+    fn try_grow_failure_does_not_update_peak() {
+        // Pool of size 100. First grow to 80, then try_grow(50) fails (would
+        // exceed limit); peak should stay at 80.
+        let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(100));
+        let tracked = Arc::new(TrackedMemoryPool::new(inner));
+        let pool: Arc<dyn MemoryPool> = tracked.clone();
+
+        let r = reserve(&pool, "t", 80);
+        assert_eq!(tracked.peak(), 80);
+        assert!(r.try_grow(50).is_err());
+        assert_eq!(tracked.peak(), 80);
+    }
+
+    #[test]
+    fn delegates_memory_limit() {
+        let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(1024));
+        let tracked = TrackedMemoryPool::new(inner);
+        assert!(matches!(tracked.memory_limit(), MemoryLimit::Finite(1024)));
+    }
+}

--- a/ballista/executor/src/memory_pool.rs
+++ b/ballista/executor/src/memory_pool.rs
@@ -37,7 +37,7 @@ use datafusion::error::Result;
 use datafusion::execution::memory_pool::{
     MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
 };
-use log::info;
+use log::{info, warn};
 
 /// Monotonic pool identifier. Wraps around after `usize::MAX` pools, which is
 /// a non-concern in practice.
@@ -181,13 +181,29 @@ impl MemoryPool for TrackedMemoryPool {
 
 impl Drop for TrackedMemoryPool {
     fn drop(&mut self) {
-        info!(
-            target: LOG_TARGET,
-            "memory pool dropped pool_id={} peak_bytes={} limit_bytes={}",
-            self.id,
-            self.peak.load(Ordering::Relaxed),
-            memory_limit_bytes(self.inner.memory_limit()),
-        );
+        // `residual_bytes` should always be 0 at this point: `MemoryReservation`
+        // holds an `Arc<dyn MemoryPool>`, so the pool can only be dropped once
+        // every reservation has been released — and each release calls
+        // `shrink()`, which decrements `reserved`. A non-zero value here is an
+        // accounting anomaly (e.g. a reservation whose Drop bypassed
+        // `shrink()`), worth surfacing at WARN.
+        let peak = self.peak.load(Ordering::Relaxed);
+        let limit = memory_limit_bytes(self.inner.memory_limit());
+        let residual = self.inner.reserved();
+        if residual > 0 {
+            warn!(
+                target: LOG_TARGET,
+                "memory pool dropped with residual reservation \
+                 pool_id={} peak_bytes={} limit_bytes={} residual_bytes={}",
+                self.id, peak, limit, residual,
+            );
+        } else {
+            info!(
+                target: LOG_TARGET,
+                "memory pool dropped pool_id={} peak_bytes={} limit_bytes={} residual_bytes=0",
+                self.id, peak, limit,
+            );
+        }
     }
 }
 
@@ -247,5 +263,35 @@ mod tests {
         let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(1024));
         let tracked = TrackedMemoryPool::new(inner);
         assert!(matches!(tracked.memory_limit(), MemoryLimit::Finite(1024)));
+    }
+
+    #[test]
+    fn reservations_dropped_leave_zero_reserved() {
+        // Reservations released via Drop should return every byte to the pool,
+        // so `reserved()` reads 0 by the time the pool's Drop would run.
+        let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(1024));
+        let tracked = Arc::new(TrackedMemoryPool::new(inner));
+        let pool: Arc<dyn MemoryPool> = tracked.clone();
+
+        {
+            let r = reserve(&pool, "t", 300);
+            assert_eq!(tracked.reserved(), 300);
+            drop(r);
+        }
+        assert_eq!(tracked.reserved(), 0);
+    }
+
+    #[test]
+    fn forgotten_reservation_leaves_residual() {
+        // If a reservation is `mem::forget`'d, its Drop never runs and
+        // `shrink()` is never called — this is the anomaly the drop-time
+        // residual_bytes log surfaces.
+        let inner: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(1024));
+        let tracked = Arc::new(TrackedMemoryPool::new(inner));
+        let pool: Arc<dyn MemoryPool> = tracked.clone();
+
+        let r = reserve(&pool, "t", 300);
+        std::mem::forget(r);
+        assert_eq!(tracked.reserved(), 300);
     }
 }


### PR DESCRIPTION
## Summary

Add a small `TrackedMemoryPool` wrapper (`ballista/executor/src/memory_pool.rs`) around the per-task `FairSpillPool` that `memory_pool_policy()` builds. It records peak `reserved()` bytes and emits `tracing::info!` events on construction and on `Drop`, so a task's peak memory pool usage lands in executor logs when the task's `RuntimeEnv` drops.

Log format (target `ballista_executor::memory_pool`):

```
memory pool created  pool_id=<n> limit_bytes=<bytes|infinite|unknown>
memory pool dropped  pool_id=<n> peak_bytes=<n> limit_bytes=<bytes|infinite|unknown>
```

Correlate the two events by `pool_id` (monotonic within the executor process).

## Why

Ballista builds one `FairSpillPool` per task, but there is currently no way to see how close a task got to its per-task ceiling without adding operator-level tracing or a custom pool. When benchmarking SF1000 TPC-H, individual query wall times varied significantly between standalone and in-suite runs, and memory-pool state drift is one hypothesis — but it's hard to test without per-task peak numbers. This makes the numbers observable in-place from executor logs alone.

## What it does not do

- No API changes.
- No new dependencies.
- No behaviour change on the memory-pool hot path: `grow` / `shrink` / `try_grow` / `reserved` / `memory_limit` all delegate; only `grow` and successful `try_grow` additionally push the peak forward via a CAS on an `AtomicUsize`.
- No metrics endpoint (Prometheus etc.) — logs only. A metrics-first version would be a natural follow-up.

## Test plan

- [x] `cargo test -p ballista-executor` (42 tests pass, including 3 new tests for peak tracking + limit delegation).
- [x] `cargo clippy -p ballista-executor -- -D warnings` clean.
- [x] `cargo fmt`.
- [ ] Reviewer sanity-check: run a query, look for `memory pool dropped` lines with plausible `peak_bytes`.
