### PR TITLE
ci: allow the docs site deploy to be triggered manually

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,9 @@
 # under the License.
 
 on:
+  # Allow the docs site to be rebuilt and republished on demand, e.g. when a
+  # push-triggered run was dropped and the change never made it to asf-site.
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:


### PR DESCRIPTION
# Which issue does this PR close?

<!-- No issue; small CI infrastructure fix. -->

N/A

# Rationale for this change

The "Deploy DataFusion Ballista site" workflow (`.github/workflows/docs.yaml`) builds the docs and pushes the HTML to the `asf-site` branch that serves https://datafusion.apache.org/ballista/. It only runs `on: push` to `main` touching `docs/**`.

When a push event is dropped or never fires (as happened with the benchmarking.md refresh in #2171, which merged to `main` but produced no workflow runs at all), the docs change is left unpublished and there is no way to re-trigger the deploy short of pushing another commit to `docs/`.

Adding a `workflow_dispatch` trigger lets a maintainer re-run the deploy on demand from the Actions UI or `gh workflow run`, both to recover from a missed trigger and as a general safety net.

# What changes are included in this PR?

- Add a `workflow_dispatch:` trigger to `.github/workflows/docs.yaml`, alongside the existing `push` trigger.

# Are there any user-facing changes?

No. This only affects how the docs deploy workflow can be triggered.