### PR TITLE
chore: use taplo for Cargo.toml formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,22 +238,16 @@ jobs:
           rustup toolchain install stable
           rustup default stable
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
-      - name: Install cargo-tomlfmt
+      - name: Install taplo
         uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
-          tool: cargo-tomlfmt@0.2.1
+          tool: taplo-cli@0.9
 
       - name: Check Cargo.toml formatting
         run: |
-          # if you encounter error, try rerun the command below, finally run 'git diff' to
-          # check which Cargo.toml introduces formatting violation
-          #
-          # ignore ./Cargo.toml because putting workspaces in multi-line lists make it easy to read
+          # if you encounter an error, run 'ci/scripts/rust_toml_fmt.sh --write'
+          # (or 'taplo format') locally to fix the formatting, then commit the result.
           ci/scripts/rust_toml_fmt.sh
-          if test -f "./Cargo.toml.bak"; then
-              echo "cargo tomlfmt found format violations"
-              exit 1
-          fi
 
   datafusion-proto-sync-check:
     name: Check vendored DataFusion proto is in sync

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Install taplo
         uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
-          tool: taplo-cli@0.9
+          tool: taplo-cli@0.10.0
 
       - name: Check Cargo.toml formatting
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,15 @@
 
 [workspace]
 exclude = ["dev/msrvcheck", "python"]
-members = ["ballista-cli", "ballista/client", "ballista/core", "ballista/executor", "ballista/scheduler", "benchmarks", "examples"]
+members = [
+    "ballista-cli",
+    "ballista/client",
+    "ballista/core",
+    "ballista/executor",
+    "ballista/scheduler",
+    "benchmarks",
+    "examples",
+]
 resolver = "3"
 
 [workspace.package]
@@ -42,8 +50,10 @@ datafusion-proto-common = "54"
 datafusion-spark = "54"
 datafusion-substrait = "54"
 
+ctor = { version = "1.0" }
 insta = "1.47"
 itertools = "0.15"
+mimalloc = { version = "0.1" }
 object_store = "0.13.2"
 prost = "0.14"
 prost-types = "0.14"
@@ -57,22 +67,20 @@ tonic-prost-build = { version = "0.14" }
 tracing = "0.1"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ctor = { version = "1.0" }
-mimalloc = { version = "0.1" }
 
-tokio = { version = "1" }
-uuid = { version = "1.23", features = ["v4", "v7"] }
-rand = { version = "0.10" }
+async-trait = { version = "0.1" }
+dashmap = { version = "6.2" }
 env_logger = { version = "0.11" }
 futures = { version = "0.3" }
 log = { version = "0.4" }
 parking_lot = { version = "0.12" }
-tempfile = { version = "3.27" }
-dashmap = { version = "6.2" }
-async-trait = { version = "0.1" }
+rand = { version = "0.10" }
 serde = { version = "1.0" }
+tempfile = { version = "3.27" }
+tokio = { version = "1" }
 tokio-stream = { version = "0.1" }
 url = { version = "2.5" }
+uuid = { version = "1.23", features = ["v4", "v7"] }
 
 # cargo build --profile release-lto
 [profile.release-lto]

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -84,8 +84,8 @@ cli = [
     "dep:ballista",
     "dep:datafusion",
     "dep:datafusion-cli",
-    "dep:rustyline",
     "dep:mimalloc",
+    "dep:rustyline",
 ]
 
 tui = [

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -36,8 +36,8 @@ crate-type = ["cdylib", "rlib"]
 ballista = { path = "../ballista/client", version = "54.0.0", features = ["standalone"], optional = true }
 datafusion = { workspace = true, optional = true }
 datafusion-cli = { workspace = true, optional = true }
-rustyline = { version = "18.0.0", optional = true }
 mimalloc = { workspace = true, optional = true }
+rustyline = { version = "18.0.0", optional = true }
 
 # TUI/web shared deps
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
@@ -61,8 +61,8 @@ crossterm = { version = "0.29.0", features = ["event-stream"], optional = true }
 tracing-appender = { version = "0.2", optional = true }
 
 # Web-only deps (WASM)
-critical-section = { version = "1.2.0", features = ["std"], optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
+critical-section = { version = "1.2.0", features = ["std"], optional = true }
 gloo-timers = { version = "0.4", features = ["futures"], optional = true }
 js-sys = { version = "0.3.95", optional = true }
 ratzilla = { version = "0.3.1", optional = true }
@@ -81,25 +81,57 @@ tokio = { workspace = true, features = ["macros", "sync", "time"] }
 default = ["cli", "tui"]
 
 cli = [
-    "dep:ballista", "dep:datafusion", "dep:datafusion-cli",
-    "dep:rustyline", "dep:mimalloc",
+    "dep:ballista",
+    "dep:datafusion",
+    "dep:datafusion-cli",
+    "dep:rustyline",
+    "dep:mimalloc",
 ]
 
 tui = [
-    "dep:chrono", "dep:config", "dep:crossterm", "dep:dotparser", "dep:futures",
-    "dep:percent-encoding", "dep:prometheus-parse", "dep:ratatui", "dep:reqwest",
-    "dep:serde", "dep:serde_json", "dep:tracing-appender",
-    "dep:tui-shimmer", "ratatui/crossterm", "ratatui/all-widgets", "ratatui/macros",
-    "ratatui/layout-cache", "ratatui/underline-color", "ratatui/serde"
+    "dep:chrono",
+    "dep:config",
+    "dep:crossterm",
+    "dep:dotparser",
+    "dep:futures",
+    "dep:percent-encoding",
+    "dep:prometheus-parse",
+    "dep:ratatui",
+    "dep:reqwest",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:tracing-appender",
+    "dep:tui-shimmer",
+    "ratatui/crossterm",
+    "ratatui/all-widgets",
+    "ratatui/macros",
+    "ratatui/layout-cache",
+    "ratatui/underline-color",
+    "ratatui/serde",
 ]
 
 web = [
-    "dep:chrono", "dep:config", "dep:critical-section", "dep:dotparser", "dep:futures", "dep:percent-encoding",
-    "dep:prometheus-parse", "dep:ratatui", "ratatui/serde", "dep:reqwest",
-    "dep:serde", "dep:serde_json", "dep:tui-shimmer",
-    "dep:ratzilla", "dep:wasm-bindgen", "dep:wasm-bindgen-futures",
-    "dep:gloo-timers", "dep:console_error_panic_hook",
-    "dep:tracing-web", "dep:web-sys", "dep:js-sys",
+    "dep:chrono",
+    "dep:config",
+    "dep:critical-section",
+    "dep:dotparser",
+    "dep:futures",
+    "dep:percent-encoding",
+    "dep:prometheus-parse",
+    "dep:ratatui",
+    "ratatui/serde",
+    "dep:reqwest",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:tui-shimmer",
+    "dep:ratzilla",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:gloo-timers",
+    "dep:console_error_panic_hook",
+    "dep:tracing-web",
+    "dep:web-sys",
+    "dep:js-sys",
 ]
 
 [[bin]]

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -30,7 +30,9 @@ rust-version = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 ballista-core = { path = "../core", version = "54.0.0" }
-ballista-executor = { path = "../executor", version = "54.0.0", optional = true, default-features = false, features = ["arrow-ipc-optimizations"] }
+ballista-executor = { path = "../executor", version = "54.0.0", optional = true, default-features = false, features = [
+    "arrow-ipc-optimizations",
+] }
 ballista-scheduler = { path = "../scheduler", version = "54.0.0", optional = true, default-features = false }
 datafusion = { workspace = true }
 log = { workspace = true }
@@ -46,8 +48,8 @@ datafusion-proto = { workspace = true }
 env_logger = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
-uuid = { workspace = true }
 tonic = { workspace = true }
+uuid = { workspace = true }
 
 [features]
 default = ["standalone"]

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -34,7 +34,15 @@ required-features = ["build-binary"]
 
 [features]
 arrow-ipc-optimizations = []
-build-binary = ["clap", "tracing-subscriber", "tracing-appender", "tracing", "ballista-core/build-binary", "mimalloc", "dep:axum"]
+build-binary = [
+    "clap",
+    "tracing-subscriber",
+    "tracing-appender",
+    "tracing",
+    "ballista-core/build-binary",
+    "mimalloc",
+    "dep:axum",
+]
 default = ["arrow-ipc-optimizations", "build-binary"]
 spark-compat = ["ballista-core/spark-compat"]
 

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -49,7 +49,6 @@ substrait = ["dep:datafusion-substrait"]
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.8.9"
-tower-http = { version = "0.7", features = ["cors"] }
 ballista-core = { path = "../core", version = "54.0.0" }
 clap = { workspace = true, optional = true }
 dashmap = { workspace = true }
@@ -74,6 +73,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true, features = ["router"] }
 tonic-prost = { workspace = true, optional = true }
+tower-http = { version = "0.7", features = ["cors"] }
 tracing = { workspace = true, optional = true }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }

--- a/ci/scripts/rust_toml_fmt.sh
+++ b/ci/scripts/rust_toml_fmt.sh
@@ -17,5 +17,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -ex
-find . -mindepth 2 -name 'Cargo.toml' -exec cargo tomlfmt -k -p {} \;
+# Checks Cargo.toml formatting using taplo. The formatting rules live in
+# taplo.toml at the repository root.
+#
+# Usage:
+#   ci/scripts/rust_toml_fmt.sh            # check formatting (default, used in CI)
+#   ci/scripts/rust_toml_fmt.sh --write    # reformat files in place
+
+set -e
+
+if [ "${1:-}" = "--write" ]; then
+    taplo format
+else
+    # `taplo format --check` exits non-zero if any file is not correctly
+    # formatted. Run `ci/scripts/rust_toml_fmt.sh --write` to fix violations.
+    taplo format --check
+fi

--- a/ci/scripts/rust_toml_fmt.sh
+++ b/ci/scripts/rust_toml_fmt.sh
@@ -26,6 +26,11 @@
 
 set -e
 
+if ! command -v taplo &> /dev/null; then
+    echo "Installing taplo using cargo"
+    cargo install taplo-cli --version 0.10.0 --locked
+fi
+
 if [ "${1:-}" = "--write" ]; then
     taplo format
 else

--- a/dev/rust_lint.sh
+++ b/dev/rust_lint.sh
@@ -17,9 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 set -e
-if ! command -v cargo-tomlfmt &> /dev/null; then
-    echo "Installing cargo-tomlfmt using cargo"
-    cargo install cargo-tomlfmt
+if ! command -v taplo &> /dev/null; then
+    echo "Installing taplo using cargo"
+    cargo install taplo-cli --locked
 fi
 
 ci/scripts/rust_fmt.sh

--- a/dev/rust_lint.sh
+++ b/dev/rust_lint.sh
@@ -17,10 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 set -e
-if ! command -v taplo &> /dev/null; then
-    echo "Installing taplo using cargo"
-    cargo install taplo-cli --locked
-fi
 
 ci/scripts/rust_fmt.sh
 ci/scripts/rust_clippy.sh

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -76,7 +76,7 @@ tokio = { workspace = true, features = [
     "rt",
     "rt-multi-thread",
     "sync",
-    "parking_lot"
+    "parking_lot",
 ] }
 tonic = { workspace = true }
 url = { workspace = true }

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+## https://taplo.tamasfe.dev/configuration/file.html
+
+include = ["**/Cargo.toml"]
+exclude = ["target/*"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = false
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 120
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '    '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = false
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false
+
+[[rule]]
+keys = [
+    "build-dependencies",
+    "dependencies",
+    "dev-dependencies",
+    "workspace.dependencies",
+]
+formatting = { reorder_keys = true }
+
+[[rule]]
+keys = ["package"]
+formatting = { reorder_keys = false }


### PR DESCRIPTION
## Background

The `Check Cargo.toml formatting` CI job does not currently fail on formatting violations, for two reasons:

- `ci/scripts/rust_toml_fmt.sh` runs `cargo tomlfmt -k -p` via `find … -exec`. `find` does not propagate the tool's non-zero exit code, so `set -e` is not triggered.
- The workflow's failure guard checks for a `Cargo.toml.bak` file, but `cargo-tomlfmt` 0.2.1 writes `Cargo.toml.new` rather than `.bak`, so the guard does not match.

As a result the job passes regardless of manifest formatting, and the manifests have drifted from a consistent style. Separately, `cargo-tomlfmt` 0.2.1 has some limitations for this use case: it writes a `.new` file rather than formatting in place, and it does not preserve comments when reformatting (see [tbrand/cargo-tomlfmt#40](https://github.com/tbrand/cargo-tomlfmt/issues/40)).

## Change

Move Cargo.toml formatting to **taplo**, aligning with the parent [apache/datafusion](https://github.com/apache/datafusion) project:

- Add `taplo.toml` (copied from apache/datafusion) — Cargo.toml-only scope, 4-space indent to match the existing style, `reorder_keys = false` for `[package]` (preserves key order and comments), alphabetized dependency tables.
- Rewrite `ci/scripts/rust_toml_fmt.sh` to run `taplo format --check` (with a `--write` mode to fix in place). This returns a non-zero exit code on violations, so the check enforces formatting, and it leaves no scratch files.
- `.github/workflows/rust.yml`: install `taplo-cli@0.9` via `taiki-e/install-action` and remove the `.bak` guard, which is no longer needed.
- `dev/rust_lint.sh`: install `taplo` instead of `cargo-tomlfmt`.
- Reformat the manifests to satisfy the check (dependency reordering and array expansion; comments preserved).

## Consistency with apache/datafusion

The parent project uses the same setup:

| | apache/datafusion | this PR |
|---|---|---|
| Install | `taplo-cli@0.9` via `taiki-e/install-action` | same |
| Check command | `taplo format --check` | same (via `rust_toml_fmt.sh`) |
| Rules | root `taplo.toml` | verbatim copy |

## Verification

- `ci/scripts/rust_toml_fmt.sh` (check) exits `0` on the formatted tree.
- Introducing a formatting violation in a manifest causes the check to exit non-zero (verified locally).
- No `Cargo.toml.new` / `.bak` scratch files are left behind.
- `ci/scripts/rust_toml_fmt.sh --write` reformats in place.
- No comment lines were removed by the reformat.