### PR TITLE
ci: run TPC-DS with AQE on/off at 1 and 16 partitions

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -56,6 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
+    # A passing run takes ~7 minutes. Cap the job well under the 6-hour
+    # default so a hung query fails fast and frees the runner rather than
+    # sitting for hours with no useful signal.
+    timeout-minutes: 45
     steps:
       - name: Install dependencies
         run: |
@@ -93,6 +97,10 @@ jobs:
             --output-dir "$RUNNER_TEMP/tpcds-data"
 
       - name: Run TPC-DS queries against Ballista cluster
+        # Primary timeout, on the step rather than the job, so that a hang
+        # still runs the log-upload step below and leaves something to
+        # diagnose. The job-level cap is only a backstop.
+        timeout-minutes: 30
         env:
           DATA_DIR: ${{ runner.temp }}/tpcds-data
           WORK_DIR: ${{ runner.temp }}/work
@@ -153,10 +161,9 @@ jobs:
           # internally loops all non-skipped queries and exits non-zero on any
           # failure, so a single invocation covers the whole suite.
           #
-          # The adaptive planner (AQE on) is intentionally not run here yet: it
-          # currently fails many TPC-DS queries with an `EmptyExec invalid
-          # partition` assertion (issue #2047). Re-add an `AQE on` invocation
-          # once that is fixed.
+          # Coverage for the adaptive planner (AQE on) and for single-partition
+          # execution is being added separately; both currently fail on
+          # pre-existing bugs.
           run_suite() {
             local label="$1"; shift
             echo "::group::[$label] TPC-DS suite"
@@ -173,7 +180,10 @@ jobs:
             -c datafusion.optimizer.prefer_hash_join=false
 
       - name: Upload cluster logs on failure
-        if: failure()
+        # `!success()` rather than `failure()` so a timed-out or cancelled
+        # run still surfaces its scheduler/executor logs — the hang case is
+        # exactly when they are most worth having.
+        if: ${{ !success() }}
         uses: actions/upload-artifact@v7
         with:
           name: tpcds-sf1-cluster-logs

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -52,14 +52,34 @@ on:
 
 jobs:
   tpcds-sf1:
-    name: TPC-DS SF1 (all queries, static planner)
+    name: TPC-DS SF1 (${{ matrix.label }})
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
-    # A passing run takes ~7 minutes. Cap the job well under the 6-hour
+    # A passing leg takes ~7 minutes. Cap the job well under the 6-hour
     # default so a hung query fails fast and frees the runner rather than
     # sitting for hours with no useful signal.
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: "AQE off, 16 partitions"
+            planner_args: ""
+            partitions: 16
+            slug: "aqe-off-p16"
+          - label: "AQE off, 1 partition"
+            planner_args: ""
+            partitions: 1
+            slug: "aqe-off-p1"
+          - label: "AQE on, 16 partitions"
+            planner_args: "-c ballista.planner.adaptive.enabled=true"
+            partitions: 16
+            slug: "aqe-on-p16"
+          - label: "AQE on, 1 partition"
+            planner_args: "-c ballista.planner.adaptive.enabled=true"
+            partitions: 1
+            slug: "aqe-on-p1"
     steps:
       - name: Install dependencies
         run: |
@@ -76,6 +96,10 @@ jobs:
           rust-version: stable
 
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
+        with:
+          # Share the build cache across all matrix legs — the compiled
+          # binaries are identical; only the per-suite CLI args differ.
+          shared-key: tpcds-sf1
 
       - name: Build Ballista binaries
         run: |
@@ -157,27 +181,19 @@ jobs:
           done
           nc -z 127.0.0.1 50051 || { echo "executor did not start"; exit 1; }
 
-          # Run the suite under the default (static) planner. The tpcds binary
-          # internally loops all non-skipped queries and exits non-zero on any
-          # failure, so a single invocation covers the whole suite.
-          #
-          # Coverage for the adaptive planner (AQE on) and for single-partition
-          # execution is being added separately; both currently fail on
-          # pre-existing bugs.
-          run_suite() {
-            local label="$1"; shift
-            echo "::group::[$label] TPC-DS suite"
-            ./target/tpch-ci/tpcds \
-              --host 127.0.0.1 --port 50050 \
-              --path "$DATA_DIR" \
-              --partitions 16 \
-              --verify \
-              "$@"
-            echo "::endgroup::"
-          }
-
-          run_suite "static planner" \
-            -c datafusion.optimizer.prefer_hash_join=false
+          # This matrix leg runs one planner/partitioning configuration over the
+          # whole suite. The tpcds binary internally loops all non-skipped
+          # queries and exits non-zero on any failure, so a single invocation
+          # covers the suite. The other legs run in parallel jobs.
+          echo "::group::[${{ matrix.label }}] TPC-DS suite"
+          ./target/tpch-ci/tpcds \
+            --host 127.0.0.1 --port 50050 \
+            --path "$DATA_DIR" \
+            --partitions ${{ matrix.partitions }} \
+            --verify \
+            -c datafusion.optimizer.prefer_hash_join=false \
+            ${{ matrix.planner_args }}
+          echo "::endgroup::"
 
       - name: Upload cluster logs on failure
         # `!success()` rather than `failure()` so a timed-out or cancelled
@@ -186,7 +202,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@v7
         with:
-          name: tpcds-sf1-cluster-logs
+          name: tpcds-sf1-cluster-logs-${{ matrix.slug }}
           retention-days: 14
           path: |
             ${{ runner.temp }}/scheduler.log

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -101,6 +101,9 @@ impl PropagateEmptyExecRule {
             Ok(Transformed::yes(limit.input().clone()))
         } else if let Some(aggregation) = plan.downcast_ref::<AggregateExec>()
             && is_empty_exec!(aggregation.input())
+            // An aggregate with no GROUP BY emits exactly one row even over zero
+            // input rows (`sum` -> NULL, `count` -> 0), so it must be preserved.
+            && !aggregation.group_expr().is_empty()
         {
             empty_exec!(aggregation)
         } else if let Some(repartition) = plan.downcast_ref::<RepartitionExec>()
@@ -328,8 +331,12 @@ mod tests {
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema},
         common::{ColumnStatistics, JoinType, NullEquality, Statistics},
+        physical_expr::aggregate::AggregateExprBuilder,
         physical_plan::{
-            expressions::Column, joins::PartitionMode, test::exec::StatisticsExec,
+            aggregates::{AggregateMode, PhysicalGroupBy},
+            expressions::Column,
+            joins::PartitionMode,
+            test::exec::StatisticsExec,
         },
     };
 
@@ -869,6 +876,75 @@ mod tests {
         );
         let result = transform(plan);
         assert!(result.downcast_ref::<StatisticsExec>().is_some());
+    }
+
+    // ── Aggregate ────────────────────────────────────────────────────────────
+
+    /// Build an `AggregateExec` over `input` with the given grouping.
+    fn aggregate(
+        input: Arc<dyn ExecutionPlan>,
+        group_by: PhysicalGroupBy,
+        mode: AggregateMode,
+    ) -> Arc<dyn ExecutionPlan> {
+        let aggr = AggregateExprBuilder::new(
+            datafusion::functions_aggregate::count::count_udaf(),
+            vec![Arc::new(Column::new("a", 0))],
+        )
+        .schema(input.schema())
+        .alias("count(a)")
+        .build()
+        .unwrap();
+
+        Arc::new(
+            AggregateExec::try_new(
+                mode,
+                group_by,
+                vec![Arc::new(aggr)],
+                vec![None],
+                input,
+                schema(),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn aggregate_with_grouping_over_empty_eliminated() {
+        // GROUP BY over zero rows produces zero groups — collapsing is correct.
+        let group_by = PhysicalGroupBy::new_single(vec![(
+            Arc::new(Column::new("a", 0)),
+            "a".into(),
+        )]);
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            group_by,
+            AggregateMode::Single,
+        );
+        assert_empty(&transform(plan));
+    }
+
+    #[test]
+    fn aggregate_without_grouping_over_empty_is_preserved() {
+        // No GROUP BY means exactly one output row even over zero input rows
+        // (`sum` -> NULL, `count` -> 0). Collapsing to EmptyExec loses that row.
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            PhysicalGroupBy::default(),
+            AggregateMode::Single,
+        );
+        assert_untouched(&transform(plan));
+    }
+
+    #[test]
+    fn partial_aggregate_without_grouping_over_empty_is_preserved() {
+        // Same holds for a partial aggregate: it emits one row of accumulator
+        // state per partition, which the final aggregate needs.
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            PhysicalGroupBy::default(),
+            AggregateMode::Partial,
+        );
+        assert_untouched(&transform(plan));
     }
 
     // ── unknown stats — never optimised ─────────────────────────────────────

--- a/benchmarks/src/bin/tpcds.rs
+++ b/benchmarks/src/bin/tpcds.rs
@@ -58,8 +58,7 @@ const TABLES: &[&str] = &[
     "web_site",
 ];
 
-/// Queries excluded from the correctness gate, with the reason. The gate runs
-/// under the default (static) planner; this list reflects that configuration.
+/// Queries excluded from the correctness gate, with the reason.
 /// Remove an entry as the underlying cause is fixed.
 const SKIP: &[(usize, &str)] = &[
     // Non-deterministic: LIMIT/ORDER BY ties without a total order make the
@@ -69,17 +68,30 @@ const SKIP: &[(usize, &str)] = &[
         71,
         "non-deterministic (ORDER BY ext_price ties; varies run-to-run)",
     ),
-    // tpcgen-cli's TPC-DS schema uses column names that differ from the
-    // DataFusion (branch-54) query text, so these fail at plan time. Not a
-    // Ballista issue (e.g. cr_return_amount_inc_tax vs cr_return_amt_inc_tax).
-    (64, "tpcgen-cli schema column-name mismatch with query text"),
-    (81, "tpcgen-cli schema column-name mismatch with query text"),
-    (84, "tpcgen-cli schema column-name mismatch with query text"),
-    (85, "tpcgen-cli schema column-name mismatch with query text"),
-    (93, "tpcgen-cli schema column-name mismatch with query text"),
-    // Note: the adaptive planner (AQE on) additionally fails many queries with an
-    // `EmptyExec invalid partition` assertion (issue #2047); the gate runs the
-    // static planner, so those are not listed here.
+];
+
+/// Column renames applied to the query text before planning, as
+/// `(query text, tpcgen-cli)` pairs.
+///
+/// `tpcgen-cli` names three columns differently from the TPC-DS spec, and the
+/// DataFusion query text follows the spec, so these queries would otherwise
+/// fail at plan time with "column not found". These are pure renames -- the
+/// data is present under the other name -- so rewriting the reference is
+/// enough. The identical rewrite is applied to the Ballista and oracle runs,
+/// so the comparison stays apples-to-apples.
+///
+/// This is applied at load time rather than by editing the files under
+/// `benchmarks/queries-tpcds/`, because `dev/vendor-tpcds-queries.sh`
+/// re-downloads all 99 queries and would clobber any local edit.
+///
+/// Drop a pair once `tpcgen-cli` renames the column to its spec name.
+const COLUMN_RENAMES: &[(&str, &str)] = &[
+    // income_band: affects q64, q84.
+    ("ib_income_band_sk", "ib_income_band_id"),
+    // reason: affects q85, q93.
+    ("r_reason_desc", "r_reason_description"),
+    // catalog_returns: affects q81.
+    ("cr_return_amt_inc_tax", "cr_return_amount_inc_tax"),
 ];
 
 #[derive(Debug, StructOpt)]
@@ -138,6 +150,38 @@ fn split_statements(contents: &str) -> Vec<String> {
         .collect()
 }
 
+/// Replace whole-word occurrences of `from` with `to`.
+///
+/// A plain `str::replace` is not safe here: `r_reason_desc` is a prefix of
+/// `r_reason_description`, so a substring replace would corrupt an already
+/// correct reference. A character is part of a word if it is alphanumeric or
+/// `_`, which matches how SQL identifiers are spelled in these queries.
+fn replace_word(haystack: &str, from: &str, to: &str) -> String {
+    let is_word = |c: char| c.is_alphanumeric() || c == '_';
+    let mut out = String::with_capacity(haystack.len());
+    let mut rest = haystack;
+    while let Some(pos) = rest.find(from) {
+        let (before, after) = rest.split_at(pos);
+        let tail = &after[from.len()..];
+        let boundary_ok = !before.chars().next_back().is_some_and(is_word)
+            && !tail.chars().next().is_some_and(is_word);
+        out.push_str(before);
+        out.push_str(if boundary_ok { to } else { from });
+        rest = tail;
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Rewrite spec column names to the names `tpcgen-cli` actually emits.
+fn apply_column_renames(sql: &str) -> String {
+    COLUMN_RENAMES
+        .iter()
+        .fold(sql.to_string(), |acc, (from, to)| {
+            replace_word(&acc, from, to)
+        })
+}
+
 fn get_query_sql(query: usize) -> Result<Vec<String>> {
     let possibilities = [
         format!("queries-tpcds/q{query}.sql"),
@@ -146,7 +190,9 @@ fn get_query_sql(query: usize) -> Result<Vec<String>> {
     let mut errors = vec![];
     for filename in &possibilities {
         match fs::read_to_string(filename) {
-            Ok(contents) => return Ok(split_statements(&contents)),
+            Ok(contents) => {
+                return Ok(split_statements(&apply_column_renames(&contents)));
+            }
             Err(e) => errors.push(format!("{filename}: {e}")),
         }
     }
@@ -326,5 +372,54 @@ mod tests {
     fn explicit_query_overrides_skiplist() {
         let skip: &[(usize, &str)] = &[(1, "should be overridden")];
         assert_eq!(selected_queries(Some(1), skip), vec![1]);
+    }
+
+    #[test]
+    fn replace_word_only_matches_whole_identifiers() {
+        assert_eq!(
+            replace_word("a.r_reason_desc, b", "r_reason_desc", "x"),
+            "a.x, b"
+        );
+        // A longer identifier that merely contains the needle is left alone.
+        assert_eq!(
+            replace_word("r_reason_desc_2", "r_reason_desc", "x"),
+            "r_reason_desc_2"
+        );
+        assert_eq!(
+            replace_word("my_r_reason_desc", "r_reason_desc", "x"),
+            "my_r_reason_desc"
+        );
+    }
+
+    #[test]
+    fn column_renames_are_idempotent() {
+        // `r_reason_desc` is a prefix of its replacement, so a second pass must
+        // not extend it again.
+        let once = apply_column_renames("select r_reason_desc from reason");
+        assert_eq!(once, "select r_reason_description from reason");
+        assert_eq!(apply_column_renames(&once), once);
+    }
+
+    #[test]
+    fn column_renames_cover_every_spec_name() {
+        let sql = "ib_income_band_sk, r_reason_desc, cr_return_amt_inc_tax";
+        assert_eq!(
+            apply_column_renames(sql),
+            "ib_income_band_id, r_reason_description, cr_return_amount_inc_tax"
+        );
+    }
+
+    #[test]
+    fn renames_are_applied_when_loading_a_query() {
+        // q93 references `r_reason_desc`; after loading, only the tpcgen-cli
+        // spelling should remain. Guards against the rewrite being dropped
+        // from the load path.
+        let Ok(sqls) = get_query_sql(93) else {
+            // Query files are not present in every build context.
+            return;
+        };
+        let joined = sqls.join(" ");
+        assert!(joined.contains("r_reason_description"));
+        assert!(!replace_word(&joined, "r_reason_desc", "?").contains('?'));
     }
 }


### PR DESCRIPTION
> **Stacked on #2194** (the GROUP BY-less aggregate fix for #2185), which is merged into this branch so the `aqe-on-p1` leg exercises it. Review that one first; this PR's diff is the matrix alone once #2194 merges. #2183, the previous base, is now merged.
>
> **This PR is expected to be red.** Three of its four legs fail on pre-existing bugs — that is the point of the coverage. It is a live tracker, not a merge candidate, until those are fixed.

# Which issue does this PR close?

Part of #2092.

# Rationale for this change

The TPC-DS gate ran exactly one configuration: the static planner at 16 partitions. The adaptive planner was deliberately left out because it failed many TPC-DS queries with an `EmptyExec invalid partition` assertion, tracked as #2047 — which is now closed. So AQE has no TPC-DS coverage at all, even though #2092 aims to enable it by default. That is the configuration most in need of a correctness gate.

Single-partition execution was also never covered, and it turns out to be where the interesting failures are.

# What changes are included in this PR?

Replaces the single job with a four-leg matrix, following the shape `tpch.yml` already uses:

| Leg | Planner | `--partitions` | Status |
|---|---|---|---|
| `aqe-off-p16` | static | 16 | **passes** (97/99) |
| `aqe-off-p1` | static | 1 | fails |
| `aqe-on-p16` | adaptive | 16 | hangs |
| `aqe-on-p1` | adaptive | 1 | fails |

- Per-leg `label` / `planner_args` / `partitions` / `slug`, matching `tpch.yml`'s convention.
- `fail-fast: false`, so one red leg does not mask the others.
- All legs share one `swatinem/rust-cache` entry via `shared-key: tpcds-sf1`, so the binaries are compiled once and restored by the remaining legs rather than rebuilt four times. This mirrors `tpch.yml`'s `shared-key: tpch-sf10`.
- The cluster-log artifact is named per leg so failures do not collide.

# What the new coverage found

All of these reproduce on `main` and are independent of this PR.

**1. UNION scan restriction is wrong at `target_partitions=1`** (#2184)

| Query | Symptom |
|---|---|
| q5 | expected `73724.99`, got `294899.96` — exactly **4x** |
| q80 | expected `11343.60`, got `22687.20` — exactly **2x** |
| q49 | `Internal("FileStreamBuilder invalid partition index: 0")` |

q5, q80 and q49 are exactly the three affected queries containing `UNION`. #2070 ("map a task's partition through UnionExec when restricting file scans") fixed this precise inflation symptom and states it was verified correct "at every partition count tried (4, 5, 6, 8, 16, 20, 32)" — **1 was never tried**.

A candidate mechanism, in `restrict_plan_to_partitions` (`ballista/scheduler/src/state/task_builder.rs`): the walker passes the parent's partition indices unchanged through interior nodes, then applies them to leaf file scans via `config.file_groups.get(i)`. When an index exceeds the scan's file-group count, `filter_map` silently drops it. An empty `file_groups` is exactly what makes `FileStreamBuilder` reject partition 0, and a *missed* restriction leaves a scan free to read its whole table and inflate the answer. The comment at that call site already notes the non-empty branch is "currently safe because the only shape emitted is `partitions == 1`".

**2. AQE hangs on q16 at 16 partitions**

The leg produced `Query 15 verified against DataFusion: OK` and then no further output for over three hours before being cancelled, against ~7 minutes for a passing leg. Consistent with #2063.

**3. q61 returns 0 rows instead of 1** under AQE at 1 partition (#2185). Fixed by #2194, which this branch now merges in.

**Not bugs:** q47 and q72 exhaust memory at 1 partition. `--memory-pool-size 2GB` split across `--concurrent-tasks 4` gives each task a 476.8 MB fair share, and collapsing to one partition pushes the whole table through a single task. That is workflow tuning, to be addressed when the legs are made green.

# Are there any user-facing changes?

No. CI coverage only.
