### PR TITLE
fix: stop every task running every union branch at low partition counts

### DIFF
--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -43,6 +43,7 @@ use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{
     ExecutionPlan, Partitioning, with_new_children_if_necessary,
 };
@@ -51,6 +52,7 @@ use log::debug;
 use crate::physical_optimizer::join_selection::{
     collect_left_broadcast_safe, should_swap_join_order,
 };
+use crate::state::task_builder::restrict_plan_to_partitions;
 
 type PartialQueryStageResult = (Arc<dyn ExecutionPlan>, Vec<Arc<dyn ShuffleWriter>>);
 
@@ -184,6 +186,55 @@ impl DefaultDistributedPlanner {
             let new_join =
                 execution_plan.with_new_children(vec![broadcast_left, probe])?;
             return Ok((new_join, stages));
+        }
+
+        // UnionExec: a branch that cannot be restricted away needs its own
+        // stage. Per-task restriction gives each branch of a union the
+        // partitions that task owns and an empty slice to the rest, relying on
+        // an unowned branch becoming 0-partition so `UnionExec`'s index
+        // arithmetic routes past it.
+        //
+        // That fails when the branch's partition count does not come from
+        // restrictable leaves — a `CoalescePartitionsExec` or non-preserving
+        // `SortExec` reports one partition whatever its leaves do, and a
+        // broadcast `ShuffleReaderExec` is deliberately never pruned. The
+        // branch keeps reporting a partition and keeps producing all of its
+        // data, so every task runs every branch: results come back inflated by
+        // the branch count, or a task executes a branch whose scan was emptied
+        // (#2184).
+        //
+        // Cutting a boundary beneath such a branch turns it into a
+        // `ShuffleReaderExec`, which restricts to nothing cleanly, and leaves
+        // the collapse in its own stage where it sees its whole input.
+        if execution_plan.is::<UnionExec>() {
+            let mut stages = vec![];
+            let mut children = vec![];
+            for child in execution_plan.children() {
+                let (new_child, mut child_stages) =
+                    self.plan_query_stages_internal(job_id, child.clone(), config)?;
+                stages.append(&mut child_stages);
+
+                if new_child.is::<UnresolvedShuffleExec>()
+                    || restricts_to_nothing(&new_child)
+                {
+                    children.push(new_child);
+                    continue;
+                }
+
+                let writer = create_shuffle_writer_with_config(
+                    job_id,
+                    self.next_stage_id(),
+                    new_child,
+                    None,
+                    config,
+                )?;
+                children.push(create_unresolved_shuffle(writer.as_ref()));
+                stages.push(writer);
+            }
+            return Ok((
+                with_new_children_if_necessary(execution_plan, children)?,
+                stages,
+            ));
         }
 
         let mut stages = vec![];
@@ -532,6 +583,42 @@ impl DefaultDistributedPlanner {
     }
 }
 
+/// Whether per-task restriction can reduce `plan` to zero partitions.
+///
+/// This asks the real rewriter rather than testing for particular operators,
+/// so it stays correct as the rewriter's handling of collapses, broadcast
+/// readers and leaf types evolves. An empty slice means "this task polls
+/// nothing here", so a branch that still reports a partition afterwards is one
+/// that cannot be restricted away.
+fn restricts_to_nothing(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    !holds_a_broadcast(plan)
+        && restrict_plan_to_partitions(plan.clone(), &[])
+            .map(|p| p.properties().output_partitioning().partition_count() == 0)
+            .unwrap_or(false)
+}
+
+/// Whether `plan` contains a broadcast input or a `CollectLeft` join.
+///
+/// Asking the rewriter alone is not enough here. A `CollectLeft` join's build
+/// and probe sides can still be swapped after stage planning, and the two
+/// orders restrict differently: the build side is read in full (it must see
+/// its whole input), while a broadcast input is never pruned at all. So a
+/// branch that looks restrictable now can stop being restrictable by the time
+/// the task is built, which is exactly the case that left TPC-DS q5's catalog
+/// branch running in every task.
+///
+/// Treat any such branch as needing its own stage. The cost is one extra
+/// stage; the alternative is a silently inflated result.
+fn holds_a_broadcast(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    let here = plan
+        .downcast_ref::<UnresolvedShuffleExec>()
+        .is_some_and(|u| u.broadcast)
+        || plan
+            .downcast_ref::<HashJoinExec>()
+            .is_some_and(|j| *j.partition_mode() == PartitionMode::CollectLeft);
+    here || plan.children().iter().any(|c| holds_a_broadcast(c))
+}
+
 fn create_unresolved_shuffle(
     shuffle_writer: &dyn ShuffleWriter,
 ) -> Arc<UnresolvedShuffleExec> {
@@ -803,6 +890,74 @@ mod test {
         assert_eq!(
             displayable(rewritten.as_ref()).indent(false).to_string(),
             "EmptyExec\n"
+        );
+    }
+
+    use super::restricts_to_nothing;
+    use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+
+    /// Build a `DataSourceExec` over `n` single-file groups, so its output
+    /// partition count is `n` and every group is restrictable.
+    fn scan(n: usize) -> Arc<dyn ExecutionPlan> {
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::datasource::listing::PartitionedFile;
+        use datafusion::datasource::physical_plan::{
+            FileGroup, FileScanConfigBuilder, ParquetSource,
+        };
+        use datafusion::datasource::source::DataSourceExec;
+        use datafusion::execution::object_store::ObjectStoreUrl;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let source = Arc::new(ParquetSource::new(schema));
+        let mut builder =
+            FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source);
+        for i in 0..n {
+            builder =
+                builder.with_file_group(FileGroup::new(vec![PartitionedFile::new(
+                    format!("f{i}.parquet"),
+                    10,
+                )]));
+        }
+        DataSourceExec::from_data_source(builder.build())
+    }
+
+    /// A plain scan branch restricts away cleanly, so it can stay inline in
+    /// the union's stage.
+    #[test]
+    fn plain_union_branch_needs_no_stage_of_its_own() {
+        assert!(restricts_to_nothing(&scan(4)));
+    }
+
+    /// A branch that collapses internally reports one partition whatever its
+    /// leaves do, so restriction cannot empty it and it needs its own stage.
+    #[test]
+    fn collapsing_union_branch_needs_its_own_stage() {
+        let branch: Arc<dyn ExecutionPlan> =
+            Arc::new(CoalescePartitionsExec::new(scan(4)));
+        assert_eq!(
+            branch.properties().output_partitioning().partition_count(),
+            1
+        );
+        assert!(
+            !restricts_to_nothing(&branch),
+            "a collapsing branch cannot be restricted away"
+        );
+    }
+
+    /// A branch holding a broadcast input is treated as needing its own stage
+    /// even though restriction looks like it would empty it: the build and
+    /// probe sides of a `CollectLeft` join can still be swapped after stage
+    /// planning, and a broadcast input is never pruned.
+    #[test]
+    fn broadcast_union_branch_needs_its_own_stage() {
+        use ballista_core::execution_plans::UnresolvedShuffleExec;
+
+        let inner = scan(4);
+        let broadcast: Arc<dyn ExecutionPlan> =
+            Arc::new(UnresolvedShuffleExec::new_broadcast(1, inner.schema(), 4));
+        assert!(
+            !restricts_to_nothing(&broadcast),
+            "a broadcast input is never pruned, so it cannot be restricted away"
         );
     }
 

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -188,6 +188,15 @@ impl DefaultDistributedPlanner {
             return Ok((new_join, stages));
         }
 
+        let mut stages = vec![];
+        let mut children = vec![];
+        for child in execution_plan.children() {
+            let (new_child, mut child_stages) =
+                self.plan_query_stages_internal(job_id, child.clone(), config)?;
+            children.push(new_child);
+            stages.append(&mut child_stages);
+        }
+
         // UnionExec: a branch that cannot be restricted away needs its own
         // stage. Per-task restriction gives each branch of a union the
         // partitions that task owns and an empty slice to the rest, relying on
@@ -207,43 +216,24 @@ impl DefaultDistributedPlanner {
         // `ShuffleReaderExec`, which restricts to nothing cleanly, and leaves
         // the collapse in its own stage where it sees its whole input.
         if execution_plan.is::<UnionExec>() {
-            let mut stages = vec![];
-            let mut children = vec![];
-            for child in execution_plan.children() {
-                let (new_child, mut child_stages) =
-                    self.plan_query_stages_internal(job_id, child.clone(), config)?;
-                stages.append(&mut child_stages);
-
-                if new_child.is::<UnresolvedShuffleExec>()
-                    || restricts_to_nothing(&new_child)
-                {
-                    children.push(new_child);
+            for child in &mut children {
+                if can_stay_inline(child) {
                     continue;
                 }
-
                 let writer = create_shuffle_writer_with_config(
                     job_id,
                     self.next_stage_id(),
-                    new_child,
+                    child.clone(),
                     None,
                     config,
                 )?;
-                children.push(create_unresolved_shuffle(writer.as_ref()));
+                *child = create_unresolved_shuffle(writer.as_ref());
                 stages.push(writer);
             }
             return Ok((
                 with_new_children_if_necessary(execution_plan, children)?,
                 stages,
             ));
-        }
-
-        let mut stages = vec![];
-        let mut children = vec![];
-        for child in execution_plan.children() {
-            let (new_child, mut child_stages) =
-                self.plan_query_stages_internal(job_id, child.clone(), config)?;
-            children.push(new_child);
-            stages.append(&mut child_stages);
         }
 
         if let Some(_coalesce) = execution_plan.downcast_ref::<CoalescePartitionsExec>() {
@@ -583,29 +573,39 @@ impl DefaultDistributedPlanner {
     }
 }
 
-/// Whether per-task restriction can reduce `plan` to zero partitions.
+/// Whether a union branch can be left in the union's own stage.
 ///
-/// This asks the real rewriter rather than testing for particular operators,
-/// so it stays correct as the rewriter's handling of collapses, broadcast
-/// readers and leaf types evolves. An empty slice means "this task polls
-/// nothing here", so a branch that still reports a partition afterwards is one
-/// that cannot be restricted away.
+/// A branch already sitting behind a stage boundary needs nothing more, and
+/// neither does one that per-task restriction can reduce to zero partitions —
+/// that is the property the union's index arithmetic relies on. The second
+/// question is put to the real rewriter rather than to a list of operators, so
+/// it stays correct as the rewriter's handling of collapses, broadcast readers
+/// and leaf types evolves.
+fn can_stay_inline(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    if plan.is::<UnresolvedShuffleExec>() {
+        return true;
+    }
+    !holds_a_broadcast(plan) && restricts_to_nothing(plan)
+}
+
+/// Whether per-task restriction can reduce `plan` to zero partitions. An empty
+/// slice means "this task polls nothing here", so a branch that still reports a
+/// partition afterwards is one that cannot be restricted away.
 fn restricts_to_nothing(plan: &Arc<dyn ExecutionPlan>) -> bool {
-    !holds_a_broadcast(plan)
-        && restrict_plan_to_partitions(plan.clone(), &[])
-            .map(|p| p.properties().output_partitioning().partition_count() == 0)
-            .unwrap_or(false)
+    restrict_plan_to_partitions(plan.clone(), &[])
+        .is_ok_and(|p| p.properties().output_partitioning().partition_count() == 0)
 }
 
 /// Whether `plan` contains a broadcast input or a `CollectLeft` join.
 ///
 /// Asking the rewriter alone is not enough here. A `CollectLeft` join's build
-/// and probe sides can still be swapped after stage planning, and the two
-/// orders restrict differently: the build side is read in full (it must see
-/// its whole input), while a broadcast input is never pruned at all. So a
-/// branch that looks restrictable now can stop being restrictable by the time
-/// the task is built, which is exactly the case that left TPC-DS q5's catalog
-/// branch running in every task.
+/// and probe sides can still be swapped after stage planning — `JoinSelection`
+/// runs on the resolved stage plan (see `ExecutionStage`) — and the two orders
+/// restrict differently: the build side is read in full (it must see its whole
+/// input), while a broadcast input is never pruned at all. So a branch that
+/// looks restrictable now can stop being restrictable by the time the task is
+/// built, which is exactly the case that left TPC-DS q5's catalog branch
+/// running in every task.
 ///
 /// Treat any such branch as needing its own stage. The cost is one extra
 /// stage; the alternative is a silently inflated result.
@@ -831,9 +831,10 @@ pub(crate) fn create_shuffle_writer_with_config(
 
 #[cfg(test)]
 mod test {
+    use super::{can_stay_inline, holds_a_broadcast};
     use crate::assert_plan;
     use crate::planner::{DefaultDistributedPlanner, DistributedPlanner};
-    use crate::test_utils::datafusion_test_context;
+    use crate::test_utils::{datafusion_test_context, scan_with_file_groups};
     use ballista_core::error::BallistaError;
     use ballista_core::execution_plans::{SortShuffleWriterExec, UnresolvedShuffleExec};
     use ballista_core::serde::BallistaCodec;
@@ -842,6 +843,7 @@ mod test {
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::expressions::Column;
     use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode};
+    use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 
     use datafusion::physical_plan::filter::FilterExec;
 
@@ -893,39 +895,23 @@ mod test {
         );
     }
 
-    use super::restricts_to_nothing;
-    use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
-
-    /// Build a `DataSourceExec` over `n` single-file groups, so its output
-    /// partition count is `n` and every group is restrictable.
-    fn scan(n: usize) -> Arc<dyn ExecutionPlan> {
-        use datafusion::arrow::datatypes::{DataType, Field, Schema};
-        use datafusion::datasource::listing::PartitionedFile;
-        use datafusion::datasource::physical_plan::{
-            FileGroup, FileScanConfigBuilder, ParquetSource,
-        };
-        use datafusion::datasource::source::DataSourceExec;
-        use datafusion::execution::object_store::ObjectStoreUrl;
-
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
-        let source = Arc::new(ParquetSource::new(schema));
-        let mut builder =
-            FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source);
-        for i in 0..n {
-            builder =
-                builder.with_file_group(FileGroup::new(vec![PartitionedFile::new(
-                    format!("f{i}.parquet"),
-                    10,
-                )]));
-        }
-        DataSourceExec::from_data_source(builder.build())
+    /// A plain scan branch restricts away cleanly, so it can stay inline in
+    /// the union's stage and needs no extra shuffle.
+    #[test]
+    fn plain_union_branch_stays_inline() {
+        assert!(can_stay_inline(&scan_with_file_groups(4)));
     }
 
-    /// A plain scan branch restricts away cleanly, so it can stay inline in
-    /// the union's stage.
+    /// A branch already sitting behind a stage boundary needs nothing more.
     #[test]
-    fn plain_union_branch_needs_no_stage_of_its_own() {
-        assert!(restricts_to_nothing(&scan(4)));
+    fn branch_behind_a_stage_boundary_stays_inline() {
+        let schema = scan_with_file_groups(1).schema();
+        let reader: Arc<dyn ExecutionPlan> = Arc::new(UnresolvedShuffleExec::new(
+            1,
+            schema,
+            Partitioning::UnknownPartitioning(4),
+        ));
+        assert!(can_stay_inline(&reader));
     }
 
     /// A branch that collapses internally reports one partition whatever its
@@ -933,31 +919,39 @@ mod test {
     #[test]
     fn collapsing_union_branch_needs_its_own_stage() {
         let branch: Arc<dyn ExecutionPlan> =
-            Arc::new(CoalescePartitionsExec::new(scan(4)));
+            Arc::new(CoalescePartitionsExec::new(scan_with_file_groups(4)));
         assert_eq!(
             branch.properties().output_partitioning().partition_count(),
             1
         );
         assert!(
-            !restricts_to_nothing(&branch),
+            !can_stay_inline(&branch),
             "a collapsing branch cannot be restricted away"
         );
     }
 
-    /// A branch holding a broadcast input is treated as needing its own stage
-    /// even though restriction looks like it would empty it: the build and
-    /// probe sides of a `CollectLeft` join can still be swapped after stage
-    /// planning, and a broadcast input is never pruned.
+    /// The broadcast guard looks through the whole branch, not just its root:
+    /// a `CollectLeft` join's sides can be swapped after stage planning, and
+    /// the two orders restrict differently, so any branch holding one is
+    /// treated as needing its own stage.
     #[test]
-    fn broadcast_union_branch_needs_its_own_stage() {
-        use ballista_core::execution_plans::UnresolvedShuffleExec;
-
-        let inner = scan(4);
-        let broadcast: Arc<dyn ExecutionPlan> =
-            Arc::new(UnresolvedShuffleExec::new_broadcast(1, inner.schema(), 4));
+    fn broadcast_is_detected_anywhere_in_a_branch() {
+        let plain = scan_with_file_groups(4);
         assert!(
-            !restricts_to_nothing(&broadcast),
-            "a broadcast input is never pruned, so it cannot be restricted away"
+            !holds_a_broadcast(&plain),
+            "a plain scan holds no broadcast"
+        );
+
+        let broadcast: Arc<dyn ExecutionPlan> =
+            Arc::new(UnresolvedShuffleExec::new_broadcast(1, plain.schema(), 4));
+        assert!(holds_a_broadcast(&broadcast));
+
+        // Buried a level down, which is where it actually shows up.
+        let buried: Arc<dyn ExecutionPlan> =
+            Arc::new(CoalescePartitionsExec::new(broadcast));
+        assert!(
+            holds_a_broadcast(&buried),
+            "the guard must search the branch, not just its root"
         );
     }
 

--- a/ballista/scheduler/src/state/task_builder.rs
+++ b/ballista/scheduler/src/state/task_builder.rs
@@ -147,7 +147,10 @@ fn union_child_partitions(
 ///   every child (it's sticky — descendants of a collapse all read
 ///   everything).
 /// - `CoalescePartitionsExec` / `SortPreservingMergeExec`: set for all
-///   children.
+///   children. These cannot be derived from the rule below — both declare
+///   `UnspecifiedDistribution`, because they consume every input partition
+///   without constraining how the input is partitioned. Keep the explicit
+///   case.
 /// - Anything else: set per child from `required_input_distribution()`. An
 ///   input declared `SinglePartition` is one the operator consumes whole —
 ///   a join or cross-join build side, for instance — so restricting it to
@@ -159,7 +162,9 @@ fn union_child_partitions(
 ///   `CrossJoinExec` also collects its left input but was not on that list,
 ///   so each task of a multi-partition stage rebuilt the cross-join's left
 ///   side from its own slice and the result came back inflated (seen on
-///   TPC-DS q77, whose catalog branch is `from cs, cr`).
+///   TPC-DS q77, whose catalog branch is `from cs, cr`). It also brings in
+///   a non-preserving `SortExec` and `GlobalLimitExec`, which declare
+///   `SinglePartition` for the same reason.
 ///
 /// `UnionExec` is handled by the caller before reaching this function —
 /// its children need per-child *partition* sub-slices, not just per-child
@@ -173,13 +178,19 @@ fn child_scopes(plan: &Arc<dyn ExecutionPlan>, under_collect: bool) -> Vec<bool>
         return vec![true; children.len()];
     }
     let required = plan.required_input_distribution();
-    if required.len() == children.len() {
-        return required
-            .into_iter()
-            .map(|d| matches!(d, Distribution::SinglePartition))
-            .collect();
+    if required.len() != children.len() {
+        // The trait contract is one entry per child, so a mismatch means a
+        // broken operator. Stay partition-aligned rather than reading whole:
+        // `true` here is not the safe direction, it makes every task of the
+        // stage read the entire input, which duplicates the data instead of
+        // protecting it. `false` is also what every operator outside the
+        // cases above got before this rule generalized.
+        return vec![false; children.len()];
     }
-    vec![false; children.len()]
+    required
+        .into_iter()
+        .map(|d| matches!(d, Distribution::SinglePartition))
+        .collect()
 }
 
 /// Restrict a plan node to a subset of its output partitions, re-indexed
@@ -487,30 +498,8 @@ mod tests {
     // upstream fix used a per-single-partition helper on the executor side;
     // this suite ports the same invariants to the scheduler-side rewriter.
 
-    use datafusion::arrow::datatypes::SchemaRef;
-    use datafusion::datasource::listing::PartitionedFile;
-    use datafusion::datasource::physical_plan::ParquetSource;
-    use datafusion::execution::object_store::ObjectStoreUrl;
+    use crate::test_utils::scan_with_file_groups;
     use datafusion::physical_plan::union::UnionExec;
-
-    /// Build a `DataSourceExec` over `n` file groups (one file each), so
-    /// every group is exactly one partition. The scan's output partition
-    /// count equals `n`.
-    fn scan_with_file_groups(n: usize) -> Arc<dyn ExecutionPlan> {
-        let schema: SchemaRef =
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
-        let source = Arc::new(ParquetSource::new(schema));
-        let mut builder =
-            FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source);
-        for i in 0..n {
-            builder =
-                builder.with_file_group(FileGroup::new(vec![PartitionedFile::new(
-                    format!("file{i}.parquet"),
-                    100,
-                )]));
-        }
-        DataSourceExec::from_data_source(builder.build())
-    }
 
     /// File counts per file group of a `DataSourceExec` — the shape a union
     /// test cares about after restriction.
@@ -608,10 +597,10 @@ mod tests {
     fn cross_join_left_side_is_read_whole() {
         use datafusion::physical_plan::joins::CrossJoinExec;
 
-        let left = scan_with_file_groups(4);
-        let right = scan_with_file_groups(4);
-        let join: Arc<dyn ExecutionPlan> =
-            Arc::new(CrossJoinExec::new(left, right.clone()));
+        let join: Arc<dyn ExecutionPlan> = Arc::new(CrossJoinExec::new(
+            scan_with_file_groups(4),
+            scan_with_file_groups(4),
+        ));
 
         // Sanity: the operator really does declare its left input collected.
         assert!(

--- a/ballista/scheduler/src/state/task_builder.rs
+++ b/ballista/scheduler/src/state/task_builder.rs
@@ -46,7 +46,6 @@ use datafusion::error::Result;
 use datafusion::physical_expr::Distribution;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::joins::{HashJoinExec, NestedLoopJoinExec};
 use datafusion::physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::union::UnionExec;
@@ -149,10 +148,18 @@ fn union_child_partitions(
 ///   everything).
 /// - `CoalescePartitionsExec` / `SortPreservingMergeExec`: set for all
 ///   children.
-/// - `HashJoinExec` / `NestedLoopJoinExec`: set per child based on
-///   `required_input_distribution()`. Typically only the build side is
-///   `SinglePartition`, so the probe side inherits `false` and remains
-///   partition-aligned.
+/// - Anything else: set per child from `required_input_distribution()`. An
+///   input declared `SinglePartition` is one the operator consumes whole —
+///   a join or cross-join build side, for instance — so restricting it to
+///   the task's slice would hand each sibling task a different fraction of
+///   it. Typically only the build side is `SinglePartition`, so the probe
+///   side inherits `false` and remains partition-aligned.
+///
+///   This is asked of every operator rather than a list of join types.
+///   `CrossJoinExec` also collects its left input but was not on that list,
+///   so each task of a multi-partition stage rebuilt the cross-join's left
+///   side from its own slice and the result came back inflated (seen on
+///   TPC-DS q77, whose catalog branch is `from cs, cr`).
 ///
 /// `UnionExec` is handled by the caller before reaching this function —
 /// its children need per-child *partition* sub-slices, not just per-child
@@ -165,9 +172,9 @@ fn child_scopes(plan: &Arc<dyn ExecutionPlan>, under_collect: bool) -> Vec<bool>
     if plan.is::<CoalescePartitionsExec>() || plan.is::<SortPreservingMergeExec>() {
         return vec![true; children.len()];
     }
-    if plan.is::<HashJoinExec>() || plan.is::<NestedLoopJoinExec>() {
-        return plan
-            .required_input_distribution()
+    let required = plan.required_input_distribution();
+    if required.len() == children.len() {
+        return required
             .into_iter()
             .map(|d| matches!(d, Distribution::SinglePartition))
             .collect();
@@ -587,5 +594,45 @@ mod tests {
         let plan = scan_with_file_groups(4);
         let restricted = restrict_plan_to_partitions(plan, &[2]).unwrap();
         assert_eq!(group_file_counts(&restricted), vec![1]);
+    }
+
+    /// A `CrossJoinExec` collects its left input, so that side must be read
+    /// whole. Scoping is taken from `required_input_distribution()` rather
+    /// than a list of join types, which is what brings cross joins in.
+    ///
+    /// Restricting the collected side would give each sibling task a
+    /// different fraction of it, and the join would emit a different subset
+    /// of the cartesian product per task — TPC-DS q77's `from cs, cr` branch
+    /// came back inflated exactly this way.
+    #[test]
+    fn cross_join_left_side_is_read_whole() {
+        use datafusion::physical_plan::joins::CrossJoinExec;
+
+        let left = scan_with_file_groups(4);
+        let right = scan_with_file_groups(4);
+        let join: Arc<dyn ExecutionPlan> =
+            Arc::new(CrossJoinExec::new(left, right.clone()));
+
+        // Sanity: the operator really does declare its left input collected.
+        assert!(
+            matches!(
+                join.required_input_distribution().first(),
+                Some(Distribution::SinglePartition)
+            ),
+            "CrossJoinExec must declare SinglePartition on its left input"
+        );
+
+        let restricted = restrict_plan_to_partitions(join, &[1]).unwrap();
+        let children = restricted.children();
+        assert_eq!(
+            group_file_counts(children[0]),
+            vec![1, 1, 1, 1],
+            "collected left side keeps every group"
+        );
+        assert_eq!(
+            group_file_counts(children[1]),
+            vec![1],
+            "streaming right side is pinned to this task's partition"
+        );
     }
 }

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -1243,3 +1243,30 @@ pub fn mock_failed_task(task: TaskDescription, failed_task: FailedTask) -> TaskS
         status: Some(task_status::Status::Failed(failed_task)),
     }
 }
+
+/// A `DataSourceExec` over `n` single-file groups, so its output partition
+/// count is `n` and each group is independently restrictable.
+///
+/// Shared by the planner and task-builder tests, both of which need a leaf
+/// whose partitions per-task restriction can actually slice.
+pub fn scan_with_file_groups(n: usize) -> Arc<dyn ExecutionPlan> {
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::physical_plan::{
+        FileGroup, FileScanConfigBuilder, ParquetSource,
+    };
+    use datafusion::datasource::source::DataSourceExec;
+    use datafusion::execution::object_store::ObjectStoreUrl;
+
+    let schema: SchemaRef =
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+    let source = Arc::new(ParquetSource::new(schema));
+    let mut builder =
+        FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source);
+    for i in 0..n {
+        builder = builder.with_file_group(FileGroup::new(vec![PartitionedFile::new(
+            format!("file{i}.parquet"),
+            100,
+        )]));
+    }
+    DataSourceExec::from_data_source(builder.build())
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2184.

# Rationale for this change

Per-task restriction gives each branch of a `UnionExec` the partitions that task owns and an empty slice to the rest, relying on an unowned branch becoming 0-partition so the union's index arithmetic routes past it.

That fails when a branch's partition count does not come from restrictable leaves. A `CoalescePartitionsExec` or a non-preserving `SortExec` reports one partition whatever its leaves do, and a broadcast `ShuffleReaderExec` is deliberately never pruned. The branch keeps reporting a partition and keeps producing all of its data, so the executor — which runs every partition of the plan it is handed — runs every branch for every task.

At SF1 with `target_partitions=1`:

| Query | Expected | Got | |
|---|---|---|---|
| q5 | `73724.99` | `294899.96` | 4x |
| q80 | `11343.60` | `22687.20` | 2x |
| q49 | — | `Internal("FileStreamBuilder invalid partition index: 0")` | |

This does not show at higher partition counts because those union stages are capped by a hash repartition, where the writer's output is an intrinsic K-space and inner partition counts do not matter. Confirmed by instrumenting the rewriter: restricting q49's 3-partition union stage to `[0]` returned a plan that still had 3 partitions.

# What changes are included in this PR?

**`planner.rs` — cut a stage boundary beneath a union branch that cannot be restricted away.** The branch becomes a `ShuffleReaderExec`, which restricts to nothing cleanly, and the collapse moves into its own stage where it still sees its whole input. Branches that already restrict away stay inline, so a union of plain scans is unaffected and pays no extra shuffle.

Whether a branch can be restricted away is decided by *asking the rewriter* (`restrict_plan_to_partitions(branch, &[])`) rather than by matching operator types, so it stays correct as the rewriter evolves.

Branches holding a broadcast input or a `CollectLeft` join are treated as unrestrictable regardless. Those build and probe sides can still be swapped after stage planning, and the two orders restrict differently — the build side is read whole, a broadcast input is never pruned — so a branch that looks restrictable at planning time may not be by the time the task is built. That is exactly what left q5's catalog branch running in every task after the first version of this fix.

**`task_builder.rs` — take restriction scope from `required_input_distribution()` for every operator** instead of a hardcoded list of join types. `CrossJoinExec` collects its left input but was not on that list, so each task of a multi-partition stage rebuilt the cross join's left side from its own slice. This surfaced as an inflated q77 (whose catalog branch is `from cs, cr`) once that branch got a stage of its own — caught by the full-suite run, not by the original repro.

# Are there any user-facing changes?

No API change. Union queries whose branches collapse internally now materialize those branches as their own stage, which costs one extra shuffle per affected branch and is what makes the result correct.

## Testing

Four unit tests: a plain branch needs no stage of its own, a collapsing branch and a broadcast-holding branch do, and a cross join's collected side is read whole.

End-to-end at SF1 against a single-process DataFusion oracle:

- `--partitions 16` — **the full suite passes**, so the currently-green configuration is unaffected.
- `--partitions 1` — q5, q49, q80, q61 and q77 all verify OK. Only q72 remains, and it exhausts its per-task memory share rather than returning a wrong answer.

## Not covered

The adaptive planner builds stages through its own path (`state/aqe/`) and is untouched here; q5, q80 and q61 still fail under `ballista.planner.adaptive.enabled=true` at one partition. #2185 stays open, and #2182 will still show the AQE legs red.