### PR TITLE
fix(scheduler): keep GROUP BY-less aggregates when propagating empty stages

### DIFF
--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -101,6 +101,9 @@ impl PropagateEmptyExecRule {
             Ok(Transformed::yes(limit.input().clone()))
         } else if let Some(aggregation) = plan.downcast_ref::<AggregateExec>()
             && is_empty_exec!(aggregation.input())
+            // An aggregate with no GROUP BY emits exactly one row even over zero
+            // input rows (`sum` -> NULL, `count` -> 0), so it must be preserved.
+            && !aggregation.group_expr().is_empty()
         {
             empty_exec!(aggregation)
         } else if let Some(repartition) = plan.downcast_ref::<RepartitionExec>()
@@ -328,8 +331,12 @@ mod tests {
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema},
         common::{ColumnStatistics, JoinType, NullEquality, Statistics},
+        physical_expr::aggregate::AggregateExprBuilder,
         physical_plan::{
-            expressions::Column, joins::PartitionMode, test::exec::StatisticsExec,
+            aggregates::{AggregateMode, PhysicalGroupBy},
+            expressions::Column,
+            joins::PartitionMode,
+            test::exec::StatisticsExec,
         },
     };
 
@@ -869,6 +876,75 @@ mod tests {
         );
         let result = transform(plan);
         assert!(result.downcast_ref::<StatisticsExec>().is_some());
+    }
+
+    // ── Aggregate ────────────────────────────────────────────────────────────
+
+    /// Build an `AggregateExec` over `input` with the given grouping.
+    fn aggregate(
+        input: Arc<dyn ExecutionPlan>,
+        group_by: PhysicalGroupBy,
+        mode: AggregateMode,
+    ) -> Arc<dyn ExecutionPlan> {
+        let aggr = AggregateExprBuilder::new(
+            datafusion::functions_aggregate::count::count_udaf(),
+            vec![Arc::new(Column::new("a", 0))],
+        )
+        .schema(input.schema())
+        .alias("count(a)")
+        .build()
+        .unwrap();
+
+        Arc::new(
+            AggregateExec::try_new(
+                mode,
+                group_by,
+                vec![Arc::new(aggr)],
+                vec![None],
+                input,
+                schema(),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn aggregate_with_grouping_over_empty_eliminated() {
+        // GROUP BY over zero rows produces zero groups — collapsing is correct.
+        let group_by = PhysicalGroupBy::new_single(vec![(
+            Arc::new(Column::new("a", 0)),
+            "a".into(),
+        )]);
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            group_by,
+            AggregateMode::Single,
+        );
+        assert_empty(&transform(plan));
+    }
+
+    #[test]
+    fn aggregate_without_grouping_over_empty_is_preserved() {
+        // No GROUP BY means exactly one output row even over zero input rows
+        // (`sum` -> NULL, `count` -> 0). Collapsing to EmptyExec loses that row.
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            PhysicalGroupBy::default(),
+            AggregateMode::Single,
+        );
+        assert_untouched(&transform(plan));
+    }
+
+    #[test]
+    fn partial_aggregate_without_grouping_over_empty_is_preserved() {
+        // Same holds for a partial aggregate: it emits one row of accumulator
+        // state per partition, which the final aggregate needs.
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            PhysicalGroupBy::default(),
+            AggregateMode::Partial,
+        );
+        assert_untouched(&transform(plan));
     }
 
     // ── unknown stats — never optimised ─────────────────────────────────────


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2185.

# Rationale for this change

With the adaptive planner, a query stage that completes with zero rows makes `ExchangeExec::partition_statistics` report `Precision::Exact(0)`, and `PropagateEmptyExecRule` then collapses the plan above it on the next replan.

That rule replaced *any* `AggregateExec` whose input had become empty with an `EmptyExec`. This is only valid when the aggregate has a `GROUP BY`. An aggregate with no grouping expressions emits exactly one row even over zero input rows (`sum` returns NULL, `count` returns 0), so collapsing it silently drops that row. DataFusion's logical `PropagateEmptyRelation` rule has the same guard (`!agg.group_expr.is_empty()`); the physical port here was missing it.

TPC-DS q61 hits this at SF1 because no store has `s_gmt_offset = -7`, so the `store` stage legitimately returns zero rows. The correct answer is a single all-NULL row, which single-process DataFusion and the static planner both produce, but the adaptive planner returned no rows at all. The final replan rewrote

```
CrossJoinExec
  ProjectionExec: expr=[sum(store_sales.ss_ext_sales_price)@0 as promotions]
    AggregateExec: mode=Single, gby=[], aggr=[sum(store_sales.ss_ext_sales_price)]
      HashJoinExec: mode=Partitioned, join_type=Inner, ...
        EmptyExec
        ExchangeExec: partitioning=Hash([i_item_sk@0], 1), stage_id=21
  EmptyExec
```

into

```
CrossJoinExec
  EmptyExec
  EmptyExec
```

# What changes are included in this PR?

Guard the `AggregateExec` arm of `PropagateEmptyExecRule` on `!aggregation.group_expr().is_empty()`, so a grouping-less aggregate is left in place over an empty input.

Adds three unit tests covering the aggregate arm: the grouped case still collapses, and the `Single` and `Partial` grouping-less cases are preserved. Both new grouping-less tests fail before the change.

# Are there any user-facing changes?

No API changes. Queries run under `ballista.planner.adaptive.enabled=true` that contain a grouping-less aggregate over an input that turns out to be empty now return the correct single row instead of no rows.
