### PR TITLE
ci: run TPC-DS SF1 with 1 and 4 partitions per task

### DIFF
--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -52,14 +52,30 @@ on:
 
 jobs:
   tpcds-sf1:
-    name: TPC-DS SF1 (all queries, static planner)
+    name: TPC-DS SF1 (static planner, ${{ matrix.label }})
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
-    # A passing run takes ~7 minutes. Cap the job well under the 6-hour
+    # A passing leg takes ~7 minutes. Cap the job well under the 6-hour
     # default so a hung query fails fast and frees the runner rather than
     # sitting for hours with no useful signal.
     timeout-minutes: 45
+    strategy:
+      # One red leg must not cancel the other; the two task-packing modes are
+      # independent signals.
+      fail-fast: false
+      matrix:
+        include:
+          - label: "1 partition per task"
+            task_args: ""
+            slug: "mpt1"
+          # 4 rather than a larger cap because the scheduler clamps the slice to
+          # the executor's free vcores (`budget.vcores.min(cap)`), and the
+          # executor below runs `--concurrent-tasks 4`. A higher cap would be
+          # unreachable and the label would overstate what is covered.
+          - label: "4 partitions per task"
+            task_args: "-c ballista.scheduler.max_partitions_per_task=4"
+            slug: "mpt4"
     steps:
       - name: Install dependencies
         run: |
@@ -76,6 +92,10 @@ jobs:
           rust-version: stable
 
       - uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 #2.9.1
+        with:
+          # Share the build cache across all matrix legs — the compiled
+          # binaries are identical; only the per-suite CLI args differ.
+          shared-key: tpcds-sf1
 
       - name: Build Ballista binaries
         run: |
@@ -157,27 +177,22 @@ jobs:
           done
           nc -z 127.0.0.1 50051 || { echo "executor did not start"; exit 1; }
 
-          # Run the suite under the default (static) planner. The tpcds binary
-          # internally loops all non-skipped queries and exits non-zero on any
-          # failure, so a single invocation covers the whole suite.
+          # This matrix leg runs the suite under the default (static) planner at
+          # one task-packing setting. The tpcds binary internally loops all
+          # non-skipped queries and exits non-zero on any failure, so a single
+          # invocation covers the whole suite. The other leg runs in parallel.
           #
-          # Coverage for the adaptive planner (AQE on) and for single-partition
-          # execution is being added separately; both currently fail on
-          # pre-existing bugs.
-          run_suite() {
-            local label="$1"; shift
-            echo "::group::[$label] TPC-DS suite"
-            ./target/tpch-ci/tpcds \
-              --host 127.0.0.1 --port 50050 \
-              --path "$DATA_DIR" \
-              --partitions 16 \
-              --verify \
-              "$@"
-            echo "::endgroup::"
-          }
-
-          run_suite "static planner" \
-            -c datafusion.optimizer.prefer_hash_join=false
+          # Coverage for the adaptive planner (AQE on) is being added
+          # separately; it currently fails on pre-existing bugs.
+          echo "::group::[static planner, ${{ matrix.label }}] TPC-DS suite"
+          ./target/tpch-ci/tpcds \
+            --host 127.0.0.1 --port 50050 \
+            --path "$DATA_DIR" \
+            --partitions 16 \
+            --verify \
+            -c datafusion.optimizer.prefer_hash_join=false \
+            ${{ matrix.task_args }}
+          echo "::endgroup::"
 
       - name: Upload cluster logs on failure
         # `!success()` rather than `failure()` so a timed-out or cancelled
@@ -186,7 +201,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@v7
         with:
-          name: tpcds-sf1-cluster-logs
+          name: tpcds-sf1-cluster-logs-${{ matrix.slug }}
           retention-days: 14
           path: |
             ${{ runner.temp }}/scheduler.log


### PR DESCRIPTION
# Which issue does this PR close?

Part of #2092.

# Rationale for this change

The TPC-DS gate runs exactly one configuration: the static planner at 16 partitions with the default one-task-per-input-partition packing. Multi-partition tasks — where the scheduler packs several input partitions into a single task's `partition_slice` — have no TPC-DS coverage at all.

That packing is not a cosmetic scheduling detail. It changes how a task's plan is rewritten (`restrict_plan_to_partitions`), how many vcores a task reserves, and how much of the executor's memory pool the task is handed. TPC-H covers it (`tpch.yml` has an "AQE on, multi-partition tasks" leg); TPC-DS, which is the broader query set by a wide margin, does not.

# What changes are included in this PR?

Replaces the single job with a two-leg matrix over `ballista.scheduler.max_partitions_per_task`, following the shape `tpch.yml` already uses. Both legs run the static planner at `--partitions 16`; only the task-packing cap differs.

| Leg | `max_partitions_per_task` | |
|---|---|---|
| `mpt1` | 1 (default) | existing coverage |
| `mpt4` | 4 | new |

- Per-leg `label` / `task_args` / `slug`, matching `tpch.yml`'s convention.
- `fail-fast: false`, so one red leg does not mask the other.
- Both legs share one `swatinem/rust-cache` entry via `shared-key: tpcds-sf1`, so the binaries are compiled once and restored by the second leg rather than built twice. This mirrors `tpch.yml`'s `shared-key: tpch-sf10`.
- The `run_suite` shell helper is inlined, since each leg now runs exactly one invocation.
- The cluster-log artifact is named per leg so failures do not collide.

## Why the cap is 4 and not higher

`bind_one` clamps the slice to the executor's free vcores:

```rust
let max_partitions = if is_collapse { usize::MAX } else { (budget.vcores as usize).min(cap) };
```

`budget.vcores` comes from the executor's `--concurrent-tasks`, which this workflow sets to 4. Any cap above 4 is therefore unreachable here and would only make the leg's name overstate what it covers. 4 is the largest slice this cluster can actually build, and it is 4x the default — enough to exercise the multi-partition path.

`max_partitions_per_task=0` (unbounded, as `tpch.yml` uses) would behave identically at this vcore count, but naming the number keeps the leg honest about what it tests.

Adaptive-planner coverage is deliberately out of scope; it is tracked separately in #2182 and still fails on known bugs.

## How are these changes tested?

Both legs were run locally at SF1 against a single-process DataFusion oracle, using this workflow's exact cluster configuration (`--concurrent-tasks 4 --memory-pool-size 2GB`, `--partitions 16 --verify`, `prefer_hash_join=false`):

- `max_partitions_per_task=1` — 97/97 pass
- `max_partitions_per_task=4` — 97/97 pass

The matrix is green as it stands; it is a regression gate, not a tracker for known failures.

The new leg was also checked for being a no-op, since a config that silently fails to apply would leave a green leg covering nothing. Running q1 alone and counting `Execute task` lines in the executor log:

| `max_partitions_per_task` | tasks executed for q1 |
|---|---|
| 1 | 149 |
| 4 | 58 |

Fewer than a clean 4x reduction because collapse stages always pack their full pending queue regardless of the cap, and some stages have fewer than 4 partitions to begin with — but the setting is unambiguously taking effect.

# Are there any user-facing changes?

No. CI coverage only.
