### PR TITLE
fix(scheduler): harden PropagateEmptyExecRule against grouping sets, embedded projections, and dropped exchange partitioning

### DIFF
--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -330,11 +330,11 @@ mod tests {
 
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema},
-        common::{ColumnStatistics, JoinType, NullEquality, Statistics},
+        common::{ColumnStatistics, JoinType, NullEquality, ScalarValue, Statistics},
         physical_expr::aggregate::AggregateExprBuilder,
         physical_plan::{
             aggregates::{AggregateMode, PhysicalGroupBy},
-            expressions::Column,
+            expressions::{Column, Literal},
             joins::PartitionMode,
             test::exec::StatisticsExec,
         },
@@ -943,6 +943,26 @@ mod tests {
             Arc::new(EmptyExec::new(schema())),
             PhysicalGroupBy::default(),
             AggregateMode::Partial,
+        );
+        assert_untouched(&transform(plan));
+    }
+
+    #[test]
+    fn aggregate_grouping_sets_with_empty_subset_over_empty_is_preserved() {
+        // `ROLLUP(a)` / `GROUPING SETS ((a), ())` lowers to a non-empty `expr`
+        // list plus a `groups` mask containing the all-null (empty) subset.
+        // Over zero input rows, that empty subset still emits one all-NULL row
+        // — matches DataFusion's logical `has_empty_grouping_set` guard.
+        let group_by = PhysicalGroupBy::new(
+            vec![(Arc::new(Column::new("a", 0)), "a".into())],
+            vec![(Arc::new(Literal::new(ScalarValue::Int32(None))), "a".into())],
+            vec![vec![false], vec![true]],
+            true,
+        );
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            group_by,
+            AggregateMode::Single,
         );
         assert_untouched(&transform(plan));
     }

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -60,6 +60,9 @@ pub struct JoinInfo<'a> {
     pub left: &'a Arc<dyn ExecutionPlan>,
     pub right: &'a Arc<dyn ExecutionPlan>,
     pub schema: SchemaRef,
+    /// True when the join carries an embedded projection, in which case its
+    /// output schema no longer maps positionally onto the input schemas.
+    pub has_projection: bool,
 }
 
 /// This is [datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation] rule with difference
@@ -78,7 +81,10 @@ impl PropagateEmptyExecRule {
         if let Some(filter) = plan.downcast_ref::<FilterExec>()
             && is_empty_exec!(filter.input())
         {
-            Ok(Transformed::yes(filter.input().clone()))
+            // A FilterExec may carry an embedded projection, so its schema can
+            // differ from its input's — build a fresh EmptyExec instead of
+            // reusing the input.
+            empty_exec!(filter)
         } else if let Some(coalesce) = plan.downcast_ref::<CoalesceBatchesExec>()
             && is_empty_exec!(coalesce.input())
         {
@@ -86,7 +92,10 @@ impl PropagateEmptyExecRule {
         } else if let Some(exchange) = plan.downcast_ref::<ExchangeExec>()
             && is_empty_exec!(exchange.input())
         {
-            Ok(Transformed::yes(exchange.input().clone()))
+            // Keep the exchange's output partitioning: parents were planned
+            // against it, and the stats-based exchange arm below preserves it
+            // the same way.
+            empty_exec!(exchange)
         } else if let Some(projection) = plan.downcast_ref::<ProjectionExec>()
             && is_empty_exec!(projection.input())
         {
@@ -104,6 +113,15 @@ impl PropagateEmptyExecRule {
             // An aggregate with no GROUP BY emits exactly one row even over zero
             // input rows (`sum` -> NULL, `count` -> 0), so it must be preserved.
             && !aggregation.group_expr().is_empty()
+            // Same for the empty grouping set `()` of GROUPING SETS/ROLLUP/CUBE:
+            // an all-true null mask is the grand-total group, which also emits
+            // one row over empty input. Mirrors `has_empty_grouping_set` in
+            // DataFusion's logical PropagateEmptyRelation rule.
+            && !aggregation
+                .group_expr()
+                .groups()
+                .iter()
+                .any(|group| group.iter().all(|&null_masked| null_masked))
         {
             empty_exec!(aggregation)
         } else if let Some(repartition) = plan.downcast_ref::<RepartitionExec>()
@@ -126,13 +144,19 @@ impl PropagateEmptyExecRule {
 
             let left_field_count = join.left.schema().fields.len();
 
+            // Rewrites that keep one input alive assume the join schema maps
+            // positionally onto the input schemas; an embedded projection
+            // breaks that, so those arms must not fire. Arms that produce an
+            // EmptyExec use the join's own (projected) schema and stay safe.
+            let no_projection = !join.has_projection;
+
             // Checking whether join would produce an empty result
             match join.join_type {
                 JoinType::Inner if left_empty || right_empty => empty_exec!(plan),
                 JoinType::Left if left_empty => empty_exec!(plan),
                 // Left Join with empty right: all left rows survive
                 // with NULLs for right columns.
-                JoinType::Left if right_empty => {
+                JoinType::Left if right_empty && no_projection => {
                     Ok(Transformed::yes(build_null_padded_projection(
                         Arc::clone(join.left),
                         join.schema,
@@ -143,7 +167,7 @@ impl PropagateEmptyExecRule {
                 JoinType::Right if right_empty => empty_exec!(plan),
                 // Right Join with empty left: all right rows survive
                 // with NULLs for left columns.
-                JoinType::Right if left_empty => {
+                JoinType::Right if left_empty && no_projection => {
                     Ok(Transformed::yes(build_null_padded_projection(
                         Arc::clone(join.right),
                         join.schema,
@@ -154,18 +178,22 @@ impl PropagateEmptyExecRule {
                 JoinType::LeftSemi if left_empty || right_empty => empty_exec!(plan),
                 JoinType::RightSemi if left_empty || right_empty => empty_exec!(plan),
                 JoinType::LeftAnti if left_empty => empty_exec!(plan),
-                JoinType::LeftAnti if right_empty => {
+                JoinType::LeftAnti if right_empty && no_projection => {
                     Ok(Transformed::yes((*join.left).clone()))
                 }
                 JoinType::RightAnti if right_empty => empty_exec!(plan),
-                JoinType::RightAnti if left_empty => {
+                JoinType::RightAnti if left_empty && no_projection => {
                     Ok(Transformed::yes((*join.right).clone()))
                 }
                 // Return empty if both sides are empty
                 JoinType::Full if left_empty && right_empty => empty_exec!(plan),
                 // For Full Join, if one side is empty, replace with a
                 // Projection that null-pads the empty side's columns.
-                JoinType::Full if right_empty && is_guaranteed_non_empty(join.left) => {
+                JoinType::Full
+                    if right_empty
+                        && no_projection
+                        && is_guaranteed_non_empty(join.left) =>
+                {
                     Ok(Transformed::yes(build_null_padded_projection(
                         Arc::clone(join.left),
                         join.schema.clone(),
@@ -173,7 +201,11 @@ impl PropagateEmptyExecRule {
                         true,
                     )?))
                 }
-                JoinType::Full if left_empty && is_guaranteed_non_empty(join.right) => {
+                JoinType::Full
+                    if left_empty
+                        && no_projection
+                        && is_guaranteed_non_empty(join.right) =>
+                {
                     Ok(Transformed::yes(build_null_padded_projection(
                         Arc::clone(join.right),
                         join.schema.clone(),
@@ -224,6 +256,7 @@ pub fn as_join(plan: &Arc<dyn ExecutionPlan>) -> Option<JoinInfo<'_>> {
             left: join.left(),
             right: join.right(),
             schema: join.schema(),
+            has_projection: join.contains_projection(),
         });
     }
     if let Some(join) = any.downcast_ref::<SortMergeJoinExec>() {
@@ -232,6 +265,7 @@ pub fn as_join(plan: &Arc<dyn ExecutionPlan>) -> Option<JoinInfo<'_>> {
             left: join.left(),
             right: join.right(),
             schema: join.schema(),
+            has_projection: false,
         });
     }
 
@@ -965,6 +999,143 @@ mod tests {
             AggregateMode::Single,
         );
         assert_untouched(&transform(plan));
+    }
+
+    // ── embedded projections — schema no longer matches the inputs ─────────
+
+    fn two_col_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ])
+    }
+
+    fn non_empty_two_col_stats_exec() -> Arc<dyn ExecutionPlan> {
+        Arc::new(StatisticsExec::new(
+            Statistics {
+                num_rows: Precision::Exact(100),
+                total_byte_size: Precision::Exact(800),
+                column_statistics: vec![ColumnStatistics::new_unknown(); 2],
+            },
+            two_col_schema(),
+        ))
+    }
+
+    fn hash_join_with_projection(
+        left: Arc<dyn ExecutionPlan>,
+        right: Arc<dyn ExecutionPlan>,
+        join_type: JoinType,
+        projection: Vec<usize>,
+    ) -> Arc<dyn ExecutionPlan> {
+        Arc::new(
+            HashJoinExec::try_new(
+                left,
+                right,
+                join_on(),
+                None,
+                &join_type,
+                None,
+                PartitionMode::Partitioned,
+                NullEquality::NullEqualsNothing,
+                false,
+            )
+            .unwrap()
+            .with_projection(Some(projection))
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn left_join_with_embedded_projection_right_empty_untouched() {
+        // ProjectionPushdown can embed a projection into HashJoinExec. The join
+        // schema is then no longer `left fields ++ right fields`, so positional
+        // null-padding would read the wrong columns. The join must stay as is.
+        let plan = hash_join_with_projection(
+            non_empty_two_col_stats_exec(),
+            empty_stats_exec(),
+            JoinType::Left,
+            vec![1],
+        );
+        let join_schema = plan.schema();
+        let result = transform(plan);
+        assert!(
+            result.downcast_ref::<HashJoinExec>().is_some(),
+            "expected join to be untouched, got {:?}",
+            result.name()
+        );
+        assert_eq!(result.schema(), join_schema);
+    }
+
+    #[test]
+    fn left_anti_with_embedded_projection_right_empty_untouched() {
+        // A LeftAnti join with an embedded projection outputs a subset of the
+        // left columns; replacing it with the raw left child changes the schema.
+        let plan = hash_join_with_projection(
+            non_empty_two_col_stats_exec(),
+            empty_stats_exec(),
+            JoinType::LeftAnti,
+            vec![1],
+        );
+        let join_schema = plan.schema();
+        let result = transform(plan);
+        assert_eq!(result.schema(), join_schema);
+        assert!(
+            result.downcast_ref::<HashJoinExec>().is_some(),
+            "expected join to be untouched, got {:?}",
+            result.name()
+        );
+    }
+
+    #[test]
+    fn filter_with_embedded_projection_over_empty_preserves_schema() {
+        // FilterExec can carry an embedded projection, so its schema may differ
+        // from its input's. The result must use the filter's schema, not the
+        // input's.
+        use datafusion::logical_expr::Operator;
+        use datafusion::physical_plan::expressions::BinaryExpr;
+        use datafusion::physical_plan::filter::FilterExecBuilder;
+
+        let input = Arc::new(EmptyExec::new(Arc::new(two_col_schema())));
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(0)))),
+        ));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(
+            FilterExecBuilder::new(predicate, input)
+                .apply_projection(Some(vec![1]))
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let filter_schema = plan.schema();
+        let result = transform(plan);
+        assert_empty(&result);
+        assert_eq!(result.schema(), filter_schema);
+    }
+
+    // ── exchange over empty input — partitioning must survive ───────────────
+
+    #[test]
+    fn exchange_over_empty_input_preserves_partition_count() {
+        // Replacing ExchangeExec with its EmptyExec input would drop the
+        // exchange's output partitioning; parents planned against it would see
+        // the wrong partition count. Mirrors the stats-based exchange arm,
+        // which already preserves the partition count.
+        use datafusion::physical_plan::Partitioning;
+
+        let empty = Arc::new(EmptyExec::new(schema()).with_partitions(1));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(ExchangeExec::new(
+            empty,
+            Some(Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 16)),
+            0,
+        ));
+        let result = transform(plan);
+        assert_empty(&result);
+        assert_eq!(
+            result.properties().output_partitioning().partition_count(),
+            16
+        );
     }
 
     // ── unknown stats — never optimised ─────────────────────────────────────


### PR DESCRIPTION
# Which issue does this PR close?

N/A — follow-up to the review of #2194 (https://github.com/apache/datafusion-ballista/pull/2194#pullrequestreview-4797353244), which fixed #2185 for GROUP BY-less aggregates and flagged that grouping sets have the same problem. While fixing that, an audit of the other `PropagateEmptyExecRule` arms found three more cases where the rewrite changes query semantics or plan shape.

# Rationale for this change

`PropagateEmptyExecRule` is the physical port of DataFusion's logical `PropagateEmptyRelation` rule, and physical plans carry details that logical plans do not (embedded projections, output partitioning, grouping-set null masks). Four arms of the rule did not account for them:

1. **Empty grouping sets.** The logical rule guards its aggregate arm on both `!agg.group_expr.is_empty()` and `!has_empty_grouping_set(&agg.group_expr)`; #2194 ported only the first. `GROUPING SETS ((a), ())`, `ROLLUP(a)`, and `CUBE(a)` all contain the empty grouping set `()`, which emits one grand-total row even over zero input rows (DataFusion 54 implements this in `init_empty_grouping_sets` in `row_hash.rs`). Collapsing such an aggregate to `EmptyExec` silently drops that row — the same wrong-answer class as #2185.

2. **Hash joins with embedded projections.** The join rewrites that keep one input alive assume the join schema is `left fields ++ right fields`: the null-padded projection for Left/Right/Full maps columns positionally, and the anti-join arms return the raw surviving child. `ProjectionPushdown` can embed a projection into `HashJoinExec`, making the join schema a subset/reorder of the inputs; the null-padding then silently reads the wrong columns, and the anti-join replacement changes the plan's schema. The arms that collapse to `EmptyExec` use the join's own projected schema and were already correct.

3. **Filters with embedded projections.** The `FilterExec` arm returned the filter's input; with an embedded projection the filter's schema differs from its input's, so the rewrite changed the schema.

4. **Exchange over an empty input.** The `ExchangeExec` arm returned the input `EmptyExec` directly, discarding the exchange's output partition count that parent operators were planned against. The stats-based exchange arm a few lines below already preserves the partition count; the two arms now match.

# What changes are included in this PR?

- Guard the aggregate arm on the physical equivalent of `has_empty_grouping_set`: any group whose null mask is all-`true` is the empty grouping set, and the aggregate is preserved.
- Add `has_projection` to `JoinInfo` (`HashJoinExec::contains_projection()`; `SortMergeJoinExec` has no embedded projection) and skip the surviving-input rewrites when it is set, leaving the join untouched.
- Replace `FilterExec` and `ExchangeExec` over empty inputs with an `EmptyExec` built from the operator's own schema and partition count instead of returning the input.

Tests: the grouping-sets test contributed by @avantgardnerio in the #2194 review (cherry-picked, keeping authorship), plus four new tests covering Left/LeftAnti joins with embedded projections, a filter with an embedded projection, and exchange partition-count preservation. All five fail before the fix.

# Are there any user-facing changes?

No API changes (`JoinInfo` gains a public field). Queries run under `ballista.planner.adaptive.enabled=true` where a stage turns out empty now return correct results for grouping-set aggregates and for joins/filters with embedded projections, and no longer lose the exchange's partition count when a stage collapses.
