### PR TITLE
perf(kll): batch-oriented ingest KLL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "env_logger",
  "futures",
  "mimalloc",
+ "ordered-float 4.6.0",
  "rand 0.10.2",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "clap 4.6.3",
  "criterion",
  "datafusion",
+ "datafusion-functions-aggregate-common",
  "datafusion-proto",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ insta = "1.47"
 itertools = "0.15"
 mimalloc = { version = "0.1" }
 object_store = "0.13.2"
+ordered-float = "4"
 prost = "0.14"
 prost-types = "0.14"
 rstest = { version = "0.26" }

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -291,6 +291,13 @@ impl<T: Ord + Clone> KllSketch<T> {
     /// Output is bit-identical to `for x in xs { self.insert(x) }`: the
     /// compaction trigger points, coin flips, and min/max tracking are all
     /// preserved.
+    ///
+    /// TODO: retire once **Deferred optimizations** item (2) lands. The
+    /// borrowed-row ingest path there takes an arrow `Rows` directly and
+    /// holds `Row<'_>` at level 0 — a specialized API, not a generalization
+    /// of this one. This function exists as a modest speedup for the
+    /// interim OwnedRow path (~14% over `insert`-in-loop on 1M rows) and
+    /// has no other production caller.
     pub fn absorb<I: IntoIterator<Item = T>>(&mut self, xs: I) {
         // Cache level 0's capacity; recompute whenever compaction may have
         // grown the stack (which shrinks per-level capacities).

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -702,55 +702,114 @@ mod tests {
         2.296 / (k as f64).powf(0.9723)
     }
 
-    /// One trial: insert a shuffled `1..=n` stream, probe rank at 9
-    /// interior quantiles, return the max normalized rank error observed.
-    fn worst_rank_error_uniform(k: usize, n: u32, seed: u64) -> f64 {
-        use rand::seq::SliceRandom;
-        let mut shuffle_rng = StdRng::seed_from_u64(seed);
-        // Sketch RNG derived from a different sub-seed so the shuffle and
-        // the compaction coin flips aren't drawn from correlated streams.
-        let mut sketch: KllSketch<u32> =
-            KllSketch::with_seed(k, seed.wrapping_add(0x9E37_79B9));
-        let mut stream: Vec<u32> = (1..=n).collect();
-        stream.shuffle(&mut shuffle_rng);
-        for x in &stream {
+    /// Insert `stream` into a KLL sketch at capacity `k`, probe rank at 9
+    /// interior quantiles picked from a sorted copy of the stream, and
+    /// return the worst normalized rank error observed.
+    fn worst_rank_error(stream: &[u32], k: usize, sketch_seed: u64) -> f64 {
+        let mut sketch: KllSketch<u32> = KllSketch::with_seed(k, sketch_seed);
+        for x in stream {
             sketch.insert(*x);
         }
+        let mut sorted = stream.to_vec();
+        sorted.sort_unstable();
+        let n = stream.len();
         (1..10)
             .map(|i| {
-                let q = i as f64 / 10.0;
-                let probe = ((q * n as f64) as u32).max(1);
-                // For a shuffled stream of `1..=n`, the true count strictly
-                // less than `probe` is `probe - 1`.
-                let true_rank = (probe as f64 - 1.0) / n as f64;
-                let est_rank = sketch.rank(&probe) as f64 / n as f64;
-                (est_rank - true_rank).abs()
+                let idx = (i as f64 / 10.0 * n as f64) as usize;
+                let probe = sorted[idx.min(n - 1)];
+                // True rank: count of items strictly less than probe.
+                // partition_point on the sorted stream gives it in O(log n).
+                let true_rank_frac =
+                    sorted.partition_point(|x| *x < probe) as f64 / n as f64;
+                let est_rank_frac = sketch.rank(&probe) as f64 / n as f64;
+                (est_rank_frac - true_rank_frac).abs()
             })
             .fold(0.0_f64, f64::max)
     }
 
-    #[test]
-    fn rank_error_meets_datasketches_bound_across_seeds() {
-        // The DataSketches epsilon is empirically fit to the P99 max
-        // error, so ≤1% of trials should exceed it in a correct
-        // implementation. Assert ≤5% fail rate — leaves slack for tail
-        // luck without letting a real regression slip through; an
-        // optimization bug that biases the error distribution up by a few
-        // percent pushes the fail rate well past 5%.
+    /// Shuffled `1..=n` — every distinct value appears exactly once.
+    fn uniform_stream(n: u32, rng: &mut StdRng) -> Vec<u32> {
+        use rand::seq::SliceRandom;
+        let mut v: Vec<u32> = (1..=n).collect();
+        v.shuffle(rng);
+        v
+    }
+
+    /// 90% of items in the bottom 1% of the value range, remainder spread
+    /// over the rest. Cuts near the low quantiles land inside the dense
+    /// cluster; cuts near the high quantiles land in the sparse tail.
+    fn clustered_stream(n: u32, rng: &mut StdRng) -> Vec<u32> {
+        use rand::seq::SliceRandom;
+        let hot_max = (n / 100).max(2);
+        let hot = n * 9 / 10;
+        let cold = n - hot;
+        let mut v = Vec::with_capacity(n as usize);
+        for _ in 0..hot {
+            v.push(rng.random_range(1u32..=hot_max));
+        }
+        for _ in 0..cold {
+            v.push(rng.random_range(hot_max + 1..=n));
+        }
+        v.shuffle(rng);
+        v
+    }
+
+    /// Only 100 distinct values, each ~n/100 times. Exercises the sort +
+    /// coin-flip halving under degenerate orderings and confirms that
+    /// ties don't shift rank estimates.
+    fn tied_stream(n: u32, rng: &mut StdRng) -> Vec<u32> {
+        (0..n).map(|_| rng.random_range(1u32..=100)).collect()
+    }
+
+    /// Sweep `trials` seeds building a fresh stream per trial and assert
+    /// the DataSketches bound holds in ≥95% of them.
+    fn assert_ds_bound_holds(
+        distribution: &str,
+        stream_fn: impl Fn(u32, &mut StdRng) -> Vec<u32>,
+    ) {
         let k = 200;
         let n = 10_000u32;
         let bound = normalized_rank_error_ss(k);
         let trials = 100u64;
         let failures = (0..trials)
-            .filter(|&seed| worst_rank_error_uniform(k, n, seed) > bound)
+            .filter(|&seed| {
+                let mut shuffle_rng = StdRng::seed_from_u64(seed);
+                let stream = stream_fn(n, &mut shuffle_rng);
+                // Sketch RNG derived from a different sub-seed so the
+                // stream construction and the compaction coin flips aren't
+                // drawn from correlated streams.
+                let sketch_seed = seed.wrapping_add(0x9E37_79B9);
+                worst_rank_error(&stream, k, sketch_seed) > bound
+            })
             .count();
         let fail_rate = failures as f64 / trials as f64;
+        // The DataSketches eps is a P99 empirical fit, so ≤1% of trials
+        // should exceed it in a correct implementation. 5% slack absorbs
+        // tail luck without letting a real distribution shift slip
+        // through — an optimization bug that biases the error
+        // distribution up by a few percent pushes the fail rate well
+        // past 5%.
         assert!(
             fail_rate <= 0.05,
-            "rank error exceeded DataSketches bound {bound:.4} in \
-             {failures}/{trials} trials ({:.1}%); expected ≤ 5%",
+            "{distribution}: rank error exceeded DataSketches bound \
+             {bound:.4} in {failures}/{trials} trials ({:.1}%); expected ≤ 5%",
             fail_rate * 100.0
         );
+    }
+
+    #[test]
+    fn rank_error_bound_uniform_distribution() {
+        assert_ds_bound_holds("uniform", uniform_stream);
+    }
+
+    #[test]
+    fn rank_error_bound_clustered_distribution() {
+        assert_ds_bound_holds("clustered", clustered_stream);
+    }
+
+    #[test]
+    fn rank_error_bound_heavy_ties() {
+        assert_ds_bound_holds("heavy-ties", tied_stream);
     }
 
     #[test]
@@ -781,9 +840,7 @@ mod tests {
 
             let shard_size = n as usize / 4;
             let mut shards: Vec<KllSketch<u32>> = (0..4u64)
-                .map(|i| {
-                    KllSketch::with_seed(k, seed.wrapping_add(0xB504_F334 + i))
-                })
+                .map(|i| KllSketch::with_seed(k, seed.wrapping_add(0xB504_F334 + i)))
                 .collect();
             for (i, x) in stream.iter().enumerate() {
                 shards[(i / shard_size).min(3)].insert(*x);

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -250,6 +250,97 @@ impl<T: Ord + Clone> KllSketch<T> {
         self.compact_all();
     }
 
+    /// Add many items in one call, amortizing the per-item overhead of
+    /// `insert`.
+    ///
+    /// `insert` invokes `compact_all` after every row, and each call scans
+    /// every level asking "is anyone full?" That's an `O(L)` scan per row
+    /// even when the answer is universally "no." `absorb` caches level 0's
+    /// capacity once, checks a single length per row, and only fires
+    /// `compact_all` when level 0 actually reaches capacity.
+    ///
+    /// Owned-value ingest — takes items by value, no `T: Clone` needed on
+    /// the incoming stream. Prefer this for heap-heavy `T` (e.g.
+    /// `OwnedRow`) where cloning would double the allocation cost. For
+    /// `T: Copy` prefer `absorb_slice` — it uses `extend_from_slice` +
+    /// batch min/max for a memcpy-friendly hot loop.
+    ///
+    /// Output is bit-identical to `for x in xs { self.insert(x) }`: the
+    /// compaction trigger points, coin flips, and min/max tracking are all
+    /// preserved.
+    pub fn absorb<I: IntoIterator<Item = T>>(&mut self, xs: I) {
+        // Cache level 0's capacity; recompute whenever compaction may have
+        // grown the stack (which shrinks per-level capacities).
+        let mut level_0_cap = level_capacity(self.k, self.levels.len(), 0);
+        for x in xs {
+            if self.min.as_ref().is_none_or(|m| x < *m) {
+                self.min = Some(x.clone());
+            }
+            if self.max.as_ref().is_none_or(|m| x > *m) {
+                self.max = Some(x.clone());
+            }
+            self.levels[0].push(x);
+            if self.levels[0].len() >= level_0_cap {
+                self.compact_all();
+                level_0_cap = level_capacity(self.k, self.levels.len(), 0);
+            }
+        }
+    }
+
+    /// Slice-ingest variant that trades one clone per item for two extra
+    /// wins on top of `absorb`'s compact_all amortization:
+    ///
+    /// 1. Batch min/max in a single tight scan of `xs`, updating `self.min`
+    ///    / `self.max` at most once per call instead of at most once per
+    ///    row.
+    /// 2. `Vec::extend_from_slice` for chunk-fills of level 0 — one memcpy
+    ///    per chunk for `T: Copy`, potentially SIMD-vectorized by LLVM.
+    ///
+    /// Prefer this for `T: Copy` (e.g. `OrderedFloat<f64>`, `i64`) where
+    /// the clone is free. Avoid for heap-heavy `T` (e.g. `OwnedRow`) —
+    /// there the extend_from_slice clone allocates on top of whatever the
+    /// caller already paid to construct the value; `absorb` moves instead.
+    ///
+    /// Output is bit-identical to `for x in xs { self.insert(x.clone()) }`.
+    pub fn absorb_slice(&mut self, xs: &[T]) {
+        if xs.is_empty() {
+            return;
+        }
+        // One scan across xs for min/max; a single Option update per batch
+        // regardless of how many progressive extremes appear in xs.
+        let (batch_min, batch_max) = {
+            let mut min = &xs[0];
+            let mut max = &xs[0];
+            for x in &xs[1..] {
+                if x < min {
+                    min = x;
+                }
+                if x > max {
+                    max = x;
+                }
+            }
+            (min, max)
+        };
+        if self.min.as_ref().is_none_or(|m| batch_min < m) {
+            self.min = Some(batch_min.clone());
+        }
+        if self.max.as_ref().is_none_or(|m| batch_max > m) {
+            self.max = Some(batch_max.clone());
+        }
+        // Chunk-fill level 0 via memcpy-style extend; compact when it fills.
+        let mut i = 0;
+        while i < xs.len() {
+            let cap = level_capacity(self.k, self.levels.len(), 0);
+            let room = cap.saturating_sub(self.levels[0].len());
+            let take = (xs.len() - i).min(room);
+            self.levels[0].extend_from_slice(&xs[i..i + take]);
+            i += take;
+            if self.levels[0].len() >= cap {
+                self.compact_all();
+            }
+        }
+    }
+
     /// Return the estimated number of items strictly less than `x`.
     ///
     /// Sum over levels `h` of `2^h · | { y ∈ levels[h] : y < x } |`.
@@ -795,6 +886,54 @@ mod tests {
              {bound:.4} in {failures}/{trials} trials ({:.1}%); expected ≤ 5%",
             fail_rate * 100.0
         );
+    }
+
+    #[test]
+    fn absorb_apis_match_per_row_insert() {
+        // Both `absorb` and `absorb_slice` only skip work that per-row
+        // `insert` provably would have skipped too — the compaction
+        // trigger points, coin flips, and final min/max are all preserved.
+        // Three sketches seeded identically and fed the same stream via
+        // the three APIs must agree on every rank probe.
+        use rand::seq::SliceRandom;
+        let seed = 12345u64;
+        let mut shuffle_rng = StdRng::seed_from_u64(seed);
+        let n = 10_000u32;
+        let mut stream: Vec<u32> = (1..=n).collect();
+        stream.shuffle(&mut shuffle_rng);
+
+        let mut via_insert: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        for x in &stream {
+            via_insert.insert(*x);
+        }
+
+        let mut via_absorb: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        via_absorb.absorb(stream.iter().copied());
+
+        let mut via_absorb_slice: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        via_absorb_slice.absorb_slice(&stream);
+
+        // Probe every 100 to keep the test cheap; the space is dense
+        // enough that any drift would surface within these probes.
+        for probe in (1..=n).step_by(100) {
+            let r_insert = via_insert.rank(&probe);
+            let r_absorb = via_absorb.rank(&probe);
+            let r_absorb_slice = via_absorb_slice.rank(&probe);
+            assert_eq!(
+                r_insert, r_absorb,
+                "rank({probe}) diverged: insert={r_insert} absorb={r_absorb}"
+            );
+            assert_eq!(
+                r_insert, r_absorb_slice,
+                "rank({probe}) diverged: insert={r_insert} absorb_slice={r_absorb_slice}"
+            );
+        }
+        assert_eq!(via_insert.quantile(0.0), via_absorb.quantile(0.0));
+        assert_eq!(via_insert.quantile(0.0), via_absorb_slice.quantile(0.0));
+        assert_eq!(via_insert.quantile(0.5), via_absorb.quantile(0.5));
+        assert_eq!(via_insert.quantile(0.5), via_absorb_slice.quantile(0.5));
+        assert_eq!(via_insert.quantile(1.0), via_absorb.quantile(1.0));
+        assert_eq!(via_insert.quantile(1.0), via_absorb_slice.quantile(1.0));
     }
 
     #[test]

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -82,11 +82,8 @@
 //! Callers hand fully-owned items to `KllSketch::insert`. For the Arrow
 //! use case this means materializing each input `Row<'_>` into an
 //! `OwnedRow` up front — one small heap allocation per input row, most of
-//! which are eventually discarded by cascading compactions. A future
-//! optimization can defer materialization: hold borrowed `Row<'_>` in
-//! level 0 within a single batch, compact intra-batch, and only own the
-//! survivors that promote to level 1. That would trade the current
-//! per-item API for a batch-oriented one (e.g. `absorb_rows(&Rows)`).
+//! which are eventually discarded by cascading compactions. See
+//! **Deferred optimizations** below.
 //!
 //! # Level order
 //!
@@ -94,11 +91,41 @@
 //! `quantile` collects-then-sorts, and every compaction sorts before
 //! halving — so `merge` can simply extend same-height compactors without
 //! order concerns. That trades ~`log(k)` extra comparisons per amortized
-//! insert for a simpler shape. Apache DataSketches maintains per-level
-//! sortedness (with an `is_level_zero_sorted_` flag) to skip re-sorting at
-//! compact time and to merge two sketches via linear-time merge-sort
-//! rather than concatenate-and-resort — a legitimate follow-up if
-//! benchmarks demand it.
+//! insert for a simpler shape. See **Deferred optimizations** below for
+//! the per-level-sortedness follow-up that DataSketches implements.
+//!
+//! # Deferred optimizations
+//!
+//! Ingest measured at ~3.7× TDigest for `T = OrderedFloat<f64>` and ~6.7×
+//! for `T = OwnedRow` on uniform 1M-row streams (see
+//! `benchmarks/benches/quantile_sketch.rs`). Three independent wins could
+//! close most of that gap:
+//!
+//! 1. **Amortize `compact_all` across a batch.** `insert` calls
+//!    `compact_all` once per row, so 1M rows means 1M compact-driver
+//!    iterations — most just scan the levels vec and return. A batch-
+//!    oriented `absorb(&[T])` that extends level 0 by the whole batch (up
+//!    to its capacity) and calls `compact_all` only when level 0 fills
+//!    reduces that to ~1,250 driver calls for 1M rows at k=800. Helps
+//!    every `T`, so it's what closes the `KLL<OrderedFloat>` gap toward
+//!    TDigest.
+//!
+//! 2. **Defer ownership at level 0.** For `T = OwnedRow` the caller pays
+//!    one heap allocation per input row via `row.owned()`, even though
+//!    ~half of level-0 items are coin-flipped out at the first compaction
+//!    and never promoted. Holding borrowed `Row<'_>` at level 0 within a
+//!    batch and materializing `OwnedRow` only on promotion to level 1
+//!    saves the alloc/free on the discarded half. Stacks with (1): the
+//!    batch-oriented API is what makes the borrow lifetime work out —
+//!    level 0 lives for the duration of `absorb`, compacts before the
+//!    caller's `Rows` buffer goes out of scope. Only helps `T = OwnedRow`.
+//!
+//! 3. **Per-level sortedness invariant.** Apache DataSketches maintains
+//!    an `is_level_zero_sorted_` flag so `compact` skips the re-sort when
+//!    the level is already ordered, and two sketches merge via linear-
+//!    time merge-sort rather than concatenate-and-resort. Trades
+//!    bookkeeping in `insert`/`merge` for cheaper `compact` and cheaper
+//!    cross-sketch `merge`.
 //!
 //! # Reference
 //!

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -96,36 +96,40 @@
 //!
 //! # Deferred optimizations
 //!
-//! Ingest measured at ~3.7× TDigest for `T = OrderedFloat<f64>` and ~6.7×
-//! for `T = OwnedRow` on uniform 1M-row streams (see
-//! `benchmarks/benches/quantile_sketch.rs`). Three independent wins could
-//! close most of that gap:
+//! Ingest measured on uniform 1M-row streams (see
+//! `benchmarks/benches/quantile_sketch.rs`):
 //!
-//! 1. **Amortize `compact_all` across a batch.** `insert` calls
-//!    `compact_all` once per row, so 1M rows means 1M compact-driver
-//!    iterations — most just scan the levels vec and return. A batch-
-//!    oriented `absorb(&[T])` that extends level 0 by the whole batch (up
-//!    to its capacity) and calls `compact_all` only when level 0 fills
-//!    reduces that to ~1,250 driver calls for 1M rows at k=800. Helps
-//!    every `T`, so it's what closes the `KLL<OrderedFloat>` gap toward
-//!    TDigest.
+//! - `T = OrderedFloat<f64>` via `absorb_slice`: **2.1× TDigest** (down
+//!   from 3.7× on per-row `insert`).
+//! - `T = OwnedRow` via `absorb`: **5.8× TDigest** (down from 6.7× on
+//!   per-row `insert`).
+//!
+//! Item (1) below landed as `absorb` / `absorb_slice`. Two independent
+//! wins remain that could close the remaining gap:
+//!
+//! 1. ~~**Amortize `compact_all` across a batch.**~~ **Landed.** `absorb`
+//!    caches level 0's capacity and skips the `compact_all` O(L) scan
+//!    when no level is full. `absorb_slice` stacks a batch min/max and
+//!    `extend_from_slice` on top for `T: Copy`.
 //!
 //! 2. **Defer ownership at level 0.** For `T = OwnedRow` the caller pays
 //!    one heap allocation per input row via `row.owned()`, even though
 //!    ~half of level-0 items are coin-flipped out at the first compaction
 //!    and never promoted. Holding borrowed `Row<'_>` at level 0 within a
 //!    batch and materializing `OwnedRow` only on promotion to level 1
-//!    saves the alloc/free on the discarded half. Stacks with (1): the
-//!    batch-oriented API is what makes the borrow lifetime work out —
-//!    level 0 lives for the duration of `absorb`, compacts before the
-//!    caller's `Rows` buffer goes out of scope. Only helps `T = OwnedRow`.
+//!    saves the alloc/free on the discarded half. The batch-oriented
+//!    `absorb` API is what makes the borrow lifetime work out — level 0
+//!    lives for the duration of `absorb`, compacts before the caller's
+//!    `Rows` buffer goes out of scope. Only helps `T = OwnedRow`.
 //!
 //! 3. **Per-level sortedness invariant.** Apache DataSketches maintains
 //!    an `is_level_zero_sorted_` flag so `compact` skips the re-sort when
 //!    the level is already ordered, and two sketches merge via linear-
 //!    time merge-sort rather than concatenate-and-resort. Trades
 //!    bookkeeping in `insert`/`merge` for cheaper `compact` and cheaper
-//!    cross-sketch `merge`.
+//!    cross-sketch `merge` — the compaction sort dominates ingest time
+//!    once (1) is in place, so this is where the next 2× likely lives
+//!    for the Copy-T path.
 //!
 //! # Reference
 //!

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -694,4 +694,125 @@ mod tests {
         assert_eq!(sketch.rank(&10_001), 10_000);
         assert_eq!(sketch.rank(&1), 0);
     }
+
+    /// Apache DataSketches' single-sided normalized rank error, fit to the
+    /// P99 max error across thousands of empirical trials. Source:
+    /// `datasketches-cpp/kll/include/kll_sketch_impl.hpp:619`.
+    fn normalized_rank_error_ss(k: usize) -> f64 {
+        2.296 / (k as f64).powf(0.9723)
+    }
+
+    /// One trial: insert a shuffled `1..=n` stream, probe rank at 9
+    /// interior quantiles, return the max normalized rank error observed.
+    fn worst_rank_error_uniform(k: usize, n: u32, seed: u64) -> f64 {
+        use rand::seq::SliceRandom;
+        let mut shuffle_rng = StdRng::seed_from_u64(seed);
+        // Sketch RNG derived from a different sub-seed so the shuffle and
+        // the compaction coin flips aren't drawn from correlated streams.
+        let mut sketch: KllSketch<u32> =
+            KllSketch::with_seed(k, seed.wrapping_add(0x9E37_79B9));
+        let mut stream: Vec<u32> = (1..=n).collect();
+        stream.shuffle(&mut shuffle_rng);
+        for x in &stream {
+            sketch.insert(*x);
+        }
+        (1..10)
+            .map(|i| {
+                let q = i as f64 / 10.0;
+                let probe = ((q * n as f64) as u32).max(1);
+                // For a shuffled stream of `1..=n`, the true count strictly
+                // less than `probe` is `probe - 1`.
+                let true_rank = (probe as f64 - 1.0) / n as f64;
+                let est_rank = sketch.rank(&probe) as f64 / n as f64;
+                (est_rank - true_rank).abs()
+            })
+            .fold(0.0_f64, f64::max)
+    }
+
+    #[test]
+    fn rank_error_meets_datasketches_bound_across_seeds() {
+        // The DataSketches epsilon is empirically fit to the P99 max
+        // error, so ≤1% of trials should exceed it in a correct
+        // implementation. Assert ≤5% fail rate — leaves slack for tail
+        // luck without letting a real regression slip through; an
+        // optimization bug that biases the error distribution up by a few
+        // percent pushes the fail rate well past 5%.
+        let k = 200;
+        let n = 10_000u32;
+        let bound = normalized_rank_error_ss(k);
+        let trials = 100u64;
+        let failures = (0..trials)
+            .filter(|&seed| worst_rank_error_uniform(k, n, seed) > bound)
+            .count();
+        let fail_rate = failures as f64 / trials as f64;
+        assert!(
+            fail_rate <= 0.05,
+            "rank error exceeded DataSketches bound {bound:.4} in \
+             {failures}/{trials} trials ({:.1}%); expected ≤ 5%",
+            fail_rate * 100.0
+        );
+    }
+
+    #[test]
+    fn merge_matches_single_sketch_within_bound() {
+        // Insert the same shuffled `1..=n` stream two ways:
+        //   Path A: straight into one sketch.
+        //   Path B: split into 4 shards, one sketch each, merged pairwise.
+        // Both carry O(ε) rank error individually, so any single quantile
+        // probe differs by at most ~2ε in expectation. Bounds any merge
+        // bug that would shift ranks by more than the sum of the two
+        // sketches' inherent errors.
+        use rand::seq::SliceRandom;
+        let k = 200;
+        let n = 10_000u32;
+        let bound = 2.0 * normalized_rank_error_ss(k);
+        let trials = 100u64;
+        let mut failures = 0;
+        for seed in 0..trials {
+            let mut shuffle_rng = StdRng::seed_from_u64(seed);
+            let mut stream: Vec<u32> = (1..=n).collect();
+            stream.shuffle(&mut shuffle_rng);
+
+            let mut single: KllSketch<u32> =
+                KllSketch::with_seed(k, seed.wrapping_add(0x9E37_79B9));
+            for x in &stream {
+                single.insert(*x);
+            }
+
+            let shard_size = n as usize / 4;
+            let mut shards: Vec<KllSketch<u32>> = (0..4u64)
+                .map(|i| {
+                    KllSketch::with_seed(k, seed.wrapping_add(0xB504_F334 + i))
+                })
+                .collect();
+            for (i, x) in stream.iter().enumerate() {
+                shards[(i / shard_size).min(3)].insert(*x);
+            }
+            let mut merged = shards.remove(0);
+            for s in shards {
+                merged.merge(s);
+            }
+
+            let worst_diff = (1..10)
+                .map(|i| {
+                    let q = i as f64 / 10.0;
+                    let probe = ((q * n as f64) as u32).max(1);
+                    let ra = single.rank(&probe) as f64 / n as f64;
+                    let rb = merged.rank(&probe) as f64 / n as f64;
+                    (ra - rb).abs()
+                })
+                .fold(0.0_f64, f64::max);
+
+            if worst_diff > bound {
+                failures += 1;
+            }
+        }
+        let fail_rate = failures as f64 / trials as f64;
+        assert!(
+            fail_rate <= 0.05,
+            "merge vs single quantile diff exceeded {bound:.4} in \
+             {failures}/{trials} trials ({:.1}%); expected ≤ 5%",
+            fail_rate * 100.0
+        );
+    }
 }

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -130,6 +130,15 @@
 //!    two sortedness flags — cross-sketch merge-extend is a further
 //!    deferred win.
 //!
+//! 4. **Sorted-input ingest via a caller-side plan-shape change.** The
+//!    `absorb_sorted_slice` API exists but is not yet called from
+//!    production. When wired into an ORRE plan shape where a `SortExec`
+//!    is placed upstream of `RuntimeStatsExec` (with a `DamExec` between
+//!    stats and the router), level 0 stays permanently sorted and
+//!    compaction skips *every* sort — not just those at levels 1+. That
+//!    kills the largest remaining ingest cost on the `T: Copy` path.
+//!    The sketch side is free; the win requires the planner-side move.
+//!
 //! # Reference
 //!
 //! Karnin, Lang, Liberty. *Optimal Quantile Approximation in Streams.*
@@ -366,6 +375,61 @@ impl<T: Ord + Clone> KllSketch<T> {
             let take = (xs.len() - i).min(room);
             self.levels[0].extend_from_slice(&xs[i..i + take]);
             self.sorted[0] = false;
+            i += take;
+            if self.levels[0].len() >= cap {
+                self.compact_all();
+            }
+        }
+    }
+
+    /// Slice-ingest variant that assumes the input is already sorted
+    /// ascending — the caller is downstream of a `SortExec` or otherwise
+    /// producing sorted output. Keeps level 0 permanently sorted by
+    /// merge-extending each chunk into it, so `compact_level(0)` never
+    /// pays a `sort_unstable`. That's the largest remaining cost on the
+    /// `T: Copy` ingest path once the per-level sortedness invariant is
+    /// in place.
+    ///
+    /// The min/max scan is also skipped — for sorted input the extremes
+    /// are `xs[0]` and `xs[last]`.
+    ///
+    /// Precondition: `xs` is sorted ascending. Unchecked in release
+    /// builds; a `debug_assert!` catches unsorted input in tests.
+    /// Violating the precondition silently corrupts the sketch — the
+    /// sort-skip is unconditional.
+    ///
+    /// Prefer this whenever the caller can cheaply provide sorted input:
+    /// the ORRE plan shape `Scan -> Sort -> RuntimeStats -> DamExec ->
+    /// ORRE` is the motivating case, since `SortExec` already runs
+    /// upstream of `ORRE` and moving it above `RuntimeStats` costs
+    /// nothing plan-wise.
+    pub fn absorb_sorted_slice(&mut self, xs: &[T]) {
+        if xs.is_empty() {
+            return;
+        }
+        debug_assert!(
+            xs.windows(2).all(|w| w[0] <= w[1]),
+            "absorb_sorted_slice: input not sorted ascending"
+        );
+        // Sorted input: extremes are the first and last elements. No scan.
+        let batch_min = &xs[0];
+        let batch_max = &xs[xs.len() - 1];
+        if self.min.as_ref().is_none_or(|m| batch_min < m) {
+            self.min = Some(batch_min.clone());
+        }
+        if self.max.as_ref().is_none_or(|m| batch_max > m) {
+            self.max = Some(batch_max.clone());
+        }
+        // Chunk-merge sorted `xs` into (sorted) level 0. Level 0 stays
+        // sorted through the whole ingest — `sorted[0]` never flips false.
+        let mut i = 0;
+        while i < xs.len() {
+            let cap = level_capacity(self.k, self.levels.len(), 0);
+            let room = cap.saturating_sub(self.levels[0].len());
+            let take = (xs.len() - i).min(room);
+            let incoming = xs[i..i + take].to_vec();
+            let existing = std::mem::take(&mut self.levels[0]);
+            self.levels[0] = merge_sorted(existing, incoming);
             i += take;
             if self.levels[0].len() >= cap {
                 self.compact_all();
@@ -1020,6 +1084,45 @@ mod tests {
         assert_eq!(via_insert.quantile(0.5), via_absorb_slice.quantile(0.5));
         assert_eq!(via_insert.quantile(1.0), via_absorb.quantile(1.0));
         assert_eq!(via_insert.quantile(1.0), via_absorb_slice.quantile(1.0));
+    }
+
+    #[test]
+    fn absorb_sorted_slice_matches_absorb_slice_on_sorted_input() {
+        // absorb_sorted_slice's trick is to skip the compact-time sort by
+        // keeping level 0 sorted via merge-extend. On sorted input its
+        // output is bit-identical to absorb_slice because sort_unstable on
+        // an already-sorted array of distinct items is the identity, so
+        // both paths produce the same halved subsequence at each
+        // compaction.
+        let seed = 42u64;
+        let n = 10_000u32;
+        let sorted_stream: Vec<u32> = (1..=n).collect();
+
+        let mut via_absorb_slice: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        via_absorb_slice.absorb_slice(&sorted_stream);
+
+        let mut via_sorted: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        via_sorted.absorb_sorted_slice(&sorted_stream);
+
+        for probe in (1..=n).step_by(100) {
+            assert_eq!(
+                via_absorb_slice.rank(&probe),
+                via_sorted.rank(&probe),
+                "rank({probe}) diverged"
+            );
+        }
+        assert_eq!(via_absorb_slice.quantile(0.0), via_sorted.quantile(0.0));
+        assert_eq!(via_absorb_slice.quantile(0.5), via_sorted.quantile(0.5));
+        assert_eq!(via_absorb_slice.quantile(1.0), via_sorted.quantile(1.0));
+    }
+
+    #[test]
+    #[should_panic(expected = "not sorted ascending")]
+    fn absorb_sorted_slice_debug_asserts_on_unsorted() {
+        // The precondition is unchecked in release, but debug builds
+        // (including cargo test) must catch caller bugs.
+        let mut sketch: KllSketch<u32> = KllSketch::with_seed(200, 0);
+        sketch.absorb_sorted_slice(&[3u32, 1, 2]);
     }
 
     #[test]

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -417,6 +417,15 @@ impl<T: Ord + Clone> KllSketch<T> {
         if self.max.as_ref().is_none_or(|m| batch_max > m) {
             self.max = Some(batch_max.clone());
         }
+        // If a prior `insert` or `absorb_slice` left level 0 unsorted,
+        // `merge_sorted` below would interleave sorted `xs` into
+        // unsorted state and the result wouldn't be sorted. Pay the sort
+        // once here so the loop's merge-extends stay honest and the doc's
+        // "level 0 stays sorted" claim actually holds.
+        if !self.sorted[0] {
+            self.levels[0].sort_unstable();
+            self.sorted[0] = true;
+        }
         // Chunk-merge sorted `xs` into (sorted) level 0. Level 0 stays
         // sorted through the whole ingest — `sorted[0]` never flips false.
         let mut i = 0;
@@ -1111,6 +1120,39 @@ mod tests {
         assert_eq!(via_absorb_slice.quantile(0.0), via_sorted.quantile(0.0));
         assert_eq!(via_absorb_slice.quantile(0.5), via_sorted.quantile(0.5));
         assert_eq!(via_absorb_slice.quantile(1.0), via_sorted.quantile(1.0));
+    }
+
+    #[test]
+    fn absorb_sorted_slice_restores_level_0_sortedness_after_prior_insert() {
+        // Prior `insert` calls leave sorted[0] = false. absorb_sorted_slice
+        // must sort level 0 before merge-extending, otherwise it would
+        // interleave sorted input into an unsorted buffer and the doc's
+        // "level 0 stays sorted" claim would be a lie.
+        //
+        // Small enough n to avoid tripping level-0 compaction, so we can
+        // inspect the sorted[] flag and level 0 directly.
+        let mut sketch: KllSketch<u32> = KllSketch::with_seed(1024, 42);
+        for x in [7u32, 3, 10, 1, 5] {
+            sketch.insert(x);
+        }
+        assert!(
+            !sketch.sorted[0],
+            "test setup: insert should leave sorted[0] = false"
+        );
+        sketch.absorb_sorted_slice(&[2u32, 4, 6, 8, 9]);
+        assert!(
+            sketch.sorted[0],
+            "absorb_sorted_slice should sort-and-set level 0 before merge-extending"
+        );
+        assert!(
+            sketch.levels[0].is_sorted(),
+            "level 0 contents must actually be sorted: {:?}",
+            sketch.levels[0]
+        );
+        // Sanity on the final counts and extremes across the mixed ingest.
+        assert_eq!(sketch.rank(&11), 10);
+        assert_eq!(sketch.quantile(0.0), Some(&1));
+        assert_eq!(sketch.quantile(1.0), Some(&10));
     }
 
     #[test]

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -99,13 +99,13 @@
 //! Ingest measured on uniform 1M-row streams (see
 //! `benchmarks/benches/quantile_sketch.rs`):
 //!
-//! - `T = OrderedFloat<f64>` via `absorb_slice`: **2.1× TDigest** (down
-//!   from 3.7× on per-row `insert`).
-//! - `T = OwnedRow` via `absorb`: **5.8× TDigest** (down from 6.7× on
+//! - `T = OrderedFloat<f64>` via `absorb_slice`: **1.8× TDigest** (down
+//!   from 3.7× on per-row `insert` with no batch API).
+//! - `T = OwnedRow` via `absorb`: **5.7× TDigest** (down from 6.8× on
 //!   per-row `insert`).
 //!
-//! Item (1) below landed as `absorb` / `absorb_slice`. Two independent
-//! wins remain that could close the remaining gap:
+//! Items (1) and (3) below have landed. One deferred win remains, and
+//! it's the one that matters for the OwnedRow path:
 //!
 //! 1. ~~**Amortize `compact_all` across a batch.**~~ **Landed.** `absorb`
 //!    caches level 0's capacity and skips the `compact_all` O(L) scan
@@ -122,14 +122,13 @@
 //!    lives for the duration of `absorb`, compacts before the caller's
 //!    `Rows` buffer goes out of scope. Only helps `T = OwnedRow`.
 //!
-//! 3. **Per-level sortedness invariant.** Apache DataSketches maintains
-//!    an `is_level_zero_sorted_` flag so `compact` skips the re-sort when
-//!    the level is already ordered, and two sketches merge via linear-
-//!    time merge-sort rather than concatenate-and-resort. Trades
-//!    bookkeeping in `insert`/`merge` for cheaper `compact` and cheaper
-//!    cross-sketch `merge` — the compaction sort dominates ingest time
-//!    once (1) is in place, so this is where the next 2× likely lives
-//!    for the Copy-T path.
+//! 3. ~~**Per-level sortedness invariant.**~~ **Landed.** `KllSketch`
+//!    carries a `sorted: Vec<bool>` parallel to `levels`. `compact_level`
+//!    skips the sort when the level is already ordered, and promoted
+//!    items merge-extend the next level in linear time when it too was
+//!    sorted. `KllSketch::merge` (across sketches) does not yet fold the
+//!    two sortedness flags — cross-sketch merge-extend is a further
+//!    deferred win.
 //!
 //! # Reference
 //!
@@ -153,6 +152,14 @@ const MIN_LEVEL_WIDTH: usize = 8;
 pub struct KllSketch<T: Ord + Clone> {
     /// One buffer per level; `levels[h]` is the level-`h` compactor.
     levels: Vec<Vec<T>>,
+    /// `sorted[h] == true` iff `levels[h]` is in ascending order. Same
+    /// length as `levels`, kept in lockstep with every mutation.
+    /// Compaction reads this to skip the re-sort when a level was left
+    /// sorted by an earlier promotion; promotions extend the destination
+    /// level via linear-time merge instead of concatenate-then-sort when
+    /// the destination is already sorted. Matches DataSketches'
+    /// `is_level_zero_sorted_` bookkeeping, generalized per-level.
+    sorted: Vec<bool>,
     /// Nominal compactor capacity — the top level's capacity. Lower
     /// levels shrink geometrically toward `MIN_LEVEL_WIDTH`.
     k: usize,
@@ -198,6 +205,8 @@ impl<T: Ord + Clone> KllSketch<T> {
     pub fn with_seed(k: usize, seed: u64) -> Self {
         Self {
             levels: vec![Vec::new()],
+            // An empty level is trivially sorted.
+            sorted: vec![true],
             k,
             rng: StdRng::seed_from_u64(seed),
             min: None,
@@ -231,11 +240,19 @@ impl<T: Ord + Clone> KllSketch<T> {
             (None, b) => b,
         };
         // Extend same-height compactors, growing the stack as needed.
+        // Cross-sketch extend does not preserve any per-level sortedness
+        // — the concatenation of two sorted runs is not sorted, and we
+        // don't yet fold the sortedness flags of two sketches into a
+        // merge-extend. `compact_all` will sort on demand.
         for (h, level) in other.levels.into_iter().enumerate() {
             if h == self.levels.len() {
                 self.levels.push(Vec::new());
+                self.sorted.push(true);
             }
-            self.levels[h].extend(level);
+            if !level.is_empty() {
+                self.levels[h].extend(level);
+                self.sorted[h] = false;
+            }
         }
         self.compact_all();
     }
@@ -251,6 +268,8 @@ impl<T: Ord + Clone> KllSketch<T> {
             self.max = Some(x.clone());
         }
         self.levels[0].push(x);
+        // Arbitrary insertion breaks any existing sort order at level 0.
+        self.sorted[0] = false;
         self.compact_all();
     }
 
@@ -284,6 +303,7 @@ impl<T: Ord + Clone> KllSketch<T> {
                 self.max = Some(x.clone());
             }
             self.levels[0].push(x);
+            self.sorted[0] = false;
             if self.levels[0].len() >= level_0_cap {
                 self.compact_all();
                 level_0_cap = level_capacity(self.k, self.levels.len(), 0);
@@ -338,6 +358,7 @@ impl<T: Ord + Clone> KllSketch<T> {
             let room = cap.saturating_sub(self.levels[0].len());
             let take = (xs.len() - i).min(room);
             self.levels[0].extend_from_slice(&xs[i..i + take]);
+            self.sorted[0] = false;
             i += take;
             if self.levels[0].len() >= cap {
                 self.compact_all();
@@ -428,7 +449,8 @@ impl<T: Ord + Clone> KllSketch<T> {
         }
     }
 
-    /// Sort level `h`, coin-flip, promote every other item to level `h+1`.
+    /// Sort level `h` (or reuse an existing sort), coin-flip, promote every
+    /// other item to level `h+1`.
     ///
     /// On odd-length levels the smallest item stays behind at level `h`
     /// with its original weight — the algorithm requires an even-length
@@ -436,13 +458,25 @@ impl<T: Ord + Clone> KllSketch<T> {
     /// current weight is what preserves the total-weight invariant across
     /// compaction. Matches Apache DataSketches' `general_compress`
     /// odd-pop handling.
+    ///
+    /// Sortedness bookkeeping: promoted items form a sorted subsequence
+    /// (every other element of a sorted array). If the destination level
+    /// was already sorted (which it is by default when previously touched
+    /// only by this function), we merge-extend in linear time instead of
+    /// concatenate-then-sort. The saving compounds up the stack — for
+    /// large streams, levels 1+ are always sorted going into compaction,
+    /// so the `sort_unstable` at level 0 is the only one paid.
     fn compact_level(&mut self, h: usize) {
         let level_len = self.levels[h].len();
         if level_len < 2 {
             return;
         }
         let mut buf = std::mem::take(&mut self.levels[h]);
-        buf.sort_unstable();
+        if !self.sorted[h] {
+            buf.sort_unstable();
+        }
+        // levels[h] is now empty and thus trivially sorted.
+        self.sorted[h] = true;
         let leftover = if level_len % 2 == 1 {
             Some(buf.remove(0))
         } else {
@@ -457,12 +491,53 @@ impl<T: Ord + Clone> KllSketch<T> {
             .collect();
         if h + 1 == self.levels.len() {
             self.levels.push(Vec::new());
+            self.sorted.push(true);
         }
-        self.levels[h + 1].extend(promoted);
+        // If the destination is already sorted, linear-time merge preserves
+        // its sortedness. Otherwise fall back to append; the next compaction
+        // at h+1 will pay the sort.
+        if self.sorted[h + 1] {
+            let existing = std::mem::take(&mut self.levels[h + 1]);
+            self.levels[h + 1] = merge_sorted(existing, promoted);
+        } else {
+            self.levels[h + 1].extend(promoted);
+        }
         if let Some(x) = leftover {
+            // Single-item level is trivially sorted.
             self.levels[h].push(x);
         }
     }
+}
+
+/// Merge two sorted vectors into one sorted vector in linear time.
+/// Preserves ties in source order (`a` before `b`) — matters only for
+/// non-unique `T`, where downstream halving still picks half the items
+/// but may pick different specific copies than `sort_unstable(a ++ b)`.
+fn merge_sorted<T: Ord>(a: Vec<T>, b: Vec<T>) -> Vec<T> {
+    let mut out = Vec::with_capacity(a.len() + b.len());
+    let mut ai = a.into_iter().peekable();
+    let mut bi = b.into_iter().peekable();
+    loop {
+        match (ai.peek(), bi.peek()) {
+            (Some(av), Some(bv)) => {
+                if av <= bv {
+                    out.push(ai.next().unwrap());
+                } else {
+                    out.push(bi.next().unwrap());
+                }
+            }
+            (Some(_), None) => {
+                out.extend(ai);
+                break;
+            }
+            (None, Some(_)) => {
+                out.extend(bi);
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -382,7 +382,7 @@ impl<T: Ord + Clone> KllSketch<T> {
         }
     }
 
-    /// Slice-ingest variant that assumes the input is already sorted
+    /// Slice-ingest variant that expects the input to already be sorted
     /// ascending — the caller is downstream of a `SortExec` or otherwise
     /// producing sorted output. Keeps level 0 permanently sorted by
     /// merge-extending each chunk into it, so `compact_level(0)` never
@@ -393,24 +393,21 @@ impl<T: Ord + Clone> KllSketch<T> {
     /// The min/max scan is also skipped — for sorted input the extremes
     /// are `xs[0]` and `xs[last]`.
     ///
-    /// Precondition: `xs` is sorted ascending. Unchecked in release
-    /// builds; a `debug_assert!` catches unsorted input in tests.
-    /// Violating the precondition silently corrupts the sketch — the
-    /// sort-skip is unconditional.
-    ///
-    /// Prefer this whenever the caller can cheaply provide sorted input:
-    /// the ORRE plan shape `Scan -> Sort -> RuntimeStats -> DamExec ->
-    /// ORRE` is the motivating case, since `SortExec` already runs
-    /// upstream of `ORRE` and moving it above `RuntimeStats` costs
-    /// nothing plan-wise.
+    /// Sortedness is verified unconditionally (O(n) comparisons against
+    /// the O(n log n) sort skipped when it holds). Unsorted input falls
+    /// through to `absorb_slice`, which sorts at compaction time. The
+    /// motivating plan shape is `Scan -> Sort -> RuntimeStats -> DamExec
+    /// -> ORRE`, but a future optimizer change that moves or drops the
+    /// upstream `SortExec` must not silently corrupt quantiles — the
+    /// fallback keeps this method safe under any caller.
     pub fn absorb_sorted_slice(&mut self, xs: &[T]) {
         if xs.is_empty() {
             return;
         }
-        debug_assert!(
-            xs.windows(2).all(|w| w[0] <= w[1]),
-            "absorb_sorted_slice: input not sorted ascending"
-        );
+        if !xs.is_sorted() {
+            self.absorb_slice(xs);
+            return;
+        }
         // Sorted input: extremes are the first and last elements. No scan.
         let batch_min = &xs[0];
         let batch_max = &xs[xs.len() - 1];
@@ -1117,12 +1114,35 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "not sorted ascending")]
-    fn absorb_sorted_slice_debug_asserts_on_unsorted() {
-        // The precondition is unchecked in release, but debug builds
-        // (including cargo test) must catch caller bugs.
-        let mut sketch: KllSketch<u32> = KllSketch::with_seed(200, 0);
-        sketch.absorb_sorted_slice(&[3u32, 1, 2]);
+    fn absorb_sorted_slice_falls_back_on_unsorted_input() {
+        // Fed unsorted data, absorb_sorted_slice must not silently corrupt
+        // the sketch — it verifies sortedness and falls through to
+        // absorb_slice. Guards against a future plan-shape change dropping
+        // the upstream SortExec: the sketch would still answer correctly,
+        // just without the sort-skip speedup.
+        use rand::seq::SliceRandom;
+        let seed = 12345u64;
+        let mut shuffle_rng = StdRng::seed_from_u64(seed);
+        let n = 10_000u32;
+        let mut stream: Vec<u32> = (1..=n).collect();
+        stream.shuffle(&mut shuffle_rng);
+
+        let mut via_absorb_slice: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        via_absorb_slice.absorb_slice(&stream);
+
+        let mut via_sorted: KllSketch<u32> = KllSketch::with_seed(200, seed);
+        via_sorted.absorb_sorted_slice(&stream);
+
+        for probe in (1..=n).step_by(100) {
+            assert_eq!(
+                via_absorb_slice.rank(&probe),
+                via_sorted.rank(&probe),
+                "rank({probe}) diverged"
+            );
+        }
+        assert_eq!(via_absorb_slice.quantile(0.0), via_sorted.quantile(0.0));
+        assert_eq!(via_absorb_slice.quantile(0.5), via_sorted.quantile(0.5));
+        assert_eq!(via_absorb_slice.quantile(1.0), via_sorted.quantile(1.0));
     }
 
     #[test]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -57,6 +57,7 @@ tokio = { version = "^1.52", features = [
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+ordered-float = "4"
 
 [[bench]]
 harness = false

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -37,7 +37,6 @@ ballista-core = { path = "../ballista/core", version = "54.0.0", features = [
 ] }
 clap = { workspace = true }
 datafusion = { workspace = true }
-datafusion-functions-aggregate-common = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
@@ -57,7 +56,8 @@ tokio = { version = "^1.52", features = [
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-ordered-float = "4"
+datafusion-functions-aggregate-common = { workspace = true }
+ordered-float = { workspace = true }
 
 [[bench]]
 harness = false

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -37,6 +37,7 @@ ballista-core = { path = "../ballista/core", version = "54.0.0", features = [
 ] }
 clap = { workspace = true }
 datafusion = { workspace = true }
+datafusion-functions-aggregate-common = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
@@ -60,3 +61,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [[bench]]
 harness = false
 name = "sort_shuffle"
+
+[[bench]]
+harness = false
+name = "quantile_sketch"

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -37,9 +37,7 @@
 use std::sync::Arc;
 
 use ballista_core::kll::KllSketch;
-use criterion::{
-    BatchSize, Criterion, Throughput, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion::arrow::array::{ArrayRef, Float64Array};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::row::{OwnedRow, RowConverter, SortField};
@@ -101,7 +99,10 @@ fn ingest_tdigest(batches: &[Float64Array]) -> TDigest {
 /// arrow row converter, then push per-row `OwnedRow` into a
 /// `KllSketch<OwnedRow>`. The heap alloc per `owned()` is what the
 /// level-0 borrowed-row optimization would eliminate.
-fn ingest_kll_row(batches: &[Float64Array], converter: &RowConverter) -> KllSketch<OwnedRow> {
+fn ingest_kll_row(
+    batches: &[Float64Array],
+    converter: &RowConverter,
+) -> KllSketch<OwnedRow> {
     let mut sketch = KllSketch::<OwnedRow>::new(KLL_K);
     for arr in batches {
         let col: ArrayRef = Arc::new(arr.clone());
@@ -133,8 +134,7 @@ fn bench_ingest(c: &mut Criterion) {
     // the ratios we care about and keeps the harness under a minute.
     group.sample_size(10);
 
-    let converter =
-        RowConverter::new(vec![SortField::new(DataType::Float64)]).unwrap();
+    let converter = RowConverter::new(vec![SortField::new(DataType::Float64)]).unwrap();
 
     for &n in ROW_COUNTS {
         let batches = build_batches(n);

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -81,6 +81,19 @@ fn build_batches(n: usize) -> Vec<Float64Array> {
     batches
 }
 
+/// Same underlying stream as `build_batches`, sorted globally before
+/// batching. Consecutive batches are monotonically increasing — matches
+/// what a `SortExec` upstream of `RuntimeStatsExec` would feed the sketch
+/// in the ORRE plan shape.
+fn build_globally_sorted_batches(n: usize) -> Vec<Float64Array> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let mut all: Vec<f64> = (0..n).map(|_| rng.random::<f64>()).collect();
+    all.sort_by(f64::total_cmp);
+    all.chunks(BATCH_SIZE)
+        .map(|chunk| Float64Array::from(chunk.to_vec()))
+        .collect()
+}
+
 /// Production TDigest ingest path — one `Vec<f64>` per batch through
 /// `merge_unsorted_f64`. This mirrors `runtime_stats::StreamState::record`
 /// modulo the null-flatten and partition-slot lookup.
@@ -139,6 +152,23 @@ fn ingest_kll_ordered_float_absorb_slice(
         let vals: Vec<OrderedFloat<f64>> =
             arr.values().iter().copied().map(OrderedFloat).collect();
         sketch.absorb_slice(&vals);
+    }
+    sketch
+}
+
+/// Same shape as `ingest_kll_ordered_float_absorb_slice`, but consumes
+/// pre-sorted batches via `absorb_sorted_slice` — measures the sketch
+/// side of the ORRE-plan-shape follow-up, where a `SortExec` upstream of
+/// `RuntimeStatsExec` guarantees sorted input and lets the sketch skip
+/// every compaction sort (not just those above level 0).
+fn ingest_kll_ordered_float_absorb_sorted_slice(
+    batches: &[Float64Array],
+) -> KllSketch<OrderedFloat<f64>> {
+    let mut sketch = KllSketch::<OrderedFloat<f64>>::new(KLL_K);
+    for arr in batches {
+        let vals: Vec<OrderedFloat<f64>> =
+            arr.values().iter().copied().map(OrderedFloat).collect();
+        sketch.absorb_sorted_slice(&vals);
     }
     sketch
 }
@@ -208,6 +238,15 @@ fn bench_ingest(c: &mut Criterion) {
             b.iter_batched(
                 || batches.clone(),
                 |bs| ingest_kll_ordered_float_absorb_slice(&bs),
+                BatchSize::LargeInput,
+            );
+        });
+
+        let sorted_batches = build_globally_sorted_batches(n);
+        group.bench_function(format!("kll_ordered_float_absorb_sorted_slice/{n}"), |b| {
+            b.iter_batched(
+                || sorted_batches.clone(),
+                |bs| ingest_kll_ordered_float_absorb_sorted_slice(&bs),
                 BatchSize::LargeInput,
             );
         });

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -115,6 +115,19 @@ fn ingest_tdigest(batches: &[Float64Array]) -> TDigest {
     sketch
 }
 
+/// Sorted-input TDigest ingest — same shape as `ingest_tdigest` but hits
+/// `merge_sorted_f64` on each pre-sorted batch. Answers the apples-to-
+/// apples question against `absorb_sorted_slice` on the ORRE-plan-shape
+/// arm: TDigest also benefits from sorted input (it skips its own
+/// pre-sort), so a matched race lines them up on equal footing.
+fn ingest_tdigest_sorted(batches: &[Float64Array]) -> TDigest {
+    let mut sketch = TDigest::new(TDIGEST_MAX_SIZE);
+    for arr in batches {
+        sketch = sketch.merge_sorted_f64(arr.values());
+    }
+    sketch
+}
+
 /// Multi-column-capable KLL ingest path — encode each batch through the
 /// arrow row converter, then push per-row `OwnedRow` into a
 /// `KllSketch<OwnedRow>`. The heap alloc per `owned()` is what the
@@ -211,13 +224,15 @@ fn ingest_kll_row_absorb(
 /// TDigest lacks a public rank API.
 fn print_parity_table(n: usize) {
     let batches = build_batches(n);
-    let all: Vec<f64> = batches.iter().flat_map(|b| b.values().iter().copied()).collect();
+    let all: Vec<f64> = batches
+        .iter()
+        .flat_map(|b| b.values().iter().copied())
+        .collect();
     let mut sorted = all.clone();
     sorted.sort_by(f64::total_cmp);
 
-    let true_rank_frac = |probe: f64| -> f64 {
-        sorted.partition_point(|x| *x < probe) as f64 / n as f64
-    };
+    let true_rank_frac =
+        |probe: f64| -> f64 { sorted.partition_point(|x| *x < probe) as f64 / n as f64 };
     // Nine interior deciles; hits TDigest's median hump (worst-case for it)
     // and both tails (KLL uniform, TDigest tightest).
     let qs: Vec<f64> = (1..10).map(|i| i as f64 / 10.0).collect();
@@ -309,6 +324,14 @@ fn bench_ingest(c: &mut Criterion) {
         });
 
         let sorted_batches = build_globally_sorted_batches(n);
+        group.bench_function(format!("tdigest_sorted/{n}"), |b| {
+            b.iter_batched(
+                || sorted_batches.clone(),
+                |bs| ingest_tdigest_sorted(&bs),
+                BatchSize::LargeInput,
+            );
+        });
+
         group.bench_function(format!("kll_ordered_float_absorb_sorted_slice/{n}"), |b| {
             b.iter_batched(
                 || sorted_batches.clone(),

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -128,6 +128,38 @@ fn ingest_kll_ordered_float(batches: &[Float64Array]) -> KllSketch<OrderedFloat<
     sketch
 }
 
+/// Same as `ingest_kll_ordered_float` but batches each Arrow batch into
+/// `absorb_slice` — measures the batch-oriented ingest optimization
+/// (amortized compact_all + batch min/max + memcpy-style extend).
+fn ingest_kll_ordered_float_absorb_slice(
+    batches: &[Float64Array],
+) -> KllSketch<OrderedFloat<f64>> {
+    let mut sketch = KllSketch::<OrderedFloat<f64>>::new(KLL_K);
+    for arr in batches {
+        let vals: Vec<OrderedFloat<f64>> =
+            arr.values().iter().copied().map(OrderedFloat).collect();
+        sketch.absorb_slice(&vals);
+    }
+    sketch
+}
+
+/// Same as `ingest_kll_row` but batches each Arrow batch into `absorb`
+/// (owned-iter variant) — measures the compact_all amortization win on the
+/// `OwnedRow` path without the extra clone that `absorb_slice` would
+/// force.
+fn ingest_kll_row_absorb(
+    batches: &[Float64Array],
+    converter: &RowConverter,
+) -> KllSketch<OwnedRow> {
+    let mut sketch = KllSketch::<OwnedRow>::new(KLL_K);
+    for arr in batches {
+        let col: ArrayRef = Arc::new(arr.clone());
+        let rows = converter.convert_columns(&[col]).unwrap();
+        sketch.absorb(rows.iter().map(|r| r.owned()));
+    }
+    sketch
+}
+
 fn bench_ingest(c: &mut Criterion) {
     let mut group = c.benchmark_group("runtime_stats_ingest");
     // Ingest is CPU-bound and single-threaded; ten samples is enough for
@@ -156,10 +188,26 @@ fn bench_ingest(c: &mut Criterion) {
             );
         });
 
+        group.bench_function(format!("kll_row_absorb/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_row_absorb(&bs, &converter),
+                BatchSize::LargeInput,
+            );
+        });
+
         group.bench_function(format!("kll_ordered_float/{n}"), |b| {
             b.iter_batched(
                 || batches.clone(),
                 |bs| ingest_kll_ordered_float(&bs),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll_ordered_float_absorb_slice/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_ordered_float_absorb_slice(&bs),
                 BatchSize::LargeInput,
             );
         });

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -28,11 +28,12 @@
 //! and K=64 cuts, both are 3+ orders of magnitude cheaper than ingest and
 //! would not move the swap decision.
 //!
-//! Sketch sizing is analytical — TDigest at `TDIGEST_MAX_SIZE=100` (what
-//! `runtime_stats.rs` uses today), KLL at `k=800` (roughly `1/√k ≈ 0.035`
-//! normalized error, comparable to TDigest's default compression at
-//! extreme quantiles). Empirical parity check is future work if the
-//! throughput gap turns out to be borderline.
+//! Sketch sizing is empirical, not analytical. TDigest is held at
+//! `TDIGEST_MAX_SIZE=100` (production), and `KLL_K` is picked so KLL's
+//! worst-case normalized rank error on the same uniform 1M stream is
+//! within a whisker of TDigest's — a fair race. The parity check itself
+//! prints alongside the throughput results when the env var
+//! `KLL_PARITY_CHECK=1` is set, so anyone can rerun it.
 
 use std::sync::Arc;
 
@@ -49,10 +50,16 @@ use rand::{RngExt, SeedableRng};
 /// Matches `runtime_stats::TDIGEST_MAX_SIZE` — production sizing.
 const TDIGEST_MAX_SIZE: usize = 100;
 
-/// KLL top-level compactor capacity chosen for analytical error parity with
-/// TDigest at `TDIGEST_MAX_SIZE=100`. KLL normalized error scales as
-/// `~1/√k`; k=800 gives ε ≈ 0.035, which is in the same neighborhood as
-/// TDigest's default compression at the tails.
+/// KLL top-level compactor capacity picked empirically for worst-case
+/// rank-error parity with TDigest at `TDIGEST_MAX_SIZE=100`. Measured on
+/// the uniform 1M stream this bench feeds:
+///
+/// | sketch                       | worst rank err (9 deciles) |
+/// |------------------------------|---------------------------:|
+/// | TDigest max_size=100         |                     0.0021 |
+/// | KLL k=800                    |                     0.0016 |
+///
+/// Rerun via `KLL_PARITY_CHECK=1 cargo bench --bench quantile_sketch`.
 const KLL_K: usize = 800;
 
 /// RuntimeStatsExec observes one batch at a time from the upstream
@@ -190,7 +197,66 @@ fn ingest_kll_row_absorb(
     sketch
 }
 
+/// Print worst-case quantile-inversion error at deciles for TDigest at
+/// `TDIGEST_MAX_SIZE=100` and KLL at a sweep of `k`. Called from
+/// `bench_ingest` when `KLL_PARITY_CHECK=1` is set. Reproducibility
+/// artifact for the `KLL_K` choice — a reviewer can rerun and confirm
+/// the two sketches sit at matched accuracy at the settings the bench
+/// uses.
+///
+/// Error metric: at each decile `q`, ask the sketch for `quantile(q)`,
+/// look up what fraction of the true stream is below the returned value,
+/// and take `|true_fraction - q|`. That's normalized rank error via
+/// quantile inversion — the same units for both sketches even though
+/// TDigest lacks a public rank API.
+fn print_parity_table(n: usize) {
+    let batches = build_batches(n);
+    let all: Vec<f64> = batches.iter().flat_map(|b| b.values().iter().copied()).collect();
+    let mut sorted = all.clone();
+    sorted.sort_by(f64::total_cmp);
+
+    let true_rank_frac = |probe: f64| -> f64 {
+        sorted.partition_point(|x| *x < probe) as f64 / n as f64
+    };
+    // Nine interior deciles; hits TDigest's median hump (worst-case for it)
+    // and both tails (KLL uniform, TDigest tightest).
+    let qs: Vec<f64> = (1..10).map(|i| i as f64 / 10.0).collect();
+
+    let td = ingest_tdigest(&batches);
+    let td_worst = qs
+        .iter()
+        .map(|&q| (true_rank_frac(td.estimate_quantile(q)) - q).abs())
+        .fold(0.0_f64, f64::max);
+
+    println!("\n=== quantile_sketch parity @ n={n} (uniform f64) ===");
+    println!("TDigest max_size={TDIGEST_MAX_SIZE:>4} → worst rank err = {td_worst:.4}");
+    for &k in &[50usize, 100, 200, 400, 800] {
+        let mut sk = KllSketch::<OrderedFloat<f64>>::new(k);
+        for arr in &batches {
+            for v in arr.values() {
+                sk.insert(OrderedFloat(*v));
+            }
+        }
+        let kll_worst = qs
+            .iter()
+            .map(|&q| {
+                let guess = sk.quantile(q).map(|of| of.0).unwrap_or(f64::NAN);
+                (true_rank_frac(guess) - q).abs()
+            })
+            .fold(0.0_f64, f64::max);
+        let marker = if k == KLL_K { " ← KLL_K" } else { "" };
+        println!("KLL     k       ={k:>4} → worst rank err = {kll_worst:.4}{marker}");
+    }
+    println!();
+}
+
 fn bench_ingest(c: &mut Criterion) {
+    if std::env::var_os("KLL_PARITY_CHECK").is_some() {
+        for &n in ROW_COUNTS {
+            print_parity_table(n);
+        }
+    }
+
     let mut group = c.benchmark_group("runtime_stats_ingest");
     // Ingest is CPU-bound and single-threaded; ten samples is enough for
     // the ratios we care about and keeps the harness under a minute.

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -16,7 +16,13 @@
 // under the License.
 
 //! Ingest throughput: TDigest (production RuntimeStatsExec path) vs KLL
-//! over `OwnedRow` (production-swap path).
+//! over `OwnedRow` (multi-column-capable swap path) vs KLL over
+//! `OrderedFloat<f64>` (single-column-native-Ord fast path).
+//!
+//! The three variants isolate the cost of the arrow-row encoding: TDigest
+//! is the incumbent baseline, KLL<OwnedRow> pays for `RowConverter` +
+//! per-row `owned()` heap alloc, KLL<OrderedFloat<f64>> skips both and
+//! measures the sketch algorithm on its own.
 //!
 //! Merge and quantile query are excluded: for N=1M rows at P=64 partitions
 //! and K=64 cuts, both are 3+ orders of magnitude cheaper than ingest and
@@ -38,6 +44,7 @@ use datafusion::arrow::array::{ArrayRef, Float64Array};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::row::{OwnedRow, RowConverter, SortField};
 use datafusion_functions_aggregate_common::tdigest::TDigest;
+use ordered_float::OrderedFloat;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
@@ -90,17 +97,31 @@ fn ingest_tdigest(batches: &[Float64Array]) -> TDigest {
     sketch
 }
 
-/// Production-swap KLL ingest path — encode each batch through the arrow
-/// row converter, then push per-row `OwnedRow` into a `KllSketch<OwnedRow>`.
-/// The heap alloc per `owned()` is what the level-0 borrowed-row
-/// optimization would eliminate.
-fn ingest_kll(batches: &[Float64Array], converter: &RowConverter) -> KllSketch<OwnedRow> {
+/// Multi-column-capable KLL ingest path — encode each batch through the
+/// arrow row converter, then push per-row `OwnedRow` into a
+/// `KllSketch<OwnedRow>`. The heap alloc per `owned()` is what the
+/// level-0 borrowed-row optimization would eliminate.
+fn ingest_kll_row(batches: &[Float64Array], converter: &RowConverter) -> KllSketch<OwnedRow> {
     let mut sketch = KllSketch::<OwnedRow>::new(KLL_K);
     for arr in batches {
         let col: ArrayRef = Arc::new(arr.clone());
         let rows = converter.convert_columns(&[col]).unwrap();
         for row in rows.iter() {
             sketch.insert(row.owned());
+        }
+    }
+    sketch
+}
+
+/// Single-column native-`Ord` KLL fast path — bypasses arrow-row entirely
+/// by using `OrderedFloat<f64>` as the sketch item type. Answers "what
+/// does KLL cost when we dispatch by column type instead of routing
+/// everything through OwnedRow?"
+fn ingest_kll_ordered_float(batches: &[Float64Array]) -> KllSketch<OrderedFloat<f64>> {
+    let mut sketch = KllSketch::<OrderedFloat<f64>>::new(KLL_K);
+    for arr in batches {
+        for v in arr.values() {
+            sketch.insert(OrderedFloat(*v));
         }
     }
     sketch
@@ -127,10 +148,18 @@ fn bench_ingest(c: &mut Criterion) {
             );
         });
 
-        group.bench_function(format!("kll/{n}"), |b| {
+        group.bench_function(format!("kll_row/{n}"), |b| {
             b.iter_batched(
                 || batches.clone(),
-                |bs| ingest_kll(&bs, &converter),
+                |bs| ingest_kll_row(&bs, &converter),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll_ordered_float/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_ordered_float(&bs),
                 BatchSize::LargeInput,
             );
         });

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Ingest throughput: TDigest (production RuntimeStatsExec path) vs KLL
+//! over `OwnedRow` (production-swap path).
+//!
+//! Merge and quantile query are excluded: for N=1M rows at P=64 partitions
+//! and K=64 cuts, both are 3+ orders of magnitude cheaper than ingest and
+//! would not move the swap decision.
+//!
+//! Sketch sizing is analytical — TDigest at `TDIGEST_MAX_SIZE=100` (what
+//! `runtime_stats.rs` uses today), KLL at `k=800` (roughly `1/√k ≈ 0.035`
+//! normalized error, comparable to TDigest's default compression at
+//! extreme quantiles). Empirical parity check is future work if the
+//! throughput gap turns out to be borderline.
+
+use std::sync::Arc;
+
+use ballista_core::kll::KllSketch;
+use criterion::{
+    BatchSize, Criterion, Throughput, criterion_group, criterion_main,
+};
+use datafusion::arrow::array::{ArrayRef, Float64Array};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::row::{OwnedRow, RowConverter, SortField};
+use datafusion_functions_aggregate_common::tdigest::TDigest;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+/// Matches `runtime_stats::TDIGEST_MAX_SIZE` — production sizing.
+const TDIGEST_MAX_SIZE: usize = 100;
+
+/// KLL top-level compactor capacity chosen for analytical error parity with
+/// TDigest at `TDIGEST_MAX_SIZE=100`. KLL normalized error scales as
+/// `~1/√k`; k=800 gives ε ≈ 0.035, which is in the same neighborhood as
+/// TDigest's default compression at the tails.
+const KLL_K: usize = 800;
+
+/// RuntimeStatsExec observes one batch at a time from the upstream
+/// operator. 8192 is DataFusion's default target batch size.
+const BATCH_SIZE: usize = 8192;
+
+/// Fixed PRNG seed so the harness is deterministic across runs.
+const SEED: u64 = 0xDEC0DE;
+
+/// Total row counts benched. 100K represents a small stage; 1M represents
+/// a per-partition slice of a large TPC-H stage.
+const ROW_COUNTS: &[usize] = &[100_000, 1_000_000];
+
+/// Build a `Vec<Float64Array>` of `BATCH_SIZE`-length batches whose row
+/// count sums to `n`. Uniform on [0, 1), seeded.
+fn build_batches(n: usize) -> Vec<Float64Array> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let mut batches = Vec::with_capacity(n.div_ceil(BATCH_SIZE));
+    let mut remaining = n;
+    while remaining > 0 {
+        let take = remaining.min(BATCH_SIZE);
+        let vals: Vec<f64> = (0..take).map(|_| rng.random::<f64>()).collect();
+        batches.push(Float64Array::from(vals));
+        remaining -= take;
+    }
+    batches
+}
+
+/// Production TDigest ingest path — one `Vec<f64>` per batch through
+/// `merge_unsorted_f64`. This mirrors `runtime_stats::StreamState::record`
+/// modulo the null-flatten and partition-slot lookup.
+fn ingest_tdigest(batches: &[Float64Array]) -> TDigest {
+    let mut sketch = TDigest::new(TDIGEST_MAX_SIZE);
+    for arr in batches {
+        // Uniform-f64 batches have no nulls, so `values()` matches the
+        // shape the sketch consumes after RuntimeStatsExec's flatten step.
+        let values: Vec<f64> = arr.values().to_vec();
+        sketch = sketch.merge_unsorted_f64(values);
+    }
+    sketch
+}
+
+/// Production-swap KLL ingest path — encode each batch through the arrow
+/// row converter, then push per-row `OwnedRow` into a `KllSketch<OwnedRow>`.
+/// The heap alloc per `owned()` is what the level-0 borrowed-row
+/// optimization would eliminate.
+fn ingest_kll(batches: &[Float64Array], converter: &RowConverter) -> KllSketch<OwnedRow> {
+    let mut sketch = KllSketch::<OwnedRow>::new(KLL_K);
+    for arr in batches {
+        let col: ArrayRef = Arc::new(arr.clone());
+        let rows = converter.convert_columns(&[col]).unwrap();
+        for row in rows.iter() {
+            sketch.insert(row.owned());
+        }
+    }
+    sketch
+}
+
+fn bench_ingest(c: &mut Criterion) {
+    let mut group = c.benchmark_group("runtime_stats_ingest");
+    // Ingest is CPU-bound and single-threaded; ten samples is enough for
+    // the ratios we care about and keeps the harness under a minute.
+    group.sample_size(10);
+
+    let converter =
+        RowConverter::new(vec![SortField::new(DataType::Float64)]).unwrap();
+
+    for &n in ROW_COUNTS {
+        let batches = build_batches(n);
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_function(format!("tdigest/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_tdigest(&bs),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll(&bs, &converter),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ingest);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Performance improvements for KLL to make it viable for collecting RuntimeStats.

- `absorb(&[T])` (iterator) + `absorb_slice(&[T])` — batch-oriented ingest, amortizes `compact_all`.
- Per-level sortedness invariant — `compact_level` skips re-sort when the level was left sorted by an earlier promotion; promotions merge-extend in linear time when the destination is sorted.
- `absorb_sorted_slice(&[T])` — for callers that can guarantee sorted input, keeps level 0 permanently sorted and skips *every* compaction sort.
- Statistical test coverage against the DataSketches empirical bound (uniform, clustered, heavy-ties).

The actual `RuntimeStatsExec` integration, wire format for KLL sketches across the scheduler boundary, and the ORRE plan-shape follow-up are all out of scope here — separate PRs.

## The two arms

**ORRE arm (ordered input, requires a follow-up plan-shape move):**

```
Scan ──▶ RuntimeStats ──▶ Sort ──▶  ORRE ──▶ ShuffleWrite
```

`SortExec` is already required by ORRE. Moving it above `RuntimeStats` costs nothing plan-wise — the same rows get sorted the same way. 

**URRE arm (unordered input, ships as-is with this PR's shape):**

```
Scan ──▶ RuntimeStats ──▶ BufferExec(Dam) ──▶ URRE ──▶ ShuffleWrite
```

## Why not always use TDigest?

TDigest can only sketch a single non-null `f64` column. KLL is generic over `T: Ord + Clone`, and composes with `arrow::row::OwnedRow` to cover the full ORDER BY grammar for partition-boundary picking: multi-column keys, nullable, per-column ASC/DESC, configurable NULLS FIRST/LAST. That grammar is what parallel window (and later merge-join, order-by execution) actually needs from the boundaries.

## Numbers (uniform f64, 1M rows, `k=800` for KLL, `TDIGEST_MAX_SIZE=100`)

Baseline = TDigest sorted (`merge_sorted_f64`), the fastest arm. Higher × is worse:

| variant | time | throughput | ×baseline |
|---|---:|---:|---:|
| TDigest sorted (baseline) | 2.19 ms | 457.6 M/s | 1.00× |
| KLL<OrderedFloat<f64>> `absorb_sorted_slice` (this PR + planner follow-up, ORRE arm) | 7.22 ms | 138.6 M/s | 3.30× |
| TDigest unsorted (`merge_unsorted_f64`) | 13.89 ms | 72.0 M/s | 6.36× |
| KLL<OrderedFloat<f64>> `absorb_slice` (this PR, URRE arm) | 24.78 ms | 40.4 M/s | 11.34× |
| KLL<OrderedFloat<f64>> `insert` (per-row) | 47.65 ms | 21.0 M/s | 21.80× |
| KLL<OwnedRow> `absorb` (multi-column path, this PR) | 80.22 ms | 12.5 M/s | 36.71× |
| KLL<OwnedRow> `insert` (per-row) | 92.78 ms | 10.8 M/s | 42.45× |

Accuracy parity between the sketches — both hold worst-case rank error under 0.25% on the same 1M stream:

| sketch                | worst rank err (9 deciles) |
|-----------------------|---------------------------:|
| TDigest max_size=100  |                     0.0021 |
| KLL k=800             |                     0.0016 |

Rerun via `KLL_PARITY_CHECK=1 cargo bench --bench quantile_sketch`.

The `OwnedRow` path is the real regression — the compaction cost for heap-allocated rows is dominated by cache misses on the `OwnedRow` storage, not sort-algorithm efficiency. Closing that gap is deferred-optimization item (2) in the module doc (batch-oriented level-0-borrowed-row ingest), noted as a TODO on the interim iterator API.
