### PR TITLE
fix: update mTLS example for poll_loop arguments

### DIFF
--- a/examples/examples/mtls-cluster.rs
+++ b/examples/examples/mtls-cluster.rs
@@ -433,7 +433,7 @@ async fn run_executor() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting execution poll loop...");
     let health = ballista_executor::health::ExecutorHealth::new();
     let poll_handle = tokio::spawn(async move {
-        execution_loop::poll_loop(scheduler, executor, codec, None, health).await
+        execution_loop::poll_loop(scheduler, executor, codec, None, None, health).await
     });
 
     tokio::select! {


### PR DESCRIPTION
## What changed

Pass the new `free_vcores` argument (`None`) when the mTLS cluster example starts the executor poll loop.

## Why

PR #1893 added the `free_vcores` parameter to `poll_loop`, but `examples/examples/mtls-cluster.rs` retained the old five-argument call. Current `main` therefore fails the CI Clippy gate while compiling `ballista-examples` with `E0061`.

## Validation

- `./ci/scripts/rust_clippy.sh`
- `cargo fmt --all -- --check`

The Clippy failure was reproduced on Apache `main` at `10d4d087` before this change; the complete gate passes after it.
