### PR TITLE
fix: [branch-54] bind the gRPC listener before registering with the scheduler (backport of #2225)

### DIFF
--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -32,11 +32,13 @@ use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream, metrics};
 use futures::StreamExt;
 use log::error;
 use std::io::BufWriter;
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs::File, pin::Pin};
 use tonic::codegen::StdError;
+use tonic::transport::server::TcpIncoming;
 use tonic::transport::{Channel, Endpoint, Error, Server};
 
 /// Configuration for gRPC client connections.
@@ -343,6 +345,30 @@ pub fn create_grpc_server(config: &GrpcServerConfig) -> Server {
         )))
 }
 
+/// Binds a gRPC server's listening socket, for use with tonic's
+/// `serve_with_incoming` / `serve_with_incoming_shutdown`. Unlike tonic's
+/// `serve`, which binds lazily inside the future it returns, the socket is
+/// listening by the time this returns — so use this whenever a peer may be
+/// told to connect as soon as the server is started.
+///
+/// tonic ignores the builder's `tcp_nodelay` and `tcp_keepalive` when serving
+/// from a pre-bound listener, so this applies the same values that
+/// [`create_grpc_server`] sets, for the same reasons. The remaining settings
+/// still come from the builder.
+///
+/// # Panics
+///
+/// The listener is registered with the Tokio reactor, so this must be called
+/// from within a Tokio runtime.
+pub fn create_grpc_server_incoming(
+    addr: SocketAddr,
+    config: &GrpcServerConfig,
+) -> Result<TcpIncoming> {
+    Ok(TcpIncoming::bind(addr)?
+        .with_nodelay(Some(true))
+        .with_keepalive(Some(Duration::from_secs(config.tcp_keepalive_seconds))))
+}
+
 /// Recursively collects metrics from an execution plan and all its children.
 pub fn collect_plan_metrics(plan: &dyn ExecutionPlan) -> Vec<MetricsSet> {
     let mut metrics_array = Vec::<MetricsSet>::new();
@@ -425,6 +451,39 @@ mod tests {
     #[test]
     fn test_create_grpc_client_endpoint_invalid_url() {
         let result = create_grpc_client_endpoint("not a valid url", None);
+        assert!(result.is_err());
+    }
+
+    /// The point of binding up front is that the port is reachable before
+    /// anything is served on it, so a peer told to connect back cannot arrive
+    /// too early.
+    #[tokio::test]
+    async fn test_create_grpc_server_incoming_binds_eagerly() {
+        let incoming = create_grpc_server_incoming(
+            "127.0.0.1:0".parse().unwrap(),
+            &GrpcServerConfig::default(),
+        )
+        .expect("bind");
+        let addr = incoming.local_addr().expect("local addr");
+
+        // `incoming` is never handed to a server, and yet:
+        tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("port is already listening");
+    }
+
+    /// Binding eagerly means a port conflict surfaces here, as an error, rather
+    /// than later inside the spawned server task.
+    #[tokio::test]
+    async fn test_create_grpc_server_incoming_port_in_use() {
+        let first = create_grpc_server_incoming(
+            "127.0.0.1:0".parse().unwrap(),
+            &GrpcServerConfig::default(),
+        )
+        .expect("bind");
+        let addr = first.local_addr().expect("local addr");
+
+        let result = create_grpc_server_incoming(addr, &GrpcServerConfig::default());
         assert!(result.is_err());
     }
 }

--- a/ballista/executor/src/executor_server.rs
+++ b/ballista/executor/src/executor_server.rs
@@ -53,7 +53,9 @@ use ballista_core::serde::scheduler::TaskDefinition;
 use ballista_core::serde::scheduler::from_proto::{
     get_task_definition, get_task_definition_vec,
 };
-use ballista_core::utils::{create_grpc_client_endpoint, create_grpc_server};
+use ballista_core::utils::{
+    create_grpc_client_endpoint, create_grpc_server, create_grpc_server_incoming,
+};
 
 use dashmap::DashMap;
 use datafusion::execution::TaskContext;
@@ -123,12 +125,19 @@ pub async fn startup<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>(
     );
 
     // 1. Start executor grpc service
+    //
+    // The listening socket is bound here rather than inside the spawned task,
+    // because step 2 registers with the scheduler and the scheduler dials this
+    // port back to check connectivity. Binding lazily inside the server future
+    // let that callback lose the race and get ECONNREFUSED, which fails
+    // registration and takes the executor down with it.
     let server = {
         let executor_meta = executor.metadata.clone();
         let addr = format!("{}:{}", config.bind_host, executor_meta.grpc_port);
         let addr = addr.parse().unwrap();
         let grpc_server_config = config.grpc_server_config.clone();
 
+        let incoming = create_grpc_server_incoming(addr, &grpc_server_config)?;
         info!(
             "Ballista v{BALLISTA_VERSION} Rust Executor Grpc Server listening on {addr:?}"
         );
@@ -140,7 +149,7 @@ pub async fn startup<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>(
             let shutdown_signal = grpc_shutdown.recv();
             let grpc_server_future = create_grpc_server(&grpc_server_config)
                 .add_service(server)
-                .serve_with_shutdown(addr, shutdown_signal);
+                .serve_with_incoming_shutdown(incoming, shutdown_signal);
             grpc_server_future.await.map_err(|e| {
                 error!("Tonic error, Could not start Executor Grpc Server.");
                 BallistaError::TonicError(e)
@@ -149,7 +158,6 @@ pub async fn startup<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>(
     };
 
     // 2. Do executor registration
-    // TODO the executor registration should happen only after the executor grpc server started.
     let executor_server = Arc::new(executor_server);
     match register_executor(&mut scheduler, executor.clone()).await {
         Ok(_) => {


### PR DESCRIPTION
# Which issue does this PR close?

Backport of #2225 to `branch-54`. The issue it fixes is #2224.

# Rationale for this change

In push-based scheduling the executor tells the scheduler about itself before its own gRPC server is listening, and the scheduler dials that port back to verify connectivity. When the callback wins the race, the executor dies at startup.

The ordering in `executor_server::startup` is:

1. `tokio::spawn` the tonic server. `Server::serve` binds *inside* the future, so the socket does not exist yet when `spawn` returns, even though the `"... Grpc Server listening on ..."` line is already in the log.
2. `register_executor`, immediately.

On the scheduler side `ExecutorManager::register_executor` calls `test_connectivity`, a single `ExecutorGrpcClient::connect(...)` with no retry and no backoff. If the spawned task has not reached its `bind` yet, that connect gets `ECONNREFUSED`, registration returns an error, and `executor_process` treats a registration error as fatal, so the executor exits instead of joining the cluster.

The opposite direction is already tolerant: the executor retries its connection *to* the scheduler in a loop. Only the scheduler's callback to the executor is one-shot, which is why the executor's own startup ordering has to be right.

It is timing-dependent, so it shows up rarely and on loaded machines. Outside of tests the consequence is an otherwise healthy executor failing to join, and in a restart loop it can keep failing to join.

# What changes are included in this PR?

A clean cherry-pick of 984513ee, unmodified.

- `ballista/core/src/utils.rs` — new `create_grpc_server_incoming(addr, &GrpcServerConfig)`, which binds the listening socket eagerly and returns tonic's `TcpIncoming`. tonic ignores the server builder's `tcp_nodelay` / `tcp_keepalive` when serving from a pre-bound listener, so the helper applies the same values `create_grpc_server` sets and keeps the two in one place. The remaining settings still come from the builder as before, so the socket is configured exactly as it was.
- `ballista/executor/src/executor_server.rs` — `startup` binds via that helper on the current task, before spawning, and the spawned task serves with `serve_with_incoming_shutdown`. Registration therefore cannot run before the port is accepting connections.

One incidental improvement falls out of binding eagerly: a port conflict now fails `startup` directly, with the bind error, rather than being discovered later through the spawned server task.

New tests in `ballista-core`:

- `test_create_grpc_server_incoming_binds_eagerly` — connects to the bound address while nothing is serving on it. This is the property the fix depends on, and it fails against a lazily-bound socket.
- `test_create_grpc_server_incoming_port_in_use` — binding an address twice is an error rather than a panic.

# Are there any user-facing changes?

No behaviour changes for a successfully started executor and no API breakage. `create_grpc_server_incoming` is a new public function in `ballista-core`, additive alongside `create_grpc_server`. It must be called from within a Tokio runtime, since the listener registers with the reactor; this is documented on the function.

---

Verified locally on the `branch-54` base: `cargo fmt --all -- --check` is clean, and `cargo check --workspace --all-targets --locked` completes with no warnings on a combined stack of the six backports being proposed together. Test execution is left to CI.
