### PR TITLE
fix: [branch-54] send the shutdown notification before dropping the notifier (backport of #2107)

### DIFF
--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -647,6 +647,7 @@ pub async fn start_executor_process(
 
     // When `notify_shutdown` is dropped, all components which have `subscribe`d will
     // receive the shutdown signal and can exit
+    let _ = notify_shutdown.send(());
     drop(notify_shutdown);
     // Drop final `Sender` so the `Receiver` below can complete
     drop(shutdown_complete_tx);


### PR DESCRIPTION
# Which issue does this PR close?

Backport of #2107 to `branch-54`. The issue it fixes is #2105.

# Rationale for this change

The executor process hangs indefinitely on ctrl+c instead of shutting down. Shutdown is signalled by dropping `notify_shutdown`, the `broadcast::Sender` that every component subscribes to, but cloned instances of that sender are still outstanding at that point, so dropping the one held by `start_executor_process` does not close the channel and the subscribers never observe the shutdown.

# What changes are included in this PR?

A clean cherry-pick of c77e4812, unmodified.

Sends an explicit `notify_shutdown.send(())` before the drop, so subscribers receive the signal regardless of how many senders are still alive. One line in `ballista/executor/src/executor_process.rs`.

# Are there any user-facing changes?

The executor now exits on ctrl+c instead of hanging. No API, config, or wire format changes.

---

Verified locally on the `branch-54` base: `cargo fmt --all -- --check` is clean, and `cargo check --workspace --all-targets --locked` completes with no warnings on a combined stack of the six backports being proposed together. Test execution is left to CI.
