### PR TITLE
fix: [branch-54] spill sort shuffle writer when the memory pool rejects a reservation grow (backport of #2061)

### DIFF
--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -268,13 +268,16 @@ impl SortShuffleWriterExec {
                 growth += after.saturating_sub(before);
 
                 // Mirror the growth in the runtime pool reservation so the pool
-                // sees this writer's memory usage. Best-effort: if the pool is
-                // bounded and rejects the grow, that's fine — the absolute
-                // counter below still triggers a spill.
-                let _ = reservation.try_grow(growth);
+                // sees this writer's memory usage. A rejected grow means the
+                // pool is under pressure and has *not* accounted for the batch
+                // just buffered, so spill instead of holding memory the pool
+                // believes is free. Spilling flushes that batch to disk and
+                // frees the reservation, which is the response a spillable
+                // consumer owes the pool.
+                let pool_rejected_growth = reservation.try_grow(growth).is_err();
                 buffered_bytes = buffered_bytes.saturating_add(growth);
 
-                if buffered_bytes >= memory_limit {
+                if pool_rejected_growth || buffered_bytes >= memory_limit {
                     let spill_timer = metrics.spill_time.timer();
                     let (event_batches, event_bytes) = spill_all_partitions(
                         &mut buffered,
@@ -866,7 +869,8 @@ mod tests {
     /// `rows_per_batch` rows each with schema `(k: Int64, v: Int64)`, writes
     /// them through `SortShuffleWriterExec` into `num_partitions` output
     /// partitions with a per-task buffered-bytes budget of
-    /// `sort_shuffle_memory_limit_bytes`, reads every partition back via
+    /// `sort_shuffle_memory_limit_bytes` against a `FairSpillPool` of
+    /// `pool_bytes`, reads every partition back via
     /// `stream_sort_shuffle_partition`, and asserts:
     ///   - Every input key `0..total_rows` is present exactly once in the union
     ///     of partition outputs.
@@ -877,6 +881,7 @@ mod tests {
         rows_per_batch: usize,
         num_partitions: usize,
         sort_shuffle_memory_limit_bytes: usize,
+        pool_bytes: usize,
         expect_spills: bool,
     ) -> Result<()> {
         use super::super::reader::stream_sort_shuffle_partition;
@@ -914,13 +919,9 @@ mod tests {
         let input: Arc<dyn ExecutionPlan> =
             Arc::new(DataSourceExec::new(memory_data_source));
 
-        // The runtime pool is sized generously: spill decisions are now driven
-        // by `SortShuffleConfig::memory_limit_per_task_bytes`, but we keep a
-        // bounded pool so the post-test `pool.reserved() == 0` assertion still
-        // checks that the writer releases its `MemoryReservation`.
         let runtime_env = Arc::new(
             RuntimeEnvBuilder::new()
-                .with_memory_pool(Arc::new(FairSpillPool::new(64 * 1024 * 1024)))
+                .with_memory_pool(Arc::new(FairSpillPool::new(pool_bytes)))
                 .build()?,
         );
         let session_ctx = SessionContext::new_with_config_rt(
@@ -1006,15 +1007,35 @@ mod tests {
         Ok(())
     }
 
+    // The writer has two independent spill triggers, and these tests arm exactly
+    // one at a time so a failure names its cause:
+    //
+    //   1. the shared `MemoryPool` rejecting a `try_grow` — sized by `pool_bytes`
+    //   2. the private per-task budget `memory_limit_per_task_bytes` being
+    //      reached — sized by `sort_shuffle_memory_limit_bytes`
+    //
+    // The `*_DISARMED` constants below are the "this trigger is not what is
+    // under test" settings. A test payload batch is 8192 rows x 2 Int64 columns,
+    // i.e. ~128 KiB.
+
+    /// Pool far larger than any test payload, so `try_grow` always succeeds and
+    /// trigger 1 never fires. Still bounded, so the `pool.reserved() == 0`
+    /// assertion after the run stays meaningful.
+    const POOL_NEVER_REJECTS: usize = 64 * 1024 * 1024;
+
+    /// Per-task budget far above any test payload, so trigger 2 never fires.
+    const BUDGET_NEVER_REACHED: usize = 1024 * 1024 * 1024;
+
     #[tokio::test]
-    async fn spills_under_memory_pressure_and_round_trips() -> Result<()> {
-        // 10 batches of 8192 rows each. With a 512 KiB per-task buffer budget,
-        // this forces spilling.
+    async fn spills_when_per_task_budget_reached_and_round_trips() -> Result<()> {
+        // Trigger 2 only: 10 batches (~1.28 MiB) against a 512 KiB per-task
+        // budget forces spilling, while the pool stays out of the picture.
         run_round_trip(
             /* num_batches */ 10,
             /* rows_per_batch */ 8192,
             /* num_partitions */ 4,
             /* sort_shuffle_memory_limit_bytes */ 512 * 1024,
+            /* pool_bytes */ POOL_NEVER_REJECTS,
             /* expect_spills */ true,
         )
         .await
@@ -1022,16 +1043,17 @@ mod tests {
 
     #[tokio::test]
     async fn multi_spill_round_trips() -> Result<()> {
-        // Larger total payload + tighter buffer budget than the baseline test,
-        // so we expect multiple spill events per partition. The byte-copy
-        // finalize path should produce a partition section that is
-        // `spill_stream || in_memory_stream` (two concatenated IPC streams),
-        // and the reader must yield every input row regardless.
+        // Trigger 2 only, with a larger total payload and a tighter budget than
+        // the baseline test, so we expect multiple spill events per partition.
+        // The byte-copy finalize path should produce a partition section that is
+        // `spill_stream || in_memory_stream` (two concatenated IPC streams), and
+        // the reader must yield every input row regardless.
         run_round_trip(
             /* num_batches */ 20,
             /* rows_per_batch */ 8192,
             /* num_partitions */ 2,
             /* sort_shuffle_memory_limit_bytes */ 256 * 1024,
+            /* pool_bytes */ POOL_NEVER_REJECTS,
             /* expect_spills */ true,
         )
         .await
@@ -1039,15 +1061,35 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_only_round_trips() -> Result<()> {
-        // Generous per-task buffer budget so no partition spills. Validates
-        // the path where each partition section is exactly one in-memory IPC
-        // stream.
+        // Neither trigger armed, so nothing spills. Validates the path where
+        // each partition section is exactly one in-memory IPC stream.
         run_round_trip(
             /* num_batches */ 4,
             /* rows_per_batch */ 1024,
             /* num_partitions */ 4,
-            /* sort_shuffle_memory_limit_bytes */ 64 * 1024 * 1024,
+            /* sort_shuffle_memory_limit_bytes */ BUDGET_NEVER_REACHED,
+            /* pool_bytes */ POOL_NEVER_REJECTS,
             /* expect_spills */ false,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn spills_when_memory_pool_rejects_growth() -> Result<()> {
+        // Trigger 1 only: a 64 KiB pool cannot admit even one ~128 KiB batch, so
+        // every `try_grow` is rejected, while the per-task budget can never fire.
+        // Pool rejection is therefore the only signal that can produce a spill.
+        //
+        // A rejected grow means the pool has not accounted for the batch just
+        // buffered. The writer must spill in response rather than keep buffering
+        // memory the pool believes is free.
+        run_round_trip(
+            /* num_batches */ 8,
+            /* rows_per_batch */ 8192,
+            /* num_partitions */ 2,
+            /* sort_shuffle_memory_limit_bytes */ BUDGET_NEVER_REACHED,
+            /* pool_bytes */ 64 * 1024,
+            /* expect_spills */ true,
         )
         .await
     }


### PR DESCRIPTION
# Which issue does this PR close?

Backport of #2061 to `branch-54`. The issue it fixes is #2060.

# Rationale for this change

`SortShuffleWriterExec` registers its `MemoryConsumer` with `.with_can_spill(true)` but then discards the result of the grow:

```rust
// Best-effort: if the pool is bounded and rejects the grow, that's fine —
// the absolute counter below still triggers a spill.
let _ = reservation.try_grow(growth);
```

The comment's reasoning does not hold. `buffered_bytes` is a private per-task counter compared against `memory_limit_per_task_bytes`; it knows nothing about the shared `MemoryPool`, so a rejected grow produces no spill at all. The batch has already been pushed into `BufferedBatches` at that point, so the writer holds memory the pool has no record of, and other consumers on the same pool then see bytes as free that are not.

Registering with `can_spill(true)` is a contract: the pool rejects a grow to ask the consumer to spill. This writer declines to answer, which is a direct contributor to executor OOMs on shuffle-heavy stages.

# What changes are included in this PR?

A clean cherry-pick of 173e28f6, unmodified.

Treats a rejected grow as a spill trigger alongside the existing per-task budget:

```rust
let pool_rejected_growth = reservation.try_grow(growth).is_err();
buffered_bytes = buffered_bytes.saturating_add(growth);

if pool_rejected_growth || buffered_bytes >= memory_limit {
```

No retry of the grow is needed after spilling. `push_batch` appends to `batches` unconditionally, so at the point of rejection the batch is always spillable; `spill_all_partitions` flushes it and calls `reservation.free()`, leaving the writer holding nothing.

Adds `spills_when_memory_pool_rejects_growth`, which sets the per-task budget to 1 GiB (far above the payload, so the private counter can never fire) against a 64 KiB pool that cannot admit even one ~128 KiB batch, making pool rejection the only possible spill signal. The commit also renames the spill-trigger constants in the existing tests so each test reads as one trigger armed and the other disarmed.

# Are there any user-facing changes?

No API changes. Behaviourally, a sort shuffle writer running against a contended bounded pool now spills where it previously buffered without limit, which is the intended behaviour for a consumer registered with `can_spill(true)`.

---

Verified locally on the `branch-54` base: `cargo fmt --all -- --check` is clean, and `cargo check --workspace --all-targets --locked` completes with no warnings on a combined stack of the six backports being proposed together. Test execution is left to CI.
