### PR TITLE
fix: [branch-54] see through Shared wrapper when classifying task IO errors (backport of #2119)

### DIFF
--- a/ballista/core/src/error.rs
+++ b/ballista/core/src/error.rs
@@ -235,7 +235,7 @@ impl From<BallistaError> for FailedTask {
                 }
             }
             BallistaError::DataFusionError(e)
-                if matches!(*e, DataFusionError::IoError(_)) =>
+                if matches!(e.find_root(), DataFusionError::IoError(_)) =>
             {
                 FailedTask {
                     error: format!("Task failed due to DataFusion IO error: {e:?}"),
@@ -256,3 +256,76 @@ impl From<BallistaError> for FailedTask {
 }
 
 impl Error for BallistaError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn io_failed_task(e: BallistaError) -> FailedTask {
+        FailedTask::from(e)
+    }
+
+    #[test]
+    fn bare_datafusion_io_error_is_retryable() {
+        let e = BallistaError::DataFusionError(Box::new(DataFusionError::IoError(
+            io::Error::new(io::ErrorKind::ConnectionReset, "connection reset"),
+        )));
+        let task = io_failed_task(e);
+        assert!(task.retryable);
+        assert!(matches!(task.failed_reason, Some(FailedReason::IoError(_))));
+    }
+
+    #[test]
+    fn shared_wrapped_io_error_is_retryable() {
+        // Errors from a join's shared build side arrive as Shared(Arc<IoError>);
+        // the classifier must see through the wrapper or it will not retry a
+        // transient IO failure.
+        let inner = DataFusionError::IoError(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection reset",
+        ));
+        let shared = DataFusionError::Shared(Arc::new(inner));
+        let e = BallistaError::DataFusionError(Box::new(shared));
+        let task = io_failed_task(e);
+        assert!(task.retryable);
+        assert!(matches!(task.failed_reason, Some(FailedReason::IoError(_))));
+    }
+
+    #[test]
+    fn context_wrapped_shared_io_error_is_retryable() {
+        let inner = DataFusionError::IoError(io::Error::other("s3 timeout"));
+        let shared = DataFusionError::Shared(Arc::new(inner));
+        let ctx = shared.context("reading join build side");
+        let e = BallistaError::DataFusionError(Box::new(ctx));
+        let task = io_failed_task(e);
+        assert!(task.retryable);
+        assert!(matches!(task.failed_reason, Some(FailedReason::IoError(_))));
+    }
+
+    #[test]
+    fn non_io_datafusion_error_stays_non_retryable() {
+        let e = BallistaError::DataFusionError(Box::new(DataFusionError::Plan(
+            "bad plan".to_string(),
+        )));
+        let task = io_failed_task(e);
+        assert!(!task.retryable);
+        assert!(matches!(
+            task.failed_reason,
+            Some(FailedReason::ExecutionError(_))
+        ));
+    }
+
+    #[test]
+    fn shared_wrapped_non_io_error_stays_non_retryable() {
+        let inner = DataFusionError::Plan("bad plan".to_string());
+        let shared = DataFusionError::Shared(Arc::new(inner));
+        let e = BallistaError::DataFusionError(Box::new(shared));
+        let task = io_failed_task(e);
+        assert!(!task.retryable);
+        assert!(matches!(
+            task.failed_reason,
+            Some(FailedReason::ExecutionError(_))
+        ));
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Backport of #2119 to `branch-54`. The issue it fixes is #2028.

# Rationale for this change

A transient IO error on the build side of a hash join kills the whole job instead of being retried.

The retry classifier in `ballista/core/src/error.rs` does a shallow `matches!(*e, DataFusionError::IoError(_))` on the outermost variant. Errors coming off a join's shared build side get wrapped in `DataFusionError::Shared` (an `Arc`, for sharing across consumers), so the `IoError` inside is never seen and the task falls through to the catch-all `retryable: false` arm. With AQE off the error arrives unwrapped and retry works, which is how the wrapping was narrowed down as the cause.

This turns recoverable object-store flakiness into job failures, so it is worth having on the release branch.

# What changes are included in this PR?

A clean cherry-pick of b1627080, unmodified.

Classifies on `find_root()` instead of the outermost variant, so the retryability decision is based on the root error regardless of wrapping. One-line change plus unit tests covering bare, `Shared`-wrapped, `Context`-wrapped-`Shared`, and non-IO cases.

# Are there any user-facing changes?

No API changes. Tasks that fail with an IO error wrapped in `DataFusionError::Shared` are now retried rather than failing the job.

---

Verified locally on the `branch-54` base: `cargo fmt --all -- --check` is clean, and `cargo check --workspace --all-targets --locked` completes with no warnings on a combined stack of the six backports being proposed together. Test execution is left to CI.
