### PR TITLE
docs: add 54.1.0 changelog and restore missing 54.x toctree entries

### DIFF
--- a/docs/source/changelog/54.1.0.md
+++ b/docs/source/changelog/54.1.0.md
@@ -48,4 +48,3 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 ```
 
 Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.
-

--- a/docs/source/changelog/54.1.0.md
+++ b/docs/source/changelog/54.1.0.md
@@ -1,0 +1,51 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Apache DataFusion Ballista 54.1.0 Changelog
+
+This release consists of 10 commits from 3 contributors. See credits at the end of this changelog for more information.
+
+**Fixed bugs:**
+
+- fix: [branch-54] disable the SortMergeJoinExec broadcast conversion by default [#2130](https://github.com/apache/datafusion-ballista/pull/2130) (andygrove)
+- fix: [branch-54] map a task's partition through UnionExec when restricting file scans (backport of #2070) [#2131](https://github.com/apache/datafusion-ballista/pull/2131) (andygrove)
+- fix: [branch-54] keep EmptyExec partition count intact across stage serialization (backport of #2062) [#2132](https://github.com/apache/datafusion-ballista/pull/2132) (andygrove)
+- fix: [branch-54] send the shutdown notification before dropping the notifier (backport of #2107) [#2237](https://github.com/apache/datafusion-ballista/pull/2237) (sandugood)
+- fix: [branch-54] bind the gRPC listener before registering with the scheduler (backport of #2225) [#2236](https://github.com/apache/datafusion-ballista/pull/2236) (andygrove)
+- fix: [branch-54] keep GROUP BY-less aggregates when propagating empty stages (backport of #2194) [#2235](https://github.com/apache/datafusion-ballista/pull/2235) (andygrove)
+- fix: [branch-54] spill sort shuffle writer when the memory pool rejects a reservation grow (backport of #2061) [#2238](https://github.com/apache/datafusion-ballista/pull/2238) (andygrove)
+- fix: [branch-54] enable the executor client pool by default (backport of #2069) [#2234](https://github.com/apache/datafusion-ballista/pull/2234) (andygrove)
+- fix: [branch-54] see through Shared wrapper when classifying task IO errors (backport of #2119) [#2239](https://github.com/apache/datafusion-ballista/pull/2239) (goingforstudying-ctrl)
+
+**Other:**
+
+- chore: [branch-54] upgrade DataFusion to 54.1.0 and bump Ballista version to 54.1.0 [#2127](https://github.com/apache/datafusion-ballista/pull/2127) (andygrove)
+
+## Credits
+
+Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
+
+```
+     8	Andy Grove
+     1	sandugood
+     1	goingforstudying-ctrl
+```
+
+Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.
+

--- a/docs/source/changelog/index.md
+++ b/docs/source/changelog/index.md
@@ -24,6 +24,8 @@ Per-release change logs for Apache DataFusion Ballista.
 ```{toctree}
 :maxdepth: 1
 
+54.1.0
+54.0.0
 53.0.0
 52.0.0
 51.0.0


### PR DESCRIPTION
# Which issue does this PR close?

N/A - release preparation task for 54.1.0.

# Rationale for this change

Preparing to cut the 54.1.0 patch release from `branch-54`. The release process
requires a changelog for the new version to be merged into the release branch
before the release candidate tag is created.

While generating it, I noticed the changelog toctree in `index.md` was never
updated when 54.0.0 was released, so `docs/source/changelog/54.0.0.md` exists in
the repo but is not reachable from the rendered docs site. That is fixed here
too.

# What changes are included in this PR?

- Add `docs/source/changelog/54.1.0.md`, generated with
  `./dev/release/generate-changelog.py 54.0.0 HEAD 54.1.0`. It covers the 10
  commits on `branch-54` since the 54.0.0 tag: nine bug fixes plus the
  DataFusion 54.1.0 upgrade and version bump.
- Add `54.1.0` and `54.0.0` to the toctree in
  `docs/source/changelog/index.md`.

The generated credits section attributed every entry to the author of the
backport PR. Two of these fixes were originally written by other contributors,
so the entries and the credits summary were corrected by hand to credit
@sandugood for #2107 and @goingforstudying-ctrl for #2119.

# Are there any user-facing changes?

Documentation only. No code changes.
