### PR TITLE
docs(kubernetes): two-Service pattern for scheduler bootstrap

### DIFF
--- a/docs/source/user-guide/deployment/kubernetes.md
+++ b/docs/source/user-guide/deployment/kubernetes.md
@@ -107,6 +107,30 @@ persistentvolumeclaim/data-pv-claim created
 Copy the following yaml to a `cluster.yaml` file and change `<your-image>` with the name of your Ballista Docker image.
 
 ```yaml
+# Two Services front the same scheduler pod:
+#   - `ballista-scheduler-registration` sets `publishNotReadyAddresses: true`
+#     so executors can dial the scheduler for registration BEFORE its
+#     /readyz gate flips green. Without this, the scheduler's /readyz
+#     defaults to blocking on 1+ registered executor, which keeps its
+#     Endpoints empty — executors can't reach it to register in the first
+#     place. Chicken-and-egg; cluster never converges.
+#   - `ballista-scheduler` is the client-facing Service (respects /readyz)
+#     so clients don't submit queries to a scheduler with 0 executors mid
+#     rolling upgrade.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ballista-scheduler-registration
+  labels:
+    app: ballista-scheduler
+spec:
+  publishNotReadyAddresses: true
+  ports:
+    - port: 50050
+      name: scheduler
+  selector:
+    app: ballista-scheduler
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Summary

The example `cluster.yaml` in `docs/source/user-guide/deployment/kubernetes.md` pairs a single ClusterIP Service with the scheduler's default `--min-ready-executors=1` /readyz gate. On a fresh deploy this is chicken-and-egg:

- ClusterIP only routes to Ready pods.
- The scheduler is not Ready until 1 executor registers.
- Executors resolve the scheduler through the ClusterIP.
- → executors can't reach the scheduler → scheduler never flips green → cluster never converges.

Discovered bringing the example up verbatim on a real k8s cluster.

## Fix

Add a second Service, `ballista-scheduler-registration`, with `publishNotReadyAddresses: true`, alongside the existing one:

- `ballista-scheduler` (unchanged) — **clients** dial this. The /readyz gate still protects clients during rolling scheduler upgrades: a new scheduler with 0 executors won't receive query traffic until it's Ready.
- `ballista-scheduler-registration` — **executors** dial this. Bootstrap registration works before /readyz flips green.

Both Services target the same pod via `selector: { app: ballista-scheduler }`; they only differ in the readiness-gating behavior.

Pure yaml/docs change — no code, no proto, no config.

## Test plan

- [x] `cargo doc` unaffected (docs source is under `docs/`, not `///`).
- [x] Verified on a real k8s cluster: with the two-Service pattern, fresh deploys converge without operator intervention.