### PR TITLE
chore(docker): ca-certificates + h2o binary in benchmarks image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,9 @@ CHANGELOG.md
 !target/release/ballista-executor
 !target/release/ballista-cli
 !target/release/tpch
+!target/release/h2o
 !target/release-nonlto/ballista-scheduler
 !target/release-nonlto/ballista-executor
 !target/release-nonlto/ballista-cli
 !target/release-nonlto/tpch
+!target/release-nonlto/h2o

--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -30,6 +30,7 @@ ENV RUST_BACKTRACE=full
 COPY target/${RELEASE_FLAG}/ballista-scheduler /root/ballista-scheduler
 COPY target/${RELEASE_FLAG}/ballista-executor /root/ballista-executor
 COPY target/${RELEASE_FLAG}/tpch /root/tpch
+COPY target/${RELEASE_FLAG}/h2o /root/h2o
 
 COPY benchmarks/run.sh /root/run.sh
 COPY benchmarks/queries/ /root/benchmarks/queries

--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -21,6 +21,14 @@ LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ball
 LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+# ca-certificates so DataFusion's object_store S3 client can verify TLS
+# certs. Ubuntu's minimal image doesn't populate /etc/ssl/certs, and
+# reads from s3:// paths fail with InvalidCertificate(UnknownIssuer)
+# otherwise.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG RELEASE_FLAG=release
 
 ENV RELEASE_FLAG=${RELEASE_FLAG}

--- a/dev/docker/ballista-executor.Dockerfile
+++ b/dev/docker/ballista-executor.Dockerfile
@@ -23,6 +23,13 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ARG RELEASE_FLAG=release
 
+# ca-certificates so DataFusion's object_store S3 client can verify TLS
+# certs at query time (executors do the parquet reads). Reads from
+# s3:// fail with InvalidCertificate(UnknownIssuer) otherwise.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full

--- a/dev/docker/ballista-scheduler.Dockerfile
+++ b/dev/docker/ballista-scheduler.Dockerfile
@@ -23,6 +23,14 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ARG RELEASE_FLAG=release
 
+# ca-certificates so the scheduler can complete TLS handshakes at
+# plan-time. Applies to any outbound HTTPS: e.g. STS
+# AssumeRoleWithWebIdentity for IRSA-authenticated S3 reads during
+# schema inference, or fetching from HTTPS-hosted config sources.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV RELEASE_FLAG=${RELEASE_FLAG}
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=full


### PR DESCRIPTION
## Summary

Additive Docker image changes for S3-backed EKS benchmark runs, plus wiring the
`h2o` binary (added in #2230) into the benchmarks image.

- **`ballista-scheduler` + `ballista-executor`**: install `ca-certificates`.
  Without them, DataFusion's `object_store` S3 client fails TLS verification with
  `InvalidCertificate(UnknownIssuer)`, and STS `AssumeRoleWithWebIdentity`
  (IRSA-authenticated S3 reads on EKS) fails the same way. Ubuntu's minimal
  image doesn't populate `/etc/ssl/certs`.
- **`ballista-benchmarks`**: same `ca-certificates` rationale, plus
  `COPY target/release/h2o /root/h2o` so the image bundles both the tpch and
  h2o binaries. The h2o binary shipped in #2230 but was never wired into the
  Dockerfile.
- **`.dockerignore`**: whitelist `target/release{,-nonlto}/h2o` so the
  benchmarks build context sees the h2o binary alongside tpch/etc. Missing
  whitelist entry means the `COPY` line above errors out during build.

TPC-H bench workflow is unaffected — every change is additive.

## Test plan

- [x] `docker build -f dev/docker/ballista-scheduler.Dockerfile .` succeeds
- [x] `docker build -f dev/docker/ballista-executor.Dockerfile .` succeeds
- [x] `docker build -f dev/docker/ballista-benchmarks.Dockerfile .` succeeds
- [x] `docker run --rm <benchmarks-image> ls /root/h2o` prints the binary path
- [x] `docker run --rm <executor-image> ls /etc/ssl/certs | wc -l` > 0
- [x] EKS run: h2o Q1 reads from an `s3://...` path without TLS errors