### PR TITLE
fix(core): fix main build errors

### DIFF
--- a/ballista/core/src/execution_plans/distributed_explain_analyze.rs
+++ b/ballista/core/src/execution_plans/distributed_explain_analyze.rs
@@ -337,11 +337,13 @@ mod tests {
                         metrics: vec![
                             OperatorMetric {
                                 metric: Some(operator_metric::Metric::OutputRows(4)),
+                                partition: None,
                             },
                             OperatorMetric {
                                 metric: Some(operator_metric::Metric::ElapseTime(
                                     15_000_000,
                                 )),
+                                partition: None,
                             },
                         ],
                     }],
@@ -355,6 +357,7 @@ mod tests {
                         operator_desc: "FilterExec: a@0 > 1".to_string(),
                         metrics: vec![OperatorMetric {
                             metric: Some(operator_metric::Metric::OutputRows(2)),
+                            partition: None,
                         }],
                     }],
                 },


### PR DESCRIPTION
## Summary

Main is red on [run 31258248064](https://github.com/apache/datafusion-ballista/actions/runs/31258248064) with `E0063: missing field 'partition'` in `distributed_explain_analyze.rs` at three test sites (338, 341, 356).

Root cause is a merge-order collision, not a single-PR bug:

- **#2038** added `optional uint32 partition = 16` to `OperatorMetric` in `ballista.proto`.
- **#2042** was based on pre-#2038 main and added a test with three `OperatorMetric { … }` literals that don't set `partition`.
- The merge of #2042 didn't rebase, so the combined tree stopped compiling — PR CI on #2042 was green because it ran against the old base.

Three other literals in the same file (394, 398, 414) already set `partition: None`; this PR brings the remaining three in line.

## Test plan

- [x] `cargo clippy --all-targets --package ballista-core --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Verify CI goes green on this PR (the same jobs that failed on main)
