### PR TITLE
docs: add 54.1.0 changelog to main

### DIFF
--- a/docs/source/changelog/54.1.0.md
+++ b/docs/source/changelog/54.1.0.md
@@ -1,0 +1,50 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Apache DataFusion Ballista 54.1.0 Changelog
+
+This release consists of 10 commits from 3 contributors. See credits at the end of this changelog for more information.
+
+**Fixed bugs:**
+
+- fix: [branch-54] disable the SortMergeJoinExec broadcast conversion by default [#2130](https://github.com/apache/datafusion-ballista/pull/2130) (andygrove)
+- fix: [branch-54] map a task's partition through UnionExec when restricting file scans (backport of #2070) [#2131](https://github.com/apache/datafusion-ballista/pull/2131) (andygrove)
+- fix: [branch-54] keep EmptyExec partition count intact across stage serialization (backport of #2062) [#2132](https://github.com/apache/datafusion-ballista/pull/2132) (andygrove)
+- fix: [branch-54] send the shutdown notification before dropping the notifier (backport of #2107) [#2237](https://github.com/apache/datafusion-ballista/pull/2237) (sandugood)
+- fix: [branch-54] bind the gRPC listener before registering with the scheduler (backport of #2225) [#2236](https://github.com/apache/datafusion-ballista/pull/2236) (andygrove)
+- fix: [branch-54] keep GROUP BY-less aggregates when propagating empty stages (backport of #2194) [#2235](https://github.com/apache/datafusion-ballista/pull/2235) (andygrove)
+- fix: [branch-54] spill sort shuffle writer when the memory pool rejects a reservation grow (backport of #2061) [#2238](https://github.com/apache/datafusion-ballista/pull/2238) (andygrove)
+- fix: [branch-54] enable the executor client pool by default (backport of #2069) [#2234](https://github.com/apache/datafusion-ballista/pull/2234) (andygrove)
+- fix: [branch-54] see through Shared wrapper when classifying task IO errors (backport of #2119) [#2239](https://github.com/apache/datafusion-ballista/pull/2239) (goingforstudying-ctrl)
+
+**Other:**
+
+- chore: [branch-54] upgrade DataFusion to 54.1.0 and bump Ballista version to 54.1.0 [#2127](https://github.com/apache/datafusion-ballista/pull/2127) (andygrove)
+
+## Credits
+
+Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
+
+```
+     8	Andy Grove
+     1	sandugood
+     1	goingforstudying-ctrl
+```
+
+Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.

--- a/docs/source/changelog/index.md
+++ b/docs/source/changelog/index.md
@@ -24,6 +24,7 @@ Per-release change logs for Apache DataFusion Ballista.
 ```{toctree}
 :maxdepth: 1
 
+54.1.0
 54.0.0
 53.0.0
 52.0.0


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The 54.1.0 changelog was added to `branch-54` in #2243 but never landed on `main`, so the published docs built from `main` do not list the 54.1.0 release.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Adds `docs/source/changelog/54.1.0.md` (identical to the copy on `branch-54`).
- Adds a `54.1.0` entry to the changelog toctree in `docs/source/changelog/index.md`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Documentation only. The 54.1.0 changelog now appears in the docs built from `main`. No API changes.
