### PR TITLE
fix(scheduler): key AQE shuffle output by job_id

### DIFF
--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -142,7 +142,7 @@ impl AdaptiveExecutionGraph {
         let session_id = ctx.session_id();
 
         let mut planner =
-            AdaptivePlanner::try_new(ctx, logical_plan, job_name.to_owned()).await?;
+            AdaptivePlanner::try_new(ctx, logical_plan, job_id.clone()).await?;
 
         let logical_plan = Some(logical_plan.display_indent().to_string());
 

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -70,8 +70,8 @@ pub struct AdaptivePlanner {
     pub(crate) plan: Arc<dyn ExecutionPlan>,
     /// caches current runnable stages
     runnable_stage_cache: HashMap<usize, Arc<dyn ExecutionPlan>>,
-    /// job name
-    job_name: String,
+    /// Unique identifier for the job, used to key this job's shuffle output.
+    job_id: JobId,
 
     runnable_stage_output: HashMap<usize, StageOutput>,
 }
@@ -79,7 +79,7 @@ pub struct AdaptivePlanner {
 impl Debug for AdaptivePlanner {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AdaptivePlanner")
-            .field("job_name", &self.job_name)
+            .field("job_id", &self.job_id)
             .finish()
     }
 }
@@ -90,7 +90,7 @@ impl AdaptivePlanner {
     /// # Arguments:
     /// * `state_builder` -  Session state builder,
     /// * `plan` - The physical execution plan for the job.
-    /// * `job_name` - The name of the job.
+    /// * `job_id` - The unique identifier for the job.
     /// * `physical_optimizer_rules` - A list of physical optimizer rules to apply.
     ///
     /// # Returns
@@ -98,7 +98,7 @@ impl AdaptivePlanner {
     pub fn try_new_with_optimizers(
         state_builder: SessionStateBuilder,
         plan: Arc<dyn ExecutionPlan>,
-        job_name: String,
+        job_id: JobId,
         physical_optimizer_rules: Vec<PhysicalOptimizerRuleRef>,
     ) -> common::Result<Self> {
         let session_state =
@@ -112,7 +112,7 @@ impl AdaptivePlanner {
             physical_planner: planner.into(),
             plan,
             runnable_stage_cache: HashMap::new(),
-            job_name,
+            job_id,
             runnable_stage_output: HashMap::new(),
         })
     }
@@ -122,7 +122,7 @@ impl AdaptivePlanner {
     ///
     /// * `session_config` - The session configuration for the job.
     /// * `plan` - The physical execution plan for the job.
-    /// * `job_name` - The name of the job.
+    /// * `job_id` - The unique identifier for the job.
     ///
     /// # Returns
     /// A new instance of `AdaptivePlanner` or an error if the initialization fails.
@@ -130,7 +130,7 @@ impl AdaptivePlanner {
     pub fn try_from_plan(
         session_config: &SessionConfig,
         plan: Arc<dyn ExecutionPlan>,
-        job_name: String,
+        job_id: JobId,
     ) -> common::Result<Self> {
         let plan_id_generator = Arc::new(AtomicUsize::new(0));
         let state_builder = SessionStateBuilder::new_with_default_features()
@@ -138,7 +138,7 @@ impl AdaptivePlanner {
         Self::try_new_with_optimizers(
             state_builder,
             plan,
-            job_name,
+            job_id,
             Self::default_optimizers(plan_id_generator),
         )
     }
@@ -149,14 +149,14 @@ impl AdaptivePlanner {
     ///
     /// * `ctx` - The session context
     /// * `logical_plan` - The logical plan for the job.
-    /// * `job_name` - The name of the job.
+    /// * `job_id` - The unique identifier for the job.
     ///
     /// # Returns
     /// A new instance of `AdaptivePlanner` or an error if the initialization fails.
     pub async fn try_new(
         ctx: &SessionContext,
         logical_plan: &LogicalPlan,
-        job_name: String,
+        job_id: JobId,
     ) -> common::Result<Self> {
         // session state with very limited set of optimizers.
         // this optimizer set will be executed only once, before
@@ -174,9 +174,6 @@ impl AdaptivePlanner {
             .create_physical_plan(logical_plan)
             .await?;
 
-        // Note: the signature requires a JobId, but we are passing a JobName. The below is a
-        // dirty fix but this seems like a bug or a design flaw.
-        let job_id: JobId = job_name.clone().into();
         let plan = handle_explain_plan(&job_id, ctx, logical_plan, plan)
             .await
             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
@@ -185,7 +182,7 @@ impl AdaptivePlanner {
         Self::try_new_with_optimizers(
             state_builder,
             plan,
-            job_name,
+            job_id,
             Self::default_optimizers(plan_id_generator),
         )
     }
@@ -417,9 +414,7 @@ impl AdaptivePlanner {
                         // that would arise if the rule walked the entire residual
                         // plan in `default_optimizers()`.
                         let plan = CoalescePartitionsRule.optimize(plan, config)?;
-                        // adapt_to_ballista takes an job_id, we are passing a job_name. Need to transform to fix compiler.
-                        let job_id = self.job_name.clone().into();
-                        BallistaAdapter::adapt_to_ballista(plan, &job_id, config)
+                        BallistaAdapter::adapt_to_ballista(plan, &self.job_id, config)
                             .map(|w| (w.plan.stage_id(), w))
                     })
                     .collect::<common::Result<(HashSet<_>, Vec<_>)>>()?;

--- a/ballista/scheduler/src/state/aqe/test/broadcast_thresholds.rs
+++ b/ballista/scheduler/src/state/aqe/test/broadcast_thresholds.rs
@@ -83,7 +83,7 @@ fn register(ctx: &SessionContext, name: &str, schema: Arc<Schema>, stats: Statis
 /// Resolves the join and reports whether any side ended up broadcast.
 async fn plan_broadcasts(ctx: &SessionContext, sql: &str) -> (bool, String) {
     let lp = ctx.sql(sql).await.unwrap().into_optimized_plan().unwrap();
-    let planner = AdaptivePlanner::try_new(ctx, &lp, "test_job".to_owned())
+    let planner = AdaptivePlanner::try_new(ctx, &lp, "test_job".into())
         .await
         .unwrap();
     let plan = displayable(planner.current_plan()).indent(true).to_string();

--- a/ballista/scheduler/src/state/aqe/test/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/test/join_selection.rs
@@ -154,7 +154,7 @@ async fn test_hash_join_two_tables_coalesce() -> datafusion::common::Result<()> 
         .into_optimized_plan()
         .unwrap();
 
-    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
     let plan = planner.current_plan();
     // TODO: we could probably push datasource to read single partition
     assert_plan!(plan, @ r"
@@ -185,7 +185,7 @@ async fn test_left_join_not_collected_left() -> datafusion::common::Result<()> {
         .into_optimized_plan()
         .unwrap();
 
-    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
     let plan = planner.current_plan();
     assert_plan!(plan, @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=3, stage_id=pending, stage_resolved=false
@@ -211,7 +211,7 @@ async fn test_hash_join_two_tables_repartition() -> datafusion::common::Result<(
         .into_optimized_plan()
         .unwrap();
 
-    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
 
     let plan = planner.current_plan();
     assert_plan!(plan, @ r"
@@ -272,7 +272,7 @@ async fn test_sort_merge_join_two_tables_repartition() -> datafusion::common::Re
         .into_optimized_plan()
         .unwrap();
 
-    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
 
     let plan = planner.current_plan();
     assert_plan!(plan, @ r"
@@ -338,7 +338,7 @@ async fn test_hash_join_three_tables_collect_left() -> datafusion::common::Resul
         .unwrap()
         .into_optimized_plan()
         .unwrap();
-    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let mut planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
     let plan = planner.current_plan();
 
     assert_plan!(plan, @ r"
@@ -409,7 +409,7 @@ async fn test_hash_join_three_tables_repartition() -> datafusion::common::Result
         .unwrap()
         .into_optimized_plan()
         .unwrap();
-    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
     let plan = planner.current_plan();
 
     assert_plan!(plan, @ r"
@@ -440,7 +440,7 @@ async fn test_sort_merge_join_three_tables_repartition() -> datafusion::common::
         .unwrap()
         .into_optimized_plan()
         .unwrap();
-    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".to_owned()).await?;
+    let planner = AdaptivePlanner::try_new(&ctx, &lp, "test_job".into()).await?;
     let plan = planner.current_plan();
 
     assert_plan!(plan, @ r"

--- a/ballista/scheduler/src/state/aqe/test/plan_to_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/plan_to_stages.rs
@@ -16,12 +16,16 @@
 // under the License.
 
 use crate::assert_plan;
+use crate::state::aqe::AdaptiveExecutionGraph;
 use crate::state::aqe::execution_plan::ExchangeExec;
 use crate::state::aqe::planner::AdaptivePlanner;
 use crate::state::aqe::test::{
     mock_batch, mock_context, mock_memory_table, mock_partitions_with_statistics,
 };
+use crate::state::execution_graph::ExecutionGraph;
+use ballista_core::JobId;
 use ballista_core::execution_plans::SortShuffleWriterExec;
+use ballista_core::serde::protobuf::job_status::Status;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::ColumnStatistics;
 use datafusion::physical_plan::ExecutionPlan;
@@ -40,11 +44,8 @@ async fn should_add_exchanges() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -69,11 +70,8 @@ async fn should_split_plan_into_runnable_stages_internal() -> datafusion::error:
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let mut planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -121,11 +119,8 @@ async fn should_split_plan_into_stages() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let mut planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=1, stage_id=pending, stage_resolved=false
@@ -143,6 +138,7 @@ async fn should_split_plan_into_stages() -> datafusion::error::Result<()> {
       AggregateExec: mode=Partial, gby=[c@2 as c], aggr=[min(t.a), max(t.b)]
         DataSourceExec: partitions=1, partition_sizes=[1]
     ");
+    assert_eq!(stages.first().unwrap().plan.job_id().as_str(), "test_job");
 
     planner.finalise_stage_internal(0, mock_partitions_with_statistics())?;
 
@@ -154,6 +150,7 @@ async fn should_split_plan_into_stages() -> datafusion::error::Result<()> {
         AggregateExec: mode=FinalPartitioned, gby=[c@0 as c], aggr=[min(t.a), max(t.b)]
           ShuffleReaderExec: upstream_stage: 0, partitioning: Hash([c@0], 2)
     ");
+    assert_eq!(stages.first().unwrap().plan.job_id().as_str(), "test_job");
     planner.finalise_stage_internal(1, mock_partitions_with_statistics())?;
 
     let stages = planner.runnable_stages()?;
@@ -180,11 +177,8 @@ async fn should_create_initial_plan() -> datafusion::error::Result<()> {
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     // plan has only two exchanges after initial planning
     // other stages will be added as stages get resolved
@@ -230,11 +224,8 @@ async fn should_split_stages_resolve_right_branch() -> datafusion::error::Result
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let mut planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let mut planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     let runnable_stages = planner.identify_runnable_stages()?.unwrap();
     assert_eq!(2, runnable_stages.len());
@@ -300,11 +291,8 @@ async fn should_split_stages_resolve_left_branch() -> datafusion::error::Result<
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let mut planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let mut planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     let runnable_stages = planner.identify_runnable_stages()?.unwrap();
     assert_eq!(2, runnable_stages.len());
@@ -375,11 +363,8 @@ async fn should_split_stages_resolve_both() -> datafusion::error::Result<()> {
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
 
-    let mut planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let mut planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     let runnable_stages = planner.identify_runnable_stages()?.unwrap();
     assert_eq!(2, runnable_stages.len());
@@ -438,7 +423,7 @@ async fn should_ignore_inactive_stages() -> datafusion::error::Result<()> {
     let mut planner = AdaptivePlanner::try_from_plan(
         ctx.state().config(),
         exchange_exec,
-        "test_job".to_owned(),
+        "test_job".into(),
     )?;
 
     assert_plan!(planner.current_plan(), @ r"
@@ -464,11 +449,8 @@ async fn should_use_sort_shuffle_by_default() -> datafusion::error::Result<()> {
         "#;
 
     let plan = ctx.sql(q).await?.create_physical_plan().await?;
-    let mut planner = AdaptivePlanner::try_from_plan(
-        ctx.state().config(),
-        plan,
-        "test_job".to_owned(),
-    )?;
+    let mut planner =
+        AdaptivePlanner::try_from_plan(ctx.state().config(), plan, "test_job".into())?;
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(1, stages.len());
@@ -480,6 +462,53 @@ async fn should_use_sort_shuffle_by_default() -> datafusion::error::Result<()> {
             .is_some(),
         "expected SortShuffleWriterExec by default, got plan: {plan:?}"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn newly_built_adaptive_graph_has_expected_state()
+-> ballista_core::error::Result<()> {
+    let ctx = mock_context();
+    ctx.register_batch("t", mock_batch()?)?;
+
+    let q = r#"
+            select min(a) as c0, max(b) as c1, c as c2 from t group by c
+        "#;
+    let logical_plan = ctx.sql(q).await?.logical_plan().clone();
+    let job_id: JobId = "job-id-xyz".into();
+
+    let mut graph = AdaptiveExecutionGraph::try_new(
+        "scheduler-1",
+        &job_id,
+        "my job name",
+        &ctx,
+        &logical_plan,
+        7,
+    )
+    .await?;
+
+    // Identity comes straight from the constructor arguments.
+    assert_eq!(graph.job_id().as_str(), "job-id-xyz");
+    assert_eq!(graph.job_name(), "my job name");
+    assert_eq!(graph.session_id(), ctx.session_id().as_str());
+    assert!(graph.logical_plan().is_some());
+
+    // A freshly built graph is a running job that has done no work yet.
+    assert!(matches!(
+        graph.status().status.as_ref(),
+        Some(Status::Running(_))
+    ));
+    assert!(graph.start_time() > 0);
+    assert_eq!(graph.end_time(), 0);
+    assert_eq!(graph.completed_stages(), 0);
+    assert!(!graph.is_successful());
+    assert!(graph.output_locations().is_empty());
+
+    // The plan was split into stages that expose runnable tasks once revived.
+    assert!(graph.revive());
+    assert!(!graph.running_stages().is_empty());
+    assert!(graph.available_tasks() > 0);
 
     Ok(())
 }


### PR DESCRIPTION
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1859.

# Rationale for this change
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

On the adaptive (AQE) path, `AdaptivePlanner` carried the job *name* where it needed the job *id*. At the two spots that require a `JobId` — `handle_explain_plan` and `BallistaAdapter::adapt_to_ballista` (which builds shuffle-writer output paths) — it recovered one with `job_name.clone().into()`, flagged in the code as a probable bug:

```rust
// Note: the signature requires a JobId, but we are passing a JobName. The below is a
// dirty fix but this seems like a bug or a design flaw.
let job_id: JobId = job_name.clone().into();
```

Since `job_name` is frequently empty (e.g. `"job_name": ""` from the REST API), a job's shuffle output was keyed by an empty string instead of its `job_id`. Because the output path is `work_dir / job_id / stage_id / …`, that key is the per-job directory that isolates one job's shuffle files from another's — so every job with an empty name shared the same `work_dir/ /stage_id/…` tree and concurrent **jobs could collide on the same stage/partition paths**. The static planner was already correct.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`AdaptivePlanner` now holds `job_id: JobId` instead of `job_name: String`, and `AdaptiveExecutionGraph::try_new` passes the `job_id` it already has. The two `job_name.clone().into()` placeholders are gone.

Tests: existing planner tests just pass a `JobId` (`.to_owned()` → `.into()`); `should_split_plan_into_stages` now asserts the resolved shuffle writer is keyed by the job id; and a new `newly_built_adaptive_graph_has_expected_state` — the first test to build an `AdaptiveExecutionGraph` — checks a fresh graph reflects its constructor arguments (using a distinct job id and job name) and starts as a running job with runnable tasks once revived.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Under adaptive query planning, a job's shuffle output is now keyed by its `job_id` rather than its (frequently empty) `job_name`. No API or documentation changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->