### PR TITLE
docs: clean up stale and broken documentation links

### DIFF
--- a/docs/source/contributors-guide/architecture.md
+++ b/docs/source/contributors-guide/architecture.md
@@ -96,7 +96,7 @@ There are multiple clients available for submitting jobs to a Ballista cluster:
   context with support for SQL and DataFrame operations.
 - The [ballista crate](https://crates.io/crates/ballista) provides a native Rust session context with support for
   SQL and DataFrame operations.
-- The [Flight SQL JDBC driver](https://arrow.apache.org/docs/java/flight_sql_jdbc_driver.html) can be used from
+- The [Flight SQL JDBC driver](https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html) can be used from
   popular SQL tools to execute SQL queries against a cluster.
 
 ## Distributed Query Scheduling

--- a/docs/source/contributors-guide/architecture.md
+++ b/docs/source/contributors-guide/architecture.md
@@ -33,13 +33,13 @@ than for data science.
 ### Arrow-native
 
 Ballista uses the Apache Arrow memory format during query execution, and Apache Arrow IPC format on disk for
-shuffle files and for exchanging data between executors. Queries can be submitted using the Arrow Flight SQL API
-and the Arrow Flight SQL JDBC Driver.
+shuffle files and for exchanging data between executors. Queries can be submitted from Rust and Python clients
+or the Ballista CLI.
 
 ### Language Agnostic
 
 Although most of the implementation code is written in Rust, the scheduler and executor APIs are based on open
-standards, including protocol buffers, gRPC, Apache Arrow IPC, and Apache Arrow Flight SQL.
+standards, including protocol buffers, gRPC, Apache Arrow IPC, and Apache Arrow Flight.
 
 This language agnostic approach will allow Ballista to eventually support UDFs in languages other than Rust,
 including Wasm.
@@ -72,7 +72,7 @@ between the executor(s) and the scheduler for fetching tasks and reporting task 
 The scheduler provides the following interfaces:
 
 - gRPC service for submitting and managing jobs
-- Flight SQL API
+- optional Arrow Flight proxy for fetching query results
 - REST API for monitoring jobs
 
 Jobs are submitted to the scheduler's gRPC service from a client context, either in the form of a logical query
@@ -96,8 +96,6 @@ There are multiple clients available for submitting jobs to a Ballista cluster:
   context with support for SQL and DataFrame operations.
 - The [ballista crate](https://crates.io/crates/ballista) provides a native Rust session context with support for
   SQL and DataFrame operations.
-- The [Flight SQL JDBC driver](https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html) can be used from
-  popular SQL tools to execute SQL queries against a cluster.
 
 ## Distributed Query Scheduling
 

--- a/docs/source/contributors-guide/architecture.md
+++ b/docs/source/contributors-guide/architecture.md
@@ -72,7 +72,6 @@ between the executor(s) and the scheduler for fetching tasks and reporting task 
 The scheduler provides the following interfaces:
 
 - gRPC service for submitting and managing jobs
-- optional Arrow Flight proxy for fetching query results
 - REST API for monitoring jobs
 
 Jobs are submitted to the scheduler's gRPC service from a client context, either in the form of a logical query

--- a/docs/source/contributors-guide/code-organization.md
+++ b/docs/source/contributors-guide/code-organization.md
@@ -33,7 +33,6 @@ This section provides links to the source code for major areas of functionality.
 - [Crate Source](https://github.com/apache/datafusion-ballista/tree/main/ballista/scheduler)
 - [Distributed Query Planner](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/planner.rs)
 - [gRPC Service](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/scheduler_server/grpc.rs)
-- [Flight Proxy Service](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/flight_proxy_service.rs)
 - [REST API](https://github.com/apache/datafusion-ballista/tree/main/ballista/scheduler/src/api)
 - [Prometheus Integration](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/metrics/prometheus.rs)
 
@@ -51,4 +50,3 @@ This section provides links to the source code for major areas of functionality.
 ### PyBallista
 
 - [Source](https://github.com/apache/datafusion-ballista/tree/main/python)
-- [Context](https://github.com/apache/datafusion-ballista/blob/main/python/python/ballista/extension.py)

--- a/docs/source/contributors-guide/code-organization.md
+++ b/docs/source/contributors-guide/code-organization.md
@@ -23,7 +23,7 @@ This section provides links to the source code for major areas of functionality.
 
 ### ballista-core crate
 
-- [Crate Source](https://github.com/apache/datafusion-ballista/blob/main/ballista/core)
+- [Crate Source](https://github.com/apache/datafusion-ballista/tree/main/ballista/core)
 - [Protocol Buffer Definition](https://github.com/apache/datafusion-ballista/blob/main/ballista/core/proto/ballista.proto)
 - [Execution Plans](https://github.com/apache/datafusion-ballista/tree/main/ballista/core/src/execution_plans)
 - [Ballista Client](https://github.com/apache/datafusion-ballista/blob/main/ballista/core/src/client.rs)
@@ -33,7 +33,7 @@ This section provides links to the source code for major areas of functionality.
 - [Crate Source](https://github.com/apache/datafusion-ballista/tree/main/ballista/scheduler)
 - [Distributed Query Planner](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/planner.rs)
 - [gRPC Service](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/scheduler_server/grpc.rs)
-- [Flight SQL Service](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/flight_sql.rs)
+- [Flight Proxy Service](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/flight_proxy_service.rs)
 - [REST API](https://github.com/apache/datafusion-ballista/tree/main/ballista/scheduler/src/api)
 - [Prometheus Integration](https://github.com/apache/datafusion-ballista/blob/main/ballista/scheduler/src/metrics/prometheus.rs)
 
@@ -46,9 +46,9 @@ This section provides links to the source code for major areas of functionality.
 ### ballista crate
 
 - [Crate Source](https://github.com/apache/datafusion-ballista/tree/main/ballista/client)
-- [Context](https://github.com/apache/datafusion-ballista/blob/main/ballista/client/src/context.rs)
+- [Context Extensions](https://github.com/apache/datafusion-ballista/blob/main/ballista/client/src/extension.rs)
 
 ### PyBallista
 
 - [Source](https://github.com/apache/datafusion-ballista/tree/main/python)
-- [Context](https://github.com/apache/datafusion-ballista/blob/main/python/src/context.rs)
+- [Context](https://github.com/apache/datafusion-ballista/blob/main/python/python/ballista/extension.py)

--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -24,11 +24,10 @@ Ballista is a distributed compute platform primarily implemented in Rust, and po
 Ballista has both scheduler and an executor component processes that are standard Rust executables.
 
 Dockerfiles are also provided to build images for use in containerized environments, such as Docker, Docker Compose,
-and Kubernetes. See the [deployment guide](deployment.md) for more information.
+and Kubernetes. See the [deployment guide](deployment/) for more information.
 
-SQL and DataFrame queries can be submitted from Python and Rust, and SQL queries can be submitted via the Arrow
-Flight SQL JDBC driver, supporting your favorite JDBC compliant tools such as [DataGrip](datagrip)
-or [tableau](tableau). For setup instructions, please see the [FlightSQL guide](flightsql.md).
+SQL and DataFrame queries can be submitted from Python and Rust, and SQL queries can also be submitted using the
+Ballista CLI.
 
 ## How does this compare to Apache Spark?
 
@@ -44,7 +43,3 @@ Although Ballista is largely inspired by Apache Spark, there are some key differ
   distributed compute.
 - The use of Apache Arrow as the memory model and network protocol means that data can be exchanged between executors
   in any programming language with minimal serialization overhead.
-
-[deployment](./deployment)
-[datagrip](https://www.jetbrains.com/datagrip/)
-[tableau](https://help.tableau.com/current/pro/desktop/en-us/examples_otherdatabases_jdbc.htm)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2286

# Rationale for this change

Ballista's embedded Flight SQL server was removed in #1228, which was merged in April 2025. The architecture diagram was subsequently updated in #1253 to reflect the deprecation of Flight SQL, but several references in the textual documentation were left behind.

While investigating the broken link to the Flight SQL JDBC driver documentation, I found that the surrounding documentation was also stale: it still described Flight SQL and the JDBC driver as supported client interfaces, linked to the removed `flight_sql.rs`, and contained several other links to files or pages that have since moved or been removed.

This PR updates those references to match the current Ballista codebase.

# What changes are included in this PR?

- Remove stale Flight SQL and JDBC client references from the architecture and introduction pages.
- Replace the removed Flight SQL service link with the current Arrow Flight proxy implementation.
- Update links to the current Rust and Python client implementations.
- Fix broken links in the user guide introduction and code organization documentation.

# Are there any user-facing changes?

Documentation only. The documentation now reflects the current Ballista interfaces and source layout.