### PR TITLE
fix(docs): k8s executors dial the registration Service; scheduler needs maxUnavailable: 1

### DIFF
--- a/docs/source/user-guide/deployment/kubernetes.md
+++ b/docs/source/user-guide/deployment/kubernetes.md
@@ -152,6 +152,14 @@ metadata:
   name: ballista-scheduler
 spec:
   replicas: 1
+  # The outgoing pod must be allowed to go first: a new scheduler is not Ready
+  # until an executor registers with it, and the executors stay attached to the
+  # pod it is replacing. See Rolling both Deployments together.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: ballista-scheduler
@@ -194,6 +202,13 @@ metadata:
   name: ballista-executor
 spec:
   replicas: 2
+  # Surge new executors before retiring old ones, so capacity stays at roughly
+  # 100% through the roll.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: ballista-executor
@@ -323,11 +338,10 @@ The rejection happens only when a _new_ scheduler sees an _old_ executor,
 which is the case the version check is designed to protect against —
 mismatched pairs never exchange work, so they cannot corrupt state.
 
-Give each Deployment a `maxSurge` so Kubernetes brings new pods up before
-tearing old ones down; this keeps executor capacity at roughly 100% during
-the roll:
+The two Deployments want different rollout strategies.
 
 ```yaml
+# executor Deployment: keeps capacity at roughly 100% through the roll
 spec:
   strategy:
     type: RollingUpdate
@@ -336,11 +350,27 @@ spec:
       maxUnavailable: 0
 ```
 
-The scheduler's `/readyz` gate (`--min-ready-executors`, default `1`) means
-a fresh scheduler pod does not receive `Service` traffic until at least one
-matching-version executor has registered with it, so clients keep hitting
-the old scheduler until the new one has real capacity behind it. Set
-`--min-ready-executors=0` if you want the scheduler to advertise readiness
+```yaml
+# scheduler Deployment
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+```
+
+`maxUnavailable: 1` lets the outgoing scheduler go first, so its executors lose
+their connection and re-register through `ballista-scheduler-registration`,
+which is what makes the incoming pod Ready. With `maxUnavailable: 0` the
+outgoing pod cannot be retired until the incoming one is Ready, and it cannot
+become Ready while the executors are still attached to the pod it is replacing.
+The cost is a short window with no scheduler, so queries in flight fail.
+
+This is not `type: Recreate`. With `replicas: 3` Kubernetes still rolls one
+scheduler at a time and keeps the other two serving.
+
+Set `--min-ready-executors=0` if you want the scheduler to advertise readiness
 immediately (e.g. single-node development clusters).
 
 ## Port Forwarding

--- a/docs/source/user-guide/deployment/kubernetes.md
+++ b/docs/source/user-guide/deployment/kubernetes.md
@@ -208,7 +208,11 @@ spec:
           image: <your-repo>/datafusion-ballista-executor:latest
           args:
             - "--bind-port=50051"
-            - "--scheduler-host=ballista-scheduler"
+            # Registration Service, not the client-facing one: the client-facing
+            # `ballista-scheduler` respects /readyz, which stays 503 until an
+            # executor registers, so its Endpoints are empty and executors can
+            # never reach it to register in the first place.
+            - "--scheduler-host=ballista-scheduler-registration"
             - "--scheduler-port=50050"
           ports:
             - containerPort: 50051


### PR DESCRIPTION
Two fixes to the Kubernetes deployment guide. Docs only, no code changes.

## 1. Executors dialed the /readyz-gated Service, so the example cluster could not bootstrap

The executor Deployment was configured with `--scheduler-host=ballista-scheduler`,
the client-facing Service, which respects `/readyz`. The scheduler's `/readyz`
returns 503 until at least `--min-ready-executors` (default 1) executors have
registered, so on a cold start that Service has no ready Endpoints, executors
cannot reach the scheduler to register, and the scheduler never becomes ready.

`ballista-scheduler-registration` is already defined in the same manifest for
exactly this purpose, with `publishNotReadyAddresses: true`, and the file's own
comment describes the chicken-and-egg it exists to prevent. Nothing dialed it.

#2088 introduced the `/readyz` gate and readinessProbe; #2245 added the
registration Service to solve the resulting bootstrap problem but did not
repoint the executor at it. So the remedy already shipped, it just was not
connected.

## 2. The scheduler Deployment needs `maxUnavailable: 1`

The guide recommended `maxSurge: 25% / maxUnavailable: 0` for both Deployments.
That is right for the executors, where it preserves capacity through the roll,
and it deadlocks the scheduler.

A new scheduler pod is not Ready until an executor registers with it, but
running executors hold established connections to the pod being replaced and
have no reason to re-register. With `maxUnavailable: 0` Kubernetes cannot retire
that outgoing pod until the incoming one is Ready, so the rollout stalls and the
cluster keeps serving the old image with nothing reported as failed. The default
policy behaves the same way, since 25% of 1 replica rounds down to 0.

`maxUnavailable: 1` lets the outgoing pod go first. Its executors lose their
connection, re-register through `ballista-scheduler-registration`, and the
incoming pod reaches Ready. The cost is that clusters with 1-2 schedulers have
a period with no scheduler available. With `replicas: 3` Kubernetes still
rolls one scheduler at a time and keeps the other two serving, so concurrent
schedulers remain possible, pending the return of HA backing storage.

Both strategies are now in the example manifest rather than only in prose.

## Validation

Fix 2 is confirmed on a 32-executor EKS cluster (Kubernetes 1.34, TPC-H SF1000).
Rolling the scheduler to a different image with the default policy stalled on
"1 old replicas are pending termination" until timeout while the old pod kept
serving. With `maxUnavailable: 1` the same change rolled cleanly twice,
reporting `0 of 1 updated replicas are available` and then success, with all 32
executors re-registering against the new pod.

Fix 1 is reasoned rather than reproduced: a Service with no ready Endpoints
cannot be dialed. It also matches the wiring our working cluster uses, which is
how the discrepancy surfaced.
