### PR TITLE
feat(core): quantile sketching for any fixed-width ORDER BY key

### DIFF
--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -202,6 +202,19 @@ fn level_capacity(k: usize, num_levels: usize, height: usize) -> usize {
     raw.max(MIN_LEVEL_WIDTH)
 }
 
+/// Summarizes rather than dumping the compactor stack, which holds on the
+/// order of `3k` items and would bury whatever else a caller was printing.
+impl<T: Ord + Clone> std::fmt::Debug for KllSketch<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KllSketch")
+            .field("k", &self.k)
+            .field("count", &self.count())
+            .field("levels", &self.levels.len())
+            .field("retained", &self.levels.iter().map(Vec::len).sum::<usize>())
+            .finish()
+    }
+}
+
 /// Clone copies the compactor stack and the tracked extremes, and gives
 /// the copy a fresh PRNG rather than duplicating the original's position.
 ///
@@ -530,6 +543,33 @@ impl<T: Ord + Clone> KllSketch<T> {
         if total_weight == 0 {
             return None;
         }
+        self.at_rank((q * total_weight as f64) as u64)
+    }
+
+    /// Return the item at `rank`, counting cumulative weight from the
+    /// smallest item up. `None` if the sketch is empty.
+    ///
+    /// Semantics: the smallest retained item whose cumulative weight is at
+    /// least `rank`. Ranks at or beyond the ends give the tracked extremes,
+    /// which bypass the compactor so coin-flip history can't move them.
+    ///
+    /// This is the primitive [`Self::quantile`] is expressed in, and the
+    /// one to prefer whenever the caller already knows the rank it wants.
+    /// Converting a known rank into a fraction and back loses it: for 99
+    /// items, rank 59 becomes `59/99`, and multiplying that back by 99
+    /// yields `58.999…`, which truncates to 58. Callers that adjust a rank
+    /// — stepping over a run of NULLs, say — must stay in integers.
+    pub fn at_rank(&self, rank: u64) -> Option<&T> {
+        let total_weight = self.count();
+        if total_weight == 0 {
+            return None;
+        }
+        if rank == 0 {
+            return self.min.as_ref();
+        }
+        if rank >= total_weight {
+            return self.max.as_ref();
+        }
         let mut pairs: Vec<(&T, u64)> = self
             .levels
             .iter()
@@ -541,17 +581,16 @@ impl<T: Ord + Clone> KllSketch<T> {
             .collect();
         pairs.sort_by_key(|(item, _)| *item);
 
-        let target = (q * total_weight as f64) as u64;
         let mut cumulative = 0u64;
         for (item, weight) in &pairs {
             cumulative += weight;
-            if cumulative >= target {
+            if cumulative >= rank {
                 return Some(*item);
             }
         }
-        // total_weight > 0 and q ≤ 1 ⇒ cumulative reaches total_weight ≥ target
-        // on the final iteration, so the loop always returns.
-        unreachable!("quantile: threshold not reached despite non-empty sketch")
+        // rank < total_weight ⇒ cumulative reaches total_weight > rank on
+        // the final iteration, so the loop always returns.
+        unreachable!("at_rank: threshold not reached despite non-empty sketch")
     }
 
     /// Compact until every level fits within its (dynamically shrinking)

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -202,6 +202,26 @@ fn level_capacity(k: usize, num_levels: usize, height: usize) -> usize {
     raw.max(MIN_LEVEL_WIDTH)
 }
 
+/// Clone copies the compactor stack and the tracked extremes, and gives
+/// the copy a fresh PRNG rather than duplicating the original's position.
+///
+/// Written by hand because `StdRng` is not `Clone`. Reseeding is the
+/// correct behaviour anyway: two sketches sharing a coin-flip sequence
+/// would correlate their compaction decisions, and every quantile the
+/// clone can answer is already determined by the state that was copied.
+impl<T: Ord + Clone> Clone for KllSketch<T> {
+    fn clone(&self) -> Self {
+        Self {
+            levels: self.levels.clone(),
+            sorted: self.sorted.clone(),
+            k: self.k,
+            rng: StdRng::seed_from_u64(rand::random::<u64>()),
+            min: self.min.clone(),
+            max: self.max.clone(),
+        }
+    }
+}
+
 impl<T: Ord + Clone> KllSketch<T> {
     /// Construct an empty sketch with top-level compactor capacity `k`,
     /// seeded from OS entropy.
@@ -443,6 +463,35 @@ impl<T: Ord + Clone> KllSketch<T> {
         }
     }
 
+    /// The stream's true minimum, or `None` if nothing has been ingested.
+    ///
+    /// Tracked outside the compactor stack, so this is exact rather than
+    /// estimated — a coin flip can evict the smallest retained item but
+    /// cannot move this.
+    pub fn min(&self) -> Option<&T> {
+        self.min.as_ref()
+    }
+
+    /// The stream's true maximum, or `None` if nothing has been ingested.
+    /// Exact for the same reason as [`Self::min`].
+    pub fn max(&self) -> Option<&T> {
+        self.max.as_ref()
+    }
+
+    /// Number of items ingested so far.
+    ///
+    /// Exact, not estimated. Compaction halves an even buffer while
+    /// doubling the survivors' weight, and leaves the odd item behind at
+    /// its original weight, so the weighted sum over levels is invariant
+    /// under compaction and equals the ingested count.
+    pub fn count(&self) -> u64 {
+        self.levels
+            .iter()
+            .enumerate()
+            .map(|(h, level)| (1u64 << h) * level.len() as u64)
+            .sum()
+    }
+
     /// Return the estimated number of items strictly less than `x`.
     ///
     /// Sum over levels `h` of `2^h · | { y ∈ levels[h] : y < x } |`.
@@ -477,12 +526,7 @@ impl<T: Ord + Clone> KllSketch<T> {
         if q == 1.0 {
             return self.max.as_ref();
         }
-        let total_weight: u64 = self
-            .levels
-            .iter()
-            .enumerate()
-            .map(|(h, level)| (1u64 << h) * level.len() as u64)
-            .sum();
+        let total_weight = self.count();
         if total_weight == 0 {
             return None;
         }

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -244,6 +244,11 @@ impl<T: Ord + Clone> KllSketch<T> {
 
     /// Construct an empty sketch with top-level compactor capacity `k`
     /// and a fixed PRNG seed. Intended for deterministic tests.
+    ///
+    /// The seed does not survive [`Clone`], which reseeds from OS entropy
+    /// to keep two sketches from correlating their compaction decisions. A
+    /// test that needs two reproducible sketches builds both with
+    /// `with_seed` rather than cloning one.
     pub fn with_seed(k: usize, seed: u64) -> Self {
         Self {
             levels: vec![Vec::new()],

--- a/ballista/core/src/kll.rs
+++ b/ballista/core/src/kll.rs
@@ -565,16 +565,29 @@ impl<T: Ord + Clone> KllSketch<T> {
     /// yields `58.999…`, which truncates to 58. Callers that adjust a rank
     /// — stepping over a run of NULLs, say — must stay in integers.
     pub fn at_rank(&self, rank: u64) -> Option<&T> {
+        self.at_ranks(&[rank]).into_iter().next().flatten()
+    }
+
+    /// Answer several ranks against one pass over the retained items,
+    /// returning one answer per entry of `ranks`, positionally.
+    ///
+    /// Semantics per rank are [`Self::at_rank`]'s exactly. The difference is
+    /// cost: resolving a rank means materializing every retained item with
+    /// its level weight and sorting them, and that work does not depend on
+    /// the rank. Asking one at a time repeats it per rank, which makes
+    /// `cuts` over P partitions P-1 sorts of the whole retained set. Here it
+    /// happens once.
+    ///
+    /// `ranks` may be in any order; the answers come back in the order
+    /// asked. Internally they are walked smallest-first so a single
+    /// cumulative sweep serves all of them.
+    pub fn at_ranks(&self, ranks: &[u64]) -> Vec<Option<&T>> {
+        let mut answers: Vec<Option<&T>> = vec![None; ranks.len()];
         let total_weight = self.count();
         if total_weight == 0 {
-            return None;
+            return answers;
         }
-        if rank == 0 {
-            return self.min.as_ref();
-        }
-        if rank >= total_weight {
-            return self.max.as_ref();
-        }
+
         let mut pairs: Vec<(&T, u64)> = self
             .levels
             .iter()
@@ -586,16 +599,38 @@ impl<T: Ord + Clone> KllSketch<T> {
             .collect();
         pairs.sort_by_key(|(item, _)| *item);
 
+        let mut slots: Vec<usize> = (0..ranks.len()).collect();
+        slots.sort_by_key(|&slot| ranks[slot]);
+
+        // Resumed across ranks rather than restarted: `cumulative` is
+        // monotone and so are the ranks in `slots` order, so a rank already
+        // covered by the current item answers with that same item.
+        let mut consumed = 0usize;
         let mut cumulative = 0u64;
-        for (item, weight) in &pairs {
-            cumulative += weight;
-            if cumulative >= rank {
-                return Some(*item);
+        let mut current: Option<&T> = None;
+        for slot in slots {
+            let rank = ranks[slot];
+            // The extremes are tracked outside the compactor, so no
+            // coin-flip history can move them.
+            if rank == 0 {
+                answers[slot] = self.min.as_ref();
+                continue;
             }
+            if rank >= total_weight {
+                answers[slot] = self.max.as_ref();
+                continue;
+            }
+            while cumulative < rank {
+                let (item, weight) = pairs[consumed];
+                cumulative += weight;
+                current = Some(item);
+                consumed += 1;
+            }
+            // `rank < total_weight`, which is the sum of every pair's
+            // weight, so the sweep above always consumed at least one item.
+            answers[slot] = current;
         }
-        // rank < total_weight ⇒ cumulative reaches total_weight > rank on
-        // the final iteration, so the loop always returns.
-        unreachable!("at_rank: threshold not reached despite non-empty sketch")
+        answers
     }
 
     /// Compact until every level fits within its (dynamically shrinking)
@@ -984,6 +1019,128 @@ mod tests {
                 "quantile({q}) = {item} → rank = {observed}, expected ~{expected} ±{slack}"
             );
         }
+    }
+
+    /// `n < k` leaves every item at level 0 with weight 1, so rank `r`
+    /// names the `r`-th smallest exactly and the expected answers can be
+    /// written down rather than derived.
+    fn exact_sketch_of_1_to_10() -> KllSketch<u32> {
+        let mut sketch: KllSketch<u32> = KllSketch::with_seed(1024, 42);
+        for x in 1u32..=10 {
+            sketch.insert(x);
+        }
+        sketch
+    }
+
+    /// Nothing observed is distinct from a rank that finds nothing: the
+    /// caller still gets one answer per rank it asked for, so it can zip
+    /// the answers back against its own inputs.
+    #[test]
+    fn at_ranks_on_an_empty_sketch_answers_none_for_every_rank() {
+        let sketch: KllSketch<u32> = KllSketch::with_seed(1024, 42);
+        assert_eq!(sketch.at_ranks(&[0, 1, 99]), vec![None, None, None]);
+        assert!(sketch.at_ranks(&[]).is_empty(), "no ranks, no answers");
+    }
+
+    /// Answers are positional. The sweep visits ranks smallest-first for
+    /// its own benefit, and that reordering must not reach the caller.
+    #[test]
+    fn at_ranks_answers_in_the_order_asked_not_in_rank_order() {
+        let sketch = exact_sketch_of_1_to_10();
+        assert_eq!(
+            sketch.at_ranks(&[7, 2, 5]),
+            vec![Some(&7), Some(&2), Some(&5)]
+        );
+    }
+
+    /// A repeated rank is answered afresh each time it appears.
+    ///
+    /// This is the case the cumulative sweep can get wrong. It advances
+    /// only while `cumulative < rank`, so a rank already covered by the
+    /// current item has to consume nothing and reuse it. Advancing
+    /// unconditionally would hand the second `5` the item after the first.
+    #[test]
+    fn at_ranks_repeats_the_answer_for_a_repeated_rank() {
+        let sketch = exact_sketch_of_1_to_10();
+        assert_eq!(
+            sketch.at_ranks(&[5, 5, 5]),
+            vec![Some(&5), Some(&5), Some(&5)]
+        );
+        assert_eq!(
+            sketch.at_ranks(&[5, 3, 5]),
+            vec![Some(&5), Some(&3), Some(&5)],
+            "a lower rank between two copies must not disturb either"
+        );
+    }
+
+    /// Rank 0 and ranks at or past the total skip the sweep entirely.
+    /// Mixed into a batch with interior ranks so that skipping cannot
+    /// desynchronize the sweep's position from the answers it still owes.
+    #[test]
+    fn at_ranks_mixes_extreme_ranks_with_interior_ones() {
+        let sketch = exact_sketch_of_1_to_10();
+        let total = sketch.count();
+        assert_eq!(total, 10, "no compaction below capacity");
+        assert_eq!(
+            sketch.at_ranks(&[0, 5, total, total + 5, 3]),
+            vec![Some(&1), Some(&5), Some(&10), Some(&10), Some(&3)]
+        );
+    }
+
+    /// The extremes come from the tracked pair rather than from the sweep.
+    ///
+    /// Below capacity the two agree, so nothing there can tell them apart:
+    /// the largest retained item *is* the stream max. `k = 8` over 10K
+    /// items with this seed flips both extremes out of the levels, leaving
+    /// 1187..=9999 retained, so the sweep on its own cannot reach either
+    /// end and the assertions below discriminate.
+    #[test]
+    fn at_ranks_reads_extremes_the_compactor_no_longer_holds() {
+        let n = 10_000u32;
+        let mut sketch: KllSketch<u32> = KllSketch::with_seed(8, 2);
+        for x in 1..=n {
+            sketch.insert(x);
+        }
+        let total = sketch.count();
+        let answers = sketch.at_ranks(&[0, 1, total - 1, total, total + 5]);
+
+        assert_eq!(answers[0], Some(&1), "rank 0 is the stream min");
+        assert_eq!(answers[3], Some(&n), "rank == total is the stream max");
+        assert_eq!(answers[4], Some(&n), "past the total is still the max");
+        assert!(
+            answers[1] > Some(&1),
+            "premise: compaction dropped the min, so the sweep cannot reach it"
+        );
+        assert!(
+            answers[2] < Some(&n),
+            "premise: compaction dropped the max, so the sweep cannot reach it"
+        );
+    }
+
+    /// Past capacity, items carry their level weight and one retained item
+    /// answers a whole run of ranks. Ranks ascend, so answers must too, and
+    /// some adjacent pair must repeat — with every weight 1 each rank would
+    /// name a distinct item, so a repeat is what shows the weights are
+    /// actually being accumulated.
+    #[test]
+    fn at_ranks_accumulates_level_weights_after_compaction() {
+        let n = 10_000u32;
+        let mut sketch: KllSketch<u32> = KllSketch::with_seed(64, 42);
+        for x in 1..=n {
+            sketch.insert(x);
+        }
+        let total = sketch.count();
+        let ranks: Vec<u64> = (1..total).collect();
+        let answers = sketch.at_ranks(&ranks);
+
+        assert!(
+            answers.windows(2).all(|pair| pair[0] <= pair[1]),
+            "ascending ranks must give non-decreasing items"
+        );
+        assert!(
+            answers.windows(2).any(|pair| pair[0] == pair[1]),
+            "a retained item weighing more than 1 must answer several ranks"
+        );
     }
 
     #[test]

--- a/ballista/core/src/lib.rs
+++ b/ballista/core/src/lib.rs
@@ -77,7 +77,7 @@ pub mod planner;
 pub mod registry;
 /// Serialization and deserialization for Ballista messages and plans.
 pub mod serde;
-/// Order-preserving `u64` encoding of a fixed-width `ORDER BY` key.
+/// Quantile sketching of a fixed-width `ORDER BY` key, NULLs included.
 pub mod sort_key;
 /// General utility functions for Ballista operations.
 pub mod utils;

--- a/ballista/core/src/lib.rs
+++ b/ballista/core/src/lib.rs
@@ -77,6 +77,8 @@ pub mod planner;
 pub mod registry;
 /// Serialization and deserialization for Ballista messages and plans.
 pub mod serde;
+/// Order-preserving `u64` encoding of a fixed-width `ORDER BY` key.
+pub mod sort_key;
 /// General utility functions for Ballista operations.
 pub mod utils;
 

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -1,0 +1,825 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Order-preserving `u64` encoding of a single fixed-width `ORDER BY` key,
+//! so [`crate::kll::KllSketch`] can sketch it without knowing the column's
+//! type or sort direction.
+//!
+//! # Why an integer key
+//!
+//! The sketch needs `T: Ord`, and the obvious candidates for an `ORDER BY`
+//! column are a type-specific wrapper (`OrderedFloat<f64>` and friends) or
+//! the arrow row format. Both were measured against this encoding in
+//! `benchmarks/benches/quantile_sketch.rs`; at n=1M, ratios to the
+//! incumbent T-Digest are 1.23× for this encoding, 1.80× for
+//! `OrderedFloat<f64>`, and 3.75× for arrow-row bytes held inline.
+//!
+//! Ingest cost is dominated by the `sort_unstable` inside KLL's compaction,
+//! so the comparator is what matters: a `u64` compare is one instruction,
+//! where a float total order is bit manipulation plus branches and
+//! arrow-row pays ~25 ns/row to encode in the first place. Collapsing every
+//! fixed-width type to a plain integer therefore wins on speed as well as
+//! on uniformity.
+//!
+//! It also keeps sort direction out of the type system. `DESC` is a
+//! bitwise NOT of the key rather than a second `Ord` implementation, so one
+//! sketch type serves both directions instead of one per combination.
+//!
+//! # NULLs are out of band
+//!
+//! Encoding skips NULLs entirely; callers track the count separately. A
+//! NULL has no position among the values, only a side, and `nulls_first` /
+//! `nulls_last` says which — that is one bit of plan-time information, not
+//! something the sketch needs to carry. Keeping it out of the key leaves
+//! the key 8 bytes wide rather than 16, which the same benchmark measured
+//! at 1.23× versus 1.58×.
+//!
+//! # The row format is the rulebook
+//!
+//! Arrow's row format is the only complete statement of what a SQL
+//! `ORDER BY` means: it folds the column type, `nulls_first`, and
+//! `descending` into a single memcmp order, and arrow's own sort agrees
+//! with it. So it defines the answer, and anything faster is only allowed
+//! to be an implementation of that answer.
+//!
+//! This encoding is exactly that. Its float transform is the same one
+//! `arrow_row::fixed` applies, and both reduce to `total_cmp`, which is
+//! what `ArrowNativeTypeOp::compare` uses. The test
+//! `integer_keys_order_identically_to_arrow_row` pins the agreement on a
+//! fixture containing ±NaN, ±0.0 and both infinities, so a divergence fails
+//! a test rather than surfacing as misrouted rows.
+//!
+//! Following the rulebook is also what makes NaN a non-event. NaN has a
+//! defined place in `total_cmp` — beyond the infinity of its own sign — so
+//! it becomes an ordinary key, at the top or bottom of the `u64` range.
+//! Comparisons against it behave, and this module contains no NaN handling
+//! whatsoever. Code that compares raw `f64` instead has to special-case it,
+//! because `partial_cmp` answers "no" to every question a router asks.
+//!
+//! # Exactness
+//!
+//! Every encoding here is a bijection on its type's value range, so a
+//! quantile drawn from the sketch converts back to the precise value it
+//! came from — not an approximation of it. That is what lets a
+//! `Timestamp(Nanosecond)` cut stay nanosecond-exact; casting through
+//! `f64` would round it to a 256 ns grid at 2020s epoch magnitudes, since
+//! those sit above `f64`'s 2^53 integer limit.
+//!
+//! Exactness matters most at the extremes. A sketch's `min` and `max` are
+//! what decide which shuffle files overlap which output partition, so an
+//! extreme that gets dropped drops rows with it. Keys compare with `Ord`
+//! over every element, which has no value it silently ignores.
+//!
+//! # Coverage
+//!
+//! Signed and unsigned integers, `Float32`/`Float64`, and the temporal
+//! types that are `i32` or `i64` underneath (`Date`, `Time`, `Timestamp`,
+//! `Duration`). [`crate::sort_key::SortKeyCodec::try_new`] returns `None`
+//! for anything else
+//! — `Decimal128` and wider don't fit in `u64`, `Interval` has no total
+//! order, and variable-width types have no fixed encoding — leaving those
+//! to the arrow-row path.
+
+use datafusion::arrow::array::{Array, ArrowPrimitiveType, AsArray, PrimitiveArray};
+use datafusion::arrow::datatypes::{
+    DataType, Date32Type, Date64Type, DurationMicrosecondType, DurationMillisecondType,
+    DurationNanosecondType, DurationSecondType, Float32Type, Float64Type, Int8Type,
+    Int16Type, Int32Type, Int64Type, Time32MillisecondType, Time32SecondType,
+    Time64MicrosecondType, Time64NanosecondType, TimeUnit, TimestampMicrosecondType,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, UInt8Type,
+    UInt16Type, UInt32Type, UInt64Type,
+};
+use datafusion::common::{Result, ScalarValue, internal_datafusion_err};
+
+/// Bijection between a primitive's native value and a `u64` whose ascending
+/// order matches the native ascending order.
+trait SortableNative: Copy {
+    /// Map to the ascending `u64` key space.
+    fn to_key(self) -> u64;
+    /// Inverse of [`Self::to_key`], exact for any key that method produced.
+    fn from_key(key: u64) -> Self;
+}
+
+/// Signed integers: flipping the sign bit maps the two's-complement order
+/// onto unsigned order, because it slides the negative half below the
+/// positive half. Narrower widths sign-extend to `i64` first, which
+/// preserves order within their range.
+macro_rules! impl_sortable_signed {
+    ($native:ty) => {
+        impl SortableNative for $native {
+            fn to_key(self) -> u64 {
+                (self as i64 as u64) ^ (1 << 63)
+            }
+            fn from_key(key: u64) -> Self {
+                (key ^ (1 << 63)) as i64 as Self
+            }
+        }
+    };
+}
+
+/// Unsigned integers are already in key order; widening preserves it.
+macro_rules! impl_sortable_unsigned {
+    ($native:ty) => {
+        impl SortableNative for $native {
+            fn to_key(self) -> u64 {
+                self as u64
+            }
+            fn from_key(key: u64) -> Self {
+                key as Self
+            }
+        }
+    };
+}
+
+/// IEEE-754 floats.
+///
+/// This is a permutation, not a packing: 64 bits in, 64 bits out, nothing
+/// compressed and nothing lost, which is why it inverts exactly.
+///
+/// The layout was designed to almost sort as an integer already.
+///
+/// ```text
+///  63   62            52   51                                      0
+/// ┌────┬─────────────────┬──────────────────────────────────────────┐
+/// │ S  │    exponent     │                mantissa                  │
+/// │ 1  │       11        │                   52                     │
+/// └────┴─────────────────┴──────────────────────────────────────────┘
+///   ^          ^                            ^
+///   │          │                            └── low bits
+///   │          └── high bits, right below the sign
+///   └── 0 = positive, 1 = negative
+/// ```
+///
+/// The exponent sits *above* the mantissa deliberately. Compare two
+/// same-sign floats as plain integers and the exponent dominates while the
+/// mantissa breaks ties, which is exactly magnitude order. The bits already
+/// sort themselves. Two things are wrong with them:
+///
+/// ```text
+/// as raw unsigned integers:
+///
+///   0x0000...  +0.0 ─┐
+///   0x3FF0...  +1.0  │  positives: right order, stuck at the BOTTOM
+///   0x7FF0...  +inf ─┘
+///   0x8000...  -0.0 ─┐
+///   0xBFF0...  -1.0  │  negatives: at the TOP, and running BACKWARDS
+///   0xFFF0...  -inf ─┘
+///
+/// problem 1: a set sign bit makes negatives look huge
+/// problem 2: within negatives, bigger magnitude = bigger integer
+/// ```
+///
+/// One branch on the sign bit fixes both:
+///
+/// ```text
+/// sign bit 0 (non-negative):  key = bits ^ 0x8000000000000000
+///                                   └─ flip only the sign bit, moving
+///                                      them to the TOP half; the order
+///                                      among them is untouched
+///
+/// sign bit 1 (negative):      key = !bits
+///                                   └─ flip every bit: sign 1→0 moves
+///                                      them to the BOTTOM half, and
+///                                      inverting the rest reverses their
+///                                      order, which is problem 2's fix
+/// ```
+///
+/// What comes out the other end:
+///
+/// ```text
+///    value      f64 bits             key (u64)            order
+///   ───────────────────────────────────────────────────────────
+///    -NaN     0xFFF8000000000000    0x0007FFFFFFFFFFFF     ▲ smallest
+///    -inf     0xFFF0000000000000    0x000FFFFFFFFFFFFF     │
+///    -2.0     0xC000000000000000    0x3FFFFFFFFFFFFFFF     │
+///    -1.0     0xBFF0000000000000    0x400FFFFFFFFFFFFF     │
+///    -0.0     0x8000000000000000    0x7FFFFFFFFFFFFFFF     │
+///    +0.0     0x0000000000000000    0x8000000000000000     │
+///    +1.0     0x3FF0000000000000    0xBFF0000000000000     │
+///    +2.0     0x4000000000000000    0xC000000000000000     │
+///    +inf     0x7FF0000000000000    0xFFF0000000000000     │
+///    +NaN     0x7FF8000000000000    0xFFF8000000000000     ▼ largest
+/// ```
+///
+/// That is `f64::total_cmp` order, which is what arrow sorts by.
+///
+/// NaN needed no work. Its exponent is all ones with a nonzero mantissa,
+/// so its pattern sits just above the infinity on its own side, which has
+/// the same exponent and a zero mantissa. It lands past infinity by
+/// itself. Nothing here tests for it: NaN is only awkward when compared
+/// *as a float*.
+///
+/// Note that all 2^64 keys are spoken for, so there is no spare slot to
+/// mean NULL. That would need a 65th bit, and in practice a 16-byte key —
+/// which is why NULLs are counted out of band instead. See the module
+/// docs.
+macro_rules! impl_sortable_float {
+    ($native:ty, $bits:ty, $width:expr) => {
+        impl SortableNative for $native {
+            fn to_key(self) -> u64 {
+                let bits = self.to_bits();
+                let sign: $bits = 1 << ($width - 1);
+                let key: $bits = if bits & sign != 0 { !bits } else { bits ^ sign };
+                // Zero-extending a narrower key preserves order, since
+                // every key of that width is below the widened range.
+                key as u64
+            }
+            fn from_key(key: u64) -> Self {
+                let bits = key as $bits;
+                let sign = 1 << ($width - 1);
+                // Forward maps negatives to a cleared top bit and
+                // non-negatives to a set one, so the top bit selects the
+                // branch to undo.
+                let bits = if bits & sign != 0 { bits ^ sign } else { !bits };
+                Self::from_bits(bits)
+            }
+        }
+    };
+}
+
+impl_sortable_signed!(i8);
+impl_sortable_signed!(i16);
+impl_sortable_signed!(i32);
+impl_sortable_signed!(i64);
+impl_sortable_unsigned!(u8);
+impl_sortable_unsigned!(u16);
+impl_sortable_unsigned!(u32);
+impl_sortable_unsigned!(u64);
+impl_sortable_float!(f32, u32, 32);
+impl_sortable_float!(f64, u64, 64);
+
+/// Invoke `$handler!(ArrowPrimitiveType)` for the arrow type backing
+/// `$data_type`, or evaluate `$fallback` when it isn't one this module
+/// encodes.
+///
+/// This allowlist *is* the tier boundary: every type named here gets the
+/// `u64` fast path, and everything omitted falls through to arrow-row.
+/// Adding a type means adding it here and nowhere else.
+macro_rules! dispatch_sortable {
+    ($data_type:expr, $handler:ident, $fallback:expr) => {
+        match $data_type {
+            DataType::Int8 => $handler!(Int8Type),
+            DataType::Int16 => $handler!(Int16Type),
+            DataType::Int32 => $handler!(Int32Type),
+            DataType::Int64 => $handler!(Int64Type),
+            DataType::UInt8 => $handler!(UInt8Type),
+            DataType::UInt16 => $handler!(UInt16Type),
+            DataType::UInt32 => $handler!(UInt32Type),
+            DataType::UInt64 => $handler!(UInt64Type),
+            DataType::Float32 => $handler!(Float32Type),
+            DataType::Float64 => $handler!(Float64Type),
+            DataType::Date32 => $handler!(Date32Type),
+            DataType::Date64 => $handler!(Date64Type),
+            DataType::Time32(TimeUnit::Second) => $handler!(Time32SecondType),
+            DataType::Time32(TimeUnit::Millisecond) => $handler!(Time32MillisecondType),
+            DataType::Time64(TimeUnit::Microsecond) => $handler!(Time64MicrosecondType),
+            DataType::Time64(TimeUnit::Nanosecond) => $handler!(Time64NanosecondType),
+            DataType::Timestamp(TimeUnit::Second, _) => $handler!(TimestampSecondType),
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                $handler!(TimestampMillisecondType)
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                $handler!(TimestampMicrosecondType)
+            }
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                $handler!(TimestampNanosecondType)
+            }
+            DataType::Duration(TimeUnit::Second) => $handler!(DurationSecondType),
+            DataType::Duration(TimeUnit::Millisecond) => {
+                $handler!(DurationMillisecondType)
+            }
+            DataType::Duration(TimeUnit::Microsecond) => {
+                $handler!(DurationMicrosecondType)
+            }
+            DataType::Duration(TimeUnit::Nanosecond) => $handler!(DurationNanosecondType),
+            _ => $fallback,
+        }
+    };
+}
+
+/// Encodes one fixed-width `ORDER BY` key to `u64` and back. See the module
+/// docs for the encoding and for why NULLs are handled out of band.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SortKeyCodec {
+    /// The column's full arrow type, retained so [`Self::decode`] can
+    /// rebuild a `ScalarValue` that keeps the parts the key doesn't carry
+    /// — a `Timestamp`'s timezone above all.
+    data_type: DataType,
+    /// `true` inverts every key bit, reversing the sketch's ascending order
+    /// into the `DESC` order the plan asked for.
+    descending: bool,
+}
+
+impl SortKeyCodec {
+    /// Build a codec for `data_type`, or `None` if this module doesn't
+    /// encode that type and the caller should fall back to arrow-row.
+    pub fn try_new(data_type: &DataType, descending: bool) -> Option<Self> {
+        macro_rules! supported {
+            ($arrow_type:ty) => {
+                true
+            };
+        }
+        let supported = dispatch_sortable!(data_type, supported, false);
+        supported.then(|| Self {
+            data_type: data_type.clone(),
+            descending,
+        })
+    }
+
+    /// The arrow type this codec was built for.
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Encode `array`'s non-NULL values in row order.
+    ///
+    /// NULLs are skipped, so the result is shorter than `array` by exactly
+    /// `array.null_count()` — callers that need that count read it from the
+    /// array. The output is ready for `KllSketch::absorb_slice`.
+    ///
+    /// Errors if `array`'s type doesn't match the one this codec was built
+    /// for, which would mean the routing expression changed type between
+    /// planning and execution.
+    pub fn encode(&self, array: &dyn Array) -> Result<Vec<u64>> {
+        if array.data_type() != &self.data_type {
+            return Err(internal_datafusion_err!(
+                "SortKeyCodec: built for {:?} but got {:?}",
+                self.data_type,
+                array.data_type()
+            ));
+        }
+        macro_rules! encode_as {
+            ($arrow_type:ty) => {{
+                let typed = array.as_primitive_opt::<$arrow_type>().ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "SortKeyCodec: {:?} array failed to downcast to its own \
+                         primitive type",
+                        self.data_type
+                    )
+                })?;
+                Ok(self.encode_primitive(typed))
+            }};
+        }
+        dispatch_sortable!(
+            &self.data_type,
+            encode_as,
+            Err(internal_datafusion_err!(
+                "SortKeyCodec: {:?} is not encodable — try_new should have \
+                 returned None",
+                self.data_type
+            ))
+        )
+    }
+
+    /// Shared body of every [`Self::encode`] arm, monomorphized per arrow
+    /// type. Split out so the all-non-NULL case can read the values buffer
+    /// directly instead of going through the nullable iterator.
+    fn encode_primitive<T>(&self, array: &PrimitiveArray<T>) -> Vec<u64>
+    where
+        T: ArrowPrimitiveType,
+        T::Native: SortableNative,
+    {
+        let descending = self.descending;
+        let orient = move |key: u64| if descending { !key } else { key };
+        if array.null_count() == 0 {
+            array.values().iter().map(|v| orient(v.to_key())).collect()
+        } else {
+            array.iter().flatten().map(|v| orient(v.to_key())).collect()
+        }
+    }
+
+    /// Recover the value a key came from, as a `ScalarValue` carrying this
+    /// codec's full arrow type.
+    ///
+    /// Exact for any key [`Self::encode`] produced. A key from anywhere else
+    /// still decodes — the map is total — but to an arbitrary value of the
+    /// type.
+    pub fn decode(&self, key: u64) -> Result<ScalarValue> {
+        // Bitwise NOT is an involution, so the same branch undoes DESC.
+        let key = if self.descending { !key } else { key };
+        macro_rules! decode_as {
+            ($arrow_type:ty) => {{
+                let native =
+                    <<$arrow_type as ArrowPrimitiveType>::Native as SortableNative>::from_key(key);
+                ScalarValue::new_primitive::<$arrow_type>(Some(native), &self.data_type)
+            }};
+        }
+        dispatch_sortable!(
+            &self.data_type,
+            decode_as,
+            Err(internal_datafusion_err!(
+                "SortKeyCodec: {:?} is not decodable — try_new should have \
+                 returned None",
+                self.data_type
+            ))
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kll::KllSketch;
+    use datafusion::arrow::array::{
+        Float64Array, Int64Array, TimestampNanosecondArray, UInt64Array,
+    };
+    use std::sync::Arc;
+
+    /// Encoding must be monotone: sorting the keys must give the same
+    /// permutation as sorting the values. Checked over a set chosen to
+    /// straddle every boundary the encoding has to get right — sign
+    /// changes, zero, and the extremes of the type.
+    #[test]
+    fn ascending_keys_follow_value_order() {
+        let values = vec![
+            i64::MIN,
+            i64::MIN + 1,
+            -1_000_000,
+            -1,
+            0,
+            1,
+            1_000_000,
+            i64::MAX - 1,
+            i64::MAX,
+        ];
+        let codec = SortKeyCodec::try_new(&DataType::Int64, false).unwrap();
+        let keys = codec.encode(&Int64Array::from(values.clone())).unwrap();
+        assert!(
+            keys.windows(2).all(|w| w[0] < w[1]),
+            "keys must be strictly increasing for strictly increasing values: {keys:?}"
+        );
+    }
+
+    /// `DESC` must invert that order while staying a bijection.
+    #[test]
+    fn descending_keys_reverse_value_order() {
+        let values = vec![-5i64, 0, 5, 100];
+        let codec = SortKeyCodec::try_new(&DataType::Int64, true).unwrap();
+        let keys = codec.encode(&Int64Array::from(values.clone())).unwrap();
+        assert!(
+            keys.windows(2).all(|w| w[0] > w[1]),
+            "DESC keys must strictly decrease for increasing values: {keys:?}"
+        );
+        for (key, value) in keys.iter().zip(&values) {
+            assert_eq!(
+                codec.decode(*key).unwrap(),
+                ScalarValue::Int64(Some(*value))
+            );
+        }
+    }
+
+    /// Floats order by `total_cmp`, which puts `-0.0` below `+0.0` and
+    /// sorts NaN to the ends by sign. Infinities are ordinary values.
+    #[test]
+    fn float_keys_follow_total_order() {
+        let values = vec![
+            f64::NEG_INFINITY,
+            -1.5,
+            -0.0,
+            0.0,
+            f64::MIN_POSITIVE,
+            1.5,
+            f64::INFINITY,
+        ];
+        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let keys = codec.encode(&Float64Array::from(values.clone())).unwrap();
+        assert!(
+            keys.windows(2).all(|w| w[0] < w[1]),
+            "float keys must respect total_cmp order: {keys:?}"
+        );
+        // Round-trip preserves the sign of zero, which `==` on f64 would
+        // not distinguish.
+        assert_eq!(
+            codec.decode(keys[2]).unwrap(),
+            ScalarValue::Float64(Some(-0.0))
+        );
+        assert!(
+            matches!(codec.decode(keys[2]).unwrap(), ScalarValue::Float64(Some(v)) if v.is_sign_negative())
+        );
+    }
+
+    /// NaN and the infinities have defined places in `total_cmp`: a NaN
+    /// sits beyond the infinity of its own sign, and the infinities are
+    /// otherwise ordinary values. Arrow sorts floats by exactly this
+    /// predicate (`ArrowNativeTypeOp::compare` delegates to `total_cmp`),
+    /// so the key has to agree — otherwise the sketch would order its
+    /// input differently from the `SortExec` that produced it.
+    ///
+    /// Unlike T-Digest, which interpolates centroid means and can turn
+    /// `Inf - Inf` into NaN, the sketch only ever compares keys, so an
+    /// infinity is exactly as safe here as any other value.
+    #[test]
+    fn nan_and_infinities_take_their_total_cmp_positions() {
+        let values = vec![
+            -f64::NAN,
+            f64::NEG_INFINITY,
+            -1.0,
+            0.0,
+            1.0,
+            f64::INFINITY,
+            f64::NAN,
+        ];
+        assert!(
+            values.windows(2).all(|w| w[0].total_cmp(&w[1]).is_lt()),
+            "test premise: the fixture is in total_cmp order"
+        );
+
+        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let keys = codec.encode(&Float64Array::from(values.clone())).unwrap();
+        assert!(
+            keys.windows(2).all(|w| w[0] < w[1]),
+            "keys must reproduce total_cmp order: {keys:?}"
+        );
+
+        for (key, value) in keys.iter().zip(&values) {
+            match codec.decode(*key).unwrap() {
+                ScalarValue::Float64(Some(decoded)) => assert_eq!(
+                    decoded.total_cmp(value),
+                    std::cmp::Ordering::Equal,
+                    "decode must round-trip {value} bit-exactly, including NaN sign"
+                ),
+                other => panic!("expected Float64, got {other:?}"),
+            }
+        }
+    }
+
+    /// The two encoders have to agree. A column's routing must not depend
+    /// on whether it happened to qualify for the integer fast path or fell
+    /// through to arrow-row, so the orders they induce must be identical —
+    /// including on the float edge cases.
+    #[test]
+    fn integer_keys_order_identically_to_arrow_row() {
+        use datafusion::arrow::row::{RowConverter, SortField};
+
+        let values = vec![
+            -f64::NAN,
+            f64::NEG_INFINITY,
+            -7.25,
+            -0.0,
+            0.0,
+            f64::MIN_POSITIVE,
+            7.25,
+            f64::INFINITY,
+            f64::NAN,
+        ];
+        let array = Float64Array::from(values.clone());
+
+        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let keys = codec.encode(&array).unwrap();
+
+        let converter =
+            RowConverter::new(vec![SortField::new(DataType::Float64)]).unwrap();
+        let rows = converter
+            .convert_columns(&[Arc::new(array) as Arc<dyn Array>])
+            .unwrap();
+
+        let by_key = argsort(&keys);
+        let by_row: Vec<usize> = {
+            let mut order: Vec<usize> = (0..values.len()).collect();
+            order.sort_by_key(|&i| rows.row(i).as_ref().to_vec());
+            order
+        };
+        assert_eq!(
+            by_key, by_row,
+            "integer keys and arrow-row bytes must induce the same permutation"
+        );
+    }
+
+    /// Ingest keys through a sketch, one `absorb_slice` per batch.
+    fn sketch_batches(codec: &SortKeyCodec, batches: Vec<Vec<f64>>) -> KllSketch<u64> {
+        let mut sketch = KllSketch::<u64>::new(64);
+        for batch in batches {
+            let keys = codec.encode(&Float64Array::from(batch)).unwrap();
+            sketch.absorb_slice(&keys);
+        }
+        sketch
+    }
+
+    /// The extremes a sketch reports are what decides which shuffle files
+    /// overlap which output partition, so losing one loses rows. They have
+    /// to survive ingest even when a batch *begins and ends* with NaN,
+    /// which is what a `total_cmp` sort does to any batch containing one.
+    ///
+    /// This is the case DataFusion's T-Digest gets wrong. It reads a
+    /// batch's extremes from `first()` and `last()` alone and folds them in
+    /// with `f64::min`/`f64::max`, which discard NaN rather than order it.
+    /// Fed the same two batches, it reports the stream's range as
+    /// `[1.0, 5.0]` and loses both infinities. Comparing keys with `Ord`
+    /// over every element has no such blind spot.
+    #[test]
+    fn extremes_survive_a_batch_whose_ends_are_nan() {
+        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let sketch = sketch_batches(
+            &codec,
+            vec![
+                vec![1.0, 5.0],
+                vec![f64::NAN, -f64::NAN, f64::INFINITY, f64::NEG_INFINITY],
+            ],
+        );
+
+        // Per total_cmp, -NaN is below every value and +NaN above every
+        // value, so those are this stream's true extremes.
+        let min = codec.decode(*sketch.min().unwrap()).unwrap();
+        let max = codec.decode(*sketch.max().unwrap()).unwrap();
+        assert!(
+            matches!(min, ScalarValue::Float64(Some(v)) if v.is_nan() && v.is_sign_negative()),
+            "min must be -NaN, got {min:?}"
+        );
+        assert!(
+            matches!(max, ScalarValue::Float64(Some(v)) if v.is_nan() && v.is_sign_positive()),
+            "max must be +NaN, got {max:?}"
+        );
+    }
+
+    /// Same shape without NaN, which is the plainer data-loss case: a
+    /// stream spanning both infinities must report spanning both
+    /// infinities. T-Digest reports `[1.0, 5.0]` here once a NaN has
+    /// appeared in the same batch as the infinities.
+    #[test]
+    fn infinities_are_reported_as_the_extremes_they_are() {
+        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let sketch = sketch_batches(
+            &codec,
+            vec![vec![1.0, 5.0], vec![f64::INFINITY, f64::NEG_INFINITY]],
+        );
+        assert_eq!(
+            codec.decode(*sketch.min().unwrap()).unwrap(),
+            ScalarValue::Float64(Some(f64::NEG_INFINITY))
+        );
+        assert_eq!(
+            codec.decode(*sketch.max().unwrap()).unwrap(),
+            ScalarValue::Float64(Some(f64::INFINITY))
+        );
+    }
+
+    /// Batch arrival order must not change the answer. T-Digest's is order
+    /// dependent: the first batch assigns extremes directly, later batches
+    /// fold theirs in with NaN-dropping comparisons, so the same data gives
+    /// different bounds depending on which batch landed first.
+    #[test]
+    fn extremes_do_not_depend_on_batch_order() {
+        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let nan_batch = vec![f64::NAN, -f64::NAN, f64::INFINITY, f64::NEG_INFINITY];
+        let plain_batch = vec![1.0, 5.0];
+
+        let nan_first =
+            sketch_batches(&codec, vec![nan_batch.clone(), plain_batch.clone()]);
+        let nan_second = sketch_batches(&codec, vec![plain_batch, nan_batch]);
+
+        assert_eq!(nan_first.min(), nan_second.min(), "min is order dependent");
+        assert_eq!(nan_first.max(), nan_second.max(), "max is order dependent");
+    }
+
+    /// Indices of `keys` in ascending key order.
+    fn argsort(keys: &[u64]) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..keys.len()).collect();
+        order.sort_by_key(|&i| keys[i]);
+        order
+    }
+
+    /// The worked table in `impl_sortable_float`'s docs, asserted. Hex
+    /// written by hand into a comment rots silently; pinning it here makes
+    /// a drift fail instead.
+    #[test]
+    fn float_key_table_in_docs_is_accurate() {
+        let table: [(f64, u64); 10] = [
+            (-f64::NAN, 0x0007FFFFFFFFFFFF),
+            (f64::NEG_INFINITY, 0x000FFFFFFFFFFFFF),
+            (-2.0, 0x3FFFFFFFFFFFFFFF),
+            (-1.0, 0x400FFFFFFFFFFFFF),
+            (-0.0, 0x7FFFFFFFFFFFFFFF),
+            (0.0, 0x8000000000000000),
+            (1.0, 0xBFF0000000000000),
+            (2.0, 0xC000000000000000),
+            (f64::INFINITY, 0xFFF0000000000000),
+            (f64::NAN, 0xFFF8000000000000),
+        ];
+        for (value, expected) in table {
+            assert_eq!(
+                value.to_key(),
+                expected,
+                "{value} should key to {expected:#018X}, got {:#018X}",
+                value.to_key()
+            );
+        }
+        assert!(
+            table.windows(2).all(|w| w[0].1 < w[1].1),
+            "the table is written in ascending value order, so its keys \
+             must ascend too"
+        );
+    }
+
+    /// Unsigned keys must not be shifted the way signed ones are, or the
+    /// top half of the range would wrap below the bottom.
+    #[test]
+    fn unsigned_keys_span_full_range_in_order() {
+        let values = vec![0u64, 1, 1 << 62, u64::MAX - 1, u64::MAX];
+        let codec = SortKeyCodec::try_new(&DataType::UInt64, false).unwrap();
+        let keys = codec.encode(&UInt64Array::from(values.clone())).unwrap();
+        assert!(keys.windows(2).all(|w| w[0] < w[1]), "{keys:?}");
+        for (key, value) in keys.iter().zip(&values) {
+            assert_eq!(
+                codec.decode(*key).unwrap(),
+                ScalarValue::UInt64(Some(*value))
+            );
+        }
+    }
+
+    /// The motivating case: nanosecond timestamps round-trip exactly at
+    /// magnitudes where an `f64` cast would quantize them. The timezone
+    /// rides on the `DataType` rather than the key, so it has to survive
+    /// the decode as well.
+    #[test]
+    fn nanosecond_timestamps_round_trip_exactly_with_timezone() {
+        let data_type = DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()));
+        // 2026-08-12T00:00:00Z in nanos, then the next three nanoseconds.
+        // Above 2^53, so an f64 cast would collapse them onto one value.
+        let base = 1_786_233_600_000_000_000i64;
+        let values = vec![base, base + 1, base + 2, base + 3];
+        assert!(
+            base as f64 as i64 != base + 1,
+            "test premise: f64 must be unable to separate adjacent nanos here"
+        );
+
+        let array = TimestampNanosecondArray::from(values.clone())
+            .with_timezone("UTC".to_string());
+        let codec = SortKeyCodec::try_new(&data_type, false).unwrap();
+        let keys = codec.encode(&array).unwrap();
+        assert!(
+            keys.windows(2).all(|w| w[0] < w[1]),
+            "adjacent nanoseconds must stay distinct and ordered: {keys:?}"
+        );
+        for (key, value) in keys.iter().zip(&values) {
+            assert_eq!(
+                codec.decode(*key).unwrap(),
+                ScalarValue::TimestampNanosecond(Some(*value), Some("UTC".into())),
+                "decode must preserve both the instant and the timezone"
+            );
+        }
+    }
+
+    /// NULLs leave the key stream entirely, so the caller can count them
+    /// separately and place them by `nulls_first` at routing time.
+    #[test]
+    fn encode_skips_nulls_and_keeps_value_order() {
+        let array = Int64Array::from(vec![Some(3), None, Some(1), None, Some(2)]);
+        let codec = SortKeyCodec::try_new(&DataType::Int64, false).unwrap();
+        let keys = codec.encode(&array).unwrap();
+        assert_eq!(keys.len(), 3, "one key per non-NULL value");
+        assert_eq!(array.null_count(), 2, "count stays available on the array");
+        let decoded: Vec<ScalarValue> =
+            keys.iter().map(|k| codec.decode(*k).unwrap()).collect();
+        assert_eq!(
+            decoded,
+            vec![
+                ScalarValue::Int64(Some(3)),
+                ScalarValue::Int64(Some(1)),
+                ScalarValue::Int64(Some(2)),
+            ],
+            "non-NULL values keep their relative row order"
+        );
+    }
+
+    /// Types outside the allowlist must decline rather than encode wrongly
+    /// — that `None` is what routes them to the arrow-row path.
+    #[test]
+    fn unsupported_types_decline() {
+        for data_type in [
+            DataType::Utf8,
+            DataType::Binary,
+            DataType::Decimal128(38, 10),
+            DataType::Boolean,
+        ] {
+            assert!(
+                SortKeyCodec::try_new(&data_type, false).is_none(),
+                "{data_type:?} must fall through to the arrow-row path"
+            );
+        }
+    }
+
+    /// A codec must reject an array of the wrong type instead of
+    /// reinterpreting its bits.
+    #[test]
+    fn encode_rejects_mismatched_array_type() {
+        let codec = SortKeyCodec::try_new(&DataType::Int64, false).unwrap();
+        let array: Arc<dyn Array> = Arc::new(Float64Array::from(vec![1.0, 2.0]));
+        let err = codec
+            .encode(array.as_ref())
+            .expect_err("type mismatch must not silently reinterpret");
+        assert!(err.to_string().contains("built for"), "got: {err}");
+    }
+}

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -483,7 +483,7 @@ impl SortKeyCodec {
 /// accuracy: on a uniform 1M stream, 0.0016 worst-case normalized rank
 /// error against T-Digest's 0.0021. Rerun with `KLL_PARITY_CHECK=1 cargo
 /// bench --bench quantile_sketch`.
-const KLL_K: usize = 800;
+pub const KLL_K: usize = 800;
 
 /// One `ORDER BY` key's observed distribution: a quantile sketch over the
 /// non-NULL values, plus the count of the NULLs that have no place in it.

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -1410,6 +1410,110 @@ mod tests {
         }
     }
 
+    /// Encode `ascending` under both directions, asserting the keys run
+    /// the way the direction asks and that each one decodes back to the
+    /// value it came from.
+    ///
+    /// `ascending` must be in `total_cmp` order and free of duplicates,
+    /// since the keys are checked for strict monotonicity.
+    fn check_dispatched<T: ArrowPrimitiveType>(ascending: Vec<T::Native>) {
+        let array = PrimitiveArray::<T>::from_iter_values(ascending.iter().copied());
+        let data_type = array.data_type().clone();
+        for descending in [false, true] {
+            let codec = SortKeyCodec::try_new(&data_type, sort_options(descending, true))
+                .unwrap_or_else(|| {
+                    panic!("{data_type:?} is dispatched but try_new declined it")
+                });
+            let keys = codec.encode(&array).unwrap();
+            assert_eq!(keys.len(), ascending.len(), "{data_type:?}");
+
+            for pair in keys.windows(2) {
+                let [lo, hi] = pair else {
+                    unreachable!("windows(2) yields pairs")
+                };
+                let ordered = if descending { lo > hi } else { lo < hi };
+                assert!(
+                    ordered,
+                    "{data_type:?} descending={descending}: {lo:#018x} then {hi:#018x}"
+                );
+            }
+
+            for (key, value) in keys.iter().zip(&ascending) {
+                let expected =
+                    ScalarValue::new_primitive::<T>(Some(*value), &data_type).unwrap();
+                assert_eq!(
+                    codec.decode(*key).unwrap(),
+                    expected,
+                    "{data_type:?} descending={descending}"
+                );
+            }
+        }
+    }
+
+    /// Every type `dispatch_sortable!` admits, end to end: the allowlist
+    /// accepts it, the keys run the way the direction asks, and the decode
+    /// arm hands back the value that went in.
+    ///
+    /// The narrow widths are their own code rather than a special case of
+    /// the 64-bit ones. `impl_sortable_float!(f32, u32, 32)` zero-extends a
+    /// 32-bit key that DESC then inverts across all 64 bits, and the narrow
+    /// signed arms sign-extend on the way out and truncate on the way back.
+    #[test]
+    fn every_dispatched_type_encodes_in_order_and_decodes_back() {
+        check_dispatched::<Int8Type>(vec![i8::MIN, -1, 0, 1, i8::MAX]);
+        check_dispatched::<Int16Type>(vec![i16::MIN, -1, 0, 1, i16::MAX]);
+        check_dispatched::<Int32Type>(vec![i32::MIN, -1, 0, 1, i32::MAX]);
+        check_dispatched::<Int64Type>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+
+        check_dispatched::<UInt8Type>(vec![0, 1, u8::MAX]);
+        check_dispatched::<UInt16Type>(vec![0, 1, u16::MAX]);
+        check_dispatched::<UInt32Type>(vec![0, 1, u32::MAX]);
+        check_dispatched::<UInt64Type>(vec![0, 1, u64::MAX]);
+
+        // `total_cmp` order, so both NaNs sit outside their own infinity
+        // and the two zeros are distinct.
+        check_dispatched::<Float32Type>(vec![
+            -f32::NAN,
+            f32::NEG_INFINITY,
+            -1.0,
+            -0.0,
+            0.0,
+            1.0,
+            f32::INFINITY,
+            f32::NAN,
+        ]);
+        check_dispatched::<Float64Type>(vec![
+            -f64::NAN,
+            f64::NEG_INFINITY,
+            -1.0,
+            -0.0,
+            0.0,
+            1.0,
+            f64::INFINITY,
+            f64::NAN,
+        ]);
+
+        check_dispatched::<Date32Type>(vec![i32::MIN, -1, 0, 1, i32::MAX]);
+        check_dispatched::<Date64Type>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+
+        // Times are an offset within a day, so their range is bounded by
+        // the unit rather than by the width that carries it.
+        check_dispatched::<Time32SecondType>(vec![0, 1, 86_399]);
+        check_dispatched::<Time32MillisecondType>(vec![0, 1, 86_399_999]);
+        check_dispatched::<Time64MicrosecondType>(vec![0, 1, 86_399_999_999]);
+        check_dispatched::<Time64NanosecondType>(vec![0, 1, 86_399_999_999_999]);
+
+        check_dispatched::<TimestampSecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+        check_dispatched::<TimestampMillisecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+        check_dispatched::<TimestampMicrosecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+        check_dispatched::<TimestampNanosecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+
+        check_dispatched::<DurationSecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+        check_dispatched::<DurationMillisecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+        check_dispatched::<DurationMicrosecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+        check_dispatched::<DurationNanosecondType>(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+    }
+
     /// NULLs leave the key stream entirely, so the caller can count them
     /// separately and place them by `nulls_first` at routing time.
     #[test]

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -634,44 +634,42 @@ impl SortKeySketch {
     /// 99` is `58.999…`, which truncates to 58. That off-by-one was caught
     /// by `quantiles_match_the_nulls_in_key_oracle`.
     pub fn quantile(&self, q: f64) -> Result<Option<ScalarValue>> {
-        let total = self.count();
-        if total == 0 {
+        if self.count() == 0 {
             return Ok(None);
         }
-        // No NULL run to step over, so the population rank *is* the value
-        // rank and the sketch can answer directly. Also the only path that
-        // reaches the sketch's exact-extreme handling at q = 0 and q = 1.
-        if self.null_count == 0 {
-            return self
+        match self.value_rank(q) {
+            None => Ok(Some(self.codec.null_value()?)),
+            Some(rank) => self
                 .sketch
-                .quantile(q)
+                .at_rank(rank)
                 .map(|key| self.codec.decode(*key))
-                .transpose();
+                .transpose(),
+        }
+    }
+
+    /// The rank *among the values* that population-quantile `q` asks for,
+    /// or `None` when it lands inside the NULL run.
+    ///
+    /// This is the remap [`Self::quantile`] documents, split out so that
+    /// [`Self::cuts`] can resolve every boundary against one pass over the
+    /// sketch. Callers must have checked that something was observed.
+    fn value_rank(&self, q: f64) -> Option<u64> {
+        let rank = (q.clamp(0.0, 1.0) * self.count() as f64) as u64;
+        // No NULL run to step over, so the population rank *is* the value
+        // rank. This is also the only path that reaches the sketch's
+        // exact-extreme handling at q = 0 and q = 1.
+        if self.null_count == 0 {
+            return Some(rank);
         }
         let values = self.sketch.count();
         if values == 0 {
-            return Ok(Some(self.codec.null_value()?));
+            return None;
         }
-
-        // Same rank arithmetic the sketch itself would do, so that
-        // stepping over the NULL run is the only difference between this
-        // answer and a sketch of the whole population.
-        let rank = (q.clamp(0.0, 1.0) * total as f64) as u64;
-        let value_rank = if self.codec.options().nulls_first {
-            if rank <= self.null_count {
-                return Ok(Some(self.codec.null_value()?));
-            }
-            rank - self.null_count
+        if self.codec.options().nulls_first {
+            (rank > self.null_count).then(|| rank - self.null_count)
         } else {
-            if rank > values {
-                return Ok(Some(self.codec.null_value()?));
-            }
-            rank
-        };
-        self.sketch
-            .at_rank(value_rank)
-            .map(|key| self.codec.decode(*key))
-            .transpose()
+            (rank <= values).then_some(rank)
+        }
     }
 
     /// The `partitions - 1` boundaries that split everything observed into
@@ -686,19 +684,33 @@ impl SortKeySketch {
         if partitions < 2 || self.count() == 0 {
             return Ok(Vec::new());
         }
-        (1..partitions)
-            .map(|cut| {
-                let q = cut as f64 / partitions as f64;
-                // Having observed something, every rank in `0..count` names
-                // a row, so the only way back is a full vector. Dropping a
-                // missing cut instead would renumber every partition above
-                // it, and silently.
-                self.quantile(q)?.ok_or_else(|| {
-                    internal_datafusion_err!(
-                        "SortKeySketch: no value at quantile {q} of {} observations",
-                        self.count()
-                    )
-                })
+        let targets: Vec<Option<u64>> = (1..partitions)
+            .map(|cut| self.value_rank(cut as f64 / partitions as f64))
+            .collect();
+        // One sorted pass over the retained items for every boundary. Going
+        // through `quantile` per cut instead re-sorts the whole retained set
+        // each time, which at 256 partitions costs more than the ingest that
+        // built the sketch.
+        let value_ranks: Vec<u64> = targets.iter().flatten().copied().collect();
+        let mut value_keys = self.sketch.at_ranks(&value_ranks).into_iter();
+
+        targets
+            .iter()
+            .map(|target| match target {
+                None => self.codec.null_value(),
+                // Having observed something, every rank the remap produces
+                // names a row, so the only way back is a full vector.
+                // Dropping a missing cut would renumber every partition
+                // above it, and silently.
+                Some(rank) => {
+                    let key = value_keys.next().flatten().ok_or_else(|| {
+                        internal_datafusion_err!(
+                            "SortKeySketch: no value at rank {rank} of {} values",
+                            self.sketch.count()
+                        )
+                    })?;
+                    self.codec.decode(*key)
+                }
             })
             .collect()
     }

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -585,7 +585,11 @@ impl SortKeySketch {
         nulls_are_on_this_end: bool,
         value_extreme: Option<&u64>,
     ) -> Result<Option<ScalarValue>> {
-        if nulls_are_on_this_end && self.null_count > 0 {
+        // With no values at all the run is unbounded on both sides, so the
+        // end it does not nominally occupy is a NULL too. Answering `None`
+        // there would claim nothing was observed while `count` says
+        // otherwise, and would hand `cut_partitions` half a range.
+        if self.null_count > 0 && (nulls_are_on_this_end || value_extreme.is_none()) {
             return Ok(Some(self.codec.null_value()?));
         }
         value_extreme.map(|key| self.codec.decode(*key)).transpose()
@@ -1061,6 +1065,30 @@ mod tests {
             );
         }
         assert_eq!(sketch.count(), 8);
+    }
+
+    /// With no values at all the NULL run is unbounded on both sides, so
+    /// both extremes are NULL whichever end the run nominally occupies.
+    ///
+    /// The end it does not occupy has no value to fall back to, and
+    /// answering `None` there would claim nothing was observed while
+    /// `count` says otherwise. `cut_partitions` routes files on the pair,
+    /// so half a range routes half the rows.
+    #[test]
+    fn an_all_null_column_is_null_at_both_extremes() {
+        for nulls_first in [true, false] {
+            let sketch = int_sketch(vec![None; 8], sort_options(false, nulls_first));
+            assert_eq!(
+                sketch.min().unwrap(),
+                Some(ScalarValue::Int64(None)),
+                "nulls_first={nulls_first}"
+            );
+            assert_eq!(
+                sketch.max().unwrap(),
+                Some(ScalarValue::Int64(None)),
+                "nulls_first={nulls_first}"
+            );
+        }
     }
 
     /// Nothing observed at all is distinct from observing NULLs.

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -670,18 +670,30 @@ impl SortKeySketch {
     /// The `partitions - 1` boundaries that split everything observed into
     /// `partitions` equally-sized runs, in sort order.
     ///
-    /// Empty when `partitions < 2` or nothing was observed. Entries may
-    /// repeat where one value dominates, and may be typed NULLs where the
-    /// NULL run spans a boundary; both are faithful answers about a skewed
-    /// distribution rather than errors.
+    /// Empty when `partitions < 2` or nothing was observed, and otherwise
+    /// exactly `partitions - 1` long so a caller can index it by output
+    /// partition. Entries may repeat where one value dominates, and may be
+    /// typed NULLs where the NULL run spans a boundary; both are faithful
+    /// answers about a skewed distribution rather than errors.
     pub fn cuts(&self, partitions: usize) -> Result<Vec<ScalarValue>> {
-        if partitions < 2 {
+        if partitions < 2 || self.count() == 0 {
             return Ok(Vec::new());
         }
         (1..partitions)
-            .map(|cut| self.quantile(cut as f64 / partitions as f64))
-            .collect::<Result<Vec<_>>>()
-            .map(|cuts| cuts.into_iter().flatten().collect())
+            .map(|cut| {
+                let q = cut as f64 / partitions as f64;
+                // Having observed something, every rank in `0..count` names
+                // a row, so the only way back is a full vector. Dropping a
+                // missing cut instead would renumber every partition above
+                // it, and silently.
+                self.quantile(q)?.ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "SortKeySketch: no value at quantile {q} of {} observations",
+                        self.count()
+                    )
+                })
+            })
+            .collect()
     }
 }
 

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -15,9 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Order-preserving `u64` encoding of a single fixed-width `ORDER BY` key,
-//! so [`crate::kll::KllSketch`] can sketch it without knowing the column's
-//! type or sort direction.
+//! Sketching a single fixed-width `ORDER BY` key.
+//!
+//! [`crate::sort_key::SortKeyCodec`] is the ordering spec for one key —
+//! its type, its direction, where its NULLs go — and encodes values to an
+//! order-preserving `u64` and back. [`crate::sort_key::SortKeySketch`]
+//! pairs that with a [`crate::kll::KllSketch`] over the encoded values and
+//! a count of the NULLs, and answers quantiles over the whole population.
+//!
+//! Consumers want the sketch, not the codec. It is the type that knows how
+//! to merge two observations, how a NULL run shifts a quantile, and what
+//! goes on the wire.
 //!
 //! # Why an integer key
 //!
@@ -41,12 +49,18 @@
 //!
 //! # NULLs are out of band
 //!
-//! Encoding skips NULLs entirely; callers track the count separately. A
-//! NULL has no position among the values, only a side, and `nulls_first` /
-//! `nulls_last` says which — that is one bit of plan-time information, not
-//! something the sketch needs to carry. Keeping it out of the key leaves
-//! the key 8 bytes wide rather than 16, which the same benchmark measured
-//! at 1.23× versus 1.58×.
+//! Encoding skips NULLs entirely and `SortKeySketch` counts them instead.
+//! A NULL has no position among the values, only a side, and `nulls_first`
+//! / `nulls_last` says which — that is one bit of plan-time information,
+//! not something the key needs to carry. Keeping it out leaves the key 8
+//! bytes wide rather than 16, which the same benchmark measured at 1.23×
+//! versus 1.58×.
+//!
+//! The cost is that a rank over the population is no longer a rank over
+//! the values: the NULL run has to be stepped over first. That remap lives
+//! in [`crate::sort_key::SortKeySketch::quantile`] and nowhere else.
+//! Spread across call sites it would be reimplemented per consumer, and
+//! getting it wrong skews every cut without failing anything.
 //!
 //! # The row format is the rulebook
 //!
@@ -95,6 +109,7 @@
 //! to the arrow-row path.
 
 use datafusion::arrow::array::{Array, ArrowPrimitiveType, AsArray, PrimitiveArray};
+use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::{
     DataType, Date32Type, Date64Type, DurationMicrosecondType, DurationMillisecondType,
     DurationNanosecondType, DurationSecondType, Float32Type, Float64Type, Int8Type,
@@ -104,6 +119,8 @@ use datafusion::arrow::datatypes::{
     UInt16Type, UInt32Type, UInt64Type,
 };
 use datafusion::common::{Result, ScalarValue, internal_datafusion_err};
+
+use crate::kll::KllSketch;
 
 /// Bijection between a primitive's native value and a `u64` whose ascending
 /// order matches the native ascending order.
@@ -311,23 +328,28 @@ macro_rules! dispatch_sortable {
     };
 }
 
-/// Encodes one fixed-width `ORDER BY` key to `u64` and back. See the module
-/// docs for the encoding and for why NULLs are handled out of band.
+/// The complete ordering spec for one fixed-width `ORDER BY` key: its
+/// type, its direction, and where its NULLs go. Encodes values to `u64`
+/// and back. See the module docs for the encoding and for why NULLs are
+/// handled out of band.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SortKeyCodec {
     /// The column's full arrow type, retained so [`Self::decode`] can
     /// rebuild a `ScalarValue` that keeps the parts the key doesn't carry
     /// — a `Timestamp`'s timezone above all.
     data_type: DataType,
-    /// `true` inverts every key bit, reversing the sketch's ascending order
-    /// into the `DESC` order the plan asked for.
-    descending: bool,
+    /// `descending` inverts every key bit, reversing the sketch's ascending
+    /// order into the order the plan asked for. `nulls_first` never touches
+    /// a key, since NULLs are not encoded; it tells a sketch which end of
+    /// the distribution its NULL count occupies.
+    options: SortOptions,
 }
 
 impl SortKeyCodec {
-    /// Build a codec for `data_type`, or `None` if this module doesn't
-    /// encode that type and the caller should fall back to arrow-row.
-    pub fn try_new(data_type: &DataType, descending: bool) -> Option<Self> {
+    /// Build a codec for `data_type` under `options`, or `None` if this
+    /// module doesn't encode that type and the caller should fall back to
+    /// arrow-row.
+    pub fn try_new(data_type: &DataType, options: SortOptions) -> Option<Self> {
         macro_rules! supported {
             ($arrow_type:ty) => {
                 true
@@ -336,13 +358,24 @@ impl SortKeyCodec {
         let supported = dispatch_sortable!(data_type, supported, false);
         supported.then(|| Self {
             data_type: data_type.clone(),
-            descending,
+            options,
         })
     }
 
     /// The arrow type this codec was built for.
     pub fn data_type(&self) -> &DataType {
         &self.data_type
+    }
+
+    /// The sort direction and NULL placement this codec encodes for.
+    pub fn options(&self) -> SortOptions {
+        self.options
+    }
+
+    /// A typed NULL of this codec's column type. What a quantile query
+    /// answers when the rank it asks for lands in the NULL run.
+    pub fn null_value(&self) -> Result<ScalarValue> {
+        ScalarValue::try_from(&self.data_type)
     }
 
     /// Encode `array`'s non-NULL values in row order.
@@ -393,7 +426,7 @@ impl SortKeyCodec {
         T: ArrowPrimitiveType,
         T::Native: SortableNative,
     {
-        let descending = self.descending;
+        let descending = self.options.descending;
         let orient = move |key: u64| if descending { !key } else { key };
         if array.null_count() == 0 {
             array.values().iter().map(|v| orient(v.to_key())).collect()
@@ -410,7 +443,7 @@ impl SortKeyCodec {
     /// type.
     pub fn decode(&self, key: u64) -> Result<ScalarValue> {
         // Bitwise NOT is an involution, so the same branch undoes DESC.
-        let key = if self.descending { !key } else { key };
+        let key = if self.options.descending { !key } else { key };
         macro_rules! decode_as {
             ($arrow_type:ty) => {{
                 let native =
@@ -430,10 +463,213 @@ impl SortKeyCodec {
     }
 }
 
+/// KLL top-level compactor capacity. Picked for worst-case rank-error
+/// parity with the T-Digest sizing it replaces (`max_size = 100`), so the
+/// swap changes the sketch's cost and exactness without changing its
+/// accuracy: on a uniform 1M stream, 0.0016 worst-case normalized rank
+/// error against T-Digest's 0.0021. Rerun with `KLL_PARITY_CHECK=1 cargo
+/// bench --bench quantile_sketch`.
+const KLL_K: usize = 800;
+
+/// One `ORDER BY` key's observed distribution: a quantile sketch over the
+/// non-NULL values, plus the count of the NULLs that have no place in it.
+///
+/// Holding both together is the point. NULLs sit at one end of the order
+/// rather than among the values, so any quantile over the *population*
+/// has to account for the NULL run before consulting the sketch. Doing
+/// that remap at call sites would mean every consumer reimplementing it,
+/// and getting it wrong skews cuts silently rather than failing. So merge,
+/// quantile, and the wire format all live here, once.
+#[derive(Debug, Clone)]
+pub struct SortKeySketch {
+    /// How values become keys, and which end the NULLs occupy.
+    codec: SortKeyCodec,
+    /// Quantile structure over the non-NULL values only.
+    sketch: KllSketch<u64>,
+    /// Rows whose key was NULL. Not in `sketch`, and not recoverable from
+    /// it.
+    null_count: u64,
+}
+
+impl SortKeySketch {
+    /// An empty sketch for the key `codec` describes.
+    pub fn new(codec: SortKeyCodec) -> Self {
+        Self {
+            codec,
+            sketch: KllSketch::new(KLL_K),
+            null_count: 0,
+        }
+    }
+
+    /// Observe every row of `array`: encode the non-NULL values into the
+    /// sketch and add the NULLs to the count.
+    ///
+    /// Errors if `array`'s type disagrees with the codec's, which would
+    /// mean the routing expression changed type between planning and
+    /// execution.
+    pub fn ingest(&mut self, array: &dyn Array) -> Result<()> {
+        let keys = self.codec.encode(array)?;
+        self.sketch.absorb_slice(&keys);
+        self.null_count += array.null_count() as u64;
+        Ok(())
+    }
+
+    /// Fold `other` into `self`.
+    ///
+    /// Errors when the two describe different keys. Merging a sketch of
+    /// one column into a sketch of another produces a plausible-looking
+    /// distribution of nothing in particular, so it is caught rather than
+    /// tolerated.
+    pub fn merge(&mut self, other: Self) -> Result<()> {
+        if self.codec != other.codec {
+            return Err(internal_datafusion_err!(
+                "SortKeySketch::merge: {:?} and {:?} describe different sort keys",
+                self.codec,
+                other.codec
+            ));
+        }
+        self.sketch.merge(other.sketch);
+        self.null_count += other.null_count;
+        Ok(())
+    }
+
+    /// Rows observed, NULLs included.
+    pub fn count(&self) -> u64 {
+        self.sketch.count() + self.null_count
+    }
+
+    /// Rows observed whose key was NULL.
+    pub fn null_count(&self) -> u64 {
+        self.null_count
+    }
+
+    /// The ordering spec these observations were made under.
+    pub fn codec(&self) -> &SortKeyCodec {
+        &self.codec
+    }
+
+    /// The least value in sort order, or `None` when nothing was observed.
+    ///
+    /// A typed NULL when NULLs sort first and at least one was seen, since
+    /// then the least *row* is a NULL rather than a value.
+    pub fn min(&self) -> Result<Option<ScalarValue>> {
+        self.extreme(self.codec.options().nulls_first, self.sketch.min())
+    }
+
+    /// The greatest value in sort order, or `None` when nothing was
+    /// observed. A typed NULL when NULLs sort last and at least one was
+    /// seen.
+    pub fn max(&self) -> Result<Option<ScalarValue>> {
+        self.extreme(!self.codec.options().nulls_first, self.sketch.max())
+    }
+
+    /// Shared body of [`Self::min`] and [`Self::max`]: the extreme is a
+    /// NULL when the NULL run is on `nulls_are_on_this_end` and non-empty,
+    /// otherwise it is `value_extreme` decoded.
+    fn extreme(
+        &self,
+        nulls_are_on_this_end: bool,
+        value_extreme: Option<&u64>,
+    ) -> Result<Option<ScalarValue>> {
+        if nulls_are_on_this_end && self.null_count > 0 {
+            return Ok(Some(self.codec.null_value()?));
+        }
+        value_extreme.map(|key| self.codec.decode(*key)).transpose()
+    }
+
+    /// The value at the `q`-quantile of everything observed, NULLs
+    /// included. `q` is clamped to `[0, 1]`.
+    ///
+    /// `Ok(None)` means nothing was observed at all. `Ok(Some(null))` means
+    /// the rank `q` asks for lands inside the NULL run, which is a real
+    /// answer: a cut there says the partition below it holds only NULLs.
+    ///
+    /// # The remap
+    ///
+    /// NULLs occupy a contiguous run at one end, so a rank over the
+    /// population maps onto a rank over the values by subtracting the run
+    /// when it sits below, and by nothing when it sits above:
+    ///
+    /// ```text
+    ///  nulls_first        nulls_last
+    ///  ┌────────┬─────┐   ┌─────┬────────┐
+    ///  │ NULLs  │ vals│   │ vals│ NULLs  │
+    ///  └────────┴─────┘   └─────┴────────┘
+    ///   0      n     N     0    v        N
+    ///
+    ///  rank = (q · N) as integer
+    ///  rank <= n  -> NULL          rank <= v -> values, at rank
+    ///  else       -> values,       else      -> NULL
+    ///                at rank - n
+    /// ```
+    ///
+    /// The subtraction stays in integers on purpose. Rescaling the rank
+    /// into a fraction of the value run and letting the sketch multiply it
+    /// back loses it: with 99 values, rank 59 becomes `59/99`, and `59/99 ·
+    /// 99` is `58.999…`, which truncates to 58. That off-by-one was caught
+    /// by `quantiles_match_the_nulls_in_key_oracle`.
+    pub fn quantile(&self, q: f64) -> Result<Option<ScalarValue>> {
+        let total = self.count();
+        if total == 0 {
+            return Ok(None);
+        }
+        // No NULL run to step over, so the population rank *is* the value
+        // rank and the sketch can answer directly. Also the only path that
+        // reaches the sketch's exact-extreme handling at q = 0 and q = 1.
+        if self.null_count == 0 {
+            return self
+                .sketch
+                .quantile(q)
+                .map(|key| self.codec.decode(*key))
+                .transpose();
+        }
+        let values = self.sketch.count();
+        if values == 0 {
+            return Ok(Some(self.codec.null_value()?));
+        }
+
+        // Same rank arithmetic the sketch itself would do, so that
+        // stepping over the NULL run is the only difference between this
+        // answer and a sketch of the whole population.
+        let rank = (q.clamp(0.0, 1.0) * total as f64) as u64;
+        let value_rank = if self.codec.options().nulls_first {
+            if rank <= self.null_count {
+                return Ok(Some(self.codec.null_value()?));
+            }
+            rank - self.null_count
+        } else {
+            if rank > values {
+                return Ok(Some(self.codec.null_value()?));
+            }
+            rank
+        };
+        self.sketch
+            .at_rank(value_rank)
+            .map(|key| self.codec.decode(*key))
+            .transpose()
+    }
+
+    /// The `partitions - 1` boundaries that split everything observed into
+    /// `partitions` equally-sized runs, in sort order.
+    ///
+    /// Empty when `partitions < 2` or nothing was observed. Entries may
+    /// repeat where one value dominates, and may be typed NULLs where the
+    /// NULL run spans a boundary; both are faithful answers about a skewed
+    /// distribution rather than errors.
+    pub fn cuts(&self, partitions: usize) -> Result<Vec<ScalarValue>> {
+        if partitions < 2 {
+            return Ok(Vec::new());
+        }
+        (1..partitions)
+            .map(|cut| self.quantile(cut as f64 / partitions as f64))
+            .collect::<Result<Vec<_>>>()
+            .map(|cuts| cuts.into_iter().flatten().collect())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kll::KllSketch;
     use datafusion::arrow::array::{
         Float64Array, Int64Array, TimestampNanosecondArray, UInt64Array,
     };
@@ -456,7 +692,8 @@ mod tests {
             i64::MAX - 1,
             i64::MAX,
         ];
-        let codec = SortKeyCodec::try_new(&DataType::Int64, false).unwrap();
+        let codec =
+            SortKeyCodec::try_new(&DataType::Int64, sort_options(false, false)).unwrap();
         let keys = codec.encode(&Int64Array::from(values.clone())).unwrap();
         assert!(
             keys.windows(2).all(|w| w[0] < w[1]),
@@ -468,7 +705,8 @@ mod tests {
     #[test]
     fn descending_keys_reverse_value_order() {
         let values = vec![-5i64, 0, 5, 100];
-        let codec = SortKeyCodec::try_new(&DataType::Int64, true).unwrap();
+        let codec =
+            SortKeyCodec::try_new(&DataType::Int64, sort_options(true, false)).unwrap();
         let keys = codec.encode(&Int64Array::from(values.clone())).unwrap();
         assert!(
             keys.windows(2).all(|w| w[0] > w[1]),
@@ -495,7 +733,8 @@ mod tests {
             1.5,
             f64::INFINITY,
         ];
-        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let codec = SortKeyCodec::try_new(&DataType::Float64, sort_options(false, false))
+            .unwrap();
         let keys = codec.encode(&Float64Array::from(values.clone())).unwrap();
         assert!(
             keys.windows(2).all(|w| w[0] < w[1]),
@@ -538,7 +777,8 @@ mod tests {
             "test premise: the fixture is in total_cmp order"
         );
 
-        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let codec = SortKeyCodec::try_new(&DataType::Float64, sort_options(false, false))
+            .unwrap();
         let keys = codec.encode(&Float64Array::from(values.clone())).unwrap();
         assert!(
             keys.windows(2).all(|w| w[0] < w[1]),
@@ -578,7 +818,8 @@ mod tests {
         ];
         let array = Float64Array::from(values.clone());
 
-        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let codec = SortKeyCodec::try_new(&DataType::Float64, sort_options(false, false))
+            .unwrap();
         let keys = codec.encode(&array).unwrap();
 
         let converter =
@@ -597,6 +838,14 @@ mod tests {
             by_key, by_row,
             "integer keys and arrow-row bytes must induce the same permutation"
         );
+    }
+
+    /// `SortOptions` without the struct-literal noise at every call site.
+    fn sort_options(descending: bool, nulls_first: bool) -> SortOptions {
+        SortOptions {
+            descending,
+            nulls_first,
+        }
     }
 
     /// Ingest keys through a sketch, one `absorb_slice` per batch.
@@ -622,7 +871,8 @@ mod tests {
     /// over every element has no such blind spot.
     #[test]
     fn extremes_survive_a_batch_whose_ends_are_nan() {
-        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let codec = SortKeyCodec::try_new(&DataType::Float64, sort_options(false, false))
+            .unwrap();
         let sketch = sketch_batches(
             &codec,
             vec![
@@ -651,7 +901,8 @@ mod tests {
     /// appeared in the same batch as the infinities.
     #[test]
     fn infinities_are_reported_as_the_extremes_they_are() {
-        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let codec = SortKeyCodec::try_new(&DataType::Float64, sort_options(false, false))
+            .unwrap();
         let sketch = sketch_batches(
             &codec,
             vec![vec![1.0, 5.0], vec![f64::INFINITY, f64::NEG_INFINITY]],
@@ -672,7 +923,8 @@ mod tests {
     /// different bounds depending on which batch landed first.
     #[test]
     fn extremes_do_not_depend_on_batch_order() {
-        let codec = SortKeyCodec::try_new(&DataType::Float64, false).unwrap();
+        let codec = SortKeyCodec::try_new(&DataType::Float64, sort_options(false, false))
+            .unwrap();
         let nan_batch = vec![f64::NAN, -f64::NAN, f64::INFINITY, f64::NEG_INFINITY];
         let plain_batch = vec![1.0, 5.0];
 
@@ -682,6 +934,348 @@ mod tests {
 
         assert_eq!(nan_first.min(), nan_second.min(), "min is order dependent");
         assert_eq!(nan_first.max(), nan_second.max(), "max is order dependent");
+    }
+
+    /// Build a sketch over `values`, ingested as one batch.
+    fn int_sketch(values: Vec<Option<i64>>, options: SortOptions) -> SortKeySketch {
+        let codec = SortKeyCodec::try_new(&DataType::Int64, options).unwrap();
+        let mut sketch = SortKeySketch::new(codec);
+        sketch.ingest(&Int64Array::from(values)).unwrap();
+        sketch
+    }
+
+    /// NULLs are counted, not sketched, so they must show up in the total
+    /// without disturbing the values.
+    #[test]
+    fn nulls_are_counted_beside_the_values() {
+        let sketch = int_sketch(
+            vec![Some(10), None, Some(20), None, None],
+            sort_options(false, true),
+        );
+        assert_eq!(sketch.count(), 5, "population is values plus NULLs");
+        assert_eq!(sketch.null_count(), 3);
+    }
+
+    /// With no NULLs the population rank is the value rank, so the remap
+    /// must be a no-op. This is the case the general path's `rank <= n`
+    /// test would get wrong at q = 0, which is why it has its own branch.
+    #[test]
+    fn quantiles_are_unshifted_when_nothing_is_null() {
+        let values: Vec<Option<i64>> = (1..=100).map(Some).collect();
+        let sketch = int_sketch(values, sort_options(false, true));
+        assert_eq!(
+            sketch.quantile(0.0).unwrap(),
+            Some(ScalarValue::Int64(Some(1))),
+            "q=0 must be the smallest value, not a NULL"
+        );
+        assert_eq!(
+            sketch.quantile(1.0).unwrap(),
+            Some(ScalarValue::Int64(Some(100)))
+        );
+    }
+
+    /// Half NULL, NULLs first. The bottom half of the population is the
+    /// NULL run, so every quantile below the midpoint is a NULL and the
+    /// top half compresses the whole value range into `q > 0.5`. A
+    /// consumer that skipped the remap would report the value median at
+    /// q=0.5 and skew every cut.
+    #[test]
+    fn nulls_first_shifts_the_value_range_upward() {
+        let mut values: Vec<Option<i64>> = (1..=50).map(Some).collect();
+        values.extend(std::iter::repeat_n(None, 50));
+        let sketch = int_sketch(values, sort_options(false, true));
+        assert_eq!(sketch.count(), 100);
+        assert_eq!(sketch.null_count(), 50);
+
+        let null = ScalarValue::Int64(None);
+        assert_eq!(sketch.quantile(0.0).unwrap(), Some(null.clone()));
+        assert_eq!(sketch.quantile(0.25).unwrap(), Some(null.clone()));
+        assert_eq!(
+            sketch.quantile(0.5).unwrap(),
+            Some(null),
+            "the NULL run reaches exactly the midpoint"
+        );
+        // Past the run, rank 0.75·100 = 75 is value 25 of 50.
+        assert_eq!(
+            sketch.quantile(0.75).unwrap(),
+            Some(ScalarValue::Int64(Some(25)))
+        );
+        assert_eq!(
+            sketch.quantile(1.0).unwrap(),
+            Some(ScalarValue::Int64(Some(50)))
+        );
+    }
+
+    /// Same data, NULLs last: the values now occupy the bottom half and
+    /// the NULL run the top.
+    #[test]
+    fn nulls_last_leaves_the_value_range_at_the_bottom() {
+        let mut values: Vec<Option<i64>> = (1..=50).map(Some).collect();
+        values.extend(std::iter::repeat_n(None, 50));
+        let sketch = int_sketch(values, sort_options(false, false));
+
+        assert_eq!(
+            sketch.quantile(0.25).unwrap(),
+            Some(ScalarValue::Int64(Some(25))),
+            "rank 25 of 100 is value 25 of 50"
+        );
+        assert_eq!(
+            sketch.quantile(0.5).unwrap(),
+            Some(ScalarValue::Int64(Some(50))),
+            "the value run ends exactly at the midpoint"
+        );
+        assert_eq!(
+            sketch.quantile(0.75).unwrap(),
+            Some(ScalarValue::Int64(None))
+        );
+        assert_eq!(
+            sketch.quantile(1.0).unwrap(),
+            Some(ScalarValue::Int64(None))
+        );
+    }
+
+    /// All NULL: every quantile is a NULL, and nothing consults the empty
+    /// value sketch.
+    #[test]
+    fn an_all_null_column_answers_null_everywhere() {
+        let sketch = int_sketch(vec![None; 8], sort_options(false, true));
+        for q in [0.0, 0.5, 1.0] {
+            assert_eq!(
+                sketch.quantile(q).unwrap(),
+                Some(ScalarValue::Int64(None)),
+                "q={q}"
+            );
+        }
+        assert_eq!(sketch.count(), 8);
+    }
+
+    /// Nothing observed at all is distinct from observing NULLs.
+    #[test]
+    fn an_empty_sketch_answers_none_not_null() {
+        let codec =
+            SortKeyCodec::try_new(&DataType::Int64, sort_options(false, true)).unwrap();
+        let sketch = SortKeySketch::new(codec);
+        assert_eq!(sketch.count(), 0);
+        assert_eq!(sketch.quantile(0.5).unwrap(), None);
+        assert_eq!(sketch.min().unwrap(), None);
+        assert!(sketch.cuts(4).unwrap().is_empty());
+    }
+
+    /// The extremes follow NULL placement: with NULLs first the least row
+    /// is a NULL, and the greatest is still the largest value.
+    #[test]
+    fn extremes_account_for_where_nulls_sort() {
+        let values = vec![Some(10), None, Some(20)];
+        let first = int_sketch(values.clone(), sort_options(false, true));
+        assert_eq!(first.min().unwrap(), Some(ScalarValue::Int64(None)));
+        assert_eq!(first.max().unwrap(), Some(ScalarValue::Int64(Some(20))));
+
+        let last = int_sketch(values, sort_options(false, false));
+        assert_eq!(last.min().unwrap(), Some(ScalarValue::Int64(Some(10))));
+        assert_eq!(last.max().unwrap(), Some(ScalarValue::Int64(None)));
+    }
+
+    /// Merging folds both the value sketches and the NULL counts. Losing
+    /// the second sketch's NULLs would silently shift every quantile.
+    #[test]
+    fn merge_folds_values_and_null_counts() {
+        let options = sort_options(false, true);
+        let mut left = int_sketch(vec![Some(1), Some(2), None], options);
+        let right = int_sketch(vec![Some(3), Some(4), None, None], options);
+        left.merge(right).unwrap();
+
+        assert_eq!(left.count(), 7, "3 + 4 rows");
+        assert_eq!(left.null_count(), 3, "1 + 2 NULLs");
+        assert_eq!(left.max().unwrap(), Some(ScalarValue::Int64(Some(4))));
+        assert_eq!(left.min().unwrap(), Some(ScalarValue::Int64(None)));
+    }
+
+    /// Sketches of different keys must not fold together. The result would
+    /// look like a perfectly ordinary distribution of nothing in
+    /// particular.
+    #[test]
+    fn merge_rejects_a_different_sort_key() {
+        let options = sort_options(false, true);
+        let mut ints = int_sketch(vec![Some(1)], options);
+
+        let float_codec = SortKeyCodec::try_new(&DataType::Float64, options).unwrap();
+        let floats = SortKeySketch::new(float_codec);
+        let err = ints
+            .merge(floats)
+            .expect_err("merging Int64 with Float64 must be refused");
+        assert!(
+            err.to_string().contains("different sort keys"),
+            "got: {err}"
+        );
+
+        // Direction is part of the key's identity too: the same column
+        // sketched ASC and DESC has keys running opposite ways.
+        let mut ascending = int_sketch(vec![Some(1)], sort_options(false, true));
+        let descending = int_sketch(vec![Some(1)], sort_options(true, true));
+        assert!(
+            ascending.merge(descending).is_err(),
+            "ASC and DESC keys are inverses; folding them is meaningless"
+        );
+    }
+
+    /// `cuts` splits the population, NULL run included, so a mostly-NULL
+    /// column spends its low cuts inside that run and only crosses into
+    /// the values once the run is behind it.
+    ///
+    /// 60 NULLs then values 1..=40, NULLs first. Quartile ranks are 25, 50
+    /// and 75 of 100; the first two sit inside the 60-row NULL run, and the
+    /// third is 15 rows past it, which is value 15 of 40.
+    #[test]
+    fn cuts_split_the_population_including_nulls() {
+        let mut values: Vec<Option<i64>> = vec![None; 60];
+        values.extend((1..=40).map(Some));
+        let sketch = int_sketch(values, sort_options(false, true));
+
+        let cuts = sketch.cuts(4).unwrap();
+        assert_eq!(cuts.len(), 3, "K-1 cuts for K partitions");
+        assert_eq!(
+            cuts[0],
+            ScalarValue::Int64(None),
+            "the first quarter is entirely NULL"
+        );
+        assert_eq!(cuts[1], ScalarValue::Int64(None), "so is the second");
+        assert_eq!(
+            cuts[2],
+            ScalarValue::Int64(Some(15)),
+            "the third crosses out of the run"
+        );
+    }
+
+    /// A NULL run ending exactly on a cut still belongs to the NULL side:
+    /// the rank it occupies is the run's last row, not the values' first.
+    /// 75 NULLs of 100 rows puts the 0.75 cut precisely there.
+    #[test]
+    fn a_cut_landing_on_the_end_of_the_null_run_is_null() {
+        let mut values: Vec<Option<i64>> = vec![None; 75];
+        values.extend((1..=25).map(Some));
+        let sketch = int_sketch(values, sort_options(false, true));
+        assert_eq!(
+            sketch.quantile(0.75).unwrap(),
+            Some(ScalarValue::Int64(None)),
+            "rank 75 of 100 is the last NULL, so three of four partitions \
+             hold only NULLs"
+        );
+    }
+
+    /// The design priced and dropped in `benchmarks/benches/
+    /// quantile_sketch.rs` as `kll_norm_u128`, kept here as an oracle.
+    ///
+    /// It puts NULLs *inside* the key, tagged above the value bits, so the
+    /// sketch sees the whole population in order and a quantile is a
+    /// straight lookup with no arithmetic. That makes it the independent
+    /// check on [`SortKeySketch::quantile`], whose whole job is to
+    /// reproduce this answer while keeping the key 8 bytes wide.
+    ///
+    /// Value encoding is shared, so a disagreement can only come from NULL
+    /// placement or the rank remap.
+    struct NullsInKeyOracle {
+        sketch: KllSketch<u128>,
+        codec: SortKeyCodec,
+        null_tag: u128,
+    }
+
+    impl NullsInKeyOracle {
+        fn new(values: &[Option<i64>], options: SortOptions) -> Self {
+            let codec = SortKeyCodec::try_new(&DataType::Int64, options).unwrap();
+            // The tag alone decides which side the NULL run sits on.
+            let (null_tag, value_tag) = if options.nulls_first {
+                (0u128, 1u128)
+            } else {
+                (1u128, 0u128)
+            };
+            let keys: Vec<u128> = values
+                .iter()
+                .map(|value| match value {
+                    None => null_tag << 64,
+                    Some(value) => {
+                        let key =
+                            codec.encode(&Int64Array::from(vec![*value])).unwrap()[0];
+                        (value_tag << 64) | key as u128
+                    }
+                })
+                .collect();
+            let mut sketch = KllSketch::<u128>::new(KLL_K);
+            sketch.absorb_slice(&keys);
+            Self {
+                sketch,
+                codec,
+                null_tag,
+            }
+        }
+
+        fn quantile(&self, q: f64) -> Option<ScalarValue> {
+            let key = self.sketch.quantile(q)?;
+            if (key >> 64) == self.null_tag {
+                Some(self.codec.null_value().unwrap())
+            } else {
+                Some(self.codec.decode(*key as u64).unwrap())
+            }
+        }
+    }
+
+    /// Differential test: the shipped out-of-band-NULL sketch must answer
+    /// exactly what the nulls-in-the-key oracle answers, across every NULL
+    /// fraction and both placements.
+    ///
+    /// Both sketches are exact here — the fixtures are far below `KLL_K`,
+    /// so nothing compacts — which means any disagreement is the rank
+    /// remap and not sketch error.
+    #[test]
+    fn quantiles_match_the_nulls_in_key_oracle() {
+        // Deliberately includes 0 and every-row-NULL, plus fractions whose
+        // ranks land exactly on the run boundary for some q.
+        let null_counts = [0usize, 1, 25, 50, 60, 75, 99, 100];
+        let quantile_probes: Vec<f64> = (0..=20).map(|step| step as f64 / 20.0).collect();
+
+        for nulls in null_counts {
+            let mut values: Vec<Option<i64>> = vec![None; nulls];
+            values.extend((1..=(100 - nulls) as i64).map(Some));
+            for nulls_first in [true, false] {
+                let options = sort_options(false, nulls_first);
+                let oracle = NullsInKeyOracle::new(&values, options);
+                let sketch = int_sketch(values.clone(), options);
+
+                assert_eq!(
+                    sketch.count(),
+                    100,
+                    "nulls={nulls} nulls_first={nulls_first}: population size"
+                );
+                for &q in &quantile_probes {
+                    assert_eq!(
+                        sketch.quantile(q).unwrap(),
+                        oracle.quantile(q),
+                        "nulls={nulls} nulls_first={nulls_first} q={q}: \
+                         out-of-band NULLs disagreed with nulls-in-key"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The same agreement has to hold under `DESC`, where the value keys
+    /// are inverted but the NULL run still sits where `nulls_first` says.
+    #[test]
+    fn descending_quantiles_match_the_nulls_in_key_oracle() {
+        let mut values: Vec<Option<i64>> = vec![None; 30];
+        values.extend((1..=70).map(Some));
+        for nulls_first in [true, false] {
+            let options = sort_options(true, nulls_first);
+            let oracle = NullsInKeyOracle::new(&values, options);
+            let sketch = int_sketch(values.clone(), options);
+            for step in 0..=20 {
+                let q = step as f64 / 20.0;
+                assert_eq!(
+                    sketch.quantile(q).unwrap(),
+                    oracle.quantile(q),
+                    "DESC nulls_first={nulls_first} q={q}"
+                );
+            }
+        }
     }
 
     /// Indices of `keys` in ascending key order.
@@ -728,7 +1322,8 @@ mod tests {
     #[test]
     fn unsigned_keys_span_full_range_in_order() {
         let values = vec![0u64, 1, 1 << 62, u64::MAX - 1, u64::MAX];
-        let codec = SortKeyCodec::try_new(&DataType::UInt64, false).unwrap();
+        let codec =
+            SortKeyCodec::try_new(&DataType::UInt64, sort_options(false, false)).unwrap();
         let keys = codec.encode(&UInt64Array::from(values.clone())).unwrap();
         assert!(keys.windows(2).all(|w| w[0] < w[1]), "{keys:?}");
         for (key, value) in keys.iter().zip(&values) {
@@ -757,7 +1352,8 @@ mod tests {
 
         let array = TimestampNanosecondArray::from(values.clone())
             .with_timezone("UTC".to_string());
-        let codec = SortKeyCodec::try_new(&data_type, false).unwrap();
+        let codec =
+            SortKeyCodec::try_new(&data_type, sort_options(false, false)).unwrap();
         let keys = codec.encode(&array).unwrap();
         assert!(
             keys.windows(2).all(|w| w[0] < w[1]),
@@ -777,7 +1373,8 @@ mod tests {
     #[test]
     fn encode_skips_nulls_and_keeps_value_order() {
         let array = Int64Array::from(vec![Some(3), None, Some(1), None, Some(2)]);
-        let codec = SortKeyCodec::try_new(&DataType::Int64, false).unwrap();
+        let codec =
+            SortKeyCodec::try_new(&DataType::Int64, sort_options(false, false)).unwrap();
         let keys = codec.encode(&array).unwrap();
         assert_eq!(keys.len(), 3, "one key per non-NULL value");
         assert_eq!(array.null_count(), 2, "count stays available on the array");
@@ -805,7 +1402,7 @@ mod tests {
             DataType::Boolean,
         ] {
             assert!(
-                SortKeyCodec::try_new(&data_type, false).is_none(),
+                SortKeyCodec::try_new(&data_type, sort_options(false, false)).is_none(),
                 "{data_type:?} must fall through to the arrow-row path"
             );
         }
@@ -815,7 +1412,8 @@ mod tests {
     /// reinterpreting its bits.
     #[test]
     fn encode_rejects_mismatched_array_type() {
-        let codec = SortKeyCodec::try_new(&DataType::Int64, false).unwrap();
+        let codec =
+            SortKeyCodec::try_new(&DataType::Int64, sort_options(false, false)).unwrap();
         let array: Arc<dyn Array> = Arc::new(Float64Array::from(vec![1.0, 2.0]));
         let err = codec
             .encode(array.as_ref())

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -401,6 +401,13 @@ impl SortKeyCodec {
     /// Errors if `array`'s type doesn't match the one this codec was built
     /// for, which would mean the routing expression changed type between
     /// planning and execution.
+    ///
+    /// The match is exact `DataType` equality, so a codec built for
+    /// `Timestamp(ns, Some("UTC"))` rejects an array tagged `Some("+00:00")`
+    /// even though the two encode to identical keys. Strict because the
+    /// codec's type is what [`Self::decode`] rebuilds a `ScalarValue` from,
+    /// so accepting an array of a type the codec doesn't carry would
+    /// relabel every cut it later produces.
     pub fn encode(&self, array: &dyn Array) -> Result<Vec<u64>> {
         if array.data_type() != &self.data_type {
             return Err(internal_datafusion_err!(

--- a/ballista/core/src/sort_key.rs
+++ b/ballista/core/src/sort_key.rs
@@ -93,10 +93,24 @@
 //! `f64` would round it to a 256 ns grid at 2020s epoch magnitudes, since
 //! those sit above `f64`'s 2^53 integer limit.
 //!
-//! Exactness matters most at the extremes. A sketch's `min` and `max` are
-//! what decide which shuffle files overlap which output partition, so an
-//! extreme that gets dropped drops rows with it. Keys compare with `Ord`
-//! over every element, which has no value it silently ignores.
+//! Where that exactness is worth something is narrower than it looks, and
+//! worth stating so nobody over-claims it. It is not the quantiles: those
+//! carry the sketch's own rank error, which on a uniform 1M stream is
+//! ~0.2%, and 0.2% of a partition covering one day is about three minutes.
+//! A 256 ns rounding is nine orders of magnitude beneath that. Any
+//! argument resting on quantile precision is noise.
+//!
+//! It is the extremes. `min` and `max` are exact by construction, tracked
+//! outside the compactor so no coin flip can move them, and `cut_partitions`
+//! routes shuffle files on exactly those two values. There the error bars
+//! are zero, so anything a cast rounds away is error introduced where none
+//! existed. Keys compare with `Ord` over every element, which has no value
+//! it silently ignores.
+//!
+//! The other case is a narrow spread at a large magnitude, since float
+//! precision is relative: a partition spanning a day is unaffected, one
+//! spanning 100 µs at 2020s epoch nanos is past the point where the cast
+//! costs more than the sketch does.
 //!
 //! # Coverage
 //!

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -67,6 +67,7 @@
 //! | arm                              | ×tdigest | outcome                  |
 //! |----------------------------------|---------:|--------------------------|
 //! | `tdigest`                        |     1.00 | incumbent                |
+//! | `kll_norm_u32`                   |     1.20 | dropped: 2% for an enum  |
 //! | `kll_norm_u64`                   |     1.23 | shape adopted, see above |
 //! | `kll_norm_u128`                  |     1.58 | dropped: NULL in the key |
 //! | `kll_ordered_float_absorb_slice` |     1.80 | dropped: slower, Float64 |
@@ -111,11 +112,23 @@
 //!    matters. That is the `kll_row_absorb` tier, where arrow-row encodes
 //!    NULLs inline at no extra cost.
 //!
+//! 4. **Width costs at the register boundary, not by the byte.**
+//!    `kll_norm_u32` halves the key and buys 2–3%; `kll_norm_u128` doubles
+//!    it and costs 29% at 1M. Bytes moved would make those roughly
+//!    symmetric. `u32` and `u64` are both a single register, so only their
+//!    memory traffic differs and that traffic is not the bottleneck, while
+//!    `u128` is not a register and compaction's `sort_unstable` compares it
+//!    multi-word. Getting paid for a key narrower than a register needs
+//!    SIMD over it, which is a long reach for 2%. So `SortKeyCodec` widens
+//!    every fixed-width column to one `u64` tier rather than carrying a
+//!    width enum through the sketch, its wire format and its consumers.
+//!
 //! Caveat on the 64 MiB L3: at n=1M the whole working set is cache-
 //! resident, including the key vector each KLL arm materializes per batch
-//! (8 MB for `u64`, 16 MB for `u128`). On a core with a smaller cache
-//! share that traffic is charged to DRAM, so `kll_norm_u128`'s penalty
-//! over `kll_norm_u64` should be read as a lower bound.
+//! (4 MB for `u32`, 8 MB for `u64`, 16 MB for `u128`). On a core with a
+//! smaller cache share that traffic is charged to DRAM. `kll_norm_u32`
+//! bounds how much that can matter: halving the vector is worth 2–3%, so
+//! cache pressure is a small term beside the register-width effect.
 //!
 //! Merge and quantile query are excluded: for N=1M rows at P=64 partitions
 //! and K=64 cuts, both are 3+ orders of magnitude cheaper than ingest and
@@ -380,11 +393,49 @@ fn ingest_kll_norm_u64(batches: &[Float64Array]) -> KllSketch<u64> {
     sketch
 }
 
+/// `f64_to_sortable_u64` one width down, over `f32`'s 8-bit exponent and
+/// 23-bit mantissa. Same branch, same resulting `total_cmp` order.
+fn f32_to_sortable_u32(x: f32) -> u32 {
+    let bits = x.to_bits();
+    if bits >> 31 == 1 {
+        !bits
+    } else {
+        bits ^ (1 << 31)
+    }
+}
+
+/// Half-width counterpart to `ingest_kll_norm_u64`, pricing the key width
+/// the shipped path gives up: `SortKeyCodec` widens every 32-bit column to
+/// `u64`, so a `Float32` or `Int32` column carries eight bytes through
+/// `absorb_slice` and the compactor's sorts where four would order it
+/// identically.
+///
+/// It is also the control on *why* `kll_norm_u128` is slow. Halving the
+/// key buys 2–3% where doubling it costs 29%, so the penalty tracks
+/// whether the key fits a register rather than how many bytes move.
+///
+/// Values are the same stream as every other arm, cast to `f32`. The cast
+/// costs mantissa bits, not distribution, so compaction sees the same
+/// shape.
+fn ingest_kll_norm_u32(batches: &[Float64Array]) -> KllSketch<u32> {
+    let mut sketch = KllSketch::<u32>::new(KLL_K);
+    for arr in batches {
+        let keys: Vec<u32> = arr
+            .values()
+            .iter()
+            .map(|v| f32_to_sortable_u32(*v as f32))
+            .collect();
+        sketch.absorb_slice(&keys);
+    }
+    sketch
+}
+
 /// Nullable variant of `ingest_kll_norm_u64`: a tag above the value bits
 /// gives NULL its own slot, ordered per `nulls_first` (tag 0 here, so
-/// NULLs sort below every value). Measures what the null slot costs —
-/// the key doubles to 16 bytes, which doubles memory traffic through
-/// `absorb_slice` relative to the `u64` arm.
+/// NULLs sort below every value). Measures what the null slot costs: the
+/// key doubles to 16 bytes and stops fitting a register, so compaction's
+/// sorts compare it multi-word. `ingest_kll_norm_u32` separates those two
+/// effects.
 ///
 /// The bench stream has no NULLs, so this measures the encode branch and
 /// the wider key, not NULL handling itself.
@@ -577,6 +628,14 @@ fn bench_ingest(c: &mut Criterion) {
             b.iter_batched(
                 || batches.clone(),
                 |bs| ingest_kll_row_key(&bs, &converter),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll_norm_u32/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_norm_u32(&bs),
                 BatchSize::LargeInput,
             );
         });

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -21,19 +21,24 @@
 //! (nullability, sort direction, non-`Float64` types, multi-column keys)
 //! and pays a different price for it.
 //!
+//! Most of these arms are **not** designs we adopted. They are the
+//! alternatives that were priced and dropped, kept here so the reasons
+//! stay checkable rather than becoming folklore. Two arms describe what
+//! the code actually does; the rest are receipts.
+//!
 //! Measured at n=1M on a Ryzen 9 9950X (64 MiB L3), ratio to `tdigest`:
 //!
-//! | arm                              | ×tdigest | buys                     |
+//! | arm                              | ×tdigest | outcome                  |
 //! |----------------------------------|---------:|--------------------------|
-//! | `tdigest`                        |     1.00 | Float64, non-null, ASC   |
-//! | `kll_norm_u64`                   |     1.23 | + any fixed-width dtype  |
-//! | `kll_norm_u128`                  |     1.58 | + NULL slot              |
-//! | `kll_ordered_float_absorb_slice` |     1.80 | Float64 only             |
-//! | `kll_row_key`                    |     3.75 | + arrow-row null/dir     |
-//! | `kll_row_absorb`                 |     5.85 | + multi-column, Utf8     |
-//! | `kll_row`                        |     6.85 | (per-row `insert`)       |
+//! | `tdigest`                        |     1.00 | incumbent, being removed |
+//! | `kll_norm_u64`                   |     1.23 | **adopted**: fixed-width |
+//! | `kll_norm_u128`                  |     1.58 | dropped: NULL in the key |
+//! | `kll_ordered_float_absorb_slice` |     1.80 | dropped: slower, Float64 |
+//! | `kll_row_key`                    |     3.75 | dropped: no real saving  |
+//! | `kll_row_absorb`                 |     5.85 | **adopted**: arrow-row   |
+//! | `kll_row`                        |     6.85 | dropped: per-row insert  |
 //!
-//! Two results drive the dispatch design:
+//! Three results drive the dispatch design:
 //!
 //! 1. **arrow-row can't reach the native-`Ord` tier.** `kll_row_key`
 //!    holds the row bytes inline in a `Copy` array, eliminating
@@ -47,9 +52,24 @@
 //!    despite both being 8-byte `Copy`. Compaction's `sort_unstable`
 //!    dominates ingest, and a `u64` compare is one instruction where
 //!    `OrderedFloat`'s total order is bit manipulation plus branches.
-//!    Folding sort direction and NULL placement into the key also keeps
-//!    them runtime data instead of type parameters, so one sketch type
-//!    covers all four ASC/DESC × nulls-first/last combinations.
+//!    Folding sort direction into the key also keeps it runtime data
+//!    instead of a type parameter, so one sketch type serves both ASC and
+//!    DESC instead of one per direction.
+//!
+//! 3. **A NULL does not belong in the key.** `kll_norm_u128` gives NULL
+//!    its own slot by tagging a bit above the value bits. Every one of the
+//!    2^64 keys is already spoken for, so that slot costs a 65th bit and
+//!    in practice a 16-byte key: 1.58× against `u64`'s 1.23×. Counting
+//!    NULLs beside the sketch instead reproduces the same total order for
+//!    free, because a NULL has no position *among* values, only a side,
+//!    and `nulls_first` fixes that side at plan time. So `SortKeyCodec`
+//!    skips NULLs and `KllSketch<u64>` never sees one. This arm exists to
+//!    price the alternative, not to describe the code.
+//!
+//!    The exception is a composite key, where a NULL in one column sits
+//!    beside a real value in another and the interleaving genuinely
+//!    matters. That is the `kll_row_absorb` tier, where arrow-row encodes
+//!    NULLs inline at no extra cost.
 //!
 //! The `n=100K` numbers tell a second story: there `kll_norm_u64` is
 //! *faster* than TDigest (1.219 ms vs 1.358 ms). KLL's per-row cost grows

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -144,6 +144,19 @@
 use std::sync::Arc;
 
 use ballista_core::kll::KllSketch;
+/// The shipped capacity, imported rather than restated: `kll_norm_u64` is
+/// only comparable to `sort_key_sketch_f64` while the two sketches are
+/// sized identically, and a local copy could drift out from under that
+/// claim. Picked for worst-case rank-error parity with TDigest at
+/// `TDIGEST_MAX_SIZE=100` on the uniform 1M stream this bench feeds:
+///
+/// | sketch                       | worst rank err (9 deciles) |
+/// |------------------------------|---------------------------:|
+/// | TDigest max_size=100         |                     0.0021 |
+/// | KLL k=800                    |                     0.0016 |
+///
+/// Rerun via `KLL_PARITY_CHECK=1 cargo bench --bench quantile_sketch`.
+use ballista_core::sort_key::KLL_K;
 use ballista_core::sort_key::{SortKeyCodec, SortKeySketch};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion::arrow::array::{
@@ -159,18 +172,6 @@ use rand::{RngExt, SeedableRng};
 
 /// Matches `runtime_stats::TDIGEST_MAX_SIZE` — production sizing.
 const TDIGEST_MAX_SIZE: usize = 100;
-
-/// KLL top-level compactor capacity picked empirically for worst-case
-/// rank-error parity with TDigest at `TDIGEST_MAX_SIZE=100`. Measured on
-/// the uniform 1M stream this bench feeds:
-///
-/// | sketch                       | worst rank err (9 deciles) |
-/// |------------------------------|---------------------------:|
-/// | TDigest max_size=100         |                     0.0021 |
-/// | KLL k=800                    |                     0.0016 |
-///
-/// Rerun via `KLL_PARITY_CHECK=1 cargo bench --bench quantile_sketch`.
-const KLL_K: usize = 800;
 
 /// RuntimeStatsExec observes one batch at a time from the upstream
 /// operator. 8192 is DataFusion's default target batch size.

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -21,22 +21,62 @@
 //! (nullability, sort direction, non-`Float64` types, multi-column keys)
 //! and pays a different price for it.
 //!
-//! Most of these arms are **not** designs we adopted. They are the
-//! alternatives that were priced and dropped, kept here so the reasons
-//! stay checkable rather than becoming folklore. Two arms describe what
-//! the code actually does; the rest are receipts.
+//! # What ships
 //!
-//! Measured at n=1M on a Ryzen 9 9950X (64 MiB L3), ratio to `tdigest`:
+//! The `sort_key_sketch_*` arms run `SortKeySketch::ingest`, which is what
+//! `RuntimeStatsExec` calls. Every other arm open-codes a transform to
+//! isolate one cost and describes a design that was priced and dropped;
+//! they are kept as receipts, not as options.
+//!
+//! Ryzen 9 9950X, 64 MiB L3:
+//!
+//! ```text
+//!  Rows   Column               TDigest             SortKeySketch       Ratio
+//!  100K   Float64              1.38 ms (72 M/s)    1.23 ms (81 M/s)    0.89×
+//!  100K   Float64, 10% NULL    1.38 ms (72 M/s)    1.27 ms (78 M/s)    0.92×
+//!  100K   Int64                unsupported         1.22 ms (82 M/s)    0.88×
+//!  100K   Timestamp(ns, UTC)   unsupported         1.21 ms (83 M/s)    0.87×
+//!  1M     Float64              13.8 ms (73 M/s)    16.4 ms (61 M/s)    1.19×
+//!  1M     Float64, 10% NULL    13.8 ms (73 M/s)    15.5 ms (65 M/s)    1.13×
+//!  1M     Int64                unsupported         16.5 ms (61 M/s)    1.20×
+//!  1M     Timestamp(ns, UTC)   unsupported         16.4 ms (61 M/s)    1.20×
+//! ```
+//!
+//! T-Digest is `Float64`-only, so the integer and temporal rows have no
+//! baseline to divide by; their ratios are against T-Digest sketching a
+//! float, which is the comparison that answers "what does widening cost".
+//!
+//! Three things to read off it:
+//!
+//! - **Column type does not move the cost.** 1.19× / 1.20× / 1.20× for
+//!   float, integer and timestamp. The integer transform is one XOR
+//!   against the float's sign-bit branch and the difference is noise,
+//!   because compaction dominates ingest and the sketch only ever sees
+//!   `u64`. One number covers every fixed-width column.
+//! - **NULLs are a discount.** 1.13× against 1.19×, because a tenth of the
+//!   rows are counted rather than sketched. Out-of-band NULLs make a
+//!   nullable column cheaper than a populated one.
+//! - **The sign flips with scale.** At 100K every arm beats T-Digest by
+//!   11–13%; by 1M it is 13–20% behind. KLL's per-row cost grows with its
+//!   compaction stack, so the crossover sits between the two sizes.
+//!
+//! # Representations that were priced and dropped
+//!
+//! Measured at n=1M, ratio to `tdigest`:
 //!
 //! | arm                              | ×tdigest | outcome                  |
 //! |----------------------------------|---------:|--------------------------|
-//! | `tdigest`                        |     1.00 | incumbent, being removed |
-//! | `kll_norm_u64`                   |     1.23 | **adopted**: fixed-width |
+//! | `tdigest`                        |     1.00 | incumbent                |
+//! | `kll_norm_u64`                   |     1.23 | shape adopted, see above |
 //! | `kll_norm_u128`                  |     1.58 | dropped: NULL in the key |
 //! | `kll_ordered_float_absorb_slice` |     1.80 | dropped: slower, Float64 |
 //! | `kll_row_key`                    |     3.75 | dropped: no real saving  |
 //! | `kll_row_absorb`                 |     5.85 | **adopted**: arrow-row   |
 //! | `kll_row`                        |     6.85 | dropped: per-row insert  |
+//!
+//! `kll_norm_u64` open-codes what `SortKeySketch` does for a non-null
+//! float; the gap to `sort_key_sketch_f64` is the real type's overhead,
+//! which measures as nothing.
 //!
 //! Three results drive the dispatch design:
 //!
@@ -71,11 +111,6 @@
 //!    matters. That is the `kll_row_absorb` tier, where arrow-row encodes
 //!    NULLs inline at no extra cost.
 //!
-//! The `n=100K` numbers tell a second story: there `kll_norm_u64` is
-//! *faster* than TDigest (1.219 ms vs 1.358 ms). KLL's per-row cost grows
-//! with its compaction stack, so the advantage inverts by 1M — TDigest
-//! scales 10.1× across the 10× row jump, `kll_norm_u64` 13.8×.
-//!
 //! Caveat on the 64 MiB L3: at n=1M the whole working set is cache-
 //! resident, including the key vector each KLL arm materializes per batch
 //! (8 MB for `u64`, 16 MB for `u128`). On a core with a smaller cache
@@ -96,9 +131,13 @@
 use std::sync::Arc;
 
 use ballista_core::kll::KllSketch;
+use ballista_core::sort_key::{SortKeyCodec, SortKeySketch};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use datafusion::arrow::array::{ArrayRef, Float64Array};
-use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::array::{
+    ArrayRef, Float64Array, Int64Array, TimestampNanosecondArray,
+};
+use datafusion::arrow::compute::SortOptions;
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::arrow::row::{OwnedRow, RowConverter, SortField};
 use datafusion_functions_aggregate_common::tdigest::TDigest;
 use ordered_float::OrderedFloat;
@@ -364,6 +403,79 @@ fn ingest_kll_norm_u128(batches: &[Float64Array]) -> KllSketch<u128> {
     sketch
 }
 
+/// Fraction of rows made NULL in the nullable arm. Low enough to be a
+/// realistic "this column is mostly populated" case rather than one where
+/// skipping NULLs does most of the work for us.
+const NULL_FRACTION: f64 = 0.1;
+
+/// `Float64` batches with `NULL_FRACTION` of the rows null. Same value
+/// stream as `build_batches` so the arms stay comparable.
+fn build_nullable_batches(n: usize) -> Vec<ArrayRef> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    build_batches(n)
+        .into_iter()
+        .map(|arr| {
+            let values: Vec<Option<f64>> = arr
+                .values()
+                .iter()
+                .map(|v| (rng.random::<f64>() >= NULL_FRACTION).then_some(*v))
+                .collect();
+            Arc::new(Float64Array::from(values)) as ArrayRef
+        })
+        .collect()
+}
+
+/// `Int64` batches. The integer transform is one XOR where the float one
+/// branches on the sign bit, so this isolates whether column type moves
+/// ingest cost at all once the sketch sees `u64` either way.
+fn build_int_batches(n: usize) -> Vec<ArrayRef> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    (0..n.div_ceil(BATCH_SIZE))
+        .map(|chunk| {
+            let take = BATCH_SIZE.min(n - chunk * BATCH_SIZE);
+            let values: Vec<i64> = (0..take).map(|_| rng.random::<i64>()).collect();
+            Arc::new(Int64Array::from(values)) as ArrayRef
+        })
+        .collect()
+}
+
+/// `Timestamp(Nanosecond, UTC)` batches at 2020s epoch magnitudes, which
+/// is where an `f64` cast would quantize onto a 256 ns grid. Physically an
+/// `i64`, so this should track the `Int64` arm; it is here because it is
+/// the column type the widening actually exists to serve, and because
+/// T-Digest cannot sketch it at all.
+fn build_timestamp_batches(n: usize) -> Vec<ArrayRef> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    // 2026-08-13T00:00:00Z, plus up to a day of jitter.
+    let base = 1_786_320_000_000_000_000i64;
+    let day = 86_400_000_000_000i64;
+    (0..n.div_ceil(BATCH_SIZE))
+        .map(|chunk| {
+            let take = BATCH_SIZE.min(n - chunk * BATCH_SIZE);
+            let values: Vec<i64> = (0..take)
+                .map(|_| base + (rng.random::<f64>() * day as f64) as i64)
+                .collect();
+            Arc::new(
+                TimestampNanosecondArray::from(values).with_timezone("UTC".to_string()),
+            ) as ArrayRef
+        })
+        .collect()
+}
+
+/// The shipped path: `SortKeySketch::ingest` per batch, which encodes the
+/// column to `u64` keys, absorbs them, and counts the NULLs it skipped.
+///
+/// Every other KLL arm here open-codes a transform to isolate one cost.
+/// This one measures what `RuntimeStatsExec` will actually run, so it is
+/// the arm the ship/no-ship numbers come from.
+fn ingest_sort_key_sketch(batches: &[ArrayRef], codec: SortKeyCodec) -> SortKeySketch {
+    let mut sketch = SortKeySketch::new(codec);
+    for arr in batches {
+        sketch.ingest(arr.as_ref()).unwrap();
+    }
+    sketch
+}
+
 /// Print worst-case quantile-inversion error at deciles for TDigest at
 /// `TDIGEST_MAX_SIZE=100` and KLL at a sweep of `k`. Called from
 /// `bench_ingest` when `KLL_PARITY_CHECK=1` is set. Reproducibility
@@ -484,6 +596,38 @@ fn bench_ingest(c: &mut Criterion) {
                 BatchSize::LargeInput,
             );
         });
+
+        let ascending = SortOptions {
+            descending: false,
+            nulls_first: true,
+        };
+        let shipped: [(&str, DataType, Vec<ArrayRef>); 4] = [
+            (
+                "f64",
+                DataType::Float64,
+                batches
+                    .iter()
+                    .map(|b| Arc::new(b.clone()) as ArrayRef)
+                    .collect(),
+            ),
+            ("f64_nulls", DataType::Float64, build_nullable_batches(n)),
+            ("i64", DataType::Int64, build_int_batches(n)),
+            (
+                "timestamp_ns",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                build_timestamp_batches(n),
+            ),
+        ];
+        for (label, data_type, arrays) in shipped {
+            let codec = SortKeyCodec::try_new(&data_type, ascending).unwrap();
+            group.bench_function(format!("sort_key_sketch_{label}/{n}"), |b| {
+                b.iter_batched(
+                    || arrays.clone(),
+                    |bs| ingest_sort_key_sketch(&bs, codec.clone()),
+                    BatchSize::LargeInput,
+                );
+            });
+        }
 
         group.bench_function(format!("kll_ordered_float/{n}"), |b| {
             b.iter_batched(

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -15,14 +15,52 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Ingest throughput: TDigest (production RuntimeStatsExec path) vs KLL
-//! over `OwnedRow` (multi-column-capable swap path) vs KLL over
-//! `OrderedFloat<f64>` (single-column-native-Ord fast path).
+//! Ingest throughput: TDigest (production RuntimeStatsExec path) against
+//! KLL over a ladder of item representations. TDigest is the incumbent
+//! baseline; each KLL arm buys a different amount of `ORDER BY` generality
+//! (nullability, sort direction, non-`Float64` types, multi-column keys)
+//! and pays a different price for it.
 //!
-//! The three variants isolate the cost of the arrow-row encoding: TDigest
-//! is the incumbent baseline, KLL<OwnedRow> pays for `RowConverter` +
-//! per-row `owned()` heap alloc, KLL<OrderedFloat<f64>> skips both and
-//! measures the sketch algorithm on its own.
+//! Measured at n=1M on a Ryzen 9 9950X (64 MiB L3), ratio to `tdigest`:
+//!
+//! | arm                              | ×tdigest | buys                     |
+//! |----------------------------------|---------:|--------------------------|
+//! | `tdigest`                        |     1.00 | Float64, non-null, ASC   |
+//! | `kll_norm_u64`                   |     1.23 | + any fixed-width dtype  |
+//! | `kll_norm_u128`                  |     1.58 | + NULL slot              |
+//! | `kll_ordered_float_absorb_slice` |     1.80 | Float64 only             |
+//! | `kll_row_key`                    |     3.75 | + arrow-row null/dir     |
+//! | `kll_row_absorb`                 |     5.85 | + multi-column, Utf8     |
+//! | `kll_row`                        |     6.85 | (per-row `insert`)       |
+//!
+//! Two results drive the dispatch design:
+//!
+//! 1. **arrow-row can't reach the native-`Ord` tier.** `kll_row_key`
+//!    holds the row bytes inline in a `Copy` array, eliminating
+//!    `kll_row_absorb`'s per-row `owned()` heap alloc — worth 5.85× →
+//!    3.75×, so the alloc was only ~36% of that path. The remaining ~25
+//!    ns/row is `RowConverter::convert_columns` itself and does not go
+//!    away. arrow-row is therefore the right encoding only where nothing
+//!    cheaper exists: multi-column and variable-width keys.
+//!
+//! 2. **A normalized integer key beats `OrderedFloat`** (1.23× vs 1.80×)
+//!    despite both being 8-byte `Copy`. Compaction's `sort_unstable`
+//!    dominates ingest, and a `u64` compare is one instruction where
+//!    `OrderedFloat`'s total order is bit manipulation plus branches.
+//!    Folding sort direction and NULL placement into the key also keeps
+//!    them runtime data instead of type parameters, so one sketch type
+//!    covers all four ASC/DESC × nulls-first/last combinations.
+//!
+//! The `n=100K` numbers tell a second story: there `kll_norm_u64` is
+//! *faster* than TDigest (1.219 ms vs 1.358 ms). KLL's per-row cost grows
+//! with its compaction stack, so the advantage inverts by 1M — TDigest
+//! scales 10.1× across the 10× row jump, `kll_norm_u64` 13.8×.
+//!
+//! Caveat on the 64 MiB L3: at n=1M the whole working set is cache-
+//! resident, including the key vector each KLL arm materializes per batch
+//! (8 MB for `u64`, 16 MB for `u128`). On a core with a smaller cache
+//! share that traffic is charged to DRAM, so `kll_norm_u128`'s penalty
+//! over `kll_norm_u64` should be read as a lower bound.
 //!
 //! Merge and quantile query are excluded: for N=1M rows at P=64 partitions
 //! and K=64 cuts, both are 3+ orders of magnitude cheaper than ingest and
@@ -210,6 +248,102 @@ fn ingest_kll_row_absorb(
     sketch
 }
 
+/// Width of the inline row key, in bytes. A single fixed-width arrow-row
+/// encoding is one null-sentinel byte plus the type's width — 9 bytes for
+/// `Float64`, 17 for `Decimal128`. 24 covers every fixed-width arrow type
+/// and keeps the key a `Copy` array.
+const ROW_KEY_WIDTH: usize = 24;
+
+/// Fixed-width arrow-row bytes held inline. Ord is lexicographic over the
+/// bytes, and every row from a single fixed-width column encodes to the
+/// same length, so zero-padding to a common width preserves the row
+/// format's memcmp order — which already folds in `nulls_first` and
+/// `descending`.
+type RowKey = [u8; ROW_KEY_WIDTH];
+
+/// Arrow-row encoding without the per-row heap allocation: copy each row's
+/// bytes into an inline `Copy` key and hand the batch to `absorb_slice`.
+/// Isolates how much of `kll_row_absorb`'s cost is `RowConverter` itself
+/// versus the `owned()` alloc — i.e. whether a fixed-width column can get
+/// arrow-row's null/direction handling at the `ordered_float` price tier.
+fn ingest_kll_row_key(
+    batches: &[Float64Array],
+    converter: &RowConverter,
+) -> KllSketch<RowKey> {
+    let mut sketch = KllSketch::<RowKey>::new(KLL_K);
+    for arr in batches {
+        let col: ArrayRef = Arc::new(arr.clone());
+        let rows = converter.convert_columns(&[col]).unwrap();
+        let keys: Vec<RowKey> = rows
+            .iter()
+            .map(|row| {
+                let bytes = row.as_ref();
+                let mut key = [0u8; ROW_KEY_WIDTH];
+                key[..bytes.len()].copy_from_slice(bytes);
+                key
+            })
+            .collect();
+        sketch.absorb_slice(&keys);
+    }
+    sketch
+}
+
+/// Order-preserving `f64` → `u64`: invert every bit for negatives, flip
+/// only the sign bit for non-negatives. Ascending `u64` order then matches
+/// `f64::total_cmp` order, and the map is exactly invertible so a cut
+/// converts back to the precise `f64` it came from. Descending would apply
+/// `!key` on top; both directions stay runtime data rather than type
+/// parameters.
+fn f64_to_sortable_u64(x: f64) -> u64 {
+    let bits = x.to_bits();
+    if bits >> 63 == 1 {
+        !bits
+    } else {
+        bits ^ (1 << 63)
+    }
+}
+
+/// Non-nullable fixed-width fast path: normalize to a sortable `u64` and
+/// absorb the batch. Same `Copy`/`absorb_slice` tier as
+/// `ingest_kll_ordered_float_absorb_slice`, but the key carries sort
+/// direction instead of encoding it in the item type.
+fn ingest_kll_norm_u64(batches: &[Float64Array]) -> KllSketch<u64> {
+    let mut sketch = KllSketch::<u64>::new(KLL_K);
+    for arr in batches {
+        let keys: Vec<u64> = arr
+            .values()
+            .iter()
+            .copied()
+            .map(f64_to_sortable_u64)
+            .collect();
+        sketch.absorb_slice(&keys);
+    }
+    sketch
+}
+
+/// Nullable variant of `ingest_kll_norm_u64`: a tag above the value bits
+/// gives NULL its own slot, ordered per `nulls_first` (tag 0 here, so
+/// NULLs sort below every value). Measures what the null slot costs —
+/// the key doubles to 16 bytes, which doubles memory traffic through
+/// `absorb_slice` relative to the `u64` arm.
+///
+/// The bench stream has no NULLs, so this measures the encode branch and
+/// the wider key, not NULL handling itself.
+fn ingest_kll_norm_u128(batches: &[Float64Array]) -> KllSketch<u128> {
+    let mut sketch = KllSketch::<u128>::new(KLL_K);
+    for arr in batches {
+        let keys: Vec<u128> = arr
+            .iter()
+            .map(|v| match v {
+                Some(x) => (1u128 << 64) | f64_to_sortable_u64(x) as u128,
+                None => 0,
+            })
+            .collect();
+        sketch.absorb_slice(&keys);
+    }
+    sketch
+}
+
 /// Print worst-case quantile-inversion error at deciles for TDigest at
 /// `TDIGEST_MAX_SIZE=100` and KLL at a sweep of `k`. Called from
 /// `bench_ingest` when `KLL_PARITY_CHECK=1` is set. Reproducibility
@@ -303,6 +437,30 @@ fn bench_ingest(c: &mut Criterion) {
             b.iter_batched(
                 || batches.clone(),
                 |bs| ingest_kll_row_absorb(&bs, &converter),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll_row_key/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_row_key(&bs, &converter),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll_norm_u64/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_norm_u64(&bs),
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("kll_norm_u128/{n}"), |b| {
+            b.iter_batched(
+                || batches.clone(),
+                |bs| ingest_kll_norm_u128(&bs),
                 BatchSize::LargeInput,
             );
         });

--- a/benchmarks/benches/quantile_sketch.rs
+++ b/benchmarks/benches/quantile_sketch.rs
@@ -130,9 +130,25 @@
 //! bounds how much that can matter: halving the vector is worth 2–3%, so
 //! cache pressure is a small term beside the register-width effect.
 //!
-//! Merge and quantile query are excluded: for N=1M rows at P=64 partitions
-//! and K=64 cuts, both are 3+ orders of magnitude cheaper than ingest and
-//! would not move the swap decision.
+//! Merge is excluded: it does not move the swap decision.
+//!
+//! Cut extraction is not, and is measured in `runtime_stats_cuts`.
+//! Resolving a rank means materializing every retained item with its level
+//! weight and sorting them, work that does not depend on the rank, so
+//! asking one rank at a time makes `cuts(P)` P-1 sorts of the whole
+//! retained set. `KllSketch::at_ranks` resolves the batch against one
+//! sorted pass instead. Measured against the ingest that built the sketch:
+//!
+//! | arm          | per rank | batched | of ingest |
+//! |--------------|---------:|--------:|----------:|
+//! | `cuts(64)`   |   279 µs | 7.56 µs |    0.045% |
+//! | `cuts(256)`  |  1.13 ms | 16.6 µs |    0.098% |
+//!
+//! Both at n=1M. Batched, the P-dependence is close to flat, since only
+//! the scatter over the answers grows with P. Per rank it is the dominant
+//! term at any stage that is not huge: at n=100K, `cuts(64)` was 30% of
+//! ingest and `cuts(256)` cost more than the ingest itself, because a
+//! smaller stage has less ingest to hide the sorts behind.
 //!
 //! Sketch sizing is empirical, not analytical. TDigest is held at
 //! `TDIGEST_MAX_SIZE=100` (production), and `KLL_K` is picked so KLL's
@@ -726,5 +742,42 @@ fn bench_ingest(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_ingest);
+/// Cut extraction, measured against the ingest that produced the sketch.
+///
+/// Ingest is amortized over every row; `cuts` runs once per stage over the
+/// retained items alone, so the two are only comparable as a ratio at a
+/// fixed `n`. That ratio is the question: `KllSketch::at_rank` materializes
+/// and sorts the retained pairs on each call and `cuts(P)` calls it `P - 1`
+/// times, which is a different shape from T-Digest's interpolation over
+/// ~100 centroids.
+///
+/// Partition counts span what a stage plausibly asks for. 64 is the width
+/// the module docs quote.
+fn bench_cuts(c: &mut Criterion) {
+    let ascending = SortOptions {
+        descending: false,
+        nulls_first: true,
+    };
+    let codec = SortKeyCodec::try_new(&DataType::Float64, ascending).unwrap();
+
+    let mut group = c.benchmark_group("runtime_stats_cuts");
+    group.sample_size(10);
+    for &n in ROW_COUNTS {
+        let arrays: Vec<ArrayRef> = build_batches(n)
+            .into_iter()
+            .map(|b| Arc::new(b) as ArrayRef)
+            .collect();
+        // Ingest once, outside the timing loop: `cuts` is a read over the
+        // finished sketch and every partition count reads the same one.
+        let sketch = ingest_sort_key_sketch(&arrays, codec.clone());
+        for partitions in [8usize, 64, 256] {
+            group.bench_function(format!("cuts_{partitions}/{n}"), |b| {
+                b.iter(|| sketch.cuts(partitions).unwrap());
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_ingest, bench_cuts);
 criterion_main!(benches);


### PR DESCRIPTION
I tried making a PR to add KLL to RuntimeStatsExec, along with TDigest, but what accidentally came out is another KLL performance improvement PR:

1. RowConverter was slow and needed for NULLs because it does heap allocations, ~~has variable width~~ (I found FixedLengthEncoding, but it's private), and because it stores NULLs as another bit, it doesn't fit in a u64 register
2. Instead, Claude stole the RowConverter trick and turned f64s into sortable u64s which improved speed a good bit
3. We came up with this SortKeySketch concept that tracks NULLs out-of-band, so it can handle NULLs and it goes faster when they are present.



**This PR is purely additive.** Nothing in the tree constructs any of it, `RuntimeStatsExec` is untouched, and T-Digest is neither modified nor removed. `main` behaviour is byte-for-byte identical. It is the foundation for widening `RuntimeStatsExec` past the single non-nullable `Float64` sketch it accepts today, split out so the widening itself can be reviewed on its own.

## What it adds

`ballista/core/src/sort_key.rs`:

- **`SortKeyCodec`** is the complete ordering spec for one fixed-width `ORDER BY` key: its arrow type, its direction, and where its NULLs sort. It encodes values to an order-preserving `u64` and back. Covers signed and unsigned integers, `Float32`/`Float64`, and the temporal types that are `i32` or `i64` underneath. Returns `None` for anything else, which is the signal to fall back to arrow-row.
- **`SortKeySketch`** pairs that codec with a `KllSketch<u64>` over the encoded values and a count of the NULLs, and owns `ingest` / `merge` / `quantile` / `cuts` / `min` / `max`.

`ballista/core/src/kll.rs` gains `min()`, `max()`, `count()`, `at_rank()`, `at_ranks()`, `Clone` and `Debug`.

`benchmarks/benches/quantile_sketch.rs` gains arms that measure the shipped path rather than an open-coded stand-in, price a `u32` sketch key against the `u64` one, and measure cut extraction against ingest.

## Why

Two things the current sketch cannot express.

### NULLs have no representation

T-Digest has no NULL slot, and no sentinel `f64` can serve as one: `±inf` collides with real infinities, and there is nothing else outside the value range. `RuntimeStatsExec::try_new` therefore rejects nullable routing expressions outright, and `split_batch_by_range` sends NULL keys to partition 0 regardless of what `nulls_first` says (there is a TODO to that effect at `range_repartition_common.rs:162`).

`SortKeySketch` counts NULLs beside the sketch instead of encoding them. A NULL has no position among the values, only a side, and `nulls_first` fixes that side at plan time. Keeping it out of the key also leaves the key 8 bytes wide instead of 16, which the benchmark prices at 1.19x against 1.58x.

The cost is that a rank over the population is no longer a rank over the values, so the NULL run has to be stepped over. That remap lives in `SortKeySketch::value_rank` and nowhere else - `quantile` and `cuts` both go through it - which is the main reason the type exists rather than a loose `(sketch, null_count)` pair.

### A sketch can lose its extremes

`tdigest.rs:210-215` reads a batch's extremes from `first()` and `last()` only, then folds them with `f64::min` / `f64::max`, which are the NaN-ignoring variants:

```rust
let maybe_min = *sorted_values.first().unwrap();
let maybe_max = *sorted_values.last().unwrap();
if self.count() > 0.0 {
    result.min = self.min.min(maybe_min);
    result.max = self.max.max(maybe_max);
```

Sorted by `total_cmp`, any batch containing a NaN has NaN at one or both ends. That element is then discarded by the fold, and because nothing between the ends is examined, the batch's real extremes go with it:

```
input        : [1.0, 5.0, NaN, -NaN, +inf, -inf]
total_cmp    : min=NaN  max=NaN   <- the true extremes
one batch    : min=NaN  max=NaN
split batches: min=1.0  max=5.0
split, no NaN: min=-inf  max=inf
```

The last line is the control: same two-batch split without the NaN, and both infinities survive. Reproduction is four lines against `datafusion-functions-aggregate-common` alone.

This matters because `cut_partitions` routes shuffle files by exactly `[sketch.min(), sketch.max()]`. A file reporting `[1.0, 5.0]` while spanning `[-inf, +inf]` is routed only to buckets overlapping 1 to 5, and the rest of its rows are not routed anywhere. There is no error, and since the outcome depends on which batch arrived first it will not reproduce consistently.

`KllSketch` has no equivalent: `absorb_slice` scans every element using `Ord` on the key, and `-NaN` / `+NaN` are simply the smallest and largest `u64`. No shortcut, and no comparison that silently ignores a value.

## Cost

Ryzen 9 9950X, 64 MiB L3. `SortKeySketch` column is the shipped path.

| Rows | Column | T-Digest | SortKeySketch | Ratio |
|---|---|---|---|---|
| 100K | `Float64` | 1.38 ms (72 M/s) | 1.23 ms (81 M/s) | 0.89x |
| 100K | `Float64`, 10% NULL | unsupported | 1.27 ms (78 M/s) | 0.92x |
| 100K | `Int64` | unsupported | 1.22 ms (82 M/s) | 0.88x |
| 100K | `Timestamp(ns, UTC)` | unsupported | 1.21 ms (83 M/s) | 0.87x |
| 1M | `Float64` | 13.8 ms (73 M/s) | 16.4 ms (61 M/s) | 1.19x |
| 1M | `Float64`, 10% NULL | unsupported | 15.5 ms (65 M/s) | 1.13x |
| 1M | `Int64` | unsupported | 16.5 ms (61 M/s) | 1.20x |
| 1M | `Timestamp(ns, UTC)` | unsupported | 16.4 ms (61 M/s) | 1.20x |

T-Digest is `Float64`-only, so the integer and temporal rows have no baseline of their own; those ratios are against T-Digest sketching a float.

Three things to read off it:

- **Column type does not move the cost.** 1.19x, 1.20x and 1.20x for float, integer and timestamp. Compaction dominates ingest and the sketch only ever sees `u64`, so the encode difference is noise. One number covers every fixed-width column.
- **NULLs are a discount.** 1.13x against 1.19x, because a tenth of the rows are counted rather than sketched.
- **The sign flips with scale.** 11% to 13% faster than T-Digest at 100K, 13% to 20% behind at 1M, as KLL's per-row cost grows with its compaction stack.

`KLL_K` is chosen for worst-case rank-error parity with T-Digest at `max_size=100` (0.0016 against 0.0021 on a uniform 1M stream), so this is a matched race rather than a cheaper sketch looking fast. Rerun the parity check with `KLL_PARITY_CHECK=1 cargo bench --bench quantile_sketch`.

## Why not widen T-Digest instead

Worth stating plainly, because for the numeric and temporal types it is a real option. You can wrap the routing expression in a `CastExpr` to `Float64` and keep T-Digest. The precision loss is genuine but small enough not to matter: an `f64` at 2020s epoch nanoseconds quantizes onto a 256 ns grid, while T-Digest's own rank error over a day-wide partition is around three minutes. Nine orders of magnitude apart. Any argument resting on quantile precision is noise, and the sort_key docs say so explicitly so nobody over-claims it later.

What is left after discounting that:

- NULLs still have nowhere to go, and that is not a precision question.
- The extremes behaviour above is independent of column type.
- Casting is not free either. It needs a `CastExpr` planted at plan time in the AQE rule, and then `RangeFilterExec`'s halos have to be expressed in cast units rather than the column's own. That is plan surgery to avoid a code path that would otherwise already exist.
- Float precision is relative, so the cast does degrade for a narrow spread at a large magnitude. A partition covering a day is unaffected; one covering 100 µs at epoch-nanosecond magnitudes is past the point where the cast costs more than the sketch does. A corner, but a real one.

Exactness does pay in one place that is not statistical: `min` and `max` are exact by construction, tracked outside the compactor so no coin flip can move them, and they are the two values `cut_partitions` routes files on. There the error bars are zero, so anything a cast rounds away is error introduced where none existed.

## Correctness of the arrangement

Arrow's row format is treated as the definition of `ORDER BY` order throughout, since it is the only encoding that folds column type, `nulls_first` and `descending` into one memcmp order, and arrow's own sort agrees with it. The float transform here is the same one `arrow_row::fixed` applies, and both reduce to `total_cmp`, which is what `ArrowNativeTypeOp::compare` uses.

`integer_keys_order_identically_to_arrow_row` asserts the two induce the same permutation over a fixture containing ±NaN, ±0.0 and both infinities, so a divergence fails a test rather than surfacing as misrouted rows.

Following that order is also why there is no NaN handling anywhere in this PR. NaN has a defined place in `total_cmp`, beyond the infinity of its own sign, so it encodes to an ordinary key at one end of the `u64` range and comparisons against it behave normally.

## Testing

29 unit tests in `sort_key`, 27 in `kll`, full `ballista-core` suite green.

The NULL remap is validated differentially against `kll_norm_u128`, the design this PR prices and rejects. Putting NULLs inside the key needs no remap at all, which makes it an independent oracle for the arithmetic. The sweep covers NULL fractions from 0 to 100 of 100 rows, both placements, ASC and DESC, 21 quantiles each.

That oracle earned its keep immediately: it found an off-by-one that eleven hand-written tests had missed. Rescaling a rank into a fraction of the value run and letting the sketch multiply it back loses it, since with 99 values rank 59 becomes `59/99` and `59/99 * 99` is `58.999...`, truncating to 58. Fixed by keeping the subtraction in integers, which is what `KllSketch::at_rank` exists for.

The worked bit-pattern table in `impl_sortable_float`'s docs is asserted by `float_key_table_in_docs_is_accurate`, so the hex cannot rot.

## What this does not do

- Does not touch `RuntimeStatsExec`, T-Digest, or any routing code.
- `SortKeySketch` has no wire format yet. That lands with its first consumer, so the encoding is designed alongside the reader rather than guessed at.
- The arrow-row tier for multi-column and variable-width keys is measured here but not built.

## Follow-ups

1. `RuntimeStatsExec` holds a `SortKeySketch` per partition, plus the proto message.
2. Cuts become sort keys rather than floats through the router, which is what lifts the `Float64` gate in `ParallelWindowRule` and lets a `Timestamp` `ORDER BY` plan at all.
3. Multi-column and `Utf8` keys via the arrow-row tier.

