### PR TITLE
test: centralize physical plan snapshot assertions

### DIFF
--- a/ballista/core/src/lib.rs
+++ b/ballista/core/src/lib.rs
@@ -46,6 +46,22 @@ pub fn print_version() {
     println!("Ballista version: {BALLISTA_VERSION}")
 }
 
+/// Asserts an indented physical plan against an inline snapshot.
+///
+/// Keeping plan assertions behind one macro makes plan changes easier to
+/// review and update consistently across Ballista crates.
+#[macro_export]
+macro_rules! assert_plan {
+    ($plan:expr, @ $expected_lines:literal $(,)?) => {{
+        let plan = datafusion::physical_plan::displayable($plan)
+            .indent(true)
+            .to_string();
+        let actual_lines = plan.trim();
+
+        insta::assert_snapshot!(actual_lines, @ $expected_lines);
+    }};
+}
+
 /// Client utilities for connecting to Ballista schedulers.
 pub mod client;
 /// Connection pool for reusing `BallistaClient` instances across requests.

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -916,9 +916,9 @@ pub(crate) fn create_shuffle_writer_with_config(
 #[cfg(test)]
 mod test {
     use super::{can_stay_inline, holds_a_broadcast};
-    use crate::assert_plan;
     use crate::planner::{DefaultDistributedPlanner, DistributedPlanner};
     use crate::test_utils::{datafusion_test_context, scan_with_file_groups};
+    use ballista_core::assert_plan;
     use ballista_core::error::BallistaError;
     use ballista_core::execution_plans::{SortShuffleWriterExec, UnresolvedShuffleExec};
     use ballista_core::serde::BallistaCodec;
@@ -956,10 +956,10 @@ mod test {
 
         let rewritten = make_empty_exec_serde_safe(plan).unwrap();
 
-        assert_eq!(
-            displayable(rewritten.as_ref()).indent(false).to_string(),
-            "RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1\n  EmptyExec\n"
-        );
+        assert_plan!(rewritten.as_ref(), @r"
+        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+          EmptyExec
+        ");
     }
 
     #[test]
@@ -973,10 +973,7 @@ mod test {
 
         let rewritten = make_empty_exec_serde_safe(plan).unwrap();
 
-        assert_eq!(
-            displayable(rewritten.as_ref()).indent(false).to_string(),
-            "EmptyExec\n"
-        );
+        assert_plan!(rewritten.as_ref(), @"EmptyExec");
     }
 
     /// A plain scan branch restricts away cleanly, so it can stay inline in

--- a/ballista/scheduler/src/state/aqe/mod.rs
+++ b/ballista/scheduler/src/state/aqe/mod.rs
@@ -1524,15 +1524,3 @@ fn scalar_to_f64(sv: &ScalarValue) -> datafusion::common::Result<f64> {
         ),
     }
 }
-
-/// Checks is the plan same as expected string representation
-#[cfg(test)]
-#[macro_export]
-macro_rules! assert_plan {
-    ($PLAN: expr, @ $EXPECTED_LINES: literal $(,)?) => {
-        let plan = datafusion::physical_plan::displayable($PLAN).indent(true).to_string();
-        let actual_lines = plan.trim();
-
-        insta::assert_snapshot!(actual_lines, @ $EXPECTED_LINES);
-    };
-}

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/chaos_exec.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/chaos_exec.rs
@@ -109,7 +109,7 @@ impl PhysicalOptimizerRule for ChaosCreatingRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_plan;
+    use ballista_core::assert_plan;
     use ballista_core::config::BallistaConfig;
     use ballista_core::execution_plans::ChaosExec;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/distributed_exchange.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/distributed_exchange.rs
@@ -312,8 +312,8 @@ fn nearest_exchange_status(plan: &Arc<dyn ExecutionPlan>) -> ExchangeStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_plan;
     use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
+    use ballista_core::assert_plan;
     use ballista_core::execution_plans::{
         RuntimeStatsExec, UnorderedRangeRepartitionExec,
     };

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -341,7 +341,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use crate::assert_plan;
+    use ballista_core::assert_plan;
     use ballista_core::config::BallistaConfig;
     use datafusion::{
         arrow::{

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::assert_plan;
 use crate::state::aqe::planner::AdaptivePlanner;
 use crate::state::aqe::test::{
     mock_batch, mock_context, mock_partitions_with_statistics_no_data,
 };
+use ballista_core::assert_plan;
 use ballista_core::serde::scheduler::{
     ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
     PartitionId, PartitionLocation, PartitionStats,

--- a/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
+++ b/ballista/scheduler/src/state/aqe/test/coalesce_rule.rs
@@ -24,9 +24,9 @@
 //! `coalesce_target_partition_bytes` so the bin-pack outcome is hand-traceable
 //! against `split_size_list_by_target_size`.
 
-use crate::assert_plan;
 use crate::state::aqe::planner::AdaptivePlanner;
 use crate::state::aqe::test::{mock_batch, mock_schema};
+use ballista_core::assert_plan;
 use ballista_core::extension::SessionConfigExt;
 use ballista_core::serde::scheduler::{
     ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,

--- a/ballista/scheduler/src/state/aqe/test/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/test/join_selection.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    assert_plan,
-    state::aqe::{planner::AdaptivePlanner, test::mock_partitions_with_statistics},
+use crate::state::aqe::{
+    planner::AdaptivePlanner, test::mock_partitions_with_statistics,
 };
+use ballista_core::assert_plan;
 use ballista_core::extension::SessionConfigExt;
 use datafusion::{
     arrow::{

--- a/ballista/scheduler/src/state/aqe/test/plan_to_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/plan_to_stages.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::assert_plan;
 use crate::state::aqe::AdaptiveExecutionGraph;
 use crate::state::aqe::execution_plan::ExchangeExec;
 use crate::state::aqe::planner::AdaptivePlanner;
@@ -24,6 +23,7 @@ use crate::state::aqe::test::{
 };
 use crate::state::execution_graph::ExecutionGraph;
 use ballista_core::JobId;
+use ballista_core::assert_plan;
 use ballista_core::execution_plans::SortShuffleWriterExec;
 use ballista_core::serde::protobuf::job_status::Status;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2296.

# Rationale for this change

Physical-plan snapshots are useful outside the scheduler AQE module. Keeping the helper in that module forces unrelated tests to depend on a scheduler-local test macro and leaves some literal plan checks using ad hoc string equality.

# What changes are included in this PR?

- Move `assert_plan!` to `ballista-core` so Ballista crates can share one physical-plan snapshot helper.
- Update existing scheduler tests to import the macro from `ballista_core`.
- Convert the remaining literal physical-plan equality checks in `planner.rs` to inline snapshots.
- Leave semantic substring checks and dynamic before/after plan comparisons unchanged.

# Are there any user-facing changes?

No. This only standardizes test assertions.

# Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- The targeted scheduler test profile compiled successfully locally. Test execution was not completed because the local APFS volume ran out of space during post-link stripping; CI is the full test authority for this run.

AI assistance: OpenAI Codex was used to help implement and test this change.
