### PR TITLE
chore(deps): bump the DataFusion pin to the 55.0.0-rc3 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-cli"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "futures",
  "log",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-avro",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2542,12 +2542,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 
 [[package]]
 name = "datafusion-execution"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2573,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2835,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-catalog",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-models"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "datafusion-common",
  "datafusion-proto-common",
@@ -2917,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc2#209fd9406890d97d48c0fc396ce37a5e363270b4"
+source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ arrow = { version = "59.2.0", features = ["ipc_compression"] }
 arrow-flight = { version = "59.2.0", features = ["flight-sql-experimental"] }
 clap = { version = "4.5", features = ["derive", "cargo"] }
 
-# DataFusion crates are pinned to the 55.0.0-rc2 tag via `[patch.crates-io]`
+# DataFusion crates are pinned to the 55.0.0-rc3 tag via `[patch.crates-io]`
 # below. Workspace deps reference the crates.io version so the patch table is
 # the single place to bump when advancing to a newer DataFusion release.
 datafusion = { version = "55" }
@@ -137,10 +137,10 @@ incremental = false
 # Redirect the crates.io datafusion release to the pinned git tag. Bump the
 # tag here to advance DataFusion; the workspace-dep versions above stay put.
 [patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
-datafusion-cli = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
-datafusion-functions-aggregate-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
-datafusion-proto = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
-datafusion-proto-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
-datafusion-spark = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
-datafusion-substrait = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc2" }
+datafusion = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion-cli = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion-functions-aggregate-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion-proto = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion-proto-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion-spark = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion-substrait = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }


### PR DESCRIPTION
> Drafted with the help of an LLM (Claude Code), reviewed by me before posting.

# Which issue does this PR close?

Follow-up to #2241, which pinned DataFusion to the `55.0.0-rc2` tag.

# Rationale for this change

`55.0.0-rc3` has been cut, so advance the pin to the latest release candidate ahead of the final 55.0.0 release.

# What changes are included in this PR?

- `[patch.crates-io]` in the root `Cargo.toml` now points at tag `55.0.0-rc3` (`d5552342`)
- `Cargo.lock` refreshed; no non-DataFusion dependency moves
- The `python/` workspace is untouched — it still consumes released 54.0.0 crates

# Are these changes tested?

Locally on macOS (aarch64):

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean, no new warnings
- `cargo test --workspace` — **the `ballista` client tests fail**: all 18 tests in `ballista/client/tests/context_basic.rs` error out at context creation with `Configuration("IO error: Operation not permitted (os error 1)")`. The same tests pass on `main` (rc2) in the same environment, so this looks like a genuine behavior change between rc2 and rc3, not flakiness. I have not yet root-caused it — leaving CI to confirm the failure independently before digging in.

# Are there any user-facing changes?

No.
