### PR TITLE
fix(ci): apply cargo fmt to chaos-executor

### DIFF
--- a/chaos-testing/src/bin/chaos-executor.rs
+++ b/chaos-testing/src/bin/chaos-executor.rs
@@ -74,17 +74,19 @@ async fn main() -> ballista_core::error::Result<()> {
     // liveness; `/readyz` reflects heartbeat state. Only started when
     // `CHAOS_EXECUTOR_HEALTH_PORT` is set (the k8s manifest sets it), so the
     // process-based `TestCluster` harness spawns no extra server.
-    let health_server = std::env::var("CHAOS_EXECUTOR_HEALTH_PORT").ok().map(|port| {
-        let port: u16 = port
-            .parse()
-            .unwrap_or_else(|e| panic!("CHAOS_EXECUTOR_HEALTH_PORT must be a u16: {e}"));
-        let addr: SocketAddr = format!("{}:{}", config.bind_host, port)
-            .parse()
-            .expect("health server address must parse");
-        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-        let handle = spawn_health_server(addr, config.health.clone(), shutdown_rx);
-        (shutdown_tx, handle)
-    });
+    let health_server = std::env::var("CHAOS_EXECUTOR_HEALTH_PORT")
+        .ok()
+        .map(|port| {
+            let port: u16 = port.parse().unwrap_or_else(|e| {
+                panic!("CHAOS_EXECUTOR_HEALTH_PORT must be a u16: {e}")
+            });
+            let addr: SocketAddr = format!("{}:{}", config.bind_host, port)
+                .parse()
+                .expect("health server address must parse");
+            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+            let handle = spawn_health_server(addr, config.health.clone(), shutdown_rx);
+            (shutdown_tx, handle)
+        });
 
     let result = start_executor_process(Arc::new(config)).await;
 


### PR DESCRIPTION
# Which issue does this PR close?

None. `main` is currently red and this unblocks it.

# Rationale for this change

`ci/scripts/rust_fmt.sh` (`cargo fmt --all -- --check`) fails on `main` as of 1fe9e6f70 (#2244, merged today), so the `Lint` job fails on every open pull request — CI checks the PR merged with `main`, so a PR that has not touched this file still inherits the failure.

`cargo fmt --all -- --check` on `main` reports one violation:

```
Diff in chaos-testing/src/bin/chaos-executor.rs:74
```

That is the only one in the workspace.

The formatting is version-independent: rustfmt 1.97.0 and 1.97.1 both reject the current text and both produce the replacement in this PR, so this is not toolchain drift on the runner.

# What changes are included in this PR?

The output of `cargo fmt --all`, which is limited to the `health_server` binding added by #2244. The chained `.ok().map(|port| { ... })` moves onto its own lines and the `unwrap_or_else` closure wraps at `max_width = 90`.

Formatting only. No behavior change.

# Are there any user-facing changes?

No.
