### PR TITLE
docs: explain why Ballista uses a blocking shuffle

### DIFF
--- a/docs/source/contributors-guide/architecture.md
+++ b/docs/source/contributors-guide/architecture.md
@@ -194,6 +194,10 @@ Each executor will re-partition the output of the stage it is running so that it
 stage. This mechanism is known as an Exchange or a Shuffle. The logic for this can be found in the [ShuffleWriterExec]
 and [ShuffleReaderExec] operators.
 
+The shuffle is _blocking_: a stage runs to completion and materializes its output to local disk before any
+downstream stage starts. See [Shuffle Design](shuffle.md) for why Ballista made that choice, what it costs, and
+how it compares to the pipelined shuffle used by engines such as DataFusion Distributed and Sail.
+
 [shufflewriterexec]: https://github.com/apache/datafusion-ballista/blob/main/ballista/core/src/execution_plans/shuffle_writer.rs
 [shufflereaderexec]: https://github.com/apache/datafusion-ballista/blob/main/ballista/core/src/execution_plans/shuffle_reader.rs
 

--- a/docs/source/contributors-guide/architecture.md
+++ b/docs/source/contributors-guide/architecture.md
@@ -194,9 +194,12 @@ Each executor will re-partition the output of the stage it is running so that it
 stage. This mechanism is known as an Exchange or a Shuffle. The logic for this can be found in the [ShuffleWriterExec]
 and [ShuffleReaderExec] operators.
 
-The shuffle is _blocking_: a stage runs to completion and materializes its output to local disk before any
-downstream stage starts. See [Shuffle Design](shuffle.md) for why Ballista made that choice, what it costs, and
-how it compares to the pipelined shuffle used by engines such as DataFusion Distributed and Sail.
+The shuffle is _blocking_: a stage materializes its output to local storage, and today a downstream stage waits
+for the whole upstream stage to complete before it starts. Waiting on the whole stage is a property of the current
+scheduler rather than of the design — the output of a finished task is readable as soon as its files are closed,
+so a downstream stage could in principle start on partial input when the cluster has capacity to spare. See
+[Shuffle Design](shuffle.md) for why Ballista materializes shuffle output at all, what that costs, and how it
+compares to the pipelined shuffle used by engines such as DataFusion Distributed and Sail.
 
 [shufflewriterexec]: https://github.com/apache/datafusion-ballista/blob/main/ballista/core/src/execution_plans/shuffle_writer.rs
 [shufflereaderexec]: https://github.com/apache/datafusion-ballista/blob/main/ballista/core/src/execution_plans/shuffle_reader.rs

--- a/docs/source/contributors-guide/shuffle.md
+++ b/docs/source/contributors-guide/shuffle.md
@@ -20,7 +20,7 @@
 # Shuffle Design
 
 Ballista uses a **blocking shuffle**: a query stage runs to completion and
-materializes its output to local disk before any downstream stage starts. This
+materializes its output to local storage before any downstream stage starts. This
 is the same model Apache Spark uses, and it is deliberately different from the
 **pipelined shuffle** used by engines such as Apache Flink,
 [DataFusion Distributed], and [Sail], where a downstream stage streams data from
@@ -101,10 +101,15 @@ machinery handles executors disappearing outright
 Repeated failures are capped: once a stage exceeds its retry budget the job
 fails rather than looping.
 
-A pipelined engine generally cannot do this. There is no durable copy of the
-producer's output, so a consumer failure forces the producer to run again, and
-in the common case the whole query restarts. DataFusion Distributed is explicit
-about this in its own documentation:
+A pipelined engine has to work harder for the same guarantee. Without a durable
+copy of the producer's output, recovery means either re-running the producer or
+restoring from a checkpoint, and checkpointing a distributed dataflow is a hard
+problem in its own right — Flink got there with
+[asynchronous barrier snapshotting], but it took years of work, and it recovers
+by rewinding a whole pipeline region to the last snapshot rather than by
+re-running the handful of tasks that were actually lost. Engines that have not
+taken that on restart the query. DataFusion Distributed is explicit about this
+in its own documentation:
 
 > If any node fails mid-query, the whole query fails; there are no retries.
 > There's no persistence of intermediate results, so queries can't checkpoint or
@@ -114,6 +119,8 @@ For a query that runs for seconds, restarting is cheap and this hardly matters.
 For an ETL job that runs for an hour on a cluster where a spot instance
 disappears every few minutes, it is the difference between a job that finishes
 and one that never does.
+
+[asynchronous barrier snapshotting]: https://nightlies.apache.org/flink/flink-docs-stable/docs/concepts/stateful-stream-processing/
 
 ### The filesystem absorbs producer/consumer skew
 
@@ -157,6 +164,14 @@ downstream exchange with an empty node and propagates emptiness up the plan,
 requires knowing a stage produced zero rows, and no sample can establish that
 before the stage ends.
 
+Exact per-partition counts are also what makes skew mitigation tractable. The
+AQE `CoalescePartitionsRule` already uses them to merge undersized shuffle
+partitions before the next stage is scheduled, and the same information is what
+a future rule would need to go the other way and split an oversized partition,
+or to choose range boundaries that spread a hot key across several downstream
+tasks. Skew is listed below as a cost of the barrier, but the barrier is also
+where the statistics to fix it come from.
+
 ### Executors can come and go between stages
 
 Because a stage's inputs are files rather than live connections, cluster
@@ -166,6 +181,12 @@ autoscaling (including the KEDA scaler) straightforward. Shuffle files are
 cleaned up after the job finishes, on the interval set by
 `finished-job-data-clean-up-interval-seconds`.
 
+For deployments that scale continuously with demand and run on spot capacity,
+this and partial re-execution above are the same property seen twice: a fleet
+whose size changes under the query only works if a departing executor costs a
+few re-run tasks and an arriving one can be handed work with no setup. Both
+follow from stage output being a file rather than a connection.
+
 ## What the barrier costs
 
 The trade-off is real, and it is worth stating plainly.
@@ -173,16 +194,25 @@ The trade-off is real, and it is worth stating plainly.
 - **Straggler stall.** A stage finishes when its slowest task finishes. Until
   then no downstream work can start, even if 99% of the input is ready. On a
   skewed join key or a slow node, most of the cluster sits idle waiting. This is
-  the single largest source of avoidable latency in Ballista today.
+  the single largest source of avoidable latency in Ballista today — and the
+  word to note is _avoidable_: waiting on the whole stage is how the scheduler
+  works now, not something materialization forces (see
+  [partial-input early start](#directions-that-do-not-require-abandoning-the-model)).
 - **Write amplification.** Every intermediate byte is written, then read, then
   often served over the network — even when the intermediate result is a few
   kilobytes. For small queries this dominates the runtime.
-- **Poor interactive latency.** The cost above is roughly fixed per stage
+- **Higher interactive latency.** The cost above is roughly fixed per stage
   boundary, so a query with many small stages pays it repeatedly. Pipelined
   engines report substantially better latency on interactive benchmarks, and the
-  gap is structural, not an implementation detail.
-- **Local storage is required.** Executors need writable local disk sized for
-  the largest shuffle they will handle, plus cleanup.
+  gap is structural, not an implementation detail. This is a gap relative to a
+  pipelined engine, not an absolute verdict: Ballista is in production on
+  workloads where queries return in around a second.
+- **Local storage is required.** Executors need writable local storage sized for
+  the largest shuffle they will handle, plus cleanup. It does not have to be a
+  physical disk — deployments on memory-rich instances point `work_dir` at a
+  RAM-backed filesystem and never touch one — but the space has to exist
+  somewhere, and today that somewhere is attached to the executor rather than
+  to a shuffle service.
 - **No path to streaming.** A blocking barrier cannot express an unbounded
   input. Any future support for continuous queries would need a different
   exchange model.
@@ -209,15 +239,32 @@ The barrier is not all-or-nothing, and several ideas would recover part of the
 latency without giving up recovery or the ability to run wider than the cluster.
 These are open directions rather than commitments:
 
-- **Partial-input early start.** Let a consumer task begin once _some_ producer
-  tasks have finished, learning about additional `PartitionLocation`s
-  incrementally, instead of requiring `resolvable()` to be true for the whole
-  stage. This keeps files, keeps retries, and shortens the straggler stall
-  without introducing co-scheduling.
+- **Partial-input early start.** Nothing about the design requires a consumer to
+  wait for the _whole_ producer stage; that is just what `resolvable()` does
+  today. A consumer task could begin once some producer tasks have finished,
+  learning about additional `PartitionLocation`s incrementally. Where the
+  cluster has spare capacity this overlaps stages and shortens the straggler
+  stall, and it keeps files, retries, and slot accounting exactly as they are.
+  The general form of this — deciding how much of the DAG is in flight at once
+  rather than always running exactly one stage — is sometimes called bubble
+  execution.
 - **Hybrid exchange.** Stream to a consumer when one is already running and fall
   back to writing files otherwise, in the spirit of Flink's hybrid shuffle. This
   gets the latency win where capacity allows and degrades to today's behavior
   where it does not.
+- **In-memory shuffle.** Small intermediates are written and read back through
+  the filesystem regardless of size. Keeping them in memory, with a spill path
+  to files when they grow, would remove most of the write amplification for
+  short queries while leaving the durable path in place for the ones that need
+  it.
+- **A cheaper shuffle format.** The write side currently produces a file per
+  output partition per task and a metadata round-trip per partition, which is a
+  lot of small files and small reads at high partition counts. Writing one
+  indexed file per task, coalescing batches across partitions, and trimming the
+  per-partition metadata would cut the fixed cost of a stage boundary without
+  changing where the data lives.
+- **Shuffle affinity.** Schedule a consumer task on the executor that already
+  holds most of its input, turning Flight fetches into local reads.
 - **Remote shuffle service.** Offload shuffle storage to a service such as
   Apache Celeborn or Apache Uniffle
   ([#1539](https://github.com/apache/datafusion-ballista/issues/1539)), which

--- a/docs/source/contributors-guide/shuffle.md
+++ b/docs/source/contributors-guide/shuffle.md
@@ -1,0 +1,228 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Shuffle Design
+
+Ballista uses a **blocking shuffle**: a query stage runs to completion and
+materializes its output to local disk before any downstream stage starts. This
+is the same model Apache Spark uses, and it is deliberately different from the
+**pipelined shuffle** used by engines such as Apache Flink,
+[DataFusion Distributed], and [Sail], where a downstream stage streams data from
+an upstream stage that is still running.
+
+This page explains why Ballista made that choice, what it costs, and how to
+think about the trade-off when proposing changes to the exchange layer. For the
+mechanics of the shuffle writer and its tuning knobs, see the
+[Shuffle Implementation section of the tuning guide](../user-guide/tuning-guide.md#shuffle-implementation).
+
+[datafusion distributed]: https://datafusion-contrib.github.io/datafusion-distributed/
+[sail]: https://github.com/lakehq/sail
+
+## The barrier, concretely
+
+Three pieces of the system implement the barrier:
+
+1. **The write side.** `ShuffleWriterExec` (and `SortShuffleWriterExec`) drain
+   their input partitions concurrently, streaming each to an Arrow IPC file
+   under `{work_dir}/{job_id}/{stage_id}/{partition_id}/`. A partition's
+   `ShuffleWritePartition` summary — the row, batch, and byte counts that the
+   scheduler records — does not exist until that file is closed.
+
+2. **The scheduler.** An `UnresolvedStage` becomes resolvable only when every
+   input stage is marked complete:
+
+   ```rust
+   // ballista/scheduler/src/state/execution_stage.rs
+   pub fn resolvable(&self) -> bool {
+       self.inputs.iter().all(|(_, input)| input.is_complete())
+   }
+   ```
+
+   Resolution then rewrites `UnresolvedShuffleExec` nodes into
+   `ShuffleReaderExec` nodes carrying concrete `PartitionLocation`s, and runs
+   Ballista's `JoinSelection` optimizer over the result.
+
+3. **The read side.** `ShuffleReaderExec` fetches those locations, either
+   directly from the local filesystem or from the producing executor's Arrow
+   Flight service (`do_get`, or the raw-block `IO_BLOCK_TRANSPORT` action).
+
+A stage's output is therefore a durable, addressable, re-readable artifact that
+outlives the task that produced it. Almost every property below follows from
+that one fact.
+
+## Why the barrier is there
+
+### Producers and consumers never compete for slots
+
+Each executor advertises a fixed number of task slots. Under a blocking
+shuffle, a stage's tasks hold slots only while that stage runs, so a stage with
+1000 tasks executes perfectly well on a cluster with 32 slots — the scheduler
+simply feeds tasks in as slots free up.
+
+Pipelined shuffle removes that freedom. If a consumer task streams from a
+producer task, both must be resident at the same time, which turns stage
+scheduling into a co-scheduling (gang scheduling) problem. Get it wrong and the
+cluster deadlocks: every slot is held by a consumer waiting on a producer that
+cannot be scheduled. Engines that pipeline either require enough capacity for
+the whole pipeline region, provision workers on demand, or fall back to
+materialization under pressure.
+
+Ballista's ability to run a query far wider than the cluster is a direct
+consequence of blocking.
+
+### Failures cost a task, not a query
+
+Because shuffle output survives the task that wrote it, Ballista can recover
+from a lost executor by re-running only what was actually lost. When a fetch
+fails, the scheduler receives a `FetchPartitionError` and does three things: it
+drops every input partition the downstream stage was sourcing from the failed
+executor, rolls back that downstream stage, and resubmits only the map tasks
+needed to regenerate the dropped partitions. Map output that lives on surviving
+executors is not recomputed, and unrelated stages are not touched. The same
+machinery handles executors disappearing outright
+(`reset_stages_on_lost_executor`, `rollback_running_stage`,
+`rerun_successful_stage` in `ballista/scheduler/src/state/execution_graph.rs`).
+Repeated failures are capped: once a stage exceeds its retry budget the job
+fails rather than looping.
+
+A pipelined engine generally cannot do this. There is no durable copy of the
+producer's output, so a consumer failure forces the producer to run again, and
+in the common case the whole query restarts. DataFusion Distributed is explicit
+about this in its own documentation:
+
+> If any node fails mid-query, the whole query fails; there are no retries.
+> There's no persistence of intermediate results, so queries can't checkpoint or
+> resume from where they stopped.
+
+For a query that runs for seconds, restarting is cheap and this hardly matters.
+For an ETL job that runs for an hour on a cluster where a spot instance
+disappears every few minutes, it is the difference between a job that finishes
+and one that never does.
+
+### The filesystem absorbs producer/consumer skew
+
+In a blocking shuffle, the buffer between stages is the disk. A producer never
+waits for a consumer: it writes its output, reports, and releases its slot. That
+decoupling is what lets the sort-based writer bound its own memory by spilling
+and still guarantee forward progress.
+
+In a pipelined shuffle, the buffer is memory plus network, and backpressure is
+end-to-end. A slow consumer stalls its producer, which holds a slot and its
+working set while stalled. Shuffles far larger than cluster memory — the case
+Ballista is built for — need either a spill path or a remote shuffle service to
+stay safe, which is most of the blocking machinery reintroduced.
+
+Note that Ballista does apply backpressure on the _read_ side: the shuffle
+governor (`ballista.shuffle.reader.max_bytes_in_flight` and
+`max_blocks_in_flight_per_address`) bounds concurrent fetches. The point is that
+this only shapes reader memory. It cannot stall a producer that has already
+finished.
+
+### Completed stages yield exact statistics
+
+Stage resolution is where Ballista re-plans. `to_resolved()` runs
+`JoinSelection` against the resolved plan, and with
+`ballista.planner.adaptive.enabled` the `AdaptiveExecutionGraph` re-runs a set
+of physical optimizer rules after each stage completes, using the exact row and
+byte counts that stage produced. See
+[Adaptive Query Execution](architecture.md#adaptive-query-execution-aqe).
+
+It is worth being precise about what the barrier buys here, because pipelining
+does not rule out adaptivity. DataFusion Distributed performs AQE without a
+barrier by injecting a `SamplerExec` below the producer's exchange: it buffers
+early batches, reports sampled row, byte, distinct, and null counts to the
+coordinator, the coordinator sizes the next stage from that sample, and the
+buffered batches then flow on into the consumer.
+
+So the real distinction is **exact versus sampled**. Sampling is enough to size
+a stage or pick a join side. It is not enough for decisions that depend on a
+final answer — Ballista's empty-stage elimination rule, which replaces a
+downstream exchange with an empty node and propagates emptiness up the plan,
+requires knowing a stage produced zero rows, and no sample can establish that
+before the stage ends.
+
+### Executors can come and go between stages
+
+Because a stage's inputs are files rather than live connections, cluster
+membership only has to be stable for the duration of a single stage. Executors
+can register between stages and pick up work immediately, which is what makes
+autoscaling (including the KEDA scaler) straightforward. Shuffle files are
+cleaned up after the job finishes, on the interval set by
+`finished-job-data-clean-up-interval-seconds`.
+
+## What the barrier costs
+
+The trade-off is real, and it is worth stating plainly.
+
+- **Straggler stall.** A stage finishes when its slowest task finishes. Until
+  then no downstream work can start, even if 99% of the input is ready. On a
+  skewed join key or a slow node, most of the cluster sits idle waiting. This is
+  the single largest source of avoidable latency in Ballista today.
+- **Write amplification.** Every intermediate byte is written, then read, then
+  often served over the network — even when the intermediate result is a few
+  kilobytes. For small queries this dominates the runtime.
+- **Poor interactive latency.** The cost above is roughly fixed per stage
+  boundary, so a query with many small stages pays it repeatedly. Pipelined
+  engines report substantially better latency on interactive benchmarks, and the
+  gap is structural, not an implementation detail.
+- **Local storage is required.** Executors need writable local disk sized for
+  the largest shuffle they will handle, plus cleanup.
+- **No path to streaming.** A blocking barrier cannot express an unbounded
+  input. Any future support for continuous queries would need a different
+  exchange model.
+
+## Choosing a model
+
+| Workload                                          | Blocking (Ballista)  | Pipelined                            |
+| ------------------------------------------------- | -------------------- | ------------------------------------ |
+| Interactive queries, seconds, small intermediates | Slower               | Faster                               |
+| Large batch and ETL, intermediates exceeding RAM  | Designed for it      | Needs spill or a shuffle service     |
+| Cluster smaller than the query is wide            | Works                | Risks deadlock without co-scheduling |
+| Unreliable or preemptible nodes                   | Partial re-execution | Query restart                        |
+| Elastic or scale-to-zero clusters                 | Natural fit          | Requires resident workers            |
+| Unbounded or streaming input                      | Not supported        | Natural fit                          |
+
+Neither model is simply better. DataFusion Distributed reaches the same
+conclusion from the other side, recommending Ballista for "large, long-running
+batch or ETL that benefits from materializing intermediate results between
+stages" while targeting interactive analytics itself.
+
+## Directions that do not require abandoning the model
+
+The barrier is not all-or-nothing, and several ideas would recover part of the
+latency without giving up recovery or the ability to run wider than the cluster.
+These are open directions rather than commitments:
+
+- **Partial-input early start.** Let a consumer task begin once _some_ producer
+  tasks have finished, learning about additional `PartitionLocation`s
+  incrementally, instead of requiring `resolvable()` to be true for the whole
+  stage. This keeps files, keeps retries, and shortens the straggler stall
+  without introducing co-scheduling.
+- **Hybrid exchange.** Stream to a consumer when one is already running and fall
+  back to writing files otherwise, in the spirit of Flink's hybrid shuffle. This
+  gets the latency win where capacity allows and degrades to today's behavior
+  where it does not.
+- **Remote shuffle service.** Offload shuffle storage to a service such as
+  Apache Celeborn or Apache Uniffle
+  ([#1539](https://github.com/apache/datafusion-ballista/issues/1539)), which
+  decouples shuffle durability from executor lifetime and makes aggressive
+  autoscaling safer.
+
+Anyone proposing a change here should be explicit about which of the five
+properties above it preserves and which it trades away.

--- a/docs/source/contributors-guide/shuffle.md
+++ b/docs/source/contributors-guide/shuffle.md
@@ -22,7 +22,7 @@
 Ballista uses a **blocking shuffle**: a query stage runs to completion and
 materializes its output to local storage before any downstream stage starts. This
 is the same model Apache Spark uses, and it is deliberately different from the
-**pipelined shuffle** used by engines such as Apache Flink,
+**pipelined shuffle** used by engines such as [Apache Flink],
 [DataFusion Distributed], and [Sail], where a downstream stage streams data from
 an upstream stage that is still running.
 
@@ -31,6 +31,7 @@ think about the trade-off when proposing changes to the exchange layer. For the
 mechanics of the shuffle writer and its tuning knobs, see the
 [Shuffle Implementation section of the tuning guide](../user-guide/tuning-guide.md#shuffle-implementation).
 
+[apache flink]: https://flink.apache.org/
 [datafusion distributed]: https://datafusion-contrib.github.io/datafusion-distributed/
 [sail]: https://github.com/lakehq/sail
 
@@ -167,10 +168,16 @@ before the stage ends.
 Exact per-partition counts are also what makes skew mitigation tractable. The
 AQE `CoalescePartitionsRule` already uses them to merge undersized shuffle
 partitions before the next stage is scheduled, and the same information is what
-a future rule would need to go the other way and split an oversized partition,
-or to choose range boundaries that spread a hot key across several downstream
-tasks. Skew is listed below as a cost of the barrier, but the barrier is also
-where the statistics to fix it come from.
+a future rule would need to go the other way and split an oversized partition.
+Skew is listed below as a cost of the barrier, but the barrier is also where the
+statistics to fix it come from.
+
+The two sources of statistics are not exclusive, either. Ballista's range
+repartition operators already sample in flight: `RuntimeStatsExec` maintains a
+T-Digest over the routing expression, and the repartition operator snapshots it
+on the first batch to pick its quantile cuts, so range boundaries adapt to the
+data without waiting for a stage to finish. The same mechanism is what would let
+a hot key be spread across several downstream tasks.
 
 ### Executors can come and go between stages
 
@@ -237,7 +244,8 @@ stages" while targeting interactive analytics itself.
 
 The barrier is not all-or-nothing, and several ideas would recover part of the
 latency without giving up recovery or the ability to run wider than the cluster.
-These are open directions rather than commitments:
+These are open directions rather than commitments, and where one changes
+behavior it would be config-gated, leaving today's model as the default:
 
 - **Partial-input early start.** Nothing about the design requires a consumer to
   wait for the _whole_ producer stage; that is just what `resolvable()` does
@@ -247,29 +255,44 @@ These are open directions rather than commitments:
   stall, and it keeps files, retries, and slot accounting exactly as they are.
   The general form of this — deciding how much of the DAG is in flight at once
   rather than always running exactly one stage — is sometimes called bubble
-  execution.
+  execution ([#2320], [#408]).
 - **Hybrid exchange.** Stream to a consumer when one is already running and fall
   back to writing files otherwise, in the spirit of Flink's hybrid shuffle. This
   gets the latency win where capacity allows and degrades to today's behavior
-  where it does not.
+  where it does not ([#1151], [#2003]).
 - **In-memory shuffle.** Small intermediates are written and read back through
-  the filesystem regardless of size. Keeping them in memory, with a spill path
-  to files when they grow, would remove most of the write amplification for
-  short queries while leaving the durable path in place for the ones that need
-  it.
+  the filesystem regardless of size. Keeping them in a bounded in-memory buffer,
+  spilling to files only once the buffer is exceeded, would remove most of the
+  write amplification for short queries while leaving the durable path in place
+  for the ones that need it. This looks like the largest single win available:
+  simply pointing `work_dir` at a RAM disk large enough to hold the whole
+  shuffle already recovers a large share of the TPC-H gap against a pipelined
+  engine, which says the cost being paid there is the filesystem round trip
+  rather than the barrier itself ([#2318]).
 - **A cheaper shuffle format.** The write side currently produces a file per
   output partition per task and a metadata round-trip per partition, which is a
   lot of small files and small reads at high partition counts. Writing one
   indexed file per task, coalescing batches across partitions, and trimming the
   per-partition metadata would cut the fixed cost of a stage boundary without
-  changing where the data lives.
+  changing where the data lives ([#660]).
 - **Shuffle affinity.** Schedule a consumer task on the executor that already
-  holds most of its input, turning Flight fetches into local reads.
+  holds most of its input, turning Flight fetches into local reads. This one can
+  be prototyped without touching the core: task distribution is already
+  pluggable, so a `TaskDistributionPolicy::Custom` implementation can bind tasks
+  to the executors holding their `PartitionLocation`s and be measured against
+  the built-in bias and round-robin policies ([#2319]).
 - **Remote shuffle service.** Offload shuffle storage to a service such as
-  Apache Celeborn or Apache Uniffle
-  ([#1539](https://github.com/apache/datafusion-ballista/issues/1539)), which
-  decouples shuffle durability from executor lifetime and makes aggressive
-  autoscaling safer.
+  Apache Celeborn or Apache Uniffle ([#1539]), which decouples shuffle
+  durability from executor lifetime and makes aggressive autoscaling safer.
 
 Anyone proposing a change here should be explicit about which of the five
 properties above it preserves and which it trades away.
+
+[#408]: https://github.com/apache/datafusion-ballista/issues/408
+[#660]: https://github.com/apache/datafusion-ballista/issues/660
+[#1151]: https://github.com/apache/datafusion-ballista/issues/1151
+[#1539]: https://github.com/apache/datafusion-ballista/issues/1539
+[#2003]: https://github.com/apache/datafusion-ballista/issues/2003
+[#2318]: https://github.com/apache/datafusion-ballista/issues/2318
+[#2319]: https://github.com/apache/datafusion-ballista/issues/2319
+[#2320]: https://github.com/apache/datafusion-ballista/issues/2320

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,6 +77,7 @@ Table of content
    :caption: Contributors Guide
 
    contributors-guide/architecture
+   contributors-guide/shuffle
    contributors-guide/code-organization
    contributors-guide/user-personas
    contributors-guide/development

--- a/docs/source/user-guide/faq.md
+++ b/docs/source/user-guide/faq.md
@@ -26,3 +26,24 @@ model and computational kernels. It is designed to run within a single process, 
 for parallel query execution.
 
 Ballista is a distributed compute platform for DataFusion workloads.
+
+## Why does Ballista write shuffle data to disk instead of streaming it between stages?
+
+Ballista uses a blocking shuffle, like Apache Spark: each query stage runs to completion and
+writes its output to local disk before any downstream stage starts. Other DataFusion-based
+distributed engines, such as [DataFusion Distributed](https://datafusion-contrib.github.io/datafusion-distributed/)
+and [Sail](https://github.com/lakehq/sail), stream data between stages instead.
+
+The blocking model costs latency — a stage cannot start until the slowest task of its input
+stage finishes, and every intermediate byte is written and read back. In exchange it lets a
+query run wider than the cluster has slots for, lets a lost executor cost a few re-run tasks
+rather than the whole query, keeps shuffles larger than cluster memory safe, and gives the
+adaptive planner exact statistics from completed stages.
+
+If your queries are interactive, run for seconds, and produce small intermediate results, a
+pipelined engine will likely be faster. If they are large, long-running batch or ETL jobs,
+especially on preemptible nodes, the blocking model is the reason Ballista finishes them.
+
+For the full reasoning, see [Shuffle Design](../contributors-guide/shuffle.md). For the
+mechanics and tuning knobs, see the
+[Shuffle Implementation section of the tuning guide](tuning-guide.md#shuffle-implementation).

--- a/docs/source/user-guide/faq.md
+++ b/docs/source/user-guide/faq.md
@@ -30,7 +30,8 @@ Ballista is a distributed compute platform for DataFusion workloads.
 ## Why does Ballista write shuffle data to disk instead of streaming it between stages?
 
 Ballista uses a blocking shuffle, like Apache Spark: each query stage runs to completion and
-writes its output to local disk before any downstream stage starts. Other DataFusion-based
+writes its output to local storage (a disk, or a RAM-backed filesystem if you have the memory
+for it) before any downstream stage starts. Other DataFusion-based
 distributed engines, such as [DataFusion Distributed](https://datafusion-contrib.github.io/datafusion-distributed/)
 and [Sail](https://github.com/lakehq/sail), stream data between stages instead.
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This is a documentation-only change and does not have a tracking issue.

# Rationale for this change

Ballista blocks between query stages: a stage runs to completion and materializes its output to local disk before any downstream stage starts. Other DataFusion-based distributed engines, notably [DataFusion Distributed](https://datafusion-contrib.github.io/datafusion-distributed/) and [Sail](https://github.com/lakehq/sail), stream data between stages instead, and they are faster on interactive workloads as a result.

We had nothing written down explaining why Ballista chose the blocking model, so the question keeps coming up and the answer lives in people's heads. The existing docs cover the mechanics of the shuffle writer in the tuning guide, but not the design rationale.

That gap cuts both ways. Users evaluating Ballista against a pipelined engine have no way to tell whether the blocking shuffle is a deliberate trade-off or just something nobody has gotten around to fixing. Contributors proposing changes to the exchange layer have no shared statement of which properties the current design is protecting.

Worth noting that DataFusion Distributed's own documentation already points at Ballista for large batch and ETL workloads that benefit from materializing intermediate results, so this completes a comparison they started rather than opening a new one.

# What changes are included in this PR?

A new contributors-guide page, `docs/source/contributors-guide/shuffle.md`, covering:

- **The barrier, concretely.** The three places it is implemented: shuffle-write summaries not existing until files close, `UnresolvedStage::resolvable()` requiring every input stage to be complete, and `ShuffleReaderExec` fetching concrete `PartitionLocation`s.
- **Why the barrier is there.** Five properties that follow from materializing stage output: producer and consumer tasks never compete for slots, so a stage can be far wider than the cluster; a lost executor costs re-run tasks rather than the whole query; the filesystem absorbs producer/consumer skew so shuffles larger than cluster memory stay safe; completed stages give the adaptive planner exact statistics; and executors can join or leave between stages.
- **What it costs.** Straggler stall, write amplification, interactive latency, the local-disk requirement, and the absence of any path to streaming.
- **How pipelined engines differ**, including a note that pipelining does not rule out adaptive query execution. DataFusion Distributed does AQE without a barrier by sampling in-flight batches, so the real distinction is exact versus sampled statistics. Empty-stage elimination is the one rule that genuinely needs a completed stage.
- **A decision table** for when each model wins.
- **Directions that do not require abandoning the model**, framed as open questions rather than commitments: partial-input early start, hybrid exchange, and a remote shuffle service (#1539).

Supporting changes:

- A user-facing FAQ entry, "Why does Ballista write shuffle data to disk instead of streaming it between stages?", with the short version and links onward.
- A pointer from the Shuffle section of the architecture page.
- A toctree entry in `docs/source/index.rst`.

# Are there any user-facing changes?

Documentation only. No code or API changes.
