### PR TITLE
fix(scheduler): drop an executor's cached gRPC client when it is removed

### DIFF
--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -381,10 +381,7 @@ impl ExecutorManager {
         reason: Option<String>,
     ) -> Result<()> {
         info!("Removing executor {executor_id}: {reason:?}");
-        // Drop the cached client first, so that it goes even if the cluster
-        // state fails to remove the executor. Nothing else ever removes from
-        // `clients`, and an executor is never seen again under the same id, so
-        // a client left here is retained for the lifetime of the scheduler.
+        // Drop the cached client
         self.clients.remove(executor_id);
         self.cluster_state.remove_executor(executor_id).await
     }

--- a/ballista/scheduler/src/state/executor_manager.rs
+++ b/ballista/scheduler/src/state/executor_manager.rs
@@ -381,6 +381,11 @@ impl ExecutorManager {
         reason: Option<String>,
     ) -> Result<()> {
         info!("Removing executor {executor_id}: {reason:?}");
+        // Drop the cached client first, so that it goes even if the cluster
+        // state fails to remove the executor. Nothing else ever removes from
+        // `clients`, and an executor is never seen again under the same id, so
+        // a client left here is retained for the lifetime of the scheduler.
+        self.clients.remove(executor_id);
         self.cluster_state.remove_executor(executor_id).await
     }
 
@@ -608,6 +613,7 @@ mod tests {
     use crate::test_utils::test_cluster_context;
     use ballista_core::extension::SessionConfigExt;
     use datafusion::prelude::SessionConfig;
+    use tonic::transport::Endpoint;
 
     #[test]
     fn grpc_client_max_message_size_flag_reaches_client_config() {
@@ -645,5 +651,29 @@ mod tests {
             manager.grpc_client_config.max_message_size,
             32 * 1024 * 1024
         );
+    }
+
+    #[tokio::test]
+    async fn removing_an_executor_drops_its_cached_client() {
+        let manager = ExecutorManager::new(
+            test_cluster_context().cluster_state(),
+            Arc::new(SchedulerConfig::default()),
+        );
+
+        // `get_client` needs an executor to connect to, so cache a client
+        // directly. `connect_lazy` gives a `Channel` without a server behind it.
+        let channel = Endpoint::from_static("http://localhost:1").connect_lazy();
+        manager
+            .clients
+            .insert("executor-1".to_owned(), ExecutorGrpcClient::new(channel));
+
+        manager
+            .remove_executor("executor-1", None)
+            .await
+            .expect("executor removed");
+
+        // An executor id is a fresh uuid per executor process, so a client left
+        // behind here would never be reused, and never dropped either.
+        assert!(manager.clients.is_empty());
     }
 }


### PR DESCRIPTION
`ExecutorManager` caches an `ExecutorGrpcClient` per executor in `self.clients`, but nothing ever removes an entry: the map is only inserted into by `get_client` and read back. `remove_executor` drops the executor from the cluster state and leaves the client behind.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Removes some state when lots of executors exit the scheduler over time.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
