### PR TITLE
chore: bump rust-version to 1.97.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 # we should try to follow datafusion version 
-rust-version = "1.94.0"
+rust-version = "1.97.1"
 
 [workspace.dependencies]
 arrow = { version = "59.2.0", features = ["ipc_compression"] }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The workspace `rust-version` was pinned at 1.94.0. This raises it to 1.97.1, the current stable release.

## What changes are included in this PR?

A single line in the root `Cargo.toml`: `rust-version = "1.94.0"` -> `"1.97.1"`. All member crates pick it up through `rust-version = { workspace = true }`.

## Are there any user-facing changes?

Yes — the minimum supported Rust version rises from 1.94.0 to 1.97.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)