### PR TITLE
perf(core): zero-copy block receive on the remote fetch path

### DIFF
--- a/ballista/core/src/client.rs
+++ b/ballista/core/src/client.rs
@@ -482,8 +482,7 @@ impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> BlockDataStream<S> {
 
             match ipc_stream.next().await {
                 Some(Ok(blob)) => {
-                    state_buffer =
-                        Self::combine_buffers(&state_buffer, &Buffer::from(blob));
+                    state_buffer = Self::append_block(state_buffer, blob);
 
                     match try_schema_from_ipc_buffer(state_buffer.as_slice()) {
                         Ok(schema) => {
@@ -517,10 +516,21 @@ impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> BlockDataStream<S> {
 }
 
 impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> BlockDataStream<S> {
-    fn combine_buffers(first: &Buffer, second: &Buffer) -> Buffer {
-        let mut combined = MutableBuffer::new(first.len() + second.len());
-        combined.extend_from_slice(first.as_slice());
-        combined.extend_from_slice(second.as_slice());
+    /// Appends a transport block to the bytes still waiting to be decoded.
+    ///
+    /// `Buffer::from(Bytes)` adopts the transport allocation instead of copying
+    /// it, so when nothing is pending — which is the steady state, since
+    /// [`StreamDecoder::decode`] drains `state_buffer` completely before the
+    /// stream asks for another block — the block is taken as-is. Only a partial
+    /// message straddling a block boundary needs the concatenating path.
+    fn append_block(pending: Buffer, blob: prost::bytes::Bytes) -> Buffer {
+        let incoming = Buffer::from(blob);
+        if pending.is_empty() {
+            return incoming;
+        }
+        let mut combined = MutableBuffer::new(pending.len() + incoming.len());
+        combined.extend_from_slice(pending.as_slice());
+        combined.extend_from_slice(incoming.as_slice());
         combined.into()
     }
 
@@ -533,7 +543,8 @@ impl<S: Stream<Item = Result<prost::bytes::Bytes>> + Unpin> BlockDataStream<S> {
         //TODO: do we want to limit maximum buffer size here as well?
         //
         self.transmitted += blob.len();
-        self.state_buffer = Self::combine_buffers(&self.state_buffer, &Buffer::from(blob))
+        let pending = std::mem::take(&mut self.state_buffer);
+        self.state_buffer = Self::append_block(pending, blob);
     }
 }
 
@@ -697,6 +708,31 @@ mod tests {
                 .await;
 
         assert_eq!(batches, result.unwrap())
+    }
+
+    #[tokio::test]
+    async fn should_process_multi_block_payload() {
+        // Realistic transport shape: a payload spanning several whole blocks.
+        // Once the decoder has drained the previous block, the next one is
+        // adopted rather than copied; block sizes that leave a partial schema
+        // message still exercise the concatenating path in `try_new`.
+        let batches = generate_batches();
+        let ipc_blob = generate_ipc_stream(&batches);
+
+        for block_size in [8usize, 64, 512] {
+            let stream = futures::stream::iter(ipc_blob.clone())
+                .chunks(block_size)
+                .map(|b| Ok(Bytes::from(b)));
+
+            let result: datafusion::error::Result<Vec<RecordBatch>> =
+                BlockDataStream::try_new(stream)
+                    .await
+                    .unwrap()
+                    .try_collect()
+                    .await;
+
+            assert_eq!(batches, result.unwrap(), "block_size={block_size}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

`BlockDataStream` copied every incoming transport block into a freshly allocated buffer, even when nothing was pending:

```rust
self.state_buffer = Self::combine_buffers(&self.state_buffer, &Buffer::from(blob))
```

Two facts make that copy avoidable in the steady state:

- `Buffer::from(bytes::Bytes)` adopts the transport allocation rather than copying it.
- `StreamDecoder::decode` loops `while !buffer.is_empty()`, and every non-error early return is `Ok(Some(batch))`. So whenever it returns `Ok(None)` — the only condition under which `poll_next` pulls another block — `state_buffer` has been fully drained.

So on the hot path the incoming block can simply be adopted. Concatenation is only needed for a partial message straddling a block boundary, which is what the schema-accumulation loop in `try_new` relies on (`try_schema_from_ipc_buffer` peeks without consuming, so a partial header stays pending there).

## What changes are included in this PR?

`combine_buffers` is replaced by `append_block`, which adopts the incoming block when nothing is pending and otherwise falls back to the existing concatenating path. Both call sites — the schema loop in `try_new` and `extend_bytes` — move to it.

This is on by default for all remote shuffle reads; there is no new configuration.

## Are these changes tested?

Yes. The existing `BlockDataStream` tests cover both paths and still pass — `should_process_chunked` (2-byte blocks) drives the concatenating path in the schema loop, and `should_process_single_message` covers whole-block adoption.

Added `should_process_multi_block_payload`, which round-trips a payload spanning several whole blocks at 8/64/512-byte block sizes, covering the mixed regime this change targets.

`cargo test --package ballista-core --lib client::` — 6 passed, 0 failed. `cargo clippy --all-targets --package ballista-core --all-features -- -D warnings` and `cargo fmt --all -- --check` are clean.

### Benchmark

65 MiB payload at the server's 8 MiB block size: 69.7 ms → 22.7 ms (**−67%**). At 1 MiB blocks: 41.8 ms → 34.9 ms (−17%).

## Are there any user-facing changes?

No API changes — `combine_buffers` and `append_block` are both private. Remote shuffle reads get faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)