### PR TITLE
perf(core): push a consumer's row limit into RangeShuffleReaderExec

### DIFF
--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -235,6 +235,8 @@ message RangeShuffleReaderExecNode {
   // Sort key the reader's k-way merge preserves. Advertised on the reader's
   // `PlanProperties.eq_properties` for downstream consumers.
   repeated datafusion.PhysicalSortExprNode merge_ordering = 4;
+  // Row limit pushed down by a consuming merge. Absent means read everything.
+  optional uint64 fetch = 5;
 }
 
 // CoalescePartitionsRule output: groups upstream partitions into coalesced output partitions.

--- a/ballista/core/src/execution_plans/range_shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/range_shuffle_reader.rs
@@ -82,7 +82,7 @@ use log::debug;
 use std::sync::Arc;
 
 /// Ordering-preserving shuffle reader. See module docs.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RangeShuffleReaderExec {
     /// Upstream stage that produced these files.
     pub stage_id: usize,
@@ -136,33 +136,25 @@ impl RangeShuffleReaderExec {
         })
     }
 
+    /// Set the row limit at construction, without cloning the reader.
+    pub fn with_fetch_limit(mut self, fetch: Option<usize>) -> Self {
+        self.fetch = fetch;
+        self
+    }
+
     /// Late-bound by the executor.
     pub fn with_work_dir(&self, work_dir: String) -> Self {
         Self {
-            stage_id: self.stage_id,
-            schema: self.schema.clone(),
-            partition: self.partition.clone(),
-            merge_ordering: self.merge_ordering.clone(),
-            fetch: self.fetch,
-            metrics: self.metrics.clone(),
-            properties: self.properties.clone(),
             work_dir: Some(work_dir),
-            client_pool: self.client_pool.clone(),
+            ..self.clone()
         }
     }
 
     /// Late-bound by the executor.
     pub fn with_client_pool(&self, client_pool: Arc<dyn BallistaClientPool>) -> Self {
         Self {
-            stage_id: self.stage_id,
-            schema: self.schema.clone(),
-            partition: self.partition.clone(),
-            merge_ordering: self.merge_ordering.clone(),
-            fetch: self.fetch,
-            metrics: self.metrics.clone(),
-            properties: self.properties.clone(),
-            work_dir: self.work_dir.clone(),
             client_pool: Some(client_pool),
+            ..self.clone()
         }
     }
 
@@ -186,12 +178,20 @@ impl DisplayAs for RangeShuffleReaderExec {
                     self.stage_id,
                     self.partition.len(),
                     self.merge_ordering,
-                )
+                )?;
+                if let Some(fetch) = self.fetch {
+                    write!(f, ", fetch: {fetch}")?;
+                }
+                Ok(())
             }
             DisplayFormatType::TreeRender => {
                 writeln!(f, "upstream_stage={}", self.stage_id)?;
                 writeln!(f, "output_partitions={}", self.partition.len())?;
-                writeln!(f, "ordering={}", self.merge_ordering)
+                writeln!(f, "ordering={}", self.merge_ordering)?;
+                if let Some(fetch) = self.fetch {
+                    writeln!(f, "fetch={fetch}")?;
+                }
+                Ok(())
             }
         }
     }
@@ -236,15 +236,8 @@ impl ExecutionPlan for RangeShuffleReaderExec {
             ));
         }
         Ok(Arc::new(Self {
-            stage_id: self.stage_id,
-            schema: self.schema.clone(),
-            partition: self.partition.clone(),
-            merge_ordering: self.merge_ordering.clone(),
-            fetch: self.fetch,
             metrics: ExecutionPlanMetricsSet::new(),
-            properties: self.properties.clone(),
-            work_dir: self.work_dir.clone(),
-            client_pool: self.client_pool.clone(),
+            ..self.as_ref().clone()
         }))
     }
 
@@ -352,15 +345,8 @@ impl ExecutionPlan for RangeShuffleReaderExec {
     /// come from the first `n` of each input.
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
         Some(Arc::new(Self {
-            stage_id: self.stage_id,
-            schema: self.schema.clone(),
-            partition: self.partition.clone(),
-            merge_ordering: self.merge_ordering.clone(),
             fetch: limit,
-            metrics: self.metrics.clone(),
-            properties: self.properties.clone(),
-            work_dir: self.work_dir.clone(),
-            client_pool: self.client_pool.clone(),
+            ..self.clone()
         }))
     }
 
@@ -398,6 +384,7 @@ mod tests {
     use datafusion::arrow::ipc::writer::StreamWriter;
     use datafusion::physical_expr::PhysicalSortExpr;
     use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_plan::{ChildrenPropertiesMode, ReplaceChildrenOptions};
     use datafusion::prelude::SessionContext;
     use std::fs::{File, create_dir_all};
     use tempfile::tempdir;
@@ -577,10 +564,8 @@ mod tests {
         assert!(batches.is_empty());
     }
 
-    /// The reader must advertise its merge ordering so downstream operators
-    /// see the sortedness invariant (BWAG's RANGE-frame cursor, SMJ build side).
-    /// A limit must survive `with_new_children`, or the merge quietly goes
-    /// back to reading everything.
+    /// A limit must survive a rebuild, or the merge quietly goes back to
+    /// reading everything.
     #[test]
     fn fetch_roundtrips_through_with_fetch() {
         use datafusion::physical_plan::ExecutionPlan;
@@ -600,15 +585,16 @@ mod tests {
         assert_eq!(limited.fetch(), Some(20));
 
         let rebuilt = Arc::clone(&limited)
-            .with_new_children(limited.children().into_iter().cloned().collect())
+            .replace_children(
+                vec![],
+                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+            )
             .expect("rebuild");
-        assert_eq!(
-            rebuilt.fetch(),
-            Some(20),
-            "fetch must survive with_new_children"
-        );
+        assert_eq!(rebuilt.fetch(), Some(20), "fetch must survive a rebuild");
     }
 
+    /// The reader must advertise its merge ordering so downstream operators
+    /// see the sortedness invariant (BWAG's RANGE-frame cursor, SMJ build side).
     #[test]
     fn advertises_merge_ordering() {
         let schema =

--- a/ballista/core/src/execution_plans/range_shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/range_shuffle_reader.rs
@@ -93,6 +93,8 @@ pub struct RangeShuffleReaderExec {
     /// Sort key the merge preserves. Advertised in `PlanProperties.eq_properties`
     /// so downstream operators (BWAG, SMJ build side) see the output ordering.
     merge_ordering: LexOrdering,
+    /// Row limit pushed down by a consumer. `None` means read everything.
+    fetch: Option<usize>,
     metrics: ExecutionPlanMetricsSet,
     properties: Arc<PlanProperties>,
     work_dir: Option<String>,
@@ -126,6 +128,7 @@ impl RangeShuffleReaderExec {
             schema,
             partition,
             merge_ordering,
+            fetch: None,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,
@@ -140,6 +143,7 @@ impl RangeShuffleReaderExec {
             schema: self.schema.clone(),
             partition: self.partition.clone(),
             merge_ordering: self.merge_ordering.clone(),
+            fetch: self.fetch,
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
             work_dir: Some(work_dir),
@@ -154,6 +158,7 @@ impl RangeShuffleReaderExec {
             schema: self.schema.clone(),
             partition: self.partition.clone(),
             merge_ordering: self.merge_ordering.clone(),
+            fetch: self.fetch,
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
             work_dir: self.work_dir.clone(),
@@ -235,6 +240,7 @@ impl ExecutionPlan for RangeShuffleReaderExec {
             schema: self.schema.clone(),
             partition: self.partition.clone(),
             merge_ordering: self.merge_ordering.clone(),
+            fetch: self.fetch,
             metrics: ExecutionPlanMetricsSet::new(),
             properties: self.properties.clone(),
             work_dir: self.work_dir.clone(),
@@ -330,11 +336,32 @@ impl ExecutionPlan for RangeShuffleReaderExec {
             .with_schema(self.schema.clone())
             .with_expressions(&self.merge_ordering)
             .with_batch_size(config.batch_size())
+            .with_fetch(self.fetch)
             .with_metrics(baseline)
             .with_reservation(reservation)
             .build()?;
 
         Ok(merged)
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.fetch
+    }
+
+    /// The output is sorted on `merge_ordering`, so the first `n` rows of the
+    /// merge can only come from the first `n` rows of each input.
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        Some(Arc::new(Self {
+            stage_id: self.stage_id,
+            schema: self.schema.clone(),
+            partition: self.partition.clone(),
+            merge_ordering: self.merge_ordering.clone(),
+            fetch: limit,
+            metrics: self.metrics.clone(),
+            properties: self.properties.clone(),
+            work_dir: self.work_dir.clone(),
+            client_pool: self.client_pool.clone(),
+        }))
     }
 
     fn metrics(&self) -> Option<datafusion::physical_plan::metrics::MetricsSet> {
@@ -552,6 +579,36 @@ mod tests {
 
     /// The reader must advertise its merge ordering so downstream operators
     /// see the sortedness invariant (BWAG's RANGE-frame cursor, SMJ build side).
+    /// A pushed-down limit must survive `with_new_children`, or the merge
+    /// quietly reverts to reading everything.
+    #[test]
+    fn fetch_roundtrips_through_with_fetch() {
+        use datafusion::physical_plan::ExecutionPlan;
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("v", DataType::Float64, false)]));
+        let merge_ordering = LexOrdering::new(vec![PhysicalSortExpr::new_default(
+            Arc::new(Column::new("v", 0)),
+        )])
+        .unwrap();
+        let reader =
+            RangeShuffleReaderExec::try_new(3, vec![vec![]; 4], schema, merge_ordering)
+                .unwrap();
+        assert_eq!(reader.fetch(), None, "reader starts unlimited");
+
+        let limited = ExecutionPlan::with_fetch(&reader, Some(20))
+            .expect("RangeShuffleReaderExec must accept a pushed-down limit");
+        assert_eq!(limited.fetch(), Some(20));
+
+        let rebuilt = Arc::clone(&limited)
+            .with_new_children(limited.children().into_iter().cloned().collect())
+            .expect("rebuild");
+        assert_eq!(
+            rebuilt.fetch(),
+            Some(20),
+            "fetch must survive with_new_children"
+        );
+    }
+
     #[test]
     fn advertises_merge_ordering() {
         let schema =

--- a/ballista/core/src/execution_plans/range_shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/range_shuffle_reader.rs
@@ -348,8 +348,8 @@ impl ExecutionPlan for RangeShuffleReaderExec {
         self.fetch
     }
 
-    /// The output is sorted on `merge_ordering`, so the first `n` rows of the
-    /// merge can only come from the first `n` rows of each input.
+    /// Output is sorted on `merge_ordering`, so the first `n` rows can only
+    /// come from the first `n` of each input.
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
         Some(Arc::new(Self {
             stage_id: self.stage_id,
@@ -579,8 +579,8 @@ mod tests {
 
     /// The reader must advertise its merge ordering so downstream operators
     /// see the sortedness invariant (BWAG's RANGE-frame cursor, SMJ build side).
-    /// A pushed-down limit must survive `with_new_children`, or the merge
-    /// quietly reverts to reading everything.
+    /// A limit must survive `with_new_children`, or the merge quietly goes
+    /// back to reading everything.
     #[test]
     fn fetch_roundtrips_through_with_fetch() {
         use datafusion::physical_plan::ExecutionPlan;

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -300,6 +300,9 @@ pub struct RangeShuffleReaderExecNode {
     pub merge_ordering: ::prost::alloc::vec::Vec<
         ::datafusion_proto::protobuf::PhysicalSortExprNode,
     >,
+    /// Row limit pushed down by a consuming merge. Absent means read everything.
+    #[prost(uint64, optional, tag = "5")]
+    pub fetch: ::core::option::Option<u64>,
 }
 /// CoalescePartitionsRule output: groups upstream partitions into coalesced output partitions.
 /// Empty when no coalesce is applied (the optional field on the parent message is absent).

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -542,12 +542,15 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                         "RangeShuffleReaderExec: merge_ordering must be non-empty",
                     )
                 })?;
-                Ok(Arc::new(RangeShuffleReaderExec::try_new(
+                let reader = RangeShuffleReaderExec::try_new(
                     stage_id,
                     partition_location,
                     schema,
                     merge_ordering,
-                )?))
+                )?;
+                Ok(Arc::new(
+                    reader.with_fetch_limit(range_reader.fetch.map(|f| f as usize)),
+                ))
             }
             PhysicalPlanType::UnresolvedShuffle(unresolved_shuffle) => {
                 let schema: SchemaRef =
@@ -934,6 +937,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                         partition,
                         schema: Some(exec.schema().as_ref().try_into()?),
                         merge_ordering,
+                        fetch: exec.fetch().map(|f| f as u64),
                     },
                 )),
             };
@@ -1430,7 +1434,8 @@ mod test {
             schema.clone(),
             merge_ordering.clone(),
         )
-        .unwrap();
+        .unwrap()
+        .with_fetch_limit(Some(20));
 
         let codec = BallistaPhysicalExtensionCodec::default();
         let mut buf: Vec<u8> = vec![];
@@ -1461,6 +1466,13 @@ mod test {
         assert_eq!(
             decoded.merge_ordering().first().expr.to_string(),
             sort_expr.expr.to_string(),
+        );
+        // Dropped on the wire, the limit would silently stop applying: the
+        // reader only ever executes after being decoded on an executor.
+        assert_eq!(
+            ExecutionPlan::fetch(decoded),
+            Some(20),
+            "fetch must round-trip"
         );
         // The ordering must land on `PlanProperties.eq_properties` — downstream
         // consumers (BWAG, SMJ build side) read it there.

--- a/ballista/scheduler/src/state/aqe/adapter.rs
+++ b/ballista/scheduler/src/state/aqe/adapter.rs
@@ -25,6 +25,8 @@ use ballista_core::JobId;
 use ballista_core::execution_plans::{
     RangeFilterExec, RangeShuffleReaderExec, ShuffleReaderExec,
 };
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::{ChildrenPropertiesMode, ReplaceChildrenOptions};
 use datafusion::common::exec_err;
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
@@ -154,6 +156,7 @@ impl BallistaAdapter {
                 .clone()
                 .transform_down(|e| adapter.transform_children(e))?
                 .data;
+            let plan = pushdown_fetch_into_range_readers(plan)?;
             let stage_id = root.stage_id().ok_or_else(|| {
                 DataFusionError::Execution(
                     "shuffle partitions have to be resolved at this point".to_string(),
@@ -182,6 +185,7 @@ impl BallistaAdapter {
                 .clone()
                 .transform_down(|e| adapter.transform_children(e))?
                 .data;
+            let plan = pushdown_fetch_into_range_readers(plan)?;
             let stage_id = root.stage_id().ok_or_else(|| {
                 DataFusionError::Execution(
                     "shuffle partitions have to be resolved at this point".to_string(),
@@ -202,6 +206,44 @@ impl BallistaAdapter {
             )
         }
     }
+}
+
+/// Push a `SortPreservingMergeExec`'s row limit into the
+/// `RangeShuffleReaderExec` below it.
+///
+/// Both merge on the same ordering, so the consumer's first `n` rows can only
+/// come from the reader's first `n`. Without this the reader merges its whole
+/// input and the consumer throws most of it away.
+///
+/// DataFusion's limit pushdown can't do this: the reader is planted here, after
+/// the optimizer chain has run.
+fn pushdown_fetch_into_range_readers(
+    plan: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    Ok(plan
+        .transform_down(|node| {
+            let Some(spm) = node.downcast_ref::<SortPreservingMergeExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(fetch) = spm.fetch() else {
+                return Ok(Transformed::no(node));
+            };
+            let children = node.children();
+            let [child] = children.as_slice() else {
+                return Ok(Transformed::no(node));
+            };
+            if !child.is::<RangeShuffleReaderExec>() {
+                return Ok(Transformed::no(node));
+            }
+            let Some(limited) = child.with_fetch(Some(fetch)) else {
+                return Ok(Transformed::no(node));
+            };
+            Ok(Transformed::yes(node.replace_children(
+                vec![limited],
+                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+            )?))
+        })?
+        .data)
 }
 
 /// Walk `plan` and resolve every pending [`RangeFilterExec`]'s bounds from

--- a/ballista/scheduler/src/state/aqe/adapter.rs
+++ b/ballista/scheduler/src/state/aqe/adapter.rs
@@ -413,4 +413,37 @@ mod tests {
         );
         assert!(out.downcast_ref::<RangeShuffleReaderExec>().is_none());
     }
+
+    /// The consuming merge's row limit must reach the reader. The merge is
+    /// rebuilt around the new reader, so a dropped limit is silent.
+    #[test]
+    fn pushes_consumer_limit_into_range_reader() {
+        let schema = f64_schema();
+        let empty: Vec<Vec<RecordBatch>> = vec![vec![]];
+        let source =
+            MemorySourceConfig::try_new_exec(&empty, schema.clone(), None).unwrap();
+        let sort_lex = LexOrdering::new(vec![asc(&schema, "v")]).unwrap();
+        let sorted = Arc::new(
+            SortExec::new(sort_lex.clone(), source).with_preserve_partitioning(true),
+        ) as Arc<dyn ExecutionPlan>;
+
+        let exchange = ExchangeExec::new(sorted, None, 0);
+        exchange.set_stage_id(1);
+        exchange.resolve_shuffle_partitions(vec![vec![]]);
+        let merge = Arc::new(
+            SortPreservingMergeExec::new(sort_lex, Arc::new(exchange))
+                .with_fetch(Some(7)),
+        ) as Arc<dyn ExecutionPlan>;
+
+        let mut adapter = BallistaAdapter::default();
+        let out = adapter.transform_children(merge).unwrap().data;
+
+        let children = out.children();
+        let reader = children[0]
+            .downcast_ref::<RangeShuffleReaderExec>()
+            .unwrap_or_else(|| {
+                panic!("expected a range reader, got {}", children[0].name())
+            });
+        assert_eq!(reader.fetch(), Some(7));
+    }
 }

--- a/ballista/scheduler/src/state/aqe/adapter.rs
+++ b/ballista/scheduler/src/state/aqe/adapter.rs
@@ -29,8 +29,9 @@ use datafusion::common::exec_err;
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
-use datafusion::physical_plan::{ChildrenPropertiesMode, ReplaceChildrenOptions};
-use datafusion::physical_plan::{ExecutionPlanProperties, Partitioning};
+use datafusion::physical_plan::{
+    ExecutionPlanProperties, Partitioning, replace_children_if_necessary,
+};
 use datafusion::scalar::ScalarValue;
 use datafusion::{
     common::tree_node::{Transformed, TreeNode, TreeNodeRecursion},
@@ -51,10 +52,12 @@ pub(crate) struct BallistaAdapter {
 ///
 impl BallistaAdapter {
     /// Build the reader that replaces `exchange`, recording its upstream
-    /// stage as an input of this stage.
+    /// stage as an input of this stage. `fetch` is a row limit from the
+    /// consumer; only the ordered reader can honor it.
     fn build_reader(
         &mut self,
         exchange: &ExchangeExec,
+        fetch: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         let schema = exchange.schema().clone();
         let partitions = exchange.shuffle_partitions().ok_or_else(|| {
@@ -76,66 +79,67 @@ impl BallistaAdapter {
         self.inputs.insert(stage_id, stage_output);
         let partitioning = exchange.properties().partitioning.clone();
 
-        let reader: Arc<dyn ExecutionPlan> =
-            match (exchange.coalesce(), exchange.broadcast) {
-                (Some(cp), false) => {
-                    // Concatenate M-shape locations into K-shape per CoalescePlan.groups.
-                    let k_shape: Vec<Vec<_>> = cp
-                        .groups
-                        .iter()
-                        .map(|pg| {
-                            let mut concat = Vec::new();
-                            for &idx in &pg.upstream_indices {
-                                if let Some(inner) = partitions.get(idx as usize) {
-                                    concat.extend_from_slice(inner);
-                                }
+        Ok(match (exchange.coalesce(), exchange.broadcast) {
+            (Some(cp), false) => {
+                // Concatenate M-shape locations into K-shape per CoalescePlan.groups.
+                let k_shape: Vec<Vec<_>> = cp
+                    .groups
+                    .iter()
+                    .map(|pg| {
+                        let mut concat = Vec::new();
+                        for &idx in &pg.upstream_indices {
+                            if let Some(inner) = partitions.get(idx as usize) {
+                                concat.extend_from_slice(inner);
                             }
-                            concat
-                        })
-                        .collect();
-                    let new_partitioning = match &partitioning {
-                        Partitioning::Hash(keys, _m) => {
-                            Partitioning::Hash(keys.clone(), cp.groups.len())
                         }
-                        _ => Partitioning::UnknownPartitioning(cp.groups.len()),
-                    };
-                    Arc::new(ShuffleReaderExec::try_new_coalesced(
-                        stage_id,
-                        k_shape,
-                        (*cp).clone(),
-                        schema,
-                        new_partitioning,
-                    )?)
-                }
-                (None, false) => {
-                    // Ordered-writer path: when the child declared an output
-                    // ordering, preserve it across the shuffle boundary with a
-                    // k-way merge instead of the arrival-order concat that the
-                    // regular reader does.
-                    if let Some(ordering) = exchange.input().output_ordering() {
-                        Arc::new(RangeShuffleReaderExec::try_new(
+                        concat
+                    })
+                    .collect();
+                let new_partitioning = match &partitioning {
+                    Partitioning::Hash(keys, _m) => {
+                        Partitioning::Hash(keys.clone(), cp.groups.len())
+                    }
+                    _ => Partitioning::UnknownPartitioning(cp.groups.len()),
+                };
+                Arc::new(ShuffleReaderExec::try_new_coalesced(
+                    stage_id,
+                    k_shape,
+                    (*cp).clone(),
+                    schema,
+                    new_partitioning,
+                )?)
+            }
+            (None, false) => {
+                // Ordered-writer path: when the child declared an output
+                // ordering, preserve it across the shuffle boundary with a
+                // k-way merge instead of the arrival-order concat that the
+                // regular reader does.
+                if let Some(ordering) = exchange.input().output_ordering() {
+                    Arc::new(
+                        RangeShuffleReaderExec::try_new(
                             stage_id,
                             partitions,
                             schema,
                             ordering.clone(),
-                        )?)
-                    } else {
-                        Arc::new(ShuffleReaderExec::try_new(
-                            stage_id,
-                            partitions,
-                            schema,
-                            partitioning,
-                        )?)
-                    }
+                        )?
+                        .with_fetch_limit(fetch),
+                    )
+                } else {
+                    Arc::new(ShuffleReaderExec::try_new(
+                        stage_id,
+                        partitions,
+                        schema,
+                        partitioning,
+                    )?)
                 }
-                (_, true) => Arc::new(ShuffleReaderExec::try_new_broadcast(
-                    stage_id,
-                    exchange.shuffle_partitions_flattened(),
-                    schema,
-                    exchange.input().output_partitioning().partition_count(),
-                )?),
-            };
-        Ok(reader)
+            }
+            (_, true) => Arc::new(ShuffleReaderExec::try_new_broadcast(
+                stage_id,
+                exchange.shuffle_partitions_flattened(),
+                schema,
+                exchange.input().output_partitioning().partition_count(),
+            )?),
+        })
     }
 
     fn transform_children(
@@ -147,26 +151,20 @@ impl BallistaAdapter {
         // consumer's first `n` rows come from the reader's first `n`.
         if let Some(spm) = plan.downcast_ref::<SortPreservingMergeExec>()
             && let Some(fetch) = spm.fetch()
+            && let Some(exchange) = spm.input().downcast_ref::<ExchangeExec>()
         {
-            let children = plan.children();
-            if let [child] = children.as_slice()
-                && let Some(exchange) = child.downcast_ref::<ExchangeExec>()
-            {
-                let reader = self.build_reader(exchange)?;
-                let reader = reader.with_fetch(Some(fetch)).unwrap_or(reader);
-                return Ok(Transformed::yes(plan.replace_children(
-                    vec![reader],
-                    ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
-                )?));
-            }
+            let reader = self.build_reader(exchange, Some(fetch))?;
+            return Ok(Transformed::yes(replace_children_if_necessary(
+                plan,
+                vec![reader],
+            )?));
         }
 
         if let Some(exchange) = plan.downcast_ref::<ExchangeExec>() {
-            let reader = self.build_reader(exchange)?;
-            Ok(Transformed::yes(reader))
-        } else {
-            Ok(Transformed::no(plan))
+            return Ok(Transformed::yes(self.build_reader(exchange, None)?));
         }
+
+        Ok(Transformed::no(plan))
     }
 
     /// Converts Adaptive plan to plan which ballista expects

--- a/ballista/scheduler/src/state/aqe/adapter.rs
+++ b/ballista/scheduler/src/state/aqe/adapter.rs
@@ -25,11 +25,11 @@ use ballista_core::JobId;
 use ballista_core::execution_plans::{
     RangeFilterExec, RangeShuffleReaderExec, ShuffleReaderExec,
 };
-use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
-use datafusion::physical_plan::{ChildrenPropertiesMode, ReplaceChildrenOptions};
 use datafusion::common::exec_err;
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::{ChildrenPropertiesMode, ReplaceChildrenOptions};
 use datafusion::physical_plan::{ExecutionPlanProperties, Partitioning};
 use datafusion::scalar::ScalarValue;
 use datafusion::{
@@ -50,90 +50,119 @@ pub(crate) struct BallistaAdapter {
 /// ShuffleWriterExec/SortShuffleWriterExec and [ShuffleReaderExec]
 ///
 impl BallistaAdapter {
+    /// Build the reader that replaces `exchange`, recording its upstream
+    /// stage as an input of this stage.
+    fn build_reader(
+        &mut self,
+        exchange: &ExchangeExec,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let schema = exchange.schema().clone();
+        let partitions = exchange.shuffle_partitions().ok_or_else(|| {
+            DataFusionError::Execution(
+                "partitions have to be resolved at this point".to_string(),
+            )
+        })?;
+
+        let stage_id = exchange.stage_id().ok_or_else(|| {
+            DataFusionError::Execution(
+                "stage ID has to be generated at this point".to_string(),
+            )
+        })?;
+        let mut stage_output = StageOutput::new();
+        for partition in partitions.iter().flatten().cloned() {
+            stage_output.add_partition(partition);
+        }
+        stage_output.complete = true;
+        self.inputs.insert(stage_id, stage_output);
+        let partitioning = exchange.properties().partitioning.clone();
+
+        let reader: Arc<dyn ExecutionPlan> =
+            match (exchange.coalesce(), exchange.broadcast) {
+                (Some(cp), false) => {
+                    // Concatenate M-shape locations into K-shape per CoalescePlan.groups.
+                    let k_shape: Vec<Vec<_>> = cp
+                        .groups
+                        .iter()
+                        .map(|pg| {
+                            let mut concat = Vec::new();
+                            for &idx in &pg.upstream_indices {
+                                if let Some(inner) = partitions.get(idx as usize) {
+                                    concat.extend_from_slice(inner);
+                                }
+                            }
+                            concat
+                        })
+                        .collect();
+                    let new_partitioning = match &partitioning {
+                        Partitioning::Hash(keys, _m) => {
+                            Partitioning::Hash(keys.clone(), cp.groups.len())
+                        }
+                        _ => Partitioning::UnknownPartitioning(cp.groups.len()),
+                    };
+                    Arc::new(ShuffleReaderExec::try_new_coalesced(
+                        stage_id,
+                        k_shape,
+                        (*cp).clone(),
+                        schema,
+                        new_partitioning,
+                    )?)
+                }
+                (None, false) => {
+                    // Ordered-writer path: when the child declared an output
+                    // ordering, preserve it across the shuffle boundary with a
+                    // k-way merge instead of the arrival-order concat that the
+                    // regular reader does.
+                    if let Some(ordering) = exchange.input().output_ordering() {
+                        Arc::new(RangeShuffleReaderExec::try_new(
+                            stage_id,
+                            partitions,
+                            schema,
+                            ordering.clone(),
+                        )?)
+                    } else {
+                        Arc::new(ShuffleReaderExec::try_new(
+                            stage_id,
+                            partitions,
+                            schema,
+                            partitioning,
+                        )?)
+                    }
+                }
+                (_, true) => Arc::new(ShuffleReaderExec::try_new_broadcast(
+                    stage_id,
+                    exchange.shuffle_partitions_flattened(),
+                    schema,
+                    exchange.input().output_partitioning().partition_count(),
+                )?),
+            };
+        Ok(reader)
+    }
+
     fn transform_children(
         &mut self,
         plan: Arc<dyn ExecutionPlan>,
     ) -> datafusion::error::Result<Transformed<Arc<dyn ExecutionPlan>>> {
-        if let Some(exchange) = plan.downcast_ref::<ExchangeExec>() {
-            let schema = exchange.schema().clone();
-            let partitions = exchange.shuffle_partitions().ok_or_else(|| {
-                DataFusionError::Execution(
-                    "partitions have to be resolved at this point".to_string(),
-                )
-            })?;
-
-            let stage_id = exchange.stage_id().ok_or_else(|| {
-                DataFusionError::Execution(
-                    "stage ID has to be generated at this point".to_string(),
-                )
-            })?;
-            let mut stage_output = StageOutput::new();
-            for partition in partitions.iter().flatten().cloned() {
-                stage_output.add_partition(partition);
+        // A merge with a row limit on top of an exchange: build the reader
+        // with the limit already set. Both merge on the same ordering, so the
+        // consumer's first `n` rows come from the reader's first `n`.
+        if let Some(spm) = plan.downcast_ref::<SortPreservingMergeExec>()
+            && let Some(fetch) = spm.fetch()
+        {
+            let children = plan.children();
+            if let [child] = children.as_slice()
+                && let Some(exchange) = child.downcast_ref::<ExchangeExec>()
+            {
+                let reader = self.build_reader(exchange)?;
+                let reader = reader.with_fetch(Some(fetch)).unwrap_or(reader);
+                return Ok(Transformed::yes(plan.replace_children(
+                    vec![reader],
+                    ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+                )?));
             }
-            stage_output.complete = true;
-            self.inputs.insert(stage_id, stage_output);
-            let partitioning = exchange.properties().partitioning.clone();
+        }
 
-            let reader: Arc<dyn ExecutionPlan> =
-                match (exchange.coalesce(), exchange.broadcast) {
-                    (Some(cp), false) => {
-                        // Concatenate M-shape locations into K-shape per CoalescePlan.groups.
-                        let k_shape: Vec<Vec<_>> = cp
-                            .groups
-                            .iter()
-                            .map(|pg| {
-                                let mut concat = Vec::new();
-                                for &idx in &pg.upstream_indices {
-                                    if let Some(inner) = partitions.get(idx as usize) {
-                                        concat.extend_from_slice(inner);
-                                    }
-                                }
-                                concat
-                            })
-                            .collect();
-                        let new_partitioning = match &partitioning {
-                            Partitioning::Hash(keys, _m) => {
-                                Partitioning::Hash(keys.clone(), cp.groups.len())
-                            }
-                            _ => Partitioning::UnknownPartitioning(cp.groups.len()),
-                        };
-                        Arc::new(ShuffleReaderExec::try_new_coalesced(
-                            stage_id,
-                            k_shape,
-                            (*cp).clone(),
-                            schema,
-                            new_partitioning,
-                        )?)
-                    }
-                    (None, false) => {
-                        // Ordered-writer path: when the child declared an output
-                        // ordering, preserve it across the shuffle boundary with a
-                        // k-way merge instead of the arrival-order concat that the
-                        // regular reader does.
-                        if let Some(ordering) = exchange.input().output_ordering() {
-                            Arc::new(RangeShuffleReaderExec::try_new(
-                                stage_id,
-                                partitions,
-                                schema,
-                                ordering.clone(),
-                            )?)
-                        } else {
-                            Arc::new(ShuffleReaderExec::try_new(
-                                stage_id,
-                                partitions,
-                                schema,
-                                partitioning,
-                            )?)
-                        }
-                    }
-                    (_, true) => Arc::new(ShuffleReaderExec::try_new_broadcast(
-                        stage_id,
-                        exchange.shuffle_partitions_flattened(),
-                        schema,
-                        exchange.input().output_partitioning().partition_count(),
-                    )?),
-                };
+        if let Some(exchange) = plan.downcast_ref::<ExchangeExec>() {
+            let reader = self.build_reader(exchange)?;
             Ok(Transformed::yes(reader))
         } else {
             Ok(Transformed::no(plan))
@@ -156,7 +185,6 @@ impl BallistaAdapter {
                 .clone()
                 .transform_down(|e| adapter.transform_children(e))?
                 .data;
-            let plan = pushdown_fetch_into_range_readers(plan)?;
             let stage_id = root.stage_id().ok_or_else(|| {
                 DataFusionError::Execution(
                     "shuffle partitions have to be resolved at this point".to_string(),
@@ -185,7 +213,6 @@ impl BallistaAdapter {
                 .clone()
                 .transform_down(|e| adapter.transform_children(e))?
                 .data;
-            let plan = pushdown_fetch_into_range_readers(plan)?;
             let stage_id = root.stage_id().ok_or_else(|| {
                 DataFusionError::Execution(
                     "shuffle partitions have to be resolved at this point".to_string(),
@@ -206,44 +233,6 @@ impl BallistaAdapter {
             )
         }
     }
-}
-
-/// Push a `SortPreservingMergeExec`'s row limit into the
-/// `RangeShuffleReaderExec` below it.
-///
-/// Both merge on the same ordering, so the consumer's first `n` rows can only
-/// come from the reader's first `n`. Without this the reader merges its whole
-/// input and the consumer throws most of it away.
-///
-/// DataFusion's limit pushdown can't do this: the reader is planted here, after
-/// the optimizer chain has run.
-fn pushdown_fetch_into_range_readers(
-    plan: Arc<dyn ExecutionPlan>,
-) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    Ok(plan
-        .transform_down(|node| {
-            let Some(spm) = node.downcast_ref::<SortPreservingMergeExec>() else {
-                return Ok(Transformed::no(node));
-            };
-            let Some(fetch) = spm.fetch() else {
-                return Ok(Transformed::no(node));
-            };
-            let children = node.children();
-            let [child] = children.as_slice() else {
-                return Ok(Transformed::no(node));
-            };
-            if !child.is::<RangeShuffleReaderExec>() {
-                return Ok(Transformed::no(node));
-            }
-            let Some(limited) = child.with_fetch(Some(fetch)) else {
-                return Ok(Transformed::no(node));
-            };
-            Ok(Transformed::yes(node.replace_children(
-                vec![limited],
-                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
-            )?))
-        })?
-        .data)
 }
 
 /// Walk `plan` and resolve every pending [`RangeFilterExec`]'s bounds from

--- a/ballista/scheduler/src/state/task_builder.rs
+++ b/ballista/scheduler/src/state/task_builder.rs
@@ -336,7 +336,7 @@ fn select_output_partitions(
         ) else {
             return Ok(None);
         };
-        return Ok(Some(Arc::new(restricted)));
+        return Ok(Some(Arc::new(restricted.with_fetch_limit(reader.fetch()))));
     }
 
     // DataSourceExec: file-backed or in-memory scans.


### PR DESCRIPTION
Related: https://github.com/apache/datafusion-ballista/issues/2321

## Summary

`RangeShuffleReaderExec` merges all of its input streams to completion even
when the `SortPreservingMergeExec` directly above it only wants the first few
rows. Its `StreamingMerge` was built without a fetch:

```rust
StreamingMergeBuilder::new()
    .with_streams(sub_streams)
    .with_batch_size(config.batch_size())
    .with_reservation(reservation)
    .build()?                       // no .with_fetch(...)
```