### PR TITLE
perf(scheduler): read an unfiltered small scan inline instead of staging it

### DIFF
--- a/ballista/scheduler/src/state/aqe/optimizer_rule/distributed_exchange.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/distributed_exchange.rs
@@ -16,18 +16,22 @@
 // under the License.
 
 use crate::state::aqe::execution_plan::{AdaptiveDatafusionExec, ExchangeExec};
+use ballista_core::config::BallistaConfig;
 use ballista_core::execution_plans::{
     OrderedRangeRepartitionExec, RangeFilterExec, UnorderedRangeRepartitionExec,
     preserves_partitioning,
 };
 use datafusion::common::plan_err;
+use datafusion::common::stats::Precision;
 use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::datasource::source::DataSourceExec;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::statistics::{StatisticsArgs, StatisticsContext};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, ExecutionPlan, ReplaceChildrenOptions, execution_plan,
 };
@@ -53,6 +57,7 @@ impl DistributedExchangeRule {
     pub(crate) fn transform(
         &self,
         execution_plan: Arc<dyn ExecutionPlan>,
+        config: &datafusion::config::ConfigOptions,
     ) -> datafusion::error::Result<Transformed<Arc<dyn ExecutionPlan>>> {
         // DataFusion's null-aware hash join coordinates visited rows and
         // probe-side NULL state with in-process atomics. A CollectLeft join
@@ -93,6 +98,7 @@ impl DistributedExchangeRule {
             let input = coalesce.input();
             if input.downcast_ref::<ExchangeExec>().is_none()
                 && !matches!(nearest_exchange_status(input), ExchangeStatus::Unresolved)
+                && !is_inlinable_scan_pipeline(input, broadcast_threshold_bytes(config))?
             {
                 let exchange_exec = ExchangeExec::new(
                     input.clone(),
@@ -175,6 +181,67 @@ impl DistributedExchangeRule {
     }
 }
 
+/// Reuses the broadcast budget: a scan cheap enough to sit in every probe task
+/// is cheap enough to re-read there. `0` disables inlining.
+fn broadcast_threshold_bytes(config: &datafusion::config::ConfigOptions) -> usize {
+    config
+        .extensions
+        .get::<BallistaConfig>()
+        .cloned()
+        .unwrap_or_default()
+        .broadcast_join_threshold_bytes()
+}
+
+/// True when every task of the consuming stage can read `plan` directly, making
+/// a stage boundary under it pure cost: the `CoalescePartitionsExec` DataFusion
+/// plants over a `CollectLeft` build side gathers inside one task either way.
+///
+/// Filtered scans are excluded — the staged copy is then much smaller than the
+/// scan, so rebuilding it per task costs more than reading it back (inlining
+/// q19's filtered `part` cost 14%). `Precision::Exact` is the test, since the
+/// predicate is often pushed into the scan with no `FilterExec` to look for.
+fn is_inlinable_scan_pipeline(
+    plan: &Arc<dyn ExecutionPlan>,
+    max_bytes: usize,
+) -> datafusion::error::Result<bool> {
+    if max_bytes == 0 {
+        return Ok(false);
+    }
+    let mut scan_bytes = 0usize;
+    let mut leaves = 0usize;
+    if !collect_scan_bytes(plan, &mut scan_bytes, &mut leaves)? {
+        return Ok(false);
+    }
+    Ok(leaves > 0 && scan_bytes <= max_bytes)
+}
+
+/// Sums the leaf scans' bytes; `false` on any other operator or inexact leaf.
+fn collect_scan_bytes(
+    plan: &Arc<dyn ExecutionPlan>,
+    total_bytes: &mut usize,
+    leaves: &mut usize,
+) -> datafusion::error::Result<bool> {
+    if plan.is::<DataSourceExec>() {
+        let stats =
+            StatisticsContext::new().compute(plan.as_ref(), &StatisticsArgs::new())?;
+        let Precision::Exact(bytes) = stats.total_byte_size else {
+            return Ok(false);
+        };
+        *total_bytes = total_bytes.saturating_add(bytes);
+        *leaves += 1;
+        return Ok(true);
+    }
+    if !plan.is::<ProjectionExec>() {
+        return Ok(false);
+    }
+    for child in plan.children() {
+        if !collect_scan_bytes(child, total_bytes, leaves)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 /// Returns whether a plan should have distributed range-repartitioning added:
 ///
 /// `Ok(true)` - `plan` has a "range-repartitioned child" that should have an ExchangeExec
@@ -219,11 +286,11 @@ impl PhysicalOptimizerRule for DistributedExchangeRule {
     fn optimize(
         &self,
         execution_plan: std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-        _config: &datafusion::config::ConfigOptions,
+        config: &datafusion::config::ConfigOptions,
     ) -> datafusion::error::Result<
         std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
     > {
-        let result = execution_plan.transform_up(|p| self.transform(p))?;
+        let result = execution_plan.transform_up(|p| self.transform(p, config))?;
 
         if result
             .data
@@ -324,15 +391,23 @@ mod tests {
     use ballista_core::execution_plans::{
         RuntimeStatsExec, UnorderedRangeRepartitionExec,
     };
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
     use datafusion::arrow::compute::SortOptions;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::ScalarValue;
     use datafusion::common::{ColumnStatistics, Statistics};
     use datafusion::config::ConfigOptions;
-    use datafusion::physical_expr::expressions::Column;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, Literal};
     use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
     use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::aggregates::{
+        AggregateExec, AggregateMode, PhysicalGroupBy,
+    };
     use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
     use datafusion::physical_plan::execution_plan::Partitioning;
+    use datafusion::physical_plan::filter::FilterExec;
     use datafusion::physical_plan::repartition::RepartitionExec;
     use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
     use datafusion::physical_plan::test::exec::StatisticsExec;
@@ -422,6 +497,167 @@ mod tests {
             ExchangeExec: partitioning=None, plan_id=0, stage_id=pending, stage_resolved=false
               StatisticsExec: col_count=1, row_count=Absent
         ");
+    }
+
+    /// Scan with exact bytes, like a parquet scan with collected statistics.
+    fn scan_exec() -> Arc<dyn ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).unwrap()
+    }
+
+    fn config_with_broadcast_threshold(bytes: usize) -> ConfigOptions {
+        let mut config = ConfigOptions::new();
+        config.extensions.insert(BallistaConfig::default());
+        config
+            .set(
+                "ballista.optimizer.broadcast_join_threshold_bytes",
+                &bytes.to_string(),
+            )
+            .unwrap();
+        config
+    }
+
+    #[test]
+    fn coalesce_reads_small_scan_inline_instead_of_staging_it() {
+        let rule = DistributedExchangeRule::default();
+        let input =
+            Arc::new(CoalescePartitionsExec::new(scan_exec())) as Arc<dyn ExecutionPlan>;
+
+        let result = rule
+            .optimize(input, &config_with_broadcast_threshold(64 * 1024 * 1024))
+            .unwrap();
+
+        let adaptive = result.downcast_ref::<AdaptiveDatafusionExec>().unwrap();
+        let coalesce = adaptive
+            .input()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .unwrap();
+        assert!(
+            coalesce.children()[0].is::<DataSourceExec>(),
+            "small scan should stay inline, got {}",
+            coalesce.children()[0].name()
+        );
+    }
+
+    #[test]
+    fn coalesce_stages_scan_larger_than_the_broadcast_threshold() {
+        let rule = DistributedExchangeRule::default();
+        let input =
+            Arc::new(CoalescePartitionsExec::new(scan_exec())) as Arc<dyn ExecutionPlan>;
+
+        let result = rule
+            .optimize(input, &config_with_broadcast_threshold(1))
+            .unwrap();
+
+        let adaptive = result.downcast_ref::<AdaptiveDatafusionExec>().unwrap();
+        let coalesce = adaptive
+            .input()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .unwrap();
+        assert!(
+            coalesce.children()[0].is::<ExchangeExec>(),
+            "oversized scan should keep its stage boundary, got {}",
+            coalesce.children()[0].name()
+        );
+    }
+
+    #[test]
+    fn coalesce_stages_scan_when_broadcast_promotion_is_disabled() {
+        let rule = DistributedExchangeRule::default();
+        let input =
+            Arc::new(CoalescePartitionsExec::new(scan_exec())) as Arc<dyn ExecutionPlan>;
+
+        let result = rule
+            .optimize(input, &config_with_broadcast_threshold(0))
+            .unwrap();
+
+        let adaptive = result.downcast_ref::<AdaptiveDatafusionExec>().unwrap();
+        let coalesce = adaptive
+            .input()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .unwrap();
+        assert!(
+            coalesce.children()[0].is::<ExchangeExec>(),
+            "threshold 0 disables inlining, got {}",
+            coalesce.children()[0].name()
+        );
+    }
+
+    #[test]
+    fn coalesce_stages_scan_behind_a_selective_filter() {
+        // Filtering marks the estimate inexact (TPC-H q19's build side).
+        let rule = DistributedExchangeRule::default();
+        let scan = scan_exec();
+        let filter = Arc::new(
+            FilterExec::try_new(
+                Arc::new(BinaryExpr::new(
+                    Arc::new(Column::new("a", 0)),
+                    Operator::Eq,
+                    Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
+                )),
+                scan,
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+        let input =
+            Arc::new(CoalescePartitionsExec::new(filter)) as Arc<dyn ExecutionPlan>;
+
+        let result = rule
+            .optimize(input, &config_with_broadcast_threshold(64 * 1024 * 1024))
+            .unwrap();
+
+        let adaptive = result.downcast_ref::<AdaptiveDatafusionExec>().unwrap();
+        let coalesce = adaptive
+            .input()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .unwrap();
+        assert!(
+            coalesce.children()[0].is::<ExchangeExec>(),
+            "selective filter should keep its stage boundary, got {}",
+            coalesce.children()[0].name()
+        );
+    }
+
+    #[test]
+    fn coalesce_stages_pipeline_that_is_not_a_plain_scan() {
+        let rule = DistributedExchangeRule::default();
+        let scan = scan_exec();
+        let aggregate = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![(
+                    Arc::new(Column::new("a", 0)) as _,
+                    "a".to_string(),
+                )]),
+                vec![],
+                vec![],
+                scan.clone(),
+                scan.schema(),
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+        let input =
+            Arc::new(CoalescePartitionsExec::new(aggregate)) as Arc<dyn ExecutionPlan>;
+
+        let result = rule
+            .optimize(input, &config_with_broadcast_threshold(64 * 1024 * 1024))
+            .unwrap();
+
+        let adaptive = result.downcast_ref::<AdaptiveDatafusionExec>().unwrap();
+        let coalesce = adaptive
+            .input()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .unwrap();
+        assert!(
+            coalesce.children()[0].is::<ExchangeExec>(),
+            "aggregate pipeline should keep its stage boundary, got {}",
+            coalesce.children()[0].name()
+        );
     }
 
     #[test]
@@ -1041,5 +1277,48 @@ mod tests {
             "unexpected error: {err}"
         );
         assert!(err.contains("ProjectionExec"), "unexpected error: {err}");
+    }
+}
+
+#[cfg(test)]
+mod debug_stats {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::ScalarValue;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, Literal};
+    use datafusion::physical_plan::filter::FilterExec;
+
+    #[test]
+    fn print_stats() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let scan =
+            MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).unwrap();
+        let s = StatisticsContext::new()
+            .compute(scan.as_ref(), &StatisticsArgs::new())
+            .unwrap();
+        println!("SCAN rows={:?} bytes={:?}", s.num_rows, s.total_byte_size);
+        let filter = Arc::new(
+            FilterExec::try_new(
+                Arc::new(BinaryExpr::new(
+                    Arc::new(Column::new("a", 0)),
+                    Operator::Eq,
+                    Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
+                )),
+                scan,
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+        let f = StatisticsContext::new()
+            .compute(filter.as_ref(), &StatisticsArgs::new())
+            .unwrap();
+        println!("FILTER rows={:?} bytes={:?}", f.num_rows, f.total_byte_size);
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Related to the broadcast-lowering cost noted while comparing Ballista's TPC-H plans against Spark with AQE. No issue filed yet.

## Rationale for this change

DataFusion plants a `CoalescePartitionsExec` over a scan to feed a `CollectLeft` hash join's build side. `DistributedExchangeRule` planted a stage boundary under *every* such coalesce, so a build side that is just a table scan became a stage of its own.

TPC-H q7 before (AQE on, `--partitions 16`):

```
-- Stage 0                       <- exists only to feed the join below
ShuffleWriterExec: partitioning: UnknownPartitioning(16)
  DataSourceExec: supplier, file_groups={16}, proj=2c

-- Stage 2
HashJoinExec: mode=CollectLeft, on=[(s_suppkey@0, l_suppkey@1)]
  CoalescePartitionsExec
    ShuffleReaderExec: upstream_stage: 0, partitioning: UnknownPartitioning(16)
  FilterExec: l_shipdate@4 >= 1995-01-01 AND l_shipdate@4 <= 1996-12-31
    DataSourceExec: lineitem, file_groups={16}
```

The boundary costs a stage, a shuffle write of the whole scan, a re-read in every consuming task, and - because a stage cannot start before its inputs finish - a barrier in front of the join. The gather happens inside a single task either way, so it buys nothing.

## What changes are included in this PR?

`DistributedExchangeRule` skips the boundary when the coalesce input is an **unfiltered** scan whose bytes fit `ballista.optimizer.broadcast_join_threshold_bytes` - the same budget that decides whether a build side is small enough to sit in every probe task. Projections are transparent; aggregates, joins and shuffle reads keep their boundary, since they carry state that must be computed once.

Filtering is what disqualifies a scan, and this is the part worth reviewing. A filter makes the staged copy far smaller than the scan, so rebuilding it in every task costs much more than reading it back. `Precision::Exact` on the scan's `total_byte_size` is the test rather than looking for a `FilterExec`, because the interesting cases have the predicate pushed *into* the scan, where there is no filter node to find:

```
DataSourceExec: part, file_groups={16}, predicate=p_name LIKE 'forest%'   <- no FilterExec
```

Note this also means the rewrite only fires with `datafusion.execution.collect_statistics=true`; without collected statistics the estimate is not exact and every scan keeps its boundary as before.

q7 after - 8 stages become 6, with `supplier` and `customer` read directly in the stages that join them:

```
-- Stage 0
SortShuffleWriterExec: partitioning=Hash([l_orderkey@1], 16)
  HashJoinExec: mode=CollectLeft, on=[(s_suppkey@0, l_suppkey@1)]
    CoalescePartitionsExec
      DataSourceExec: supplier, file_groups={16}, proj=2c
    FilterExec: l_shipdate@4 >= 1995-01-01 AND l_shipdate@4 <= 1996-12-31
      DataSourceExec: lineitem, file_groups={16}
```

## Are these changes tested?


## Are there any user-facing changes?

Plan-only change