### PR TITLE
perf(core): share a broadcast read between the tasks on an executor

### DIFF
--- a/ballista/core/src/execution_plans/broadcast_cache.rs
+++ b/ballista/core/src/execution_plans/broadcast_cache.rs
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Executor-wide cache of broadcast-side reads.
+//!
+//! A broadcast read fetches every upstream partition in every consuming task, so
+//! an executor running N tasks of a stage fetches and decodes the same build side
+//! N times. Shuffle output is immutable once written, so those tasks can share
+//! one read.
+//!
+//! The key includes a fingerprint of the partition locations: a re-run or
+//! replanned stage writes different files, so it never sees a previous attempt's
+//! batches.
+
+use crate::JobId;
+use crate::serde::scheduler::PartitionLocation;
+use datafusion::arrow::record_batch::RecordBatch;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::{Arc, LazyLock};
+use tokio::sync::OnceCell;
+
+/// Job, upstream stage, and a fingerprint of that stage's output locations.
+type Key = (JobId, usize, u64);
+
+/// The batches of one broadcast side. `OnceCell` makes concurrent tasks share a
+/// single fetch instead of racing to fill the entry.
+pub(crate) type Slot = Arc<OnceCell<Arc<Vec<RecordBatch>>>>;
+
+static CACHE: LazyLock<Mutex<HashMap<Key, Slot>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Identifies the data behind `locations`, so a stage re-run under the same
+/// stage id keys to a different slot.
+pub(crate) fn fingerprint(locations: &[PartitionLocation]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for location in locations {
+        location.executor_meta.id.hash(&mut hasher);
+        location.map_partition_id.hash(&mut hasher);
+        location.partition_id.partition_id.hash(&mut hasher);
+        location.file_id.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// The slot for one broadcast side, created empty on first use.
+pub(crate) fn slot(job_id: &JobId, stage_id: usize, fingerprint: u64) -> Slot {
+    CACHE
+        .lock()
+        .entry((job_id.clone(), stage_id, fingerprint))
+        .or_default()
+        .clone()
+}
+
+/// Drops cached batches for a job. An empty `stage_ids` drops the whole job,
+/// matching the executor's shuffle-file cleanup.
+pub fn evict(job_id: &JobId, stage_ids: &[u32]) {
+    let mut cache = CACHE.lock();
+    cache.retain(|(cached_job, cached_stage, _), _| {
+        cached_job != job_id
+            || (!stage_ids.is_empty() && !stage_ids.contains(&(*cached_stage as u32)))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde::scheduler::{
+        ExecutorMetadata, ExecutorOperatingSystemSpecification, ExecutorSpecification,
+        PartitionId,
+    };
+
+    fn location(
+        job: &str,
+        stage: usize,
+        partition: usize,
+        file_id: Option<u64>,
+    ) -> PartitionLocation {
+        PartitionLocation {
+            map_partition_id: partition,
+            partition_id: PartitionId {
+                job_id: job.into(),
+                stage_id: stage,
+                partition_id: partition,
+            },
+            executor_meta: ExecutorMetadata {
+                id: "executor-1".to_string(),
+                host: "localhost".to_string(),
+                port: 50051,
+                grpc_port: 50052,
+                specification: ExecutorSpecification::default(),
+                os_info: ExecutorOperatingSystemSpecification::default(),
+            },
+            partition_stats: Default::default(),
+            file_id,
+            is_sort_shuffle: false,
+        }
+    }
+
+    #[test]
+    fn same_locations_share_a_slot() {
+        let locations = vec![location("job-share", 1, 0, Some(7))];
+        let f = fingerprint(&locations);
+        let first = slot(&"job-share".into(), 1, f);
+        let second = slot(&"job-share".into(), 1, f);
+        assert!(Arc::ptr_eq(&first, &second));
+        evict(&"job-share".into(), &[]);
+    }
+
+    #[test]
+    fn rerun_stage_gets_a_fresh_slot() {
+        // Same job and stage, different shuffle files: the re-run must not read
+        // the previous attempt's batches.
+        let first_attempt = vec![location("job-rerun", 1, 0, Some(1))];
+        let second_attempt = vec![location("job-rerun", 1, 0, Some(2))];
+        assert_ne!(fingerprint(&first_attempt), fingerprint(&second_attempt));
+        evict(&"job-rerun".into(), &[]);
+    }
+
+    #[test]
+    fn evict_drops_only_the_named_stages() {
+        let job: JobId = "job-evict".into();
+        let other: JobId = "job-keep".into();
+        let kept = slot(&other, 1, 0);
+        let dropped = slot(&job, 1, 0);
+        let retained = slot(&job, 2, 0);
+
+        evict(&job, &[1]);
+
+        let cache = CACHE.lock();
+        assert!(!cache.contains_key(&(job.clone(), 1, 0)), "stage 1 evicted");
+        assert!(cache.contains_key(&(job.clone(), 2, 0)), "stage 2 retained");
+        assert!(cache.contains_key(&(other.clone(), 1, 0)), "other job kept");
+        drop((kept, dropped, retained, cache));
+
+        evict(&job, &[]);
+        evict(&other, &[]);
+        let cache = CACHE.lock();
+        assert!(!cache.keys().any(|(j, _, _)| j == &job || j == &other));
+    }
+}

--- a/ballista/core/src/execution_plans/mod.rs
+++ b/ballista/core/src/execution_plans/mod.rs
@@ -18,6 +18,7 @@
 //! This module contains execution plans that are needed to distribute DataFusion's execution plans into
 //! several Ballista executors.
 
+mod broadcast_cache;
 mod buffer;
 mod chaos_exec;
 mod distributed_explain_analyze;
@@ -39,6 +40,7 @@ mod unresolved_shuffle;
 
 use std::path::{Path, PathBuf};
 
+pub use broadcast_cache::evict as evict_broadcast_cache;
 pub use buffer::{BufferExec, BufferMode};
 pub use chaos_exec::ChaosExec;
 use datafusion::common::exec_err;

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -18,6 +18,7 @@
 use crate::client::BallistaClient;
 use crate::client_pool::BallistaClientPool;
 use crate::error::BallistaError;
+use crate::execution_plans::broadcast_cache;
 use crate::execution_plans::sort_shuffle::{
     get_index_path, is_sort_shuffle_output, stream_sort_shuffle_partition,
 };
@@ -361,74 +362,29 @@ impl ExecutionPlan for ShuffleReaderExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let task_id = context.task_id().unwrap_or_else(|| partition.to_string());
-        debug!("ShuffleReaderExec::execute({task_id})");
-        // Broadcast readers have a single logical output partition; always
-        // serve from partition[0] regardless of which physical partition the
-        // caller asked for.
-        let partition = if self.broadcast { 0 } else { partition };
-
-        let config = context.session_config();
-        let batch_size = config.batch_size();
-
-        if config.ballista_shuffle_reader_force_remote_read() {
-            debug!(
-                "All shuffle partitions will be read as remote partitions! To disable this behavior set: `{}=false`",
-                crate::config::BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ
-            );
+        // Every task of the consuming stage reads the whole broadcast side, so
+        // let the tasks on this executor share one read of it.
+        if self.broadcast
+            && let Some(slot) = self.broadcast_cache_slot(&context)
+        {
+            let reader = self.clone();
+            let cached = async move {
+                let batches = slot
+                    .get_or_try_init(|| async {
+                        let stream = reader.fetch_partitions(0, context)?;
+                        stream.try_collect::<Vec<_>>().await.map(Arc::new)
+                    })
+                    .await?;
+                Ok::<_, DataFusionError>(futures::stream::iter(
+                    batches.as_ref().clone().into_iter().map(Ok),
+                ))
+            };
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                self.schema.clone(),
+                futures::stream::once(cached).try_flatten(),
+            )));
         }
-
-        log::debug!(
-            "ShuffleReaderExec::execute({task_id}) max_request_num: {}, max_message_size: {}",
-            config.ballista_shuffle_reader_maximum_concurrent_requests(),
-            config.ballista_grpc_client_max_message_size()
-        );
-        let mut partition_locations = HashMap::new();
-        for p in &self.partition[partition] {
-            partition_locations
-                .entry(p.executor_meta.id.clone())
-                .or_insert_with(Vec::new)
-                .push(p.clone());
-        }
-        // Sort partitions for evenly send fetching partition requests to avoid hot executors within one task
-        let mut partition_locations: Vec<PartitionLocation> = partition_locations
-            .into_values()
-            .flat_map(|ps| ps.into_iter().enumerate())
-            .sorted_by(|(p1_idx, _), (p2_idx, _)| Ord::cmp(p1_idx, p2_idx))
-            .map(|(_, p)| p)
-            .collect();
-        // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
-        partition_locations.shuffle(&mut rng());
-
-        let work_dir = self
-            .work_dir
-            .as_ref()
-            .ok_or(DataFusionError::Configuration(
-                "ShuffleReader work dir should have been set by executor".to_owned(),
-            ))?;
-
-        let read_metrics = ShuffleReadMetrics::new(partition, &self.metrics);
-
-        let response_receiver = send_fetch_partitions(
-            work_dir,
-            partition_locations,
-            config,
-            self.client_pool.clone(),
-            read_metrics,
-        );
-
-        let input_stream = Box::pin(RecordBatchStreamAdapter::new(
-            self.schema.clone(),
-            response_receiver.try_flatten(),
-        ));
-
-        Ok(Box::pin(CoalescedShuffleReaderStream::new(
-            input_stream,
-            batch_size,
-            None,
-            &self.metrics,
-            partition,
-        )))
+        self.fetch_partitions(partition, context)
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -1278,6 +1234,113 @@ impl Stream for CoalescedShuffleReaderStream {
 impl RecordBatchStream for CoalescedShuffleReaderStream {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+}
+
+/// Reads that are not shared through the broadcast cache.
+impl ShuffleReaderExec {
+    /// The slot every task on this executor shares for this broadcast side, or
+    /// `None` when the read should not be shared: the upstream byte size is
+    /// unknown, or above the budget that made the side broadcastable.
+    fn broadcast_cache_slot(
+        &self,
+        context: &Arc<TaskContext>,
+    ) -> Option<broadcast_cache::Slot> {
+        let max_bytes = context
+            .session_config()
+            .ballista_config()
+            .broadcast_join_threshold_bytes();
+        if max_bytes == 0 {
+            return None;
+        }
+        let locations = self.partition.first()?;
+        let job_id = &locations.first()?.partition_id.job_id;
+        let mut bytes = 0u64;
+        for location in locations {
+            bytes = bytes.checked_add(location.partition_stats.num_bytes?)?;
+        }
+        if bytes > max_bytes as u64 {
+            return None;
+        }
+        Some(broadcast_cache::slot(
+            job_id,
+            self.stage_id,
+            broadcast_cache::fingerprint(locations),
+        ))
+    }
+
+    /// Fetches one output partition's upstream locations. Broadcast readers have
+    /// a single logical output partition and always serve from `partition[0]`.
+    fn fetch_partitions(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let task_id = context.task_id().unwrap_or_else(|| partition.to_string());
+        debug!("ShuffleReaderExec::execute({task_id})");
+        let partition = if self.broadcast { 0 } else { partition };
+
+        let config = context.session_config();
+        let batch_size = config.batch_size();
+
+        if config.ballista_shuffle_reader_force_remote_read() {
+            debug!(
+                "All shuffle partitions will be read as remote partitions! To disable this behavior set: `{}=false`",
+                crate::config::BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ
+            );
+        }
+
+        log::debug!(
+            "ShuffleReaderExec::execute({task_id}) max_request_num: {}, max_message_size: {}",
+            config.ballista_shuffle_reader_maximum_concurrent_requests(),
+            config.ballista_grpc_client_max_message_size()
+        );
+        let mut partition_locations = HashMap::new();
+        for p in &self.partition[partition] {
+            partition_locations
+                .entry(p.executor_meta.id.clone())
+                .or_insert_with(Vec::new)
+                .push(p.clone());
+        }
+        // Sort partitions for evenly send fetching partition requests to avoid hot executors within one task
+        let mut partition_locations: Vec<PartitionLocation> = partition_locations
+            .into_values()
+            .flat_map(|ps| ps.into_iter().enumerate())
+            .sorted_by(|(p1_idx, _), (p2_idx, _)| Ord::cmp(p1_idx, p2_idx))
+            .map(|(_, p)| p)
+            .collect();
+        // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
+        partition_locations.shuffle(&mut rng());
+
+        let work_dir = self
+            .work_dir
+            .as_ref()
+            .ok_or(DataFusionError::Configuration(
+                "ShuffleReader work dir should have been set by executor".to_owned(),
+            ))?;
+
+        let read_metrics = ShuffleReadMetrics::new(partition, &self.metrics);
+
+        let response_receiver = send_fetch_partitions(
+            work_dir,
+            partition_locations,
+            config,
+            self.client_pool.clone(),
+            read_metrics,
+        );
+
+        let input_stream = Box::pin(RecordBatchStreamAdapter::new(
+            self.schema.clone(),
+            response_receiver.try_flatten(),
+        ));
+
+        Ok(Box::pin(CoalescedShuffleReaderStream::new(
+            input_stream,
+            batch_size,
+            None,
+            &self.metrics,
+            partition,
+        )))
     }
 }
 

--- a/ballista/executor/src/executor_process.rs
+++ b/ballista/executor/src/executor_process.rs
@@ -975,6 +975,9 @@ pub(crate) async fn remove_job_data(
     job_id: &JobId,
     remove_stage_ids: &[u32],
 ) -> ballista_core::error::Result<()> {
+    // Cached broadcast reads live as long as the shuffle files they came from.
+    ballista_core::execution_plans::evict_broadcast_cache(job_id, remove_stage_ids);
+
     let work_path = PathBuf::from(&work_dir);
     let job_path = work_path.join(job_id.as_str());
 


### PR DESCRIPTION
## Which issue does this PR close?

None filed. Found while comparing Ballista's TPC-H plans against Spark with AQE: Spark's `BroadcastExchange` materializes a build side once and every task on an executor shares it, where Ballista re-reads it per task.

## Rationale for this change

`ShuffleReaderExec` with `broadcast: true` serves partition 0 — every upstream location — on each `execute()` call, and `execute()` runs once per task. An executor running N tasks of the consuming stage therefore fetches and decodes the same build side N times. Shuffle output is immutable once written, so those reads are identical and can be shared.

How much that is worth depends on task density, which is why the numbers below are per-executor rather than per-partition:

- **`max_partitions_per_task=1` (the default)**: one task per partition, so a stage with 8 tasks on an executor performs 8 identical fetches. This is the case the change is aimed at.
- **packing on** (`=0`, a task per free vcore): DataFusion's `CollectLeft` join already shares the build across the partitions inside one task via `OnceAsync`, so the redundancy is only the number of tasks per executor — 2 in my local setup, and close to 1 at the SF1000 benchmark shape (256 partitions over 32 executors x 8 vcores).

So this is a smaller lever with packing enabled than the per-partition framing suggests. It still removes the repeat where a stage runs several waves on one executor, and where two consuming stages broadcast the same side.

## What changes are included in this PR?

A `broadcast_cache` module holding batches per `(job_id, stage_id, locations fingerprint)` behind a `tokio::sync::OnceCell`, so concurrent tasks share one fetch rather than racing to fill the entry.

Two things are worth reviewing:

- **Staleness.** The fingerprint hashes the executor ids, map partition ids and shuffle file ids behind the read, so a re-run or replanned stage — different files under the same stage id — keys to a different slot and cannot serve the previous attempt's batches.
- **Memory.** Only reads whose upstream byte size is known and within `ballista.optimizer.broadcast_join_threshold_bytes` are cached; that is the budget that made the side broadcastable, so it bounds what a cached entry can hold. Unknown or larger reads stream exactly as before. Entries are dropped alongside the shuffle files they came from, in `remove_job_data`, so both cleanup paths (push and poll) release them.

## Are these changes tested?

Three unit tests: repeated lookups share a slot, a re-run's different file ids produce a different fingerprint, and eviction drops only the named stages of the named job. `ballista-core` (319 + 26) and `ballista-executor` (53) suites pass; clippy clean on both.

Verified on a live cluster (SF10, 1 scheduler + 2 executors x 4 vcores, AQE, packing on) by instrumenting slot lookups and actual fetches on TPC-H q19:

```
executor1: slot lookups=2  fetches=1
executor2: slot lookups=2  fetches=1
```

Full 22-query suite returns byte-identical row counts to the pre-change run.

**Draft:** the end-to-end timing win at SF10 is inside the noise floor of a single machine — the fetch it removes is a local-disk read there, whereas on a cluster it is a network round trip. I would want a cluster run, and a look at whether the same sharing belongs at the level of the built hash table rather than the batches, before calling this ready.

## Are there any user-facing changes?

No API or configuration change. Broadcast reads on the same executor now share memory for the duration of a job's stage, bounded by the broadcast threshold.
