### PR TITLE
perf(scheduler): only give a broadcast build side its own stage when the probe is partitioned

### DIFF
--- a/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/join_selection.rs
@@ -134,6 +134,15 @@ impl SelectJoinRule {
     }
 }
 
+/// Whether giving the build side its own broadcast stage is worth it.
+fn broadcast_build_side_pays_off(
+    build: &dyn ExecutionPlan,
+    probe: &dyn ExecutionPlan,
+) -> bool {
+    build.properties().partitioning.partition_count() > 1
+        && probe.properties().partitioning.partition_count() > 1
+}
+
 impl PhysicalOptimizerRule for SelectJoinRule {
     fn optimize(
         &self,
@@ -246,13 +255,13 @@ impl PhysicalOptimizerRule for SelectJoinRule {
                                                 ),
                                             )?;
                                             Ok(Transformed::yes(p))
-                                        } else if hash_join
-                                            .left
-                                            .properties()
-                                            .partitioning
-                                            .partition_count()
-                                            > 1
-                                        {
+                                        } else if broadcast_build_side_pays_off(
+                                            hash_join.left.as_ref(),
+                                            hash_join.right.as_ref(),
+                                        ) {
+                                            // Broadcasting the build side buys
+                                            // nothing when the probe has a single
+                                            // partition.
                                             let left = if let Some(exchange) = hash_join
                                                 .left
                                                 .downcast_ref::<ExchangeExec>()
@@ -367,6 +376,7 @@ mod tests {
 
     use ballista_core::assert_plan;
     use ballista_core::config::BallistaConfig;
+    use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::{
         arrow::{
             array::{Int32Array, RecordBatch},
@@ -837,5 +847,25 @@ mod tests {
             DataSourceExec: partitions=1, partition_sizes=[1]
             DataSourceExec: partitions=1, partition_sizes=[1]
         ");
+    }
+    #[test]
+    fn broadcast_pays_off_only_when_both_sides_are_partitioned() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let one = Arc::new(EmptyExec::new(Arc::clone(&schema))) as Arc<dyn ExecutionPlan>;
+        let many = Arc::new(EmptyExec::new(Arc::clone(&schema)).with_partitions(4))
+            as Arc<dyn ExecutionPlan>;
+
+        assert!(
+            broadcast_build_side_pays_off(many.as_ref(), many.as_ref()),
+            "both sides partitioned: the build is worth its own stage"
+        );
+        assert!(
+            !broadcast_build_side_pays_off(many.as_ref(), one.as_ref()),
+            "single-partition probe pins the join to one task either way"
+        );
+        assert!(
+            !broadcast_build_side_pays_off(one.as_ref(), many.as_ref()),
+            "single-partition build needs no stage of its own"
+        );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

None filed. Found while checking whether AQE can hold several broadcast joins in one stage — it can (q5 stage 3 and q8 stage 4 each hold four), but q7 splits two apart and runs the second one single-threaded.

## Rationale for this change

The `CollectLeft` arm of `SelectJoinRule` puts a multi-partition build side behind a broadcast exchange, which becomes a stage of its own. That pays off only when the probe is partitioned as well:

- A **single-partition build** needs no stage — every task can read it in place.
- A **single-partition probe** pins the join to one task whatever the build does, so the stage buys nothing.

And the stage is not free. The build/probe choice comes from a size comparison, and AQE replans after every stage completion, so a later round can see statistics the first round did not have and answer that comparison the other way — swapping the inputs. The exchange created by the first answer is already a stage by then, and it is now on the **probe** side, where a broadcast read exposes a single partition. Everything above it collapses into one task.

TPC-H q7 hit exactly this. Its stage 5 read 1.46 M rows through one task, running the `nation` join, the projection and the partial aggregate single-threaded while 15 partitions of input sat ready. I confirmed the sequence by instrumenting the rule: the broadcast exchange is created once, from the branch that wraps a multi-partition build side, and the same join's swap decision is logged twice with opposite answers in the same query — `swap=Ok(false)` then `swap=Ok(true)` — as the estimates change between rounds.

## What changes are included in this PR?

One guard, extracted as `broadcast_build_side_pays_off`: wrap the build side only when both sides have more than one partition. With it, q7's swap puts `nation` on the build side, the probe keeps its 16 partitions, and no exchange is planted:

```
before  stage 5: 1 task,  broadcast: true,           task_ms 39
after   stage 5: 4 tasks, Hash([l_orderkey@3], 16),  task_ms 10/13/14
```

## Are these changes tested?

A unit test covers the three cases of the predicate (both sides partitioned, single-partition probe, single-partition build). Full `ballista-scheduler` suite passes (363 + 25); clippy clean. All 22 TPC-H queries return identical row counts, and the other 21 plans are unchanged — same stage counts, same broadcast-reader counts — so the guard is confined to the case it describes.


## Are there any user-facing changes?

No API or configuration change. One fewer stage boundary and more parallelism in plans that join a partitioned input against a single-partition side.
