### PR TITLE
perf(scheduler): push filters once, not on every replan

### DIFF
--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -591,8 +591,13 @@ impl AdaptivePlanner {
             .rules
             .into_iter()
             .flat_map(|r| match r.name() {
-                "FilterPushdown" => vec![Arc::new(FilterPushdown::new())
-                    as Arc<dyn PhysicalOptimizerRule + Send + Sync>],
+                // Pushdown runs once, from `plan_preparation_optimizers`. AQE
+                // re-optimizes after every stage completion, and pushing an
+                // already-pushed filter appends it to the scan again: TPC-H
+                // scans accumulated one copy per replan — six of
+                // `r_name = EUROPE` in q2 — and every copy is evaluated per row
+                // and again in the row-group pruning predicate.
+                "FilterPushdown" => vec![],
                 // `join_selection` promotes a small build side to `CollectLeft`
                 // without restricting by join type -- safe in one process, but
                 // Ballista runs one task per probe partition. Demote the unsafe
@@ -612,6 +617,7 @@ impl AdaptivePlanner {
         plan_id_generator: Arc<AtomicUsize>,
     ) -> Vec<PhysicalOptimizerRuleRef> {
         vec![
+            Arc::new(FilterPushdown::new()),
             Arc::new(DelayJoinSelectionRule::new(plan_id_generator)),
             Arc::new(ChaosCreatingRule::default()),
         ]


### PR DESCRIPTION
## Which issue does this PR close?

None filed. Found while building executed-plan goldens: the same query planned twice produced different plans, and the difference was how many copies of a predicate its scans carried.

## Rationale for this change

AQE re-optimizes the physical plan after every stage completion, and Ballista's rule list re-ran `FilterPushdown` each time. Pushing an already-pushed filter appends it to the scan again, so a scan accumulated one copy of its predicate per replan that touched its branch.

Across the 22 TPC-H queries at SF10, that left **17 scans in 10 queries carrying duplicated predicates — 50 redundant conjuncts**, up to six copies:

```
q2  DataSourceExec: region   predicate=r_name = EUROPE AND r_name = EUROPE AND ... (6x)
q7  DataSourceExec: nation   predicate=(n_name = FRANCE OR n_name = GERMANY) AND ... (6x)
q20 DataSourceExec: nation   predicate=n_name = CANADA AND ... (5x)
```

## What changes are included in this PR?

Move `FilterPushdown` into `plan_preparation_optimizers`, the list that already runs once before the per-replan rules, and drop it from the per-replan list. Two lines.

## Are these changes tested?

`cargo test -p ballista-scheduler` passes (362 + 25); clippy clean.

Measured on the executed plans of all 22 queries (event logs from a real run, SF10, `target_partitions=16`), predicate conjuncts per query before → after:

| q2 | q3 | q5 | q7 | q8 | q10 | q11 | q19 | q20 | q21 | q1 | q18 |
| -- | -- | -- | -- | -- | --- | --- | --- | --- | --- | -- | --- |
| 39→7 | 10→4 | 24→6 | 72→12 | 42→8 | 10→6 | 20→4 | 94→70 | 24→8 | 18→4 | 1→1 | 0→0 |


## Are there any user-facing changes?

No. A filter that a later replan would have re-pushed now stays as the `FilterExec` it already is.
