### PR TITLE
fix(chaos): harden k8s backend — supervise port-forward, guard fixture dir

### DIFF
--- a/chaos-testing/README.md
+++ b/chaos-testing/README.md
@@ -201,7 +201,9 @@ or run the steps by hand: `dev/build-chaos-docker.sh`, then `kind create cluster
 ballista-chaos:test`, and `CHAOS_BACKEND=kind cargo test -p ballista-chaos
 --features k8s --test k8s -- --test-threads=1`. Behavior is tuned through
 `CHAOS_FIXTURE_DIR` (host dir shared into the pods, default
-`$HOME/.ballista-chaos-fixtures`), `CHAOS_KEEP_NS` (keep the namespace for
+`$HOME/.ballista-chaos-fixtures`; it is cleared on each run, so point it at a
+dedicated directory — the harness refuses to wipe one it did not create),
+`CHAOS_KEEP_NS` (keep the namespace for
 `kubectl` inspection), `CLUSTER_NAME`, `KEEP_CLUSTER`, and `KIND_NODE_IMAGE`.
 
 Because the harness runs outside the cluster, a few pieces bridge the gap:

--- a/chaos-testing/src/k8s.rs
+++ b/chaos-testing/src/k8s.rs
@@ -43,11 +43,16 @@
 //! exists, `kubectl` is on `PATH` pointed at it, and the chaos image has been
 //! `kind load`ed. See `chaos-testing/k8s/` and the crate README for the runbook.
 
+use std::collections::VecDeque;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 
 /// Directory shared between the harness and the pods, holding the fixture.
 ///
@@ -72,6 +77,17 @@ const SCHEDULER_PORT: u16 = 50050;
 const EXECUTOR_HEALTH_PORT: u16 = 50053;
 const EXECUTOR_DEPLOYMENT: &str = "ballista-executor";
 
+/// Marker file dropped in any fixture directory the harness manages, so a later
+/// run can tell a directory it owns (safe to clear) from a foreign one.
+const FIXTURE_MARKER: &str = ".ballista-chaos-fixture";
+
+/// How long the port-forward supervisor waits before restarting a forward that
+/// exited or failed to spawn, so a hard-failing forward does not hot-loop.
+const PORT_FORWARD_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// How many lines of port-forward stderr to retain for diagnostics.
+const PORT_FORWARD_STDERR_LINES: usize = 20;
+
 /// Per-process counter so each `K8sCluster::start` gets a distinct namespace,
 /// even if several run in one process (`--test-threads=1` serialises them today,
 /// but this keeps namespaces unique if that ever changes or a start is retried).
@@ -93,7 +109,7 @@ pub enum KillMode {
 pub struct K8sCluster {
     namespace: String,
     scheduler_local_port: u16,
-    port_forward: Child,
+    port_forward: PortForward,
     shared_dir: PathBuf,
 }
 
@@ -118,9 +134,16 @@ impl K8sCluster {
         // non-ephemeral use; on CI the runner is fresh. We clear the contents
         // rather than the directory itself: it is the bind-mount root, and
         // removing it can sever the mount so pod writes no longer reach the node.
+        //
+        // `guard_fixture_dir` refuses to clear a directory the harness does not
+        // own, so a stray `CHAOS_FIXTURE_DIR` cannot turn this into a recursive
+        // delete of something that matters; `write_marker` then re-stamps the
+        // now-empty directory as ours for the next run.
         std::fs::create_dir_all(&shared_dir)
             .map_err(|e| format!("create shared dir {}: {e}", shared_dir.display()))?;
+        guard_fixture_dir(&shared_dir)?;
         clear_dir_contents(&shared_dir)?;
+        write_marker(&shared_dir)?;
 
         let manifests = render_manifests(&namespace, executors, &shared_dir);
         kubectl_apply(&manifests).await?;
@@ -141,7 +164,7 @@ impl K8sCluster {
         .await?;
 
         let scheduler_local_port = free_port()?;
-        let port_forward = spawn_port_forward(&namespace, scheduler_local_port)?;
+        let port_forward = PortForward::spawn(&namespace, scheduler_local_port);
 
         let cluster = Self {
             namespace,
@@ -222,6 +245,16 @@ impl K8sCluster {
                 Err(e) => eprintln!("$ kubectl {} -> {e}", args.join(" ")),
             }
         }
+
+        // The port-forward carries every out-of-cluster call (client, executor
+        // poll, results), so its stderr is often the first sign of why a wait
+        // failed — a dropped or pod-restart-killed forward, for example.
+        let forward_stderr = self.port_forward.recent_stderr();
+        if !forward_stderr.is_empty() {
+            eprintln!(
+                "--- kubectl port-forward stderr (last {PORT_FORWARD_STDERR_LINES} lines) ---\n{forward_stderr}"
+            );
+        }
     }
 
     /// How many executors the scheduler currently considers registered.
@@ -295,8 +328,8 @@ impl K8sCluster {
 
 impl Drop for K8sCluster {
     fn drop(&mut self) {
-        let _ = self.port_forward.kill();
-        let _ = self.port_forward.wait();
+        // `PortForward`'s own Drop stops the supervisor task and kills the
+        // running forward, so we only need to tear down the namespace here.
         delete_namespace(&self.namespace);
     }
 }
@@ -333,6 +366,65 @@ fn delete_namespace(namespace: &str) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+}
+
+/// Refuse to wipe a fixture directory the harness does not own.
+///
+/// [`K8sCluster::start`] clears `CHAOS_FIXTURE_DIR` on every run, so a typo or an
+/// env var inherited from another tool could otherwise turn the clear into a
+/// recursive delete of a directory that matters. Two cheap checks close that:
+/// never operate on the filesystem root or a bare home directory, and treat a
+/// non-empty directory without our [`FIXTURE_MARKER`] as foreign and leave it
+/// untouched. An empty directory (a fresh CI runner, or a path the operator just
+/// created) is fine — [`write_marker`] stamps it as ours afterwards.
+fn guard_fixture_dir(dir: &Path) -> Result<(), String> {
+    if dir == Path::new("/") {
+        return Err("refusing to use '/' as the fixture directory".to_string());
+    }
+    if let Some(home) = std::env::var_os("HOME")
+        && !home.is_empty()
+        && dir == Path::new(&home)
+    {
+        return Err(format!(
+            "refusing to use the home directory {} as the fixture directory; \
+             set CHAOS_FIXTURE_DIR to a dedicated path",
+            dir.display()
+        ));
+    }
+
+    // A directory we created carries the marker; it is safe to clear.
+    if dir.join(FIXTURE_MARKER).exists() {
+        return Ok(());
+    }
+
+    // Otherwise only proceed if it is empty — a non-empty, unmarked directory was
+    // presumably not created by the harness, so clearing it could delete
+    // something that matters.
+    let is_empty = std::fs::read_dir(dir)
+        .map_err(|e| format!("read fixture dir {}: {e}", dir.display()))?
+        .next()
+        .is_none();
+    if is_empty {
+        Ok(())
+    } else {
+        Err(format!(
+            "refusing to clear fixture directory {}: it is not empty and has no \
+             {FIXTURE_MARKER} marker, so it was not created by the chaos harness. \
+             Point CHAOS_FIXTURE_DIR at a dedicated directory, or clear it manually.",
+            dir.display()
+        ))
+    }
+}
+
+/// Stamp `dir` as harness-owned so a later run knows it is safe to clear.
+fn write_marker(dir: &Path) -> Result<(), String> {
+    let marker = dir.join(FIXTURE_MARKER);
+    std::fs::write(
+        &marker,
+        "This directory is managed by the Ballista chaos harness (K8sCluster).\n\
+         It is cleared on each run; do not store anything here.\n",
+    )
+    .map_err(|e| format!("write fixture marker {}: {e}", marker.display()))
 }
 
 /// Remove everything *inside* `dir` without removing `dir` itself. `dir` is a
@@ -398,19 +490,150 @@ fn free_port() -> Result<u16, String> {
         .map_err(|e| e.to_string())
 }
 
-fn spawn_port_forward(namespace: &str, local_port: u16) -> Result<Child, String> {
-    Command::new("kubectl")
-        .args([
-            "-n",
-            namespace,
-            "port-forward",
-            "svc/ballista-scheduler",
-            &format!("{local_port}:{SCHEDULER_PORT}"),
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| format!("spawn kubectl port-forward: {e}"))
+/// A supervised `kubectl port-forward` to the scheduler Service.
+///
+/// The forward carries everything the harness does from outside the cluster —
+/// the `df://` client connection, the `/api/executors` poll, and query results
+/// coming back through the scheduler's flight proxy. `kubectl port-forward`
+/// resolves the Service to a single pod when it starts and never re-resolves,
+/// and long-lived forwards also drop on their own from apiserver hiccups or idle
+/// timeouts. A single unmonitored forward would therefore turn a scheduler pod
+/// restart — or simply a long-running suite — into an opaque "connection
+/// refused". This owns a background task that restarts the forward whenever it
+/// exits and keeps a tail of its stderr for diagnostics.
+struct PortForward {
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<()>>,
+    stderr: Arc<Mutex<VecDeque<String>>>,
+}
+
+impl PortForward {
+    /// Start supervising a forward from `local_port` to the scheduler Service in
+    /// `namespace`. The forward is (re)established in the background, so callers
+    /// should reach the scheduler through a retrying poll rather than assuming it
+    /// is immediately up.
+    fn spawn(namespace: &str, local_port: u16) -> Self {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let stderr = Arc::new(Mutex::new(VecDeque::new()));
+        let task = tokio::spawn(supervise_port_forward(
+            namespace.to_string(),
+            local_port,
+            shutdown_rx,
+            stderr.clone(),
+        ));
+        Self {
+            shutdown: Some(shutdown_tx),
+            task: Some(task),
+            stderr,
+        }
+    }
+
+    /// The most recent port-forward stderr lines, newest last, for diagnostics.
+    fn recent_stderr(&self) -> String {
+        self.stderr
+            .lock()
+            .map(|buf| buf.iter().cloned().collect::<Vec<_>>().join("\n"))
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for PortForward {
+    fn drop(&mut self) {
+        // Ask the supervisor to stop; aborting the task then drops its child,
+        // which is `kill_on_drop`, so the running forward is killed even if the
+        // shutdown signal is not observed before the runtime goes away.
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+/// Record one stderr line into the bounded ring buffer, dropping the oldest.
+fn record_port_forward_stderr(buf: &Arc<Mutex<VecDeque<String>>>, line: String) {
+    if let Ok(mut buf) = buf.lock() {
+        while buf.len() >= PORT_FORWARD_STDERR_LINES {
+            buf.pop_front();
+        }
+        buf.push_back(line);
+    }
+}
+
+/// Supervisor loop: (re)spawn `kubectl port-forward` until asked to stop.
+async fn supervise_port_forward(
+    namespace: String,
+    local_port: u16,
+    mut shutdown: oneshot::Receiver<()>,
+    stderr: Arc<Mutex<VecDeque<String>>>,
+) {
+    loop {
+        let spawn_result = tokio::process::Command::new("kubectl")
+            .args([
+                "-n",
+                &namespace,
+                "port-forward",
+                "svc/ballista-scheduler",
+                &format!("{local_port}:{SCHEDULER_PORT}"),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn();
+
+        let mut child = match spawn_result {
+            Ok(child) => child,
+            Err(e) => {
+                record_port_forward_stderr(
+                    &stderr,
+                    format!("spawn kubectl port-forward failed: {e}"),
+                );
+                tokio::select! {
+                    _ = &mut shutdown => return,
+                    _ = tokio::time::sleep(PORT_FORWARD_RETRY_DELAY) => continue,
+                }
+            }
+        };
+
+        // Drain the forward's stderr into the ring buffer. The task ends on its
+        // own when the child exits and its pipe closes.
+        if let Some(pipe) = child.stderr.take() {
+            let stderr = stderr.clone();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(pipe).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    record_port_forward_stderr(&stderr, line);
+                }
+            });
+        }
+
+        tokio::select! {
+            _ = &mut shutdown => {
+                let _ = child.kill().await;
+                return;
+            }
+            status = child.wait() => {
+                record_port_forward_stderr(
+                    &stderr,
+                    match status {
+                        Ok(status) => {
+                            format!("kubectl port-forward exited ({status}); restarting")
+                        }
+                        Err(e) => {
+                            format!("kubectl port-forward wait failed: {e}; restarting")
+                        }
+                    },
+                );
+                // Brief backoff so a forward that fails immediately does not
+                // hot-loop; bail out early if we are shutting down.
+                tokio::select! {
+                    _ = &mut shutdown => return,
+                    _ = tokio::time::sleep(PORT_FORWARD_RETRY_DELAY) => {}
+                }
+            }
+        }
+    }
 }
 
 /// Run `kubectl` with the given args, returning stdout on success.
@@ -626,4 +849,57 @@ spec:
             type: DirectoryOrCreate
 "#
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_allows_empty_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        guard_fixture_dir(dir.path()).expect("an empty directory is safe to clear");
+    }
+
+    #[test]
+    fn guard_allows_marked_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        // A non-empty directory we own (has the marker) is safe to clear.
+        write_marker(dir.path()).unwrap();
+        std::fs::write(dir.path().join("stale.parquet"), b"old").unwrap();
+        guard_fixture_dir(dir.path())
+            .expect("a marked directory is owned by the harness");
+    }
+
+    #[test]
+    fn guard_refuses_foreign_non_empty_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        // Non-empty and unmarked: presumably not ours, so it must be refused.
+        std::fs::write(dir.path().join("important.txt"), b"do not delete").unwrap();
+        let err = guard_fixture_dir(dir.path())
+            .expect_err("an unmarked non-empty directory must be refused");
+        assert!(err.contains("not created by the chaos harness"), "{err}");
+    }
+
+    #[test]
+    fn guard_refuses_root_and_home() {
+        assert!(guard_fixture_dir(Path::new("/")).is_err());
+        if let Some(home) = std::env::var_os("HOME").filter(|h| !h.is_empty()) {
+            assert!(guard_fixture_dir(Path::new(&home)).is_err());
+        }
+    }
+
+    #[test]
+    fn marker_round_trips_through_guard() {
+        // After a clear+mark cycle, the directory is still recognised as ours
+        // even though clearing removed the previous marker.
+        let dir = tempfile::tempdir().unwrap();
+        write_marker(dir.path()).unwrap();
+        std::fs::write(dir.path().join("part-0.parquet"), b"x").unwrap();
+        guard_fixture_dir(dir.path()).unwrap();
+        clear_dir_contents(dir.path()).unwrap();
+        write_marker(dir.path()).unwrap();
+        assert!(dir.path().join(FIXTURE_MARKER).exists());
+        guard_fixture_dir(dir.path()).unwrap();
+    }
 }


### PR DESCRIPTION

Follow-ups from #2244:
- Supervise the scheduler kubectl port-forward: a background task restarts it on exit and captures its stderr for dump_diagnostics, so a scheduler-pod restart or a transient apiserver/idle drop self-heals instead of leaving a permanently dead relay.
- Guard CHAOS_FIXTURE_DIR before clearing it: refuse '/' or $HOME, and any non-empty directory the harness did not create (marker file), so a stray env var cannot turn the clear into a recursive delete.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #. #2302

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
