### PR TITLE
feat(scheduler): adopt DataFusion's cost-based join order enumeration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "datafusion-cli"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2331,6 +2331,7 @@ dependencies = [
  "clap 4.6.6",
  "datafusion",
  "datafusion-common",
+ "datafusion-spark",
  "dirs",
  "env_logger",
  "futures",
@@ -2348,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2375,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "futures",
  "log",
@@ -2385,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2421,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2445,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-avro",
@@ -2463,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2486,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2509,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2541,12 +2542,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 
 [[package]]
 name = "datafusion-execution"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2572,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2596,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2607,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2638,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2658,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2669,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2693,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2708,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2724,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2733,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2743,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2762,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2784,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2798,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2815,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2834,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2870,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-catalog",
@@ -2896,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2906,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-models"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "datafusion-common",
  "datafusion-proto-common",
@@ -2916,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2931,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2939,27 +2940,28 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-plan",
+ "futures",
  "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-spark"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
+ "base64 0.23.1",
  "bigdecimal",
  "chrono",
  "crc32fast",
  "datafusion",
- "datafusion-catalog",
  "datafusion-common",
- "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
  "datafusion-functions-nested",
+ "datafusion-session",
  "log",
  "num-traits",
  "percent-encoding",
@@ -2974,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2993,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "git+https://github.com/Dandandan/arrow-datafusion.git?rev=29c224d86b#29c224d86b1188a6341dedbdf8c7371241dfebc0"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,13 +135,17 @@ debug = false
 debug-assertions = false
 incremental = false
 
-# Redirect the crates.io datafusion release to the pinned git tag. Bump the
-# tag here to advance DataFusion; the workspace-dep versions above stay put.
+# Redirect the crates.io datafusion release to a pinned git rev. Bump the rev
+# here to advance DataFusion; the workspace-dep versions above stay put.
+#
+# Currently apache/datafusion#24456 (cost-based join order enumeration), which
+# is not merged yet. Repoint at an apache/datafusion rev once it is; its merge
+# base with main is f1f0449a5327a03cc99817fcd0ac8531f0c015ec.
 [patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-cli = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-functions-aggregate-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-proto = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-proto-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-spark = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-substrait = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
+datafusion = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }
+datafusion-cli = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }
+datafusion-functions-aggregate-common = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }
+datafusion-proto = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }
+datafusion-proto-common = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }
+datafusion-spark = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }
+datafusion-substrait = { git = "https://github.com/Dandandan/arrow-datafusion.git", rev = "29c224d86b" }

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/parallel_window.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/parallel_window.rs
@@ -392,6 +392,7 @@ mod tests {
             Field::new("id3", DataType::Int64, false),
             Field::new("v2", DataType::Float64, false),
             Field::new("name", DataType::Utf8, false),
+            Field::new("price", DataType::Decimal128(20, 4), false),
         ]));
         let ctx = SessionContext::new();
         ctx.register_table("large", Arc::new(EmptyTable::new(schema)))?;
@@ -558,10 +559,16 @@ mod tests {
 
     /// A key the sketch cannot encode declines the rewrite rather than
     /// failing: the query still runs, just not in parallel.
+    ///
+    /// Ordered by a decimal rather than a string: `SortKeyCodec` covers the
+    /// integer, float, date, time, timestamp and duration types and nothing
+    /// else, so a decimal exercises the missing-encoding path while still
+    /// accepting a numeric `RANGE` offset. A `Utf8` key used to serve here,
+    /// but DataFusion now rejects an offset frame over one at type coercion.
     #[tokio::test]
     async fn no_rewrite_on_a_key_without_an_encoding() -> datafusion::common::Result<()> {
         let plan = plan(
-            "SELECT sum(v2) OVER (ORDER BY name \
+            "SELECT sum(v2) OVER (ORDER BY price \
                 RANGE BETWEEN 3 PRECEDING AND CURRENT ROW) \
              FROM large",
         )
@@ -570,7 +577,7 @@ mod tests {
         let rendered = format!("{}", displayable(rewritten.as_ref()).indent(true));
         assert!(
             !rendered.contains("OrderedRangeRepartitionExec"),
-            "a Utf8 order key has no sort-key encoding:\n{rendered}"
+            "a Decimal128 order key has no sort-key encoding:\n{rendered}"
         );
         Ok(())
     }

--- a/ballista/scheduler/src/state/aqe/planner.rs
+++ b/ballista/scheduler/src/state/aqe/planner.rs
@@ -39,6 +39,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::{SessionState, SessionStateBuilder};
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_optimizer::join_enumeration::JoinEnumeration;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties, displayable};
 use datafusion::physical_planner::DefaultPhysicalPlanner;
 use log::debug;
@@ -598,6 +599,14 @@ impl AdaptivePlanner {
                 // `r_name = EUROPE` in q2 — and every copy is evaluated per row
                 // and again in the row-group pruning predicate.
                 "FilterPushdown" => vec![],
+                // Enumeration runs once, from `plan_preparation_optimizers`.
+                // AQE re-optimizes after every stage completion, and each
+                // replan would search the join order again against the stats
+                // of whatever has finished so far, so the order churns
+                // mid-flight: on TPC-H SF=10 q5 the replanned order built a
+                // hash join over a side that exhausted the whole memory pool.
+                // The order is a plan-time decision -- make it once, up front.
+                "join_enumeration" => vec![],
                 // `join_selection` promotes a small build side to `CollectLeft`
                 // without restricting by join type -- safe in one process, but
                 // Ballista runs one task per probe partition. Demote the unsafe
@@ -618,6 +627,11 @@ impl AdaptivePlanner {
     ) -> Vec<PhysicalOptimizerRuleRef> {
         vec![
             Arc::new(FilterPushdown::new()),
+            // After FilterPushdown, so the search costs each input with its
+            // filters already on the scan, and before DelayJoinSelectionRule,
+            // which rewrites joins into `DynamicJoinSelectionExec` nodes the
+            // search would no longer recognise as joins.
+            Arc::new(JoinEnumeration::new()),
             Arc::new(DelayJoinSelectionRule::new(plan_id_generator)),
             Arc::new(ChaosCreatingRule::default()),
         ]

--- a/ballista/scheduler/src/state/aqe/test/alter_stages.rs
+++ b/ballista/scheduler/src/state/aqe/test/alter_stages.rs
@@ -177,9 +177,9 @@ async fn should_support_join_re_ordering() -> datafusion::error::Result<()> {
     assert_plan!(join.as_ref(),  @ r"
     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(big_col@0, big_col@0)]
       RepartitionExec: partitioning=Hash([big_col@0], 2), input_partitions=2
-        MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+        MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
       RepartitionExec: partitioning=Hash([big_col@0], 2), input_partitions=2
-        MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+        MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
     ");
 
     let mut planner =
@@ -189,9 +189,9 @@ async fn should_support_join_re_ordering() -> datafusion::error::Result<()> {
     AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(big_col@0, big_col@0)]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=0, stage_id=pending, stage_resolved=false
-          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=1, stage_id=pending, stage_resolved=false
-          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
     ");
 
     let stages = planner.runnable_stages()?.unwrap();
@@ -201,9 +201,9 @@ async fn should_support_join_re_ordering() -> datafusion::error::Result<()> {
     AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(big_col@0, big_col@0)]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=0, stage_id=0, stage_resolved=false
-          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=1, stage_id=1, stage_resolved=false
-          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+          MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
     ");
 
     // we finalize stage 1 with smaller number of rows, for test purposes,
@@ -213,42 +213,42 @@ async fn should_support_join_re_ordering() -> datafusion::error::Result<()> {
 
     // join ordering changes as build side is bigger than probe side
     // after exchange statistic updated.
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=2, stage_id=pending, stage_resolved=false
       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(big_col@0, big_col@0)], projection=[big_col@1, big_col@0]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=1, stage_id=1, stage_resolved=true
           CooperativeExec
-            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=0, stage_id=0, stage_resolved=true
           CooperativeExec
-            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
     ");
 
     let stages = planner.runnable_stages()?.unwrap();
     assert_eq!(1, stages.len());
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=false
       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(big_col@0, big_col@0)], projection=[big_col@1, big_col@0]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=1, stage_id=1, stage_resolved=true
           CooperativeExec
-            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=0, stage_id=0, stage_resolved=true
           CooperativeExec
-            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
     ");
 
     planner.finalise_stage_internal(2, small_statistics_exchange())?;
 
-    assert_plan!(planner.current_plan(),  @ "
+    assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=true, plan_id=2, stage_id=2, stage_resolved=true
       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(big_col@0, big_col@0)], projection=[big_col@1, big_col@0]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=1, stage_id=1, stage_resolved=true
           CooperativeExec
-            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
         ExchangeExec: partitioning=Hash([big_col@0], 2), plan_id=0, stage_id=0, stage_resolved=true
           CooperativeExec
-            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(2097152), [(Col[0]:)]]
+            MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(262144), Bytes=Exact(8388608), [(Col[0]:)]]
     ");
 
     Ok(())
@@ -273,7 +273,7 @@ async fn should_support_cross_join() -> datafusion::error::Result<()> {
     CrossJoinExec
       RepartitionExec: partitioning=Hash([big_col@0], 2), input_partitions=2
         StatisticsExec: col_count=1, row_count=Exact(262144)
-      MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(8192), [(Col[0]:)]]
+      MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(32768), [(Col[0]:)]]
     ");
 
     let mut planner =
@@ -289,7 +289,7 @@ async fn should_support_cross_join() -> datafusion::error::Result<()> {
         CrossJoinExec
           CoalescePartitionsExec
             ExchangeExec: partitioning=None, plan_id=0, stage_id=pending, stage_resolved=false
-              MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(8192), [(Col[0]:)]]
+              MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(32768), [(Col[0]:)]]
           CooperativeExec
             StatisticsExec: col_count=1, row_count=Exact(262144)
     ");
@@ -303,7 +303,7 @@ async fn should_support_cross_join() -> datafusion::error::Result<()> {
 
     assert_plan!(stages[0].plan.as_ref(),  @ r"
     ShuffleWriterExec: partitioning: UnknownPartitioning(2)
-      MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(8192), [(Col[0]:)]]
+      MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(32768), [(Col[0]:)]]
     ");
 
     planner.finalise_stage_internal(0, small_statistics_exchange())?;
@@ -313,7 +313,7 @@ async fn should_support_cross_join() -> datafusion::error::Result<()> {
         CrossJoinExec
           CoalescePartitionsExec
             ExchangeExec: partitioning=None, plan_id=0, stage_id=0, stage_resolved=true
-              MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(8192), [(Col[0]:)]]
+              MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(32768), [(Col[0]:)]]
           CooperativeExec
             StatisticsExec: col_count=1, row_count=Exact(262144)
     ");
@@ -343,7 +343,7 @@ async fn should_support_cross_join() -> datafusion::error::Result<()> {
         CrossJoinExec
           CoalescePartitionsExec
             ExchangeExec: partitioning=None, plan_id=0, stage_id=0, stage_resolved=true
-              MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(8192), [(Col[0]:)]]
+              MockPartitionedScan: num_partitions=2, statistics=[Rows=Exact(1024), Bytes=Exact(32768), [(Col[0]:)]]
           CooperativeExec
             StatisticsExec: col_count=1, row_count=Exact(262144)
     ");

--- a/ballista/scheduler/src/state/aqe/test/join_selection.rs
+++ b/ballista/scheduler/src/state/aqe/test/join_selection.rs
@@ -386,13 +386,13 @@ async fn test_hash_join_three_tables_collect_left() -> datafusion::common::Resul
 
     assert_plan!(planner.current_plan(),  @ r"
     AdaptiveDatafusionExec: is_final=false, plan_id=3, stage_id=pending, stage_resolved=false
-      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
+      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@1]
         ExchangeExec: partitioning=None, plan_id=4, stage_id=1, stage_resolved=false, broadcast=true
-          HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
-            ExchangeExec: partitioning=None, plan_id=2, stage_id=0, stage_resolved=true, broadcast=true
-              DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+        HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[id@0]
+          ExchangeExec: partitioning=None, plan_id=2, stage_id=0, stage_resolved=true, broadcast=true
             DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
-        DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
+          DataSourceExec: partitions=4, partition_sizes=[1, 1, 1, 1]
     ");
 
     Ok(())

--- a/ballista/scheduler/src/state/aqe/test/stats_table.rs
+++ b/ballista/scheduler/src/state/aqe/test/stats_table.rs
@@ -91,7 +91,7 @@ impl TableProvider for StatsTable {
     async fn scan(
         &self,
         _state: &dyn Session,
-        projection: Option<&Vec<usize>>,
+        projection: Option<&[usize]>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -116,7 +116,7 @@ impl StatsExec {
         schema: SchemaRef,
         statistics: Statistics,
         partitions: usize,
-        projection: Option<&Vec<usize>>,
+        projection: Option<&[usize]>,
     ) -> Result<Self> {
         let schema = project_schema(&schema, projection)?;
 

--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -90,7 +90,7 @@ impl TableProvider for ExplodingTableProvider {
     async fn scan(
         &self,
         _ctx: &dyn Session,
-        _projection: Option<&Vec<usize>>,
+        _projection: Option<&[usize]>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {

--- a/ballista/scheduler/tests/tpch_plan_stability/stats_table.rs
+++ b/ballista/scheduler/tests/tpch_plan_stability/stats_table.rs
@@ -140,7 +140,7 @@ impl TableProvider for TpchStatsTable {
     async fn scan(
         &self,
         _state: &dyn Session,
-        projection: Option<&Vec<usize>>,
+        projection: Option<&[usize]>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {


### PR DESCRIPTION
# Which issue does this PR close?

None filed — happy to open one if the project would like this tracked. It adopts
[apache/datafusion#24456](https://github.com/apache/datafusion/pull/24456).

**Draft:** the `[patch.crates-io]` pin points at an unmerged fork rev
(`Dandandan/arrow-datafusion@29c224d86b`). It needs repointing at an
apache/datafusion rev before this can merge.

# Rationale for this change

apache/datafusion#24456 adds a `JoinEnumeration` physical optimizer rule that
searches join orders from cardinality estimates, considering bushy shapes as
well as left-deep ones. Taken as-is it is **not usable on Ballista**: TPC-H
SF=10 costs 45.6% overall and q5 fails outright, 3 runs out of 3, with
`ResourcesExhausted` against the whole 22.4 GB executor pool.

That is placement, not plan quality. `plan_preparation_optimizers` runs
`DelayJoinSelectionRule`, which rewrites every join into a
`DynamicJoinSelectionExec` that `SelectJoinRule` unwraps only once its
`upstream_resolved()`. DataFusion's default rule list runs after that — once at
plan time (`planner.rs:109`) and again after every stage completion
(`planner.rs:366`) — so the rule never sees the whole join graph. It re-searches
a progressively-resolving fragment and re-decides each time.

With only part of the graph visible the search split q5's composite key
`(s_suppkey = l_suppkey, s_nationkey = c_nationkey)` and scheduled
`s_nationkey = c_nationkey` as a standalone join. `nationkey` has 25 distinct
values, so it produces **1,830,400,706 rows** against an estimate of 2.3M / 36.5
MB. That estimate fits under `broadcast_join_threshold_bytes`, so AQE broadcast
it to every probe task. Plain DataFusion, seeing the whole graph, keeps the key
composite under both `prefer_hash_join` settings — so this is Ballista-only.

Join *order* is a plan-time decision over the whole graph. Join
*implementation* is local and genuinely benefits from measured statistics.
Splitting them that way is the fix.

# What changes are included in this PR?

1. **`chore(deps)`** — moves the patch off `55.0.0-rc3` onto the upstream PR,
   plus two adaptations to DataFusion main that are independent of it:
   `TableProvider::scan` now takes `Option<&[usize]>`, and apache/datafusion#24357
   rejects a `RANGE` offset frame over a `Utf8` ORDER BY, so the
   `ParallelWindowRule` test that needs an unencodable sort key orders by
   `Decimal128` instead.
2. **`fix(scheduler)`** — 14 lines in `aqe/planner.rs`. Adds `JoinEnumeration` to
   `plan_preparation_optimizers`, after `FilterPushdown` so the search costs each
   input with its filters already on the scan, and before
   `DelayJoinSelectionRule` so it sees real joins; and returns `vec![]` for
   `"join_enumeration"` in `datafusion_optimizers()` so it does not re-run per
   replan — the same exclusion `FilterPushdown` already has (#2344).
3. **`test`** — 17 snapshot byte sizes scale by 4 because the upstream PR also
   raises the default `hash_join_single_partition_threshold` from 1 MiB to 4 MiB
   (inert here, Ballista overrides that option), and
   `hash_join_three_tables_collect_left` enumerates a different order.

## Benchmarks

1 scheduler + 2 executors × 4 vcores, `target_partitions=16`, 10-core / 32 GB
host. Variant order rotated per round; medians reported. TPC-H is the median of
8 (4 rounds × 2 iterations), TPC-DS the median of 3. Every pass ran to
completion; **0 query failures and 0 row-count mismatches** across all 99 TPC-DS
queries.

| | baseline | this PR | Δ |
|---|---|---|---|
| TPC-H SF=10, 22 queries | 19.623 s | 19.423 s | **−1.0%** |
| … excluding q18 | | | **−7.9%** |
| TPC-DS SF=1, 99 queries | 58.909 s | 24.436 s | **−58.5%** |
| … excluding q72 | 26.142 s | 24.188 s | **−7.5%** |

Baseline is apache/datafusion main at `f1f0449a53`, the upstream PR's own merge
base, so the comparison isolates the PR.

Both headline figures have one query doing most of the work, so quote them by
name: TPC-DS q72 goes 32.767 s → 0.248 s (132×), which is 32.5 of the 34.5
seconds saved; TPC-H q18 costs +1.099 s on its own.

TPC-H movers: q7 −55.0%, q3 −51.5%, q12 −35.2%, q2 −26.7%, q16 −13.0%,
q11 −10.7% against q18 +35.0%, q9 +14.7%, q19 +10.6%.

Without commit 2, the same build measures **+45.6%** on TPC-H SF=10 and fails
q5. Join-free q6 regresses 189% there, so part of that cost is pure per-replan
overhead rather than plan quality.

## Known issue: q18

q18 is the one significant regression and it is **not** a reordering problem —
setting `join_enumeration=false` on this build reproduces the identical 8-stage
plan. It is a statistics regression that flips an irreversible AQE decision:

| plan_id=1 build side | estimate | AQE decision |
|---|---|---|
| baseline | rows `Inexact(1,500,000)`, bytes **`Absent`** | rejected → `Repartition` |
| → after measuring | rows `Exact(15,000,000)`, bytes `Exact(871 MB)` | `Hash(Partitioned)` |
| this PR | rows `Inexact(1,500,000)`, bytes `Inexact(99 MB)` | `CollectLeft`, never re-measured |

Both estimate the rows equally badly. Baseline had no byte estimate, so the
decision fell to the row path, hit the 1M row ceiling and took `Repartition` —
which shuffled, measured 871 MB and correctly stayed partitioned. The new 99 MB
estimate undercuts the 128 MiB byte threshold and commits to a broadcast that is
never revisited, which costs the `SinglePartitioned` aggregate, the `TopK`
pushdown into that stage, and a 180M-row shuffle on a five-column key.

The root fix is upstream: `customer ⨝ orders` on `custkey` is estimated at 1.5M
rows where it produces 15M, which looks like the PK side's cardinality with no FK
fan-out. Correct it and the byte estimate lands over the threshold, and Ballista
picks partitioned with no change here.

# Are there any user-facing changes?

Join plans change, generally for the better. Three new DataFusion options become
available and default on: `datafusion.optimizer.join_enumeration`,
`join_enumeration_min_improvement`, `join_enumeration_limit`. Setting
`join_enumeration=false` restores the previous ordering.

No Ballista public API changes.
