### PR TITLE
fix(scheduler): fix test job-completion polling 

### DIFF
--- a/ballista/scheduler/src/test_utils.rs
+++ b/ballista/scheduler/src/test_utils.rs
@@ -601,76 +601,6 @@ impl SchedulerTest {
             .await
     }
 
-    /// Waits for job completion with a timeout in milliseconds.
-    pub async fn await_completion_timeout(
-        &self,
-        job_id: &JobId,
-        timeout_ms: u64,
-    ) -> Result<JobStatus> {
-        let mut time = 0;
-        let final_status: Result<JobStatus> = loop {
-            let status = self
-                .scheduler
-                .state
-                .task_manager
-                .get_job_status(job_id)
-                .await?;
-
-            if let Some(JobStatus {
-                status: Some(inner),
-                ..
-            }) = status.as_ref()
-            {
-                match inner {
-                    Status::Failed(_) | Status::Successful(_) => {
-                        break Ok(status.unwrap());
-                    }
-                    _ => {
-                        if time >= timeout_ms {
-                            break Ok(status.unwrap());
-                        } else {
-                            continue;
-                        }
-                    }
-                }
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            time += 100;
-        };
-
-        final_status
-    }
-
-    /// Waits for job completion indefinitely.
-    pub async fn await_completion(&self, job_id: &JobId) -> Result<JobStatus> {
-        let final_status: Result<JobStatus> = loop {
-            let status = self
-                .scheduler
-                .state
-                .task_manager
-                .get_job_status(job_id)
-                .await?;
-
-            if let Some(JobStatus {
-                status: Some(inner),
-                ..
-            }) = status.as_ref()
-            {
-                match inner {
-                    Status::Failed(_) | Status::Successful(_) => {
-                        break Ok(status.unwrap());
-                    }
-                    _ => continue,
-                }
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await
-        };
-
-        final_status
-    }
-
     /// Returns job status and job_id
     pub async fn run(
         &mut self,
@@ -719,16 +649,11 @@ impl SchedulerTest {
                 .await?;
 
             if let Some(JobStatus {
-                status: Some(inner),
+                status: Some(Status::Failed(_) | Status::Successful(_)),
                 ..
             }) = status.as_ref()
             {
-                match inner {
-                    Status::Failed(_) | Status::Successful(_) => {
-                        break Ok(status.unwrap());
-                    }
-                    _ => continue,
-                }
+                break Ok(status.unwrap());
             }
 
             tokio::time::sleep(Duration::from_millis(100)).await


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

The job-completion poll loop in `SchedulerTest::run_with_subscriber` used `_ => continue`,
which skips the `sleep(100)` below the match. Once a job reports a non-terminal status the
loop polls with no delay and spins a core until the job finishes.

`await_completion` and `await_completion_timeout` had the same bug and no callers.

# What changes are included in this PR?

- `run_with_subscriber`: collapsed the inner `match` into the outer `if let` so
  non-terminal statuses fall through to the sleep.
- Deleted `await_completion` and `await_completion_timeout` (no callers).

We can also not delete the unused functions, but this is a very clear bug regardless.


# Are there any user-facing changes?
No
