### PR TITLE
perf(scheduler): stop re-encoding the session config for every task

### DIFF
--- a/ballista/scheduler/src/state/task_manager.rs
+++ b/ballista/scheduler/src/state/task_manager.rs
@@ -877,6 +877,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .as_millis() as u64;
         let codec = self.codec.physical_extension_codec();
 
+        let props = first_task.session_config.to_key_value_pairs();
         let mut multi_tasks = Vec::with_capacity(tasks.len());
         for task in tasks {
             let restricted = restrict_plan_to_partitions(
@@ -886,7 +887,6 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             let mut plan_buf: Vec<u8> = vec![];
             let plan_proto = PhysicalPlanNode::try_from_physical_plan(restricted, codec)?;
             plan_proto.try_encode(&mut plan_buf)?;
-            let props = task.session_config.to_key_value_pairs();
             let task_ids = vec![TaskId {
                 task_id: task.key.task_id as u32,
                 task_attempt_num: task.task_attempt as u32,
@@ -907,7 +907,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
                 plan: plan_buf,
                 session_id: session_id.clone(),
                 launch_time,
-                props,
+                props: props.clone(),
             });
         }
         Ok(multi_tasks)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Release build, 32-task batch, 200 iterations, measured on
`prepare_multi_task_definition` end to end:

| | per batch | per task |
|---|---|---|
| before | 3.53 ms | 110.5 µs |
| after  | 1.77 ms | **55.5 µs** |


# What changes are included in this PR?

Encode the session config once per task batch instead of once per task, cloning it into each task's definition.



