### PR TITLE
chore(deps): use the released DataFusion 55.0.0 crates from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2274,7 +2275,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79ec3460f6ed5c58f9b3f2d873fbc77748b82653bff1b4cdaf06de33bb4e05f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2298,7 +2300,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48cef241e2efcfd496fe05ae4d0d5de20793451862faefe406c397a467e12d4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2321,7 +2324,8 @@ dependencies = [
 [[package]]
 name = "datafusion-cli"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8b87ff78e243da48b836ced274799a1799b4a2fd321700e4b8f3426c01aa7e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2348,7 +2352,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f72810485975c258f1b4d00baab31728470676c60c5546f366ebd0d99f05ab6"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2375,7 +2380,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533c28e75dba52f41bde187d23a1cb24ab91c7c097966824fa471e67b60320ea"
 dependencies = [
  "futures",
  "log",
@@ -2385,7 +2391,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b00a1fa0da26f6087136a82fea7f13c76a672cbab452d4086952a7cf770a19b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2421,7 +2428,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad17ec881bff2ed7768b4bfe971d3efbf3473f2fd1f9d365447bccbdf908678"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2445,7 +2453,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c9587cff8163f9bfcb186e8664ba85cb327031b8ff14330307f961ea2fc196"
 dependencies = [
  "arrow",
  "arrow-avro",
@@ -2463,7 +2472,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5345285b0c3eaab412e7539b706973c083bd7e5bce575de5e0a3da488d08d1d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2486,7 +2496,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da02fb9324f56bd8c53f1ee2e949547425cb66f76adc6832b10d44f80a1221d2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2509,7 +2520,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0b0dc1453952952fd5c69ad1c7f6042176e69ed233011d47e07cf74ed0949e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2541,12 +2553,14 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88fd985bc0550c36f557db69543cc9d6393b1509783520b30e902f23c555da6"
 
 [[package]]
 name = "datafusion-execution"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98f1052f91b4991f0bf2ce1e4e36dfbdcda454a956b8c8d562c7c845e8fce1d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2572,7 +2586,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464625a1f0e4b9df552d894fafcc8aac953ebbc8b0fa0acdaf20975fd615040e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2596,7 +2611,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2607,7 +2623,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051e97533e6af53e4aa0a0667cadc886abcaf36c4a5925019c55c0aa4c218fde"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2638,7 +2655,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0f1bb166d3572b6ed40e1afb2faaacade962abc08c2fcf04babee74681c56b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2658,7 +2676,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ed756770f5f98369e181d692fd5ee6b1127ffd7322caba92f3730f9f5c92333"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2669,7 +2688,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91173fdb5c0ff2a41169a8ffa1b385b8844f18728747bb0a37e35ad7d5772a4f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2693,7 +2713,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bcdfb286a745461b126719c32700777e83df4f17cc44db5d71ebce5731e840"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2708,7 +2729,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec4b508f1f93f00038ba3e737e894ec6c775528b4369413386655ae6125f0fc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2724,7 +2746,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b352020834140073fbf5b46ee0ceb926e5074a9d0bcae1dbd91d0586d999cde"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2733,7 +2756,8 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2743,7 +2767,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854445d9f7847e1e46089cf61b8d341a64382f14484e912c83a0f23b31216896"
 dependencies = [
  "arrow",
  "chrono",
@@ -2762,7 +2787,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671558dad1d2aa253c39c0a4c52515958b99eb91abf649f4b88d5e69cc55282f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2784,7 +2810,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffae3d78c2da80ecc829cb58536cc5aca2e99cf1365eda694fc75bfe288861e0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2798,7 +2825,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d9092ed15e7203fbd0903215172f7c9d18f10d94cba35137f3b3836f7c46f16"
 dependencies = [
  "arrow",
  "chrono",
@@ -2815,7 +2843,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9005b6cf50b57b72d476c6ed4662b04be7ca6be5320ba9127c6d0b7e4218095b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2834,7 +2863,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787e4fcff4adc4fce8948441103a99705018b49c8dff0720b650bd7a15da112"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2870,7 +2900,8 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df0504eb9028d5e01f481af3519cde3f97ab650fd50ce7b787e94b69a7a193c"
 dependencies = [
  "arrow",
  "datafusion-catalog",
@@ -2896,7 +2927,8 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92415a2442964f180d39cdcd8ff1edd99f9260c1499ba80a396499c2154d11"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2906,7 +2938,8 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-models"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e4c0bd6af4fcabdbe201ee86fbeef2ac423a44e1d8fda56d994c9e2d1d3ad2"
 dependencies = [
  "datafusion-common",
  "datafusion-proto-common",
@@ -2916,7 +2949,8 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e651c8df0b90daed6a7be5921ec0ee379e6909705f063eeff70fd4e35010e4c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2931,7 +2965,8 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb56667ee38217efab19b895d9a936052cfb47ed438a19663351bdc42a6214a1"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2945,7 +2980,8 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "992dd0b954f24cb576cbeee3555c3083b9cf7a5a5f2448ea25f7a437d444163f"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2974,7 +3010,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c29067cb9d32f8e603c45e15d61ea18f1069f96ceafeceb4e18466b8e5b31d9"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2993,7 +3030,8 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "55.0.0"
-source = "git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3#d5552342012888b7d1a3ab88d92e3d292fc0cde0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c026ddbbc33c34d0fac95a9620367c805ad6a7174cac52b57f360746c3e282"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,16 +42,16 @@ arrow-flight = { version = "59.2.0", features = ["flight-sql-experimental"] }
 ballista-api-types = { path = "ballista/api-types", version = "54.0.0" }
 clap = { version = "4.5", features = ["derive", "cargo"] }
 
-# DataFusion crates are pinned to the 55.0.0-rc3 tag via `[patch.crates-io]`
-# below. Workspace deps reference the crates.io version so the patch table is
-# the single place to bump when advancing to a newer DataFusion release.
-datafusion = { version = "55" }
-datafusion-cli = { version = "55" }
-datafusion-functions-aggregate-common = { version = "55" }
-datafusion-proto = { version = "55" }
-datafusion-proto-common = { version = "55" }
-datafusion-spark = { version = "55" }
-datafusion-substrait = { version = "55" }
+# Keep these as minor-version requirements rather than exact patch pins so a
+# DataFusion patch release can be picked up with a lockfile bump alone.
+# Cargo.lock records the exact patch version CI builds against.
+datafusion = "55"
+datafusion-cli = "55"
+datafusion-functions-aggregate-common = "55"
+datafusion-proto = "55"
+datafusion-proto-common = "55"
+datafusion-spark = "55"
+datafusion-substrait = "55"
 
 ctor = { version = "1.0" }
 insta = "1.47"
@@ -134,14 +134,3 @@ lto = false
 debug = false
 debug-assertions = false
 incremental = false
-
-# Redirect the crates.io datafusion release to the pinned git tag. Bump the
-# tag here to advance DataFusion; the workspace-dep versions above stay put.
-[patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-cli = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-functions-aggregate-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-proto = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-proto-common = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-spark = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }
-datafusion-substrait = { git = "https://github.com/apache/datafusion.git", tag = "55.0.0-rc3" }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #2369. Follow-up to #2301, which pinned DataFusion to the `55.0.0-rc3` tag.

# Rationale for this change

DataFusion 55.0.0 is now published on crates.io, so the `[patch.crates-io]` table that redirected the DataFusion crates at a git tag has served its purpose. Depending on the released crates directly means `cargo` resolves from the registry instead of cloning `apache/datafusion` at build time, which is faster to build, works for downstream consumers of the Ballista crates, and is a prerequisite for publishing a Ballista 55.0.0 release.

# What changes are included in this PR?

- Removed the `[patch.crates-io]` table from the root `Cargo.toml`
- Workspace DataFusion deps go back to plain crates.io requirements (`datafusion = "55"` and friends), with a comment explaining why they stay minor-version rather than exact patch pins
- `Cargo.lock` refreshed: every DataFusion crate moves from `git+https://github.com/apache/datafusion.git?tag=55.0.0-rc3` to the registry at the same `55.0.0` version. No non-DataFusion dependency moved.
- The `python/` workspace is untouched — it consumes published 54.0.0 crates and has no path dependency into this workspace. Bumping the Python bindings to 55.0.0 is tracked separately in #2369.

# Are these changes tested?

Existing CI covers this. Locally on macOS (aarch64):

- `cargo check --workspace --all-targets --locked` — clean
- `cargo clippy --all-targets --workspace --all-features -- -D warnings` — clean
- `cargo check -p ballista-scheduler -p ballista-executor -p ballista-core -p ballista --no-default-features --locked` — clean (the one `unused_imports` warning in `ballista/client/src/extension.rs` is pre-existing on `main` and unrelated to this change)
- `cargo fmt --all -- --check`, `taplo` toml fmt, and `dev/update_datafusion_proto.py --check` — all clean, so the vendored DataFusion protos need no resync

# Are there any user-facing changes?

No API changes. Builds no longer need network access to `github.com/apache/datafusion` to resolve dependencies.
