### PR TITLE
feat: scheduler REST & GRPC returns ballista version headers 

### DIFF
--- a/ballista/core/src/execution_plans/distributed_query.rs
+++ b/ballista/core/src/execution_plans/distributed_query.rs
@@ -50,7 +50,7 @@ use datafusion_proto::logical_plan::{
 };
 use datafusion_proto::physical_plan::{AsExecutionPlan, PhysicalExtensionCodec};
 use futures::{Stream, StreamExt, TryStreamExt};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use parking_lot::Mutex;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -452,6 +452,22 @@ pub async fn execute_physical_plan<U: 'static + AsExecutionPlan>(
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
 }
 
+/// Logs a warning if the scheduler's advertised version (from the `server`
+/// response header, e.g. `ballista/1.2.3`) doesn't match this client's.
+fn check_scheduler_version<T>(response: &tonic::Response<T>) {
+    let expected = format!("ballista/{}", crate::BALLISTA_VERSION);
+    if let Some(server) = response
+        .metadata()
+        .get("server")
+        .and_then(|v| v.to_str().ok())
+        && server != expected
+    {
+        warn!(
+            "Scheduler version mismatch: scheduler reports '{server}', client is '{expected}'"
+        );
+    }
+}
+
 /// Client will periodically invoke scheduler to check
 /// job status. There is preconfigured wait period between
 /// pulls, which increases query latency.
@@ -501,11 +517,12 @@ async fn execute_query_pull(
     .max_encoding_message_size(max_message_size)
     .max_decoding_message_size(max_message_size);
 
-    let query_result = scheduler
+    let query_response = scheduler
         .execute_query(query)
         .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-        .into_inner();
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    check_scheduler_version(&query_response);
+    let query_result = query_response.into_inner();
 
     let query_result = match query_result.result.unwrap() {
         execute_query_result::Result::Success(success_result) => success_result,
@@ -673,11 +690,12 @@ async fn execute_query_push(
     .max_encoding_message_size(max_message_size)
     .max_decoding_message_size(max_message_size);
 
-    let mut query_status_stream = scheduler
+    let query_push_response = scheduler
         .execute_query_push(query)
         .await
-        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?
-        .into_inner();
+        .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+    check_scheduler_version(&query_push_response);
+    let mut query_status_stream = query_push_response.into_inner();
 
     let mut prev_status: Option<job_status::Status> = None;
 

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -82,7 +82,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true, features = ["router"] }
 tonic-prost = { workspace = true, optional = true }
-tower-http = { version = "0.7", features = ["cors"] }
+tower-http = { version = "0.7", features = ["cors", "set-header"] }
 tracing = { workspace = true, optional = true }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
@@ -98,7 +98,7 @@ regex = "1"
 rstest = { workspace = true }
 serde_json = "1"
 tempfile = { workspace = true }
-tower = "0.5"
+tower = { version = "0.5", features = ["util"] }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true, optional = true }

--- a/ballista/scheduler/src/scheduler_process.rs
+++ b/ballista/scheduler/src/scheduler_process.rs
@@ -40,10 +40,11 @@ use datafusion::DATAFUSION_VERSION;
 use datafusion_proto::logical_plan::AsLogicalPlan;
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
-use http::StatusCode;
+use http::{HeaderName, HeaderValue, StatusCode};
 use log::info;
 use std::{net::SocketAddr, sync::Arc};
 use tonic::service::RoutesBuilder;
+use tower_http::set_header::SetResponseHeaderLayer;
 /// Creates as initialized scheduler service
 /// without exposing it as a grpc service
 pub async fn create_scheduler<
@@ -83,6 +84,28 @@ pub async fn create_scheduler<
     scheduler_server.init().await?;
 
     Ok(scheduler_server)
+}
+
+/// Wraps a router so every response carries `Server` and `X-App-Version`
+/// headers, regardless of whether it was handled by the REST or gRPC routes
+/// merged into it.
+fn with_version_headers(router: axum::Router) -> axum::Router {
+    let server_value = HeaderValue::from_str(&format!("ballista/{BALLISTA_VERSION}"))
+        .expect("BALLISTA_VERSION should be a valid header value");
+
+    let datafusion_value =
+        HeaderValue::from_str(&format!("datafusion/{DATAFUSION_VERSION}"))
+            .expect("DATAFUSION_VERSION should be a valid header value");
+
+    router
+        .layer(SetResponseHeaderLayer::overriding(
+            http::header::SERVER,
+            server_value,
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("x-powered-by"),
+            datafusion_value,
+        ))
 }
 
 /// Exposes scheduler grpc service
@@ -134,27 +157,26 @@ pub async fn start_grpc_service<
     let health = health_routes(scheduler.clone());
 
     #[cfg(feature = "rest-api")]
-    let final_route = if config.disable_rest_api {
+    let merged = if config.disable_rest_api {
         tonic
             .merge(route_disabled(
                 "REST API has been disabled at startup".to_string(),
             ))
             .merge(health)
-            .into_make_service_with_connect_info::<SocketAddr>()
     } else {
         let axum = get_routes(scheduler);
-        axum.merge(tonic)
-            .merge(health)
-            .into_make_service_with_connect_info::<SocketAddr>()
+        axum.merge(tonic).merge(health)
     };
 
     #[cfg(not(feature = "rest-api"))]
-    let final_route = tonic
+    let merged = tonic
         .merge(route_disabled(
             "REST API has been disabled at compile time".to_string(),
         ))
-        .merge(health)
-        .into_make_service_with_connect_info::<SocketAddr>();
+        .merge(health);
+
+    let final_route =
+        with_version_headers(merged).into_make_service_with_connect_info::<SocketAddr>();
 
     let listener = tokio::net::TcpListener::bind(&address)
         .await
@@ -181,4 +203,37 @@ pub async fn start_server(
         create_scheduler::<LogicalPlanNode, PhysicalPlanNode>(cluster, config).await?;
 
     start_grpc_service(address, scheduler).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn adds_server_and_app_version_headers() {
+        let router = with_version_headers(
+            axum::Router::new().route("/ping", get(|| async { "pong" })),
+        );
+
+        let response = router
+            .oneshot(
+                http::Request::builder()
+                    .uri("/ping")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get(http::header::SERVER).unwrap(),
+            &format!("ballista/{BALLISTA_VERSION}")[..],
+        );
+        assert_eq!(
+            response.headers().get("x-powered-by").unwrap(),
+            &format!("datafusion/{DATAFUSION_VERSION}")[..],
+        );
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2370.

# Rationale for this change

scheduler returns version headers which client can compare with expected version.

schedule returns two additional header 

```
server: ballista/VERSION
x-powered-by: datafusion/VERSION
```

client which check `server/VERSION` and logs warning in case of mismatch 

# What changes are included in this PR?

# Are there any user-facing changes?
