### PR TITLE
Revert "remove redundant logic from ballista logical codec (#2348)"

### DIFF
--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -27,6 +27,10 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::Extension;
 use datafusion::physical_plan::{ExecutionPlan, Partitioning};
+use datafusion_proto::logical_plan::file_formats::{
+    ArrowLogicalExtensionCodec, AvroLogicalExtensionCodec, CsvLogicalExtensionCodec,
+    JsonLogicalExtensionCodec, ParquetLogicalExtensionCodec,
+};
 use datafusion_proto::physical_plan::from_proto::parse_physical_sort_exprs;
 use datafusion_proto::physical_plan::from_proto::parse_protobuf_hash_partitioning;
 use datafusion_proto::physical_plan::from_proto::parse_protobuf_partitioning;
@@ -188,12 +192,49 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> BallistaCodec<T, 
 #[derive(Debug)]
 pub struct BallistaLogicalExtensionCodec {
     default_codec: Arc<dyn LogicalExtensionCodec>,
+    file_format_codecs: Vec<Arc<dyn LogicalExtensionCodec>>,
+}
+
+impl BallistaLogicalExtensionCodec {
+    /// looks for a codec which can operate on this node
+    /// returns a position of codec in the list and result.
+    ///
+    /// position is important with encoding process
+    /// as position of used codecs is needed
+    /// so the same codec can be used for decoding
+    fn try_any<R>(
+        &self,
+        mut f: impl FnMut(&dyn LogicalExtensionCodec) -> Result<R>,
+    ) -> Result<(u32, R)> {
+        let mut last_err = None;
+        for (position, codec) in self.file_format_codecs.iter().enumerate() {
+            match f(codec.as_ref()) {
+                Ok(result) => return Ok((position as u32, result)),
+                Err(err) => last_err = Some(err),
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            DataFusionError::Internal(
+                "List of provided extended logical codecs is empty".to_owned(),
+            )
+        }))
+    }
 }
 
 impl Default for BallistaLogicalExtensionCodec {
     fn default() -> Self {
         Self {
             default_codec: Arc::new(DefaultLogicalExtensionCodec {}),
+            // Position in this list is important as it will be used for decoding.
+            // If new codec is added it should go to last position.
+            file_format_codecs: vec![
+                Arc::new(ParquetLogicalExtensionCodec {}),
+                Arc::new(CsvLogicalExtensionCodec {}),
+                Arc::new(JsonLogicalExtensionCodec {}),
+                Arc::new(ArrowLogicalExtensionCodec {}),
+                Arc::new(AvroLogicalExtensionCodec {}),
+            ],
         }
     }
 }
@@ -282,7 +323,17 @@ impl LogicalExtensionCodec for BallistaLogicalExtensionCodec {
         buf: &[u8],
         ctx: &TaskContext,
     ) -> Result<Arc<dyn datafusion::datasource::file_format::FileFormatFactory>> {
-        self.default_codec.try_decode_file_format(buf, ctx)
+        let proto = FileFormatProto::decode(buf)
+            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+
+        let codec = self
+            .file_format_codecs
+            .get(proto.encoder_position as usize)
+            .ok_or(DataFusionError::Internal(
+                "Can't find required codec in file codec list".to_owned(),
+            ))?;
+
+        codec.try_decode_file_format(&proto.blob, ctx)
     }
 
     fn try_encode_file_format(
@@ -290,7 +341,17 @@ impl LogicalExtensionCodec for BallistaLogicalExtensionCodec {
         buf: &mut Vec<u8>,
         node: Arc<dyn datafusion::datasource::file_format::FileFormatFactory>,
     ) -> Result<()> {
-        self.default_codec.try_encode_file_format(buf, node)
+        let mut blob = vec![];
+        let (encoder_position, _) =
+            self.try_any(|codec| codec.try_encode_file_format(&mut blob, node.clone()))?;
+
+        let proto = FileFormatProto {
+            encoder_position,
+            blob,
+        };
+        proto
+            .encode(buf)
+            .map_err(|e| DataFusionError::Internal(e.to_string()))
     }
 }
 
@@ -1360,6 +1421,25 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             )))
         }
     }
+}
+
+/// FileFormatProto captures data encoded by file format codecs
+///
+/// it captures position of codec used to encode FileFormat
+/// and actual encoded value.
+///
+/// capturing codec position is required, as same codec can decode
+/// blobs encoded by different encoders (probability is low but  it
+/// happened in the past)
+///
+#[derive(Clone, PartialEq, prost::Message)]
+struct FileFormatProto {
+    /// encoder id used to encode blob
+    /// (to be used for decoding)
+    #[prost(uint32, tag = 1)]
+    pub encoder_position: u32,
+    #[prost(bytes, tag = 2)]
+    pub blob: Vec<u8>,
 }
 
 #[cfg(test)]
@@ -2802,5 +2882,61 @@ mod test {
         assert_eq!(order_by.len(), 1, "ORDER BY must round-trip");
         assert_eq!(order_by[0].expr.to_string(), sort_expr.expr.to_string());
         assert_eq!(decoded.output_partitions(), 8, "K must round-trip");
+    }
+
+    /// Cross-version wire compatibility for `CopyTo` file formats.
+    ///
+    /// Ballista <= 54 encodes a file format as `FileFormatProto { encoder_position, blob }`,
+    /// where `encoder_position` indexes `[Parquet, Csv, Json, Arrow, Avro]`. Released clients
+    /// on the 54 crates talk to schedulers built from this branch, so the decoder has to keep
+    /// understanding those bytes.
+    ///
+    /// This is deliberately independent of the production `FileFormatProto`: it re-declares the
+    /// legacy layout locally, so a future change to how Ballista encodes file formats fails here
+    /// instead of silently mis-decoding. `file_format_serialization_roundtrip` cannot catch that,
+    /// because it encodes and decodes with the same codec and so passes for any self-consistent
+    /// encoding. See #2376, where delegating to DataFusion's codec made position 0 (Parquet)
+    /// decode as `FILE_FORMAT_KIND_UNSPECIFIED` and position 3 (Arrow) decode as Parquet.
+    #[tokio::test]
+    async fn decodes_file_format_bytes_from_a_54_client() {
+        /// The pre-#2348 on-the-wire layout, declared here so the test does not depend on the
+        /// production type.
+        #[derive(Clone, PartialEq, prost::Message)]
+        struct LegacyFileFormatProto {
+            #[prost(uint32, tag = 1)]
+            pub encoder_position: u32,
+            #[prost(bytes, tag = 2)]
+            pub blob: Vec<u8>,
+        }
+
+        let codec = BallistaLogicalExtensionCodec::default();
+        let ctx = SessionContext::new().task_ctx();
+
+        // Position -> the extension the decoded factory must report. Avro (position 4) is
+        // omitted: DataFusion's `AvroLogicalExtensionCodec::try_decode_file_format` returns an
+        // `ArrowFormatFactory` in both 54 and 55, which is an upstream bug unrelated to this.
+        for (encoder_position, expected_ext) in
+            [(0u32, "parquet"), (1, "csv"), (2, "json"), (3, "arrow")]
+        {
+            let mut buf = Vec::new();
+            LegacyFileFormatProto {
+                encoder_position,
+                blob: Vec::new(),
+            }
+            .encode(&mut buf)
+            .unwrap();
+
+            let factory = codec
+                .try_decode_file_format(&buf, &ctx)
+                .unwrap_or_else(|e| {
+                    panic!("position {encoder_position} must still decode, got {e}")
+                });
+
+            assert_eq!(
+                factory.get_ext(),
+                expected_ext,
+                "position {encoder_position} must decode as {expected_ext}"
+            );
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2376.

# Rationale for this change

#2348 delegated file format serde to DataFusion's `DefaultLogicalExtensionCodec`. That is a good cleanup in isolation, but it changed the `CopyTo` wire format in a way that older clients cannot detect, and the two encodings are structurally identical so nothing errors at the transport layer.

| | field 1 | field 2 |
|---|---|---|
| Ballista <= 54 | `encoder_position: u32`, an index into `[Parquet, Csv, Json, Arrow, Avro]` | `blob` |
| Ballista post-#2348 | `kind: FileFormatKind` (`UNSPECIFIED=0, CSV=1, JSON=2, PARQUET=3, ARROW=4, AVRO=5`) | `encoded_file_format` |

Both are a varint followed by a bytes field, so prost decodes an old message happily and the format tag is simply reinterpreted:

```
pos=0 (Parquet) -> Err(This feature is not implemented: Unspecified file format kind)
pos=1 (Csv)     -> Ok(csv)       lines up by coincidence
pos=2 (Json)    -> Ok(json)      lines up by coincidence
pos=3 (Arrow)   -> Ok(parquet)   silently wrong format
pos=4 (Avro)    -> Ok(arrow)     silently wrong format
```

Parquet at least fails loudly, which is what the new job in #2374 caught when a released 54.0.0 Python client ran against a cluster built from the branch. Arrow is the one that worries me: `ArrowLogicalExtensionCodec::try_encode_file_format` writes an empty payload and the Parquet decoder treats empty bytes as all defaults, so `COPY ... STORED AS ARROW` from a 54 client executes as Parquet with no error at all.

This is not transient skew. `pyballista` re-exports datafusion-python types, so the Python bindings cannot move to 55 until there is a matching `datafusion-python` release, and until then every Python user runs a 54 client against a 55 cluster.

Worth noting that DataFusion deliberately kept its own logical proto backward compatible across 54 to 55: removed fields became `reserved 8; // was bool collect_stat`, `string location = 2` was kept and marked deprecated alongside a new `repeated string locations = 16`, and everything else is additive. So a 54 client's plan is meant to be readable by a 55 scheduler, and 73 of the 75 Python tests in #2374 confirm it is. This encoding change was the one thing that broke it.

# What changes are included in this PR?

- Reverts 6fcc7360b, restoring the `encoder_position` based `FileFormatProto`.
- Adds `decodes_file_format_bytes_from_a_54_client`, which pins the wire format by re-declaring the legacy layout locally and asserting that those bytes still decode to the right format.

The existing `file_format_serialization_roundtrip` test could not catch this because it encodes and decodes with the same codec, so it passes for any self-consistent encoding. The new test fails on the pre-revert code with exactly the error CI hit, and passes after the revert.

Avro is deliberately left out of the new test. DataFusion's `AvroLogicalExtensionCodec::try_decode_file_format` returns an `ArrowFormatFactory` in both 54 and 55, which looks like an upstream bug and is unrelated to this change.

# Are these changes tested?

- New regression test above, verified to fail before the revert and pass after.
- `cargo test -p ballista-core --lib serde::` passes, 32 tests.
- `cargo clippy --all-targets --workspace --all-features -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- The real check is #2374, whose `Python client vs branch-built cluster` job should go green once this lands.

# Are there any user-facing changes?

Yes, in the sense that it restores compatibility. Released 54 clients can once again run `CopyTo` against a scheduler built from main.

I am not proposing we carry the duplicated codec forever. The better end state is client side validation of `BALLISTA_PROTOCOL_VERSION` (#2370), after which #2348 can land again on a bumped protocol version and old clients get a clear error instead of a mis-decode. That is a larger change than I would want to rush before 55.0.0 (#2369), and on its own it would not help the Python client, since it would turn silent breakage into a hard block that users cannot act on until datafusion-python 55 exists.

@milenkovicm sorry to revert your cleanup, happy to help re-land it behind a version check once the client handshake is in place.
