### PR TITLE
fix(docker): base runtime images on ubuntu:26.04

### DIFF
--- a/dev/docker/ballista-benchmarks.Dockerfile
+++ b/dev/docker/ballista-benchmarks.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
 LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"

--- a/dev/docker/ballista-cli.Dockerfile
+++ b/dev/docker/ballista-cli.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
 LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"

--- a/dev/docker/ballista-executor.Dockerfile
+++ b/dev/docker/ballista-executor.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
 LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"

--- a/dev/docker/ballista-scheduler.Dockerfile
+++ b/dev/docker/ballista-scheduler.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
 LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"

--- a/dev/docker/ballista-standalone.Dockerfile
+++ b/dev/docker/ballista-standalone.Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-ballista"
 LABEL org.opencontainers.image.description="Apache DataFusion Ballista Distributed SQL Query Engine"


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`dev/docker/*.Dockerfile` are not hermetic. The binary is compiled on the **host** by `dev/build-ballista-docker.sh`, and each image then does:

```dockerfile
COPY target/${RELEASE_FLAG}/ballista-executor /root/ballista-executor
```

So the host's glibc must be no newer than the base image's. Building on Ubuntu 26.04 (glibc 2.43) against `ubuntu:24.04` (glibc 2.39) produces images that fail at the dynamic loader, before `main` runs:

```
/root/ballista-executor: /lib/x86_64-linux-gnu/libm.so.6:
    version `GLIBC_2.43' not found (required by /root/ballista-executor)
```

The scheduler and executor crash-loop immediately, which on a Kubernetes deployment looks like an application fault rather than a build-environment mismatch.

# What changes are included in this PR?

Bumps the five runtime images that copy a host-built binary from `ubuntu:24.04` to `ubuntu:26.04`:

- `ballista-scheduler`
- `ballista-executor`
- `ballista-benchmarks`
- `ballista-standalone`
- `ballista-cli`

`chaos.Dockerfile` is deliberately **not** changed: it builds inside `rust:1-bookworm` and runs on `debian:bookworm-slim`, so it carries its own toolchain and does not depend on the host's glibc.

# Are these changes tested?

Yes. All five images were rebuilt on this base and exercised on a 4-node EKS cluster running h2o benchmarks at 1e9 rows — scheduler and executors registered and ran queries to completion. Each binary was also smoke-tested inside its image before deploy:

```
$ docker run --rm --entrypoint /root/ballista-executor <image> --version
ballista-executor 54.0.0
```

Building on an older host (e.g. CI on `ubuntu-24.04`) is unaffected: an older-glibc binary runs fine on a newer base.

# Are there any user-facing changes?

The published images move to an `ubuntu:26.04` userland.

One limitation worth stating plainly: **this raises the floor rather than making the build hermetic.** A host newer than the base image will break again in exactly the same way. The complete fix is to compile inside a container matching the runtime base, at the cost of a separate target directory per image; that seemed like a larger change than this bug warranted, but I'm happy to do it that way instead if maintainers prefer.
