### PR TITLE
feat: cleanup & simplify ballista config 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
  "md-5 0.11.0",
  "object_store",
  "parking_lot",
- "paste",
+ "pastey",
  "prost",
  "prost-types",
  "rand 0.10.2",
@@ -5100,10 +5100,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "md-5 0.11.0",
  "object_store",
  "parking_lot",
+ "paste",
  "prost",
  "prost-types",
  "rand 0.10.2",
@@ -5099,6 +5100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6977,7 +6984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,7 +6984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ itertools = "0.15"
 mimalloc = { version = "0.1" }
 object_store = "0.13.2"
 ordered-float = "5"
+paste = "1.0"
 prost = "0.14"
 prost-types = "0.14"
 rstest = { version = "0.26" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ itertools = "0.15"
 mimalloc = { version = "0.1" }
 object_store = "0.13.2"
 ordered-float = "5"
-paste = "1.0"
+pastey = "0.2.3"
 prost = "0.14"
 prost-types = "0.14"
 rstest = { version = "0.26" }

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -60,7 +60,7 @@ log = { workspace = true }
 md-5 = { version = "^0.11.0" }
 object_store = { workspace = true, features = ["aws", "http"], optional = true }
 parking_lot = { workspace = true }
-paste = { workspace = true }
+pastey = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -60,6 +60,7 @@ log = { workspace = true }
 md-5 = { version = "^0.11.0" }
 object_store = { workspace = true, features = ["aws", "http"], optional = true }
 parking_lot = { workspace = true }
+paste = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -809,7 +809,7 @@ impl BallistaConfig {
     }
 
     /// Deprecated alias for [`Self::use_tls`].
-    #[deprecated(note = "renamed to `use_tls`")]
+    #[deprecated(since = "55.0.0", note = "renamed to `use_tls`")]
     pub fn client_use_tls(&self) -> bool {
         self.use_tls()
     }

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -581,8 +581,14 @@ impl BallistaConfig {
     }
 
     /// Returns the standalone processing parallelism level.
-    pub fn default_standalone_parallelism(&self) -> usize {
+    pub fn standalone_parallelism(&self) -> usize {
         self.get_usize_setting(BALLISTA_STANDALONE_PARALLELISM)
+    }
+
+    /// Deprecated alias for [`Self::standalone_parallelism`].
+    #[deprecated(note = "renamed to `standalone_parallelism`")]
+    pub fn default_standalone_parallelism(&self) -> usize {
+        self.standalone_parallelism()
     }
 
     /// Returns the maximum number of concurrent shuffle reader requests.
@@ -798,8 +804,14 @@ impl BallistaConfig {
     }
 
     /// should client use TLS to communicate with ballista cluster
-    pub fn client_use_tls(&self) -> bool {
+    pub fn use_tls(&self) -> bool {
         self.get_bool_setting(BALLISTA_CLIENT_USE_TLS)
+    }
+
+    /// Deprecated alias for [`Self::use_tls`].
+    #[deprecated(note = "renamed to `use_tls`")]
+    pub fn client_use_tls(&self) -> bool {
+        self.use_tls()
     }
 
     /// Returns the number of retries for IO operations in the Ballista client.

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -752,8 +752,8 @@ impl BallistaConfig {
 
     /// Returns the target post-coalesce partition byte size in bytes
     /// (Spark's `advisoryPartitionSizeInBytes`).
-    pub fn coalesce_target_partition_bytes(&self) -> u64 {
-        self.get_usize_setting(BALLISTA_COALESCE_TARGET_PARTITION_BYTES) as u64
+    pub fn coalesce_target_partition_bytes(&self) -> usize {
+        self.get_usize_setting(BALLISTA_COALESCE_TARGET_PARTITION_BYTES)
     }
 
     /// Returns the small-partition merge factor (Spark legacy).

--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -586,7 +586,7 @@ impl BallistaConfig {
     }
 
     /// Deprecated alias for [`Self::standalone_parallelism`].
-    #[deprecated(note = "renamed to `standalone_parallelism`")]
+    #[deprecated(since = "55.0.0", note = "renamed to `standalone_parallelism`")]
     pub fn default_standalone_parallelism(&self) -> usize {
         self.standalone_parallelism()
     }

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -277,9 +277,9 @@ pub trait SessionConfigExt {
     fn with_ballista_coalesce_enabled(self, enabled: bool) -> Self;
 
     /// Returns the target post-coalesce partition byte size in bytes.
-    fn ballista_coalesce_target_partition_bytes(&self) -> u64;
+    fn ballista_coalesce_target_partition_bytes(&self) -> usize;
     /// Sets the target post-coalesce partition byte size in bytes.
-    fn with_ballista_coalesce_target_partition_bytes(self, bytes: u64) -> Self;
+    fn with_ballista_coalesce_target_partition_bytes(self, bytes: usize) -> Self;
 
     /// Returns the small-partition merge factor (Spark legacy).
     fn ballista_coalesce_small_partition_factor(&self) -> f64;
@@ -373,18 +373,36 @@ impl SessionStateExt for SessionState {
     }
 }
 
+/// Calls the `SessionConfig` setter matching `$ty`, converting `$val` first
+/// when the type needs it (only `f64` does, via `set_str`/`to_string()`,
+/// since `SessionConfig` has no `set_f64`).
+macro_rules! ballista_set_scalar {
+    (bool, $self:expr, $const:expr, $val:expr) => {
+        $self.set_bool($const, $val)
+    };
+    (usize, $self:expr, $const:expr, $val:expr) => {
+        $self.set_usize($const, $val)
+    };
+    (u64, $self:expr, $const:expr, $val:expr) => {
+        $self.set_u64($const, $val)
+    };
+    (f64, $self:expr, $const:expr, $val:expr) => {
+        $self.set_str($const, &$val.to_string())
+    };
+}
+
 /// Generates a `SessionConfigExt` getter/setter pair backed by a [BallistaConfig]
 /// value. The getter is named `ballista_<config_method>` and falls back to
 /// `BallistaConfig::default()` when the extension is unset; the setter is
-/// named `with_ballista_<config_method>` and initializes the extension first
-/// if it's not already present. Both use `$ty` as their return/argument type.
+/// named `with_ballista_<config_method>`, takes a single `value: $ty`
+/// argument, and initializes the extension first if it's not already
+/// present. The `SessionConfig` setter (and any value conversion) is derived
+/// from `$ty` via [ballista_set_scalar].
 ///
 /// Write `<config_method> as <setter_name>` when the setter doesn't follow
-/// the `with_ballista_<config_method>` convention, and `<arg> => <value>`
-/// when the value passed to `$set_method` needs converting from `$arg` (e.g.
-/// the f64 factors, stored as strings).
+/// the `with_ballista_<config_method>` convention.
 macro_rules! ballista_config_option {
-    ($ty:ty, $config_method:ident as $setter:ident, $set_method:ident, $const:expr, $arg:ident) => {
+    ($ty:ident, $config_method:ident as $setter:ident, $const:expr) => {
         paste::paste! {
             fn [<ballista_ $config_method>](&self) -> $ty {
                 self.options()
@@ -394,18 +412,19 @@ macro_rules! ballista_config_option {
                     .unwrap_or_else(|| BallistaConfig::default().$config_method())
             }
 
-            fn $setter(self, $arg: $ty) -> Self {
+            fn $setter(self, value: $ty) -> Self {
                 if self.options().extensions.get::<BallistaConfig>().is_some() {
-                    self.$set_method($const, $arg)
+                    ballista_set_scalar!($ty, self, $const, value)
                 } else {
-                    self.with_option_extension(BallistaConfig::default())
-                        .$set_method($const, $arg)
+                    ballista_set_scalar!(
+                        $ty, self.with_option_extension(BallistaConfig::default()), $const, value
+                    )
                 }
             }
         }
     };
 
-    ($ty:ty, $config_method:ident, $set_method:ident, $const:expr, $arg:ident => $val:expr) => {
+    ($ty:ident, $config_method:ident, $const:expr) => {
         paste::paste! {
             fn [<ballista_ $config_method>](&self) -> $ty {
                 self.options()
@@ -415,33 +434,13 @@ macro_rules! ballista_config_option {
                     .unwrap_or_else(|| BallistaConfig::default().$config_method())
             }
 
-            fn [<with_ballista_ $config_method>](self, $arg: $ty) -> Self {
+            fn [<with_ballista_ $config_method>](self, value: $ty) -> Self {
                 if self.options().extensions.get::<BallistaConfig>().is_some() {
-                    self.$set_method($const, $val)
+                    ballista_set_scalar!($ty, self, $const, value)
                 } else {
-                    self.with_option_extension(BallistaConfig::default())
-                        .$set_method($const, $val)
-                }
-            }
-        }
-    };
-
-    ($ty:ty, $config_method:ident, $set_method:ident, $const:expr, $arg:ident) => {
-        paste::paste! {
-            fn [<ballista_ $config_method>](&self) -> $ty {
-                self.options()
-                    .extensions
-                    .get::<BallistaConfig>()
-                    .map(|c| c.$config_method())
-                    .unwrap_or_else(|| BallistaConfig::default().$config_method())
-            }
-
-            fn [<with_ballista_ $config_method>](self, $arg: $ty) -> Self {
-                if self.options().extensions.get::<BallistaConfig>().is_some() {
-                    self.$set_method($const, $arg)
-                } else {
-                    self.with_option_extension(BallistaConfig::default())
-                        .$set_method($const, $arg)
+                    ballista_set_scalar!(
+                        $ty, self.with_option_extension(BallistaConfig::default()), $const, value
+                    )
                 }
             }
         }
@@ -565,110 +564,77 @@ impl SessionConfigExt for SessionConfig {
     ballista_config_option!(
         usize,
         standalone_parallelism,
-        set_usize,
-        BALLISTA_STANDALONE_PARALLELISM,
-        parallelism
+        BALLISTA_STANDALONE_PARALLELISM
     );
 
     ballista_config_option!(
         usize,
         grpc_client_max_message_size,
-        set_usize,
-        BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE,
-        max_size
+        BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE
     );
 
     ballista_config_option!(
         usize,
         broadcast_join_threshold_bytes,
-        set_usize,
-        BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES,
-        threshold_bytes
+        BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES
     );
 
     ballista_config_option!(
         usize,
         broadcast_join_threshold_rows,
-        set_usize,
-        BALLISTA_BROADCAST_JOIN_THRESHOLD_ROWS,
-        threshold_rows
+        BALLISTA_BROADCAST_JOIN_THRESHOLD_ROWS
     );
 
     ballista_config_option!(
         usize,
         hash_join_max_build_partition_bytes,
-        set_usize,
-        BALLISTA_HASH_JOIN_MAX_BUILD_PARTITION_BYTES,
-        max_bytes
+        BALLISTA_HASH_JOIN_MAX_BUILD_PARTITION_BYTES
     );
 
     ballista_config_option!(
         usize,
         shuffle_reader_maximum_concurrent_requests,
-        set_usize,
-        BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
-        max_requests
+        BALLISTA_SHUFFLE_READER_MAX_REQUESTS
     );
 
     ballista_config_option!(
         bool,
         shuffle_reader_force_remote_read,
-        set_bool,
-        BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ,
-        force_remote_read
+        BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ
     );
 
     ballista_config_option!(
         bool,
         shuffle_reader_remote_prefer_flight,
-        set_bool,
-        BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT,
-        prefer_flight
+        BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT
     );
 
     ballista_config_option!(
         bool,
         adaptive_query_planner_enabled as with_ballista_adaptive_query_planner,
-        set_bool,
-        BALLISTA_ADAPTIVE_PLANNER_ENABLED,
-        enabled
+        BALLISTA_ADAPTIVE_PLANNER_ENABLED
     );
 
-    ballista_config_option!(bool, use_tls, set_bool, BALLISTA_CLIENT_USE_TLS, use_tls);
+    ballista_config_option!(bool, use_tls, BALLISTA_CLIENT_USE_TLS);
+
+    ballista_config_option!(bool, coalesce_enabled, BALLISTA_COALESCE_ENABLED);
 
     ballista_config_option!(
-        bool,
-        coalesce_enabled,
-        set_bool,
-        BALLISTA_COALESCE_ENABLED,
-        enabled
-    );
-
-    ballista_config_option!(
-        u64,
+        usize,
         coalesce_target_partition_bytes,
-        set_usize,
-        BALLISTA_COALESCE_TARGET_PARTITION_BYTES,
-        bytes => bytes as usize
+        BALLISTA_COALESCE_TARGET_PARTITION_BYTES
     );
 
-    // f64 setters use set_str because SessionConfig has no set_f64 in this
-    // workspace; the stored string is round-tripped via f64::to_string() /
-    // f64::from_str(), mirroring the `with_ballista_job_name` set_str pattern.
     ballista_config_option!(
         f64,
         coalesce_small_partition_factor,
-        set_str,
-        BALLISTA_COALESCE_SMALL_PARTITION_FACTOR,
-        factor => &factor.to_string()
+        BALLISTA_COALESCE_SMALL_PARTITION_FACTOR
     );
 
     ballista_config_option!(
         f64,
         coalesce_merged_partition_factor,
-        set_str,
-        BALLISTA_COALESCE_MERGED_PARTITION_FACTOR,
-        factor => &factor.to_string()
+        BALLISTA_COALESCE_MERGED_PARTITION_FACTOR
     );
 }
 

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -399,6 +399,12 @@ macro_rules! ballista_set_scalar {
 /// present. The `SessionConfig` setter (and any value conversion) is derived
 /// from `$ty` via [ballista_set_scalar].
 ///
+/// Generated trait method name is derived from `$config_method`,
+/// this couples `BallistaConfig`'s public getter names to `SessionConfigExt`'s
+/// public method names: the two can no longer be renamed independently, since
+/// renaming a `BallistaConfig` getter also renames the `SessionConfigExt`
+/// method(s) generated for it here.
+///
 /// Write `<config_method> as <setter_name>` when the setter doesn't follow
 /// the `with_ballista_<config_method>` convention.
 macro_rules! ballista_config_option {
@@ -1092,7 +1098,7 @@ mod test {
 
     #[test]
     fn should_round_trip_all_macro_generated_options() {
-        let plain = SessionConfig::new_with_ballista()
+        let config = SessionConfig::new_with_ballista()
             .with_ballista_standalone_parallelism(123)
             .with_ballista_grpc_client_max_message_size(456)
             .with_ballista_broadcast_join_threshold_bytes(789)
@@ -1108,24 +1114,45 @@ mod test {
             .with_ballista_coalesce_small_partition_factor(1.5)
             .with_ballista_coalesce_merged_partition_factor(2.5);
 
-        assert!(plain.ballista_shuffle_reader_force_remote_read());
-        assert!(!plain.ballista_adaptive_query_planner_enabled());
-        assert!(plain.ballista_shuffle_reader_force_remote_read());
-        assert!(plain.ballista_shuffle_reader_remote_prefer_flight());
-        assert!(plain.ballista_use_tls());
-        assert!(plain.ballista_coalesce_enabled());
-        assert_eq!(plain.ballista_standalone_parallelism(), 123);
-        assert_eq!(plain.ballista_grpc_client_max_message_size(), 456);
-        assert_eq!(plain.ballista_broadcast_join_threshold_bytes(), 789);
-        assert_eq!(plain.ballista_broadcast_join_threshold_rows(), 42);
-        assert_eq!(plain.ballista_hash_join_max_build_partition_bytes(), 999);
-        assert_eq!(plain.ballista_coalesce_target_partition_bytes(), 2048);
-        assert_eq!(plain.ballista_coalesce_small_partition_factor(), 1.5);
-        assert_eq!(plain.ballista_coalesce_merged_partition_factor(), 2.5);
+        assert!(!config.ballista_adaptive_query_planner_enabled());
+        assert!(config.ballista_shuffle_reader_force_remote_read());
+        assert!(config.ballista_shuffle_reader_remote_prefer_flight());
+        assert!(config.ballista_use_tls());
+        assert!(config.ballista_coalesce_enabled());
+        assert_eq!(config.ballista_standalone_parallelism(), 123);
+        assert_eq!(config.ballista_grpc_client_max_message_size(), 456);
+        assert_eq!(config.ballista_broadcast_join_threshold_bytes(), 789);
+        assert_eq!(config.ballista_broadcast_join_threshold_rows(), 42);
+        assert_eq!(config.ballista_hash_join_max_build_partition_bytes(), 999);
+        assert_eq!(config.ballista_coalesce_target_partition_bytes(), 2048);
+        assert_eq!(config.ballista_coalesce_small_partition_factor(), 1.5);
+        assert_eq!(config.ballista_coalesce_merged_partition_factor(), 2.5);
         assert_eq!(
-            plain.ballista_shuffle_reader_maximum_concurrent_requests(),
+            config.ballista_shuffle_reader_maximum_concurrent_requests(),
             7
         );
+    }
+
+    #[test]
+    fn should_round_trip_macro_generated_options_insert_ballista_config() {
+        let config = SessionConfig::new().with_ballista_standalone_parallelism(123);
+        assert_eq!(config.ballista_standalone_parallelism(), 123);
+
+        let config = SessionConfig::new().with_ballista_grpc_client_max_message_size(456);
+        assert_eq!(config.ballista_grpc_client_max_message_size(), 456);
+
+        let config =
+            SessionConfig::new().with_ballista_broadcast_join_threshold_bytes(789);
+        assert_eq!(config.ballista_broadcast_join_threshold_bytes(), 789);
+
+        let config = SessionConfig::new().with_ballista_use_tls(true);
+        assert!(config.ballista_use_tls());
+
+        let config = SessionConfig::new().with_ballista_use_tls(false);
+        assert!(!config.ballista_use_tls());
+
+        let config = SessionConfig::new().with_ballista_coalesce_enabled(true);
+        assert!(config.ballista_coalesce_enabled());
     }
 
     #[test]

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -483,6 +483,16 @@ impl SessionConfigExt for SessionConfig {
             .cloned()
             .unwrap_or_else(BallistaConfig::default)
     }
+
+    fn with_ballista_job_name(self, job_name: &str) -> Self {
+        if self.options().extensions.get::<BallistaConfig>().is_some() {
+            self.set_str(BALLISTA_JOB_NAME, job_name)
+        } else {
+            self.with_option_extension(BallistaConfig::default())
+                .set_str(BALLISTA_JOB_NAME, job_name)
+        }
+    }
+
     fn with_ballista_logical_extension_codec(
         self,
         codec: Arc<dyn LogicalExtensionCodec>,
@@ -524,6 +534,34 @@ impl SessionConfigExt for SessionConfig {
             .map(|c| c.planner())
     }
 
+    fn with_ballista_grpc_metadata(self, metadata: HashMap<String, String>) -> Self {
+        let extension = BallistaGrpcMetadataInterceptor::new(metadata);
+        self.with_extension(Arc::new(extension))
+    }
+
+    fn ballista_grpc_interceptor(&self) -> Arc<BallistaGrpcMetadataInterceptor> {
+        self.get_extension::<BallistaGrpcMetadataInterceptor>()
+            .unwrap_or_default()
+    }
+
+    fn with_ballista_override_create_grpc_client_endpoint(
+        self,
+        override_f: Arc<
+            dyn Fn(Endpoint) -> Result<Endpoint, Box<dyn Error + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    ) -> Self {
+        let extension = BallistaConfigGrpcEndpoint::new(override_f);
+        self.with_extension(Arc::new(extension))
+    }
+
+    fn ballista_override_create_grpc_client_endpoint(
+        &self,
+    ) -> Option<Arc<BallistaConfigGrpcEndpoint>> {
+        self.get_extension::<BallistaConfigGrpcEndpoint>()
+    }
+
     ballista_config_option!(
         usize,
         standalone_parallelism,
@@ -539,15 +577,6 @@ impl SessionConfigExt for SessionConfig {
         BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE,
         max_size
     );
-
-    fn with_ballista_job_name(self, job_name: &str) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_str(BALLISTA_JOB_NAME, job_name)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_str(BALLISTA_JOB_NAME, job_name)
-        }
-    }
 
     ballista_config_option!(
         usize,
@@ -641,34 +670,6 @@ impl SessionConfigExt for SessionConfig {
         BALLISTA_COALESCE_MERGED_PARTITION_FACTOR,
         factor => &factor.to_string()
     );
-
-    fn with_ballista_grpc_metadata(self, metadata: HashMap<String, String>) -> Self {
-        let extension = BallistaGrpcMetadataInterceptor::new(metadata);
-        self.with_extension(Arc::new(extension))
-    }
-
-    fn ballista_grpc_interceptor(&self) -> Arc<BallistaGrpcMetadataInterceptor> {
-        self.get_extension::<BallistaGrpcMetadataInterceptor>()
-            .unwrap_or_default()
-    }
-
-    fn with_ballista_override_create_grpc_client_endpoint(
-        self,
-        override_f: Arc<
-            dyn Fn(Endpoint) -> Result<Endpoint, Box<dyn Error + Send + Sync>>
-                + Send
-                + Sync,
-        >,
-    ) -> Self {
-        let extension = BallistaConfigGrpcEndpoint::new(override_f);
-        self.with_extension(Arc::new(extension))
-    }
-
-    fn ballista_override_create_grpc_client_endpoint(
-        &self,
-    ) -> Option<Arc<BallistaConfigGrpcEndpoint>> {
-        self.get_extension::<BallistaConfigGrpcEndpoint>()
-    }
 }
 
 impl SessionConfigHelperExt for SessionConfig {

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -403,7 +403,7 @@ macro_rules! ballista_set_scalar {
 /// the `with_ballista_<config_method>` convention.
 macro_rules! ballista_config_option {
     ($ty:ident, $config_method:ident as $setter:ident, $const:expr) => {
-        paste::paste! {
+        pastey::paste! {
             fn [<ballista_ $config_method>](&self) -> $ty {
                 self.options()
                     .extensions
@@ -425,7 +425,7 @@ macro_rules! ballista_config_option {
     };
 
     ($ty:ident, $config_method:ident, $const:expr) => {
-        paste::paste! {
+        pastey::paste! {
             fn [<ballista_ $config_method>](&self) -> $ty {
                 self.options()
                     .extensions

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -1091,6 +1091,57 @@ mod test {
     }
 
     #[test]
+    fn should_round_trip_all_macro_generated_options() {
+        let plain = SessionConfig::new_with_ballista();
+
+        let plain = plain.with_ballista_standalone_parallelism(123);
+        assert_eq!(plain.ballista_standalone_parallelism(), 123);
+
+        let plain = plain.with_ballista_grpc_client_max_message_size(456);
+        assert_eq!(plain.ballista_grpc_client_max_message_size(), 456);
+
+        let plain = plain.with_ballista_broadcast_join_threshold_bytes(789);
+        assert_eq!(plain.ballista_broadcast_join_threshold_bytes(), 789);
+
+        let plain = plain.with_ballista_broadcast_join_threshold_rows(42);
+        assert_eq!(plain.ballista_broadcast_join_threshold_rows(), 42);
+
+        let plain = plain.with_ballista_hash_join_max_build_partition_bytes(999);
+        assert_eq!(plain.ballista_hash_join_max_build_partition_bytes(), 999);
+
+        let plain = plain.with_ballista_shuffle_reader_maximum_concurrent_requests(7);
+        assert_eq!(
+            plain.ballista_shuffle_reader_maximum_concurrent_requests(),
+            7
+        );
+
+        let plain = plain.with_ballista_coalesce_target_partition_bytes(2048);
+        assert_eq!(plain.ballista_coalesce_target_partition_bytes(), 2048);
+
+        let plain = plain.with_ballista_shuffle_reader_force_remote_read(true);
+        assert_eq!(plain.ballista_shuffle_reader_force_remote_read(), true);
+
+        let plain = plain.with_ballista_shuffle_reader_remote_prefer_flight(true);
+        assert_eq!(plain.ballista_shuffle_reader_remote_prefer_flight(), true);
+
+        let plain = plain.with_ballista_use_tls(true);
+        assert_eq!(plain.ballista_use_tls(), true);
+
+        let plain = plain.with_ballista_coalesce_enabled(true);
+        assert_eq!(plain.ballista_coalesce_enabled(), true);
+
+        // Covers the `as`-aliased macro arm: setter name diverges from `with_<getter>`.
+        let plain = plain.with_ballista_adaptive_query_planner(false);
+        assert_eq!(plain.ballista_adaptive_query_planner_enabled(), false);
+
+        let plain = plain.with_ballista_coalesce_small_partition_factor(1.5);
+        assert_eq!(plain.ballista_coalesce_small_partition_factor(), 1.5);
+
+        let plain = plain.with_ballista_coalesce_merged_partition_factor(2.5);
+        assert_eq!(plain.ballista_coalesce_merged_partition_factor(), 2.5);
+    }
+
+    #[test]
     fn test_ballista_grpc_metadata_interceptor() {
         use std::collections::HashMap;
         use tonic::Request;

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -1107,16 +1107,16 @@ mod test {
             .with_ballista_coalesce_small_partition_factor(1.5)
             .with_ballista_coalesce_merged_partition_factor(2.5);
 
+        assert!(plain.ballista_shuffle_reader_force_remote_read());
+        assert!(plain.ballista_shuffle_reader_remote_prefer_flight());
+        assert!(plain.ballista_use_tls());
+        assert!(plain.ballista_coalesce_enabled());
         assert_eq!(plain.ballista_standalone_parallelism(), 123);
         assert_eq!(plain.ballista_grpc_client_max_message_size(), 456);
         assert_eq!(plain.ballista_broadcast_join_threshold_bytes(), 789);
         assert_eq!(plain.ballista_broadcast_join_threshold_rows(), 42);
         assert_eq!(plain.ballista_hash_join_max_build_partition_bytes(), 999);
         assert_eq!(plain.ballista_coalesce_target_partition_bytes(), 2048);
-        assert_eq!(plain.ballista_shuffle_reader_force_remote_read(), true);
-        assert_eq!(plain.ballista_shuffle_reader_remote_prefer_flight(), true);
-        assert_eq!(plain.ballista_use_tls(), true);
-        assert_eq!(plain.ballista_coalesce_enabled(), true);
         assert_eq!(plain.ballista_coalesce_small_partition_factor(), 1.5);
         assert_eq!(plain.ballista_coalesce_merged_partition_factor(), 2.5);
         assert_eq!(

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -1104,9 +1104,12 @@ mod test {
             .with_ballista_shuffle_reader_remote_prefer_flight(true)
             .with_ballista_use_tls(true)
             .with_ballista_coalesce_enabled(true)
+            .with_ballista_adaptive_query_planner(false)
             .with_ballista_coalesce_small_partition_factor(1.5)
             .with_ballista_coalesce_merged_partition_factor(2.5);
 
+        assert!(plain.ballista_shuffle_reader_force_remote_read());
+        assert!(!plain.ballista_adaptive_query_planner_enabled());
         assert!(plain.ballista_shuffle_reader_force_remote_read());
         assert!(plain.ballista_shuffle_reader_remote_prefer_flight());
         assert!(plain.ballista_use_tls());

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -373,6 +373,81 @@ impl SessionStateExt for SessionState {
     }
 }
 
+/// Generates a `SessionConfigExt` getter/setter pair backed by a [BallistaConfig]
+/// value. The getter is named `ballista_<config_method>` and falls back to
+/// `BallistaConfig::default()` when the extension is unset; the setter is
+/// named `with_ballista_<config_method>` and initializes the extension first
+/// if it's not already present. Both use `$ty` as their return/argument type.
+///
+/// Write `<config_method> as <setter_name>` when the setter doesn't follow
+/// the `with_ballista_<config_method>` convention, and `<arg> => <value>`
+/// when the value passed to `$set_method` needs converting from `$arg` (e.g.
+/// the f64 factors, stored as strings).
+macro_rules! ballista_config_option {
+    ($ty:ty, $config_method:ident as $setter:ident, $set_method:ident, $const:expr, $arg:ident) => {
+        paste::paste! {
+            fn [<ballista_ $config_method>](&self) -> $ty {
+                self.options()
+                    .extensions
+                    .get::<BallistaConfig>()
+                    .map(|c| c.$config_method())
+                    .unwrap_or_else(|| BallistaConfig::default().$config_method())
+            }
+
+            fn $setter(self, $arg: $ty) -> Self {
+                if self.options().extensions.get::<BallistaConfig>().is_some() {
+                    self.$set_method($const, $arg)
+                } else {
+                    self.with_option_extension(BallistaConfig::default())
+                        .$set_method($const, $arg)
+                }
+            }
+        }
+    };
+
+    ($ty:ty, $config_method:ident, $set_method:ident, $const:expr, $arg:ident => $val:expr) => {
+        paste::paste! {
+            fn [<ballista_ $config_method>](&self) -> $ty {
+                self.options()
+                    .extensions
+                    .get::<BallistaConfig>()
+                    .map(|c| c.$config_method())
+                    .unwrap_or_else(|| BallistaConfig::default().$config_method())
+            }
+
+            fn [<with_ballista_ $config_method>](self, $arg: $ty) -> Self {
+                if self.options().extensions.get::<BallistaConfig>().is_some() {
+                    self.$set_method($const, $val)
+                } else {
+                    self.with_option_extension(BallistaConfig::default())
+                        .$set_method($const, $val)
+                }
+            }
+        }
+    };
+
+    ($ty:ty, $config_method:ident, $set_method:ident, $const:expr, $arg:ident) => {
+        paste::paste! {
+            fn [<ballista_ $config_method>](&self) -> $ty {
+                self.options()
+                    .extensions
+                    .get::<BallistaConfig>()
+                    .map(|c| c.$config_method())
+                    .unwrap_or_else(|| BallistaConfig::default().$config_method())
+            }
+
+            fn [<with_ballista_ $config_method>](self, $arg: $ty) -> Self {
+                if self.options().extensions.get::<BallistaConfig>().is_some() {
+                    self.$set_method($const, $arg)
+                } else {
+                    self.with_option_extension(BallistaConfig::default())
+                        .$set_method($const, $arg)
+                }
+            }
+        }
+    };
+}
+
 impl SessionConfigExt for SessionConfig {
     fn new_with_ballista() -> SessionConfig {
         SessionConfig::new()
@@ -449,21 +524,21 @@ impl SessionConfigExt for SessionConfig {
             .map(|c| c.planner())
     }
 
-    fn ballista_standalone_parallelism(&self) -> usize {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.default_standalone_parallelism())
-            .unwrap_or_else(|| BallistaConfig::default().default_standalone_parallelism())
-    }
+    ballista_config_option!(
+        usize,
+        standalone_parallelism,
+        set_usize,
+        BALLISTA_STANDALONE_PARALLELISM,
+        parallelism
+    );
 
-    fn ballista_grpc_client_max_message_size(&self) -> usize {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.grpc_client_max_message_size())
-            .unwrap_or_else(|| BallistaConfig::default().grpc_client_max_message_size())
-    }
+    ballista_config_option!(
+        usize,
+        grpc_client_max_message_size,
+        set_usize,
+        BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE,
+        max_size
+    );
 
     fn with_ballista_job_name(self, job_name: &str) -> Self {
         if self.options().extensions.get::<BallistaConfig>().is_some() {
@@ -474,162 +549,98 @@ impl SessionConfigExt for SessionConfig {
         }
     }
 
-    fn with_ballista_grpc_client_max_message_size(self, max_size: usize) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE, max_size)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_CLIENT_GRPC_MAX_MESSAGE_SIZE, max_size)
-        }
-    }
+    ballista_config_option!(
+        usize,
+        broadcast_join_threshold_bytes,
+        set_usize,
+        BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES,
+        threshold_bytes
+    );
 
-    fn with_ballista_standalone_parallelism(self, parallelism: usize) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_STANDALONE_PARALLELISM, parallelism)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_STANDALONE_PARALLELISM, parallelism)
-        }
-    }
+    ballista_config_option!(
+        usize,
+        broadcast_join_threshold_rows,
+        set_usize,
+        BALLISTA_BROADCAST_JOIN_THRESHOLD_ROWS,
+        threshold_rows
+    );
 
-    fn ballista_broadcast_join_threshold_bytes(&self) -> usize {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.broadcast_join_threshold_bytes())
-            .unwrap_or_else(|| BallistaConfig::default().broadcast_join_threshold_bytes())
-    }
+    ballista_config_option!(
+        usize,
+        hash_join_max_build_partition_bytes,
+        set_usize,
+        BALLISTA_HASH_JOIN_MAX_BUILD_PARTITION_BYTES,
+        max_bytes
+    );
 
-    fn with_ballista_broadcast_join_threshold_bytes(
-        self,
-        threshold_bytes: usize,
-    ) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES, threshold_bytes)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_BROADCAST_JOIN_THRESHOLD_BYTES, threshold_bytes)
-        }
-    }
+    ballista_config_option!(
+        usize,
+        shuffle_reader_maximum_concurrent_requests,
+        set_usize,
+        BALLISTA_SHUFFLE_READER_MAX_REQUESTS,
+        max_requests
+    );
 
-    fn ballista_broadcast_join_threshold_rows(&self) -> usize {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.broadcast_join_threshold_rows())
-            .unwrap_or_else(|| BallistaConfig::default().broadcast_join_threshold_rows())
-    }
+    ballista_config_option!(
+        bool,
+        shuffle_reader_force_remote_read,
+        set_bool,
+        BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ,
+        force_remote_read
+    );
 
-    fn with_ballista_broadcast_join_threshold_rows(self, threshold_rows: usize) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_BROADCAST_JOIN_THRESHOLD_ROWS, threshold_rows)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_BROADCAST_JOIN_THRESHOLD_ROWS, threshold_rows)
-        }
-    }
+    ballista_config_option!(
+        bool,
+        shuffle_reader_remote_prefer_flight,
+        set_bool,
+        BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT,
+        prefer_flight
+    );
 
-    fn ballista_hash_join_max_build_partition_bytes(&self) -> usize {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.hash_join_max_build_partition_bytes())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().hash_join_max_build_partition_bytes()
-            })
-    }
+    ballista_config_option!(
+        bool,
+        adaptive_query_planner_enabled as with_ballista_adaptive_query_planner,
+        set_bool,
+        BALLISTA_ADAPTIVE_PLANNER_ENABLED,
+        enabled
+    );
 
-    fn with_ballista_hash_join_max_build_partition_bytes(self, max_bytes: usize) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_HASH_JOIN_MAX_BUILD_PARTITION_BYTES, max_bytes)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_HASH_JOIN_MAX_BUILD_PARTITION_BYTES, max_bytes)
-        }
-    }
+    ballista_config_option!(bool, use_tls, set_bool, BALLISTA_CLIENT_USE_TLS, use_tls);
 
-    fn ballista_shuffle_reader_maximum_concurrent_requests(&self) -> usize {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.shuffle_reader_maximum_concurrent_requests())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().shuffle_reader_maximum_concurrent_requests()
-            })
-    }
+    ballista_config_option!(
+        bool,
+        coalesce_enabled,
+        set_bool,
+        BALLISTA_COALESCE_ENABLED,
+        enabled
+    );
 
-    fn with_ballista_shuffle_reader_maximum_concurrent_requests(
-        self,
-        max_requests: usize,
-    ) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_SHUFFLE_READER_MAX_REQUESTS, max_requests)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_SHUFFLE_READER_MAX_REQUESTS, max_requests)
-        }
-    }
+    ballista_config_option!(
+        u64,
+        coalesce_target_partition_bytes,
+        set_usize,
+        BALLISTA_COALESCE_TARGET_PARTITION_BYTES,
+        bytes => bytes as usize
+    );
 
-    fn ballista_shuffle_reader_force_remote_read(&self) -> bool {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.shuffle_reader_force_remote_read())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().shuffle_reader_force_remote_read()
-            })
-    }
+    // f64 setters use set_str because SessionConfig has no set_f64 in this
+    // workspace; the stored string is round-tripped via f64::to_string() /
+    // f64::from_str(), mirroring the `with_ballista_job_name` set_str pattern.
+    ballista_config_option!(
+        f64,
+        coalesce_small_partition_factor,
+        set_str,
+        BALLISTA_COALESCE_SMALL_PARTITION_FACTOR,
+        factor => &factor.to_string()
+    );
 
-    fn with_ballista_shuffle_reader_force_remote_read(
-        self,
-        force_remote_read: bool,
-    ) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_bool(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, force_remote_read)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_bool(BALLISTA_SHUFFLE_READER_FORCE_REMOTE_READ, force_remote_read)
-        }
-    }
-
-    fn ballista_shuffle_reader_remote_prefer_flight(&self) -> bool {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.shuffle_reader_remote_prefer_flight())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().shuffle_reader_remote_prefer_flight()
-            })
-    }
-
-    fn with_ballista_shuffle_reader_remote_prefer_flight(
-        self,
-        prefer_flight: bool,
-    ) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_bool(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, prefer_flight)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_bool(BALLISTA_SHUFFLE_READER_REMOTE_PREFER_FLIGHT, prefer_flight)
-        }
-    }
-
-    fn with_ballista_adaptive_query_planner(self, enabled: bool) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_bool(BALLISTA_ADAPTIVE_PLANNER_ENABLED, enabled)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_bool(BALLISTA_ADAPTIVE_PLANNER_ENABLED, enabled)
-        }
-    }
-
-    fn ballista_adaptive_query_planner_enabled(&self) -> bool {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.adaptive_query_planner_enabled())
-            .unwrap_or_else(|| BallistaConfig::default().adaptive_query_planner_enabled())
-    }
+    ballista_config_option!(
+        f64,
+        coalesce_merged_partition_factor,
+        set_str,
+        BALLISTA_COALESCE_MERGED_PARTITION_FACTOR,
+        factor => &factor.to_string()
+    );
 
     fn with_ballista_grpc_metadata(self, metadata: HashMap<String, String>) -> Self {
         let extension = BallistaGrpcMetadataInterceptor::new(metadata);
@@ -657,102 +668,6 @@ impl SessionConfigExt for SessionConfig {
         &self,
     ) -> Option<Arc<BallistaConfigGrpcEndpoint>> {
         self.get_extension::<BallistaConfigGrpcEndpoint>()
-    }
-
-    fn with_ballista_use_tls(self, use_tls: bool) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_bool(BALLISTA_CLIENT_USE_TLS, use_tls)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_bool(BALLISTA_CLIENT_USE_TLS, use_tls)
-        }
-    }
-
-    fn ballista_use_tls(&self) -> bool {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.client_use_tls())
-            .unwrap_or_else(|| BallistaConfig::default().client_use_tls())
-    }
-
-    fn ballista_coalesce_enabled(&self) -> bool {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.coalesce_enabled())
-            .unwrap_or_else(|| BallistaConfig::default().coalesce_enabled())
-    }
-
-    fn with_ballista_coalesce_enabled(self, enabled: bool) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_bool(BALLISTA_COALESCE_ENABLED, enabled)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_bool(BALLISTA_COALESCE_ENABLED, enabled)
-        }
-    }
-
-    fn ballista_coalesce_target_partition_bytes(&self) -> u64 {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.coalesce_target_partition_bytes())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().coalesce_target_partition_bytes()
-            })
-    }
-
-    fn with_ballista_coalesce_target_partition_bytes(self, bytes: u64) -> Self {
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_usize(BALLISTA_COALESCE_TARGET_PARTITION_BYTES, bytes as usize)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_usize(BALLISTA_COALESCE_TARGET_PARTITION_BYTES, bytes as usize)
-        }
-    }
-
-    fn ballista_coalesce_small_partition_factor(&self) -> f64 {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.coalesce_small_partition_factor())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().coalesce_small_partition_factor()
-            })
-    }
-
-    // f64 setter — uses set_str because SessionConfig has no set_f64 in this
-    // workspace; the stored string is round-tripped via f64::to_string() /
-    // f64::from_str(), mirroring the `with_ballista_job_name` set_str pattern.
-    fn with_ballista_coalesce_small_partition_factor(self, factor: f64) -> Self {
-        let s = factor.to_string();
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_str(BALLISTA_COALESCE_SMALL_PARTITION_FACTOR, &s)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_str(BALLISTA_COALESCE_SMALL_PARTITION_FACTOR, &s)
-        }
-    }
-
-    fn ballista_coalesce_merged_partition_factor(&self) -> f64 {
-        self.options()
-            .extensions
-            .get::<BallistaConfig>()
-            .map(|c| c.coalesce_merged_partition_factor())
-            .unwrap_or_else(|| {
-                BallistaConfig::default().coalesce_merged_partition_factor()
-            })
-    }
-
-    fn with_ballista_coalesce_merged_partition_factor(self, factor: f64) -> Self {
-        let s = factor.to_string();
-        if self.options().extensions.get::<BallistaConfig>().is_some() {
-            self.set_str(BALLISTA_COALESCE_MERGED_PARTITION_FACTOR, &s)
-        } else {
-            self.with_option_extension(BallistaConfig::default())
-                .set_str(BALLISTA_COALESCE_MERGED_PARTITION_FACTOR, &s)
-        }
     }
 }
 

--- a/ballista/core/src/extension.rs
+++ b/ballista/core/src/extension.rs
@@ -1092,53 +1092,37 @@ mod test {
 
     #[test]
     fn should_round_trip_all_macro_generated_options() {
-        let plain = SessionConfig::new_with_ballista();
+        let plain = SessionConfig::new_with_ballista()
+            .with_ballista_standalone_parallelism(123)
+            .with_ballista_grpc_client_max_message_size(456)
+            .with_ballista_broadcast_join_threshold_bytes(789)
+            .with_ballista_broadcast_join_threshold_rows(42)
+            .with_ballista_hash_join_max_build_partition_bytes(999)
+            .with_ballista_shuffle_reader_maximum_concurrent_requests(7)
+            .with_ballista_coalesce_target_partition_bytes(2048)
+            .with_ballista_shuffle_reader_force_remote_read(true)
+            .with_ballista_shuffle_reader_remote_prefer_flight(true)
+            .with_ballista_use_tls(true)
+            .with_ballista_coalesce_enabled(true)
+            .with_ballista_coalesce_small_partition_factor(1.5)
+            .with_ballista_coalesce_merged_partition_factor(2.5);
 
-        let plain = plain.with_ballista_standalone_parallelism(123);
         assert_eq!(plain.ballista_standalone_parallelism(), 123);
-
-        let plain = plain.with_ballista_grpc_client_max_message_size(456);
         assert_eq!(plain.ballista_grpc_client_max_message_size(), 456);
-
-        let plain = plain.with_ballista_broadcast_join_threshold_bytes(789);
         assert_eq!(plain.ballista_broadcast_join_threshold_bytes(), 789);
-
-        let plain = plain.with_ballista_broadcast_join_threshold_rows(42);
         assert_eq!(plain.ballista_broadcast_join_threshold_rows(), 42);
-
-        let plain = plain.with_ballista_hash_join_max_build_partition_bytes(999);
         assert_eq!(plain.ballista_hash_join_max_build_partition_bytes(), 999);
-
-        let plain = plain.with_ballista_shuffle_reader_maximum_concurrent_requests(7);
+        assert_eq!(plain.ballista_coalesce_target_partition_bytes(), 2048);
+        assert_eq!(plain.ballista_shuffle_reader_force_remote_read(), true);
+        assert_eq!(plain.ballista_shuffle_reader_remote_prefer_flight(), true);
+        assert_eq!(plain.ballista_use_tls(), true);
+        assert_eq!(plain.ballista_coalesce_enabled(), true);
+        assert_eq!(plain.ballista_coalesce_small_partition_factor(), 1.5);
+        assert_eq!(plain.ballista_coalesce_merged_partition_factor(), 2.5);
         assert_eq!(
             plain.ballista_shuffle_reader_maximum_concurrent_requests(),
             7
         );
-
-        let plain = plain.with_ballista_coalesce_target_partition_bytes(2048);
-        assert_eq!(plain.ballista_coalesce_target_partition_bytes(), 2048);
-
-        let plain = plain.with_ballista_shuffle_reader_force_remote_read(true);
-        assert_eq!(plain.ballista_shuffle_reader_force_remote_read(), true);
-
-        let plain = plain.with_ballista_shuffle_reader_remote_prefer_flight(true);
-        assert_eq!(plain.ballista_shuffle_reader_remote_prefer_flight(), true);
-
-        let plain = plain.with_ballista_use_tls(true);
-        assert_eq!(plain.ballista_use_tls(), true);
-
-        let plain = plain.with_ballista_coalesce_enabled(true);
-        assert_eq!(plain.ballista_coalesce_enabled(), true);
-
-        // Covers the `as`-aliased macro arm: setter name diverges from `with_<getter>`.
-        let plain = plain.with_ballista_adaptive_query_planner(false);
-        assert_eq!(plain.ballista_adaptive_query_planner_enabled(), false);
-
-        let plain = plain.with_ballista_coalesce_small_partition_factor(1.5);
-        assert_eq!(plain.ballista_coalesce_small_partition_factor(), 1.5);
-
-        let plain = plain.with_ballista_coalesce_merged_partition_factor(2.5);
-        assert_eq!(plain.ballista_coalesce_merged_partition_factor(), 2.5);
     }
 
     #[test]

--- a/ballista/core/src/utils.rs
+++ b/ballista/core/src/utils.rs
@@ -90,7 +90,7 @@ impl From<&BallistaConfig> for GrpcClientConfig {
             http2_keepalive_interval_seconds: config
                 .grpc_client_http2_keepalive_interval_seconds()
                 as u64,
-            use_tls: config.client_use_tls(),
+            use_tls: config.use_tls(),
             max_message_size: config.grpc_client_max_message_size(),
             io_retries_times: config.io_retries_times() as u8,
             io_retry_wait_time_ms: config.io_retry_wait_time_ms() as u64,

--- a/ballista/scheduler/src/state/aqe/optimizer_rule/coalesce_partitions.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/coalesce_partitions.rs
@@ -286,7 +286,8 @@ impl PhysicalOptimizerRule for CoalescePartitionsRule {
         // get parallelism preservation unless they explicitly trade it for
         // larger tasks. This corresponds to Spark's
         // `parallelismFirst=false` mode — direct advisory-driven packing.
-        let starts = split_size_list_by_target_size(&summed, target, small, merged);
+        let starts =
+            split_size_list_by_target_size(&summed, target as u64, small, merged);
         let k = starts.len();
         debug!("[coalesce-rule] bin-pack result: K={k} M={m}");
         if k >= m || k <= 1 {

--- a/docs/source/upgrading/55.0.0.md
+++ b/docs/source/upgrading/55.0.0.md
@@ -229,3 +229,21 @@ as_task_status(
     },
 )
 ```
+
+#### SessionConfigExt and BallistaConfig Changes
+
+Methods
+
+```rust
+SessionConfigExt::ballista_coalesce_target_partition_bytes(&self) -> u64;
+SessionConfigExt::with_ballista_coalesce_target_partition_bytes(self, bytes: u64) -> Self;
+```
+
+Changed expected type from `u64` to `usize`
+
+```rust
+SessionConfigExt::ballista_coalesce_target_partition_bytes(&self) -> usize;
+SessionConfigExt::with_ballista_coalesce_target_partition_bytes(self, bytes: usize) -> Self;
+```
+
+the change is to align method parameter and return type to actual config value.

--- a/docs/source/upgrading/55.0.0.md
+++ b/docs/source/upgrading/55.0.0.md
@@ -247,3 +247,15 @@ SessionConfigExt::with_ballista_coalesce_target_partition_bytes(self, bytes: usi
 ```
 
 the change is to align method parameter and return type to actual config value.
+
+Also,
+
+```rust
+BallistaConfig::coalesce_target_partition_bytes(&self) -> u64
+```
+
+has return type changed from `u64` to `usize`
+
+```rust
+BallistaConfig::coalesce_target_partition_bytes(&self) -> usize 
+```

--- a/docs/source/upgrading/55.0.0.md
+++ b/docs/source/upgrading/55.0.0.md
@@ -251,11 +251,11 @@ the change is to align method parameter and return type to actual config value.
 Also,
 
 ```rust
-BallistaConfig::coalesce_target_partition_bytes(&self) -> u64
+BallistaConfig::coalesce_target_partition_bytes(&self) -> u64;
 ```
 
 has return type changed from `u64` to `usize`
 
 ```rust
-BallistaConfig::coalesce_target_partition_bytes(&self) -> usize 
+BallistaConfig::coalesce_target_partition_bytes(&self) -> usize;
 ```


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

# Rationale for this change

We had quite a lot of boiler plate code to expose ballista config option, also exposed names might differ. 
Also we did not have uniform naming strategy for exposed configuration properties 


# What changes are included in this PR?

- macro which generates ballista config getters and setters
- change to some method names 
- deprecations to methods not following naming strategy

# Are there any user-facing changes?

Yes, there are method name and type changes
