### PR TITLE
feat: add Hudi contrib build gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "datafusion-proto",
  "env_logger",
  "log",
+ "prost",
  "rstest",
  "tempfile",
  "tokio",

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -35,7 +35,9 @@ ballista-executor = { path = "../executor", version = "54.0.0", optional = true,
 ] }
 ballista-scheduler = { path = "../scheduler", version = "54.0.0", optional = true, default-features = false }
 datafusion = { workspace = true }
+datafusion-proto = { workspace = true, optional = true }
 log = { workspace = true }
+prost = { workspace = true, optional = true }
 
 tokio = { workspace = true }
 url = { workspace = true }
@@ -53,6 +55,10 @@ uuid = { workspace = true }
 
 [features]
 default = ["standalone"]
+contrib-hudi = [
+    "dep:datafusion-proto",
+    "dep:prost",
+]
 standalone = ["ballista-executor", "ballista-scheduler"]
 # tests which need change of RUST_MIN_STACK in order for 
 # tests to run. 

--- a/ballista/client/src/hudi.rs
+++ b/ballista/client/src/hudi.rs
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Build gate for optional Apache Hudi support.
+//!
+//! The gate defines the Hudi wire contract and delegates provider construction
+//! to an implementation supplied by an integration crate.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use ballista_core::extension::SessionConfigExt;
+use ballista_core::serde::BallistaLogicalExtensionCodec;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::TableProvider;
+use datafusion::common::{DataFusionError, Result, TableReference};
+use datafusion::execution::TaskContext;
+use datafusion::execution::context::SessionConfig;
+use datafusion::logical_expr::Extension;
+use datafusion_proto::logical_plan::LogicalExtensionCodec;
+use prost::Message;
+
+const HUDI_PROVIDER_PREFIX: &[u8] = b"ballista-contrib-hudi-v1\0";
+
+/// Data needed to reconstruct a Hudi table provider on another Ballista node.
+#[derive(Clone, PartialEq, Message)]
+pub struct HudiProvider {
+    /// Hudi table location.
+    #[prost(string, tag = 1)]
+    pub base_uri: String,
+    /// Caller-supplied Hudi and object-store options.
+    #[prost(map = "string, string", tag = 2)]
+    pub options: HashMap<String, String>,
+}
+
+/// Hudi-specific provider serialization implemented outside Ballista's release graph.
+pub trait HudiProviderCodec: Debug + Send + Sync {
+    /// Returns the Hudi wire descriptor when this codec owns the provider.
+    fn try_encode(&self, provider: &dyn TableProvider) -> Result<Option<HudiProvider>>;
+
+    /// Reconstructs a Hudi table provider from its wire descriptor.
+    fn decode(
+        &self,
+        provider: HudiProvider,
+        schema: SchemaRef,
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn TableProvider>>;
+}
+
+/// Logical codec that combines Ballista's defaults with a Hudi provider codec.
+#[derive(Debug)]
+pub struct HudiLogicalExtensionCodec {
+    default_codec: BallistaLogicalExtensionCodec,
+    provider_codec: Arc<dyn HudiProviderCodec>,
+}
+
+impl HudiLogicalExtensionCodec {
+    /// Creates a logical codec backed by the supplied Hudi provider codec.
+    pub fn new(provider_codec: Arc<dyn HudiProviderCodec>) -> Self {
+        Self {
+            default_codec: BallistaLogicalExtensionCodec::default(),
+            provider_codec,
+        }
+    }
+}
+
+impl LogicalExtensionCodec for HudiLogicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[datafusion::logical_expr::LogicalPlan],
+        ctx: &TaskContext,
+    ) -> Result<Extension> {
+        self.default_codec.try_decode(buf, inputs, ctx)
+    }
+
+    fn try_encode(&self, node: &Extension, buf: &mut Vec<u8>) -> Result<()> {
+        self.default_codec.try_encode(node, buf)
+    }
+
+    fn try_decode_table_provider(
+        &self,
+        buf: &[u8],
+        table_ref: &TableReference,
+        schema: SchemaRef,
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let Some(payload) = buf.strip_prefix(HUDI_PROVIDER_PREFIX) else {
+            return self
+                .default_codec
+                .try_decode_table_provider(buf, table_ref, schema, ctx);
+        };
+        let provider = HudiProvider::decode(payload).map_err(|error| {
+            DataFusionError::Internal(format!("failed to decode Hudi provider: {error}"))
+        })?;
+        self.provider_codec.decode(provider, schema, ctx)
+    }
+
+    fn try_encode_table_provider(
+        &self,
+        table_ref: &TableReference,
+        node: Arc<dyn TableProvider>,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        let Some(provider) = self.provider_codec.try_encode(node.as_ref())? else {
+            return self
+                .default_codec
+                .try_encode_table_provider(table_ref, node, buf);
+        };
+        buf.extend_from_slice(HUDI_PROVIDER_PREFIX);
+        provider.encode(buf).map_err(|error| {
+            DataFusionError::Internal(format!("failed to encode Hudi provider: {error}"))
+        })
+    }
+
+    fn try_decode_file_format(
+        &self,
+        buf: &[u8],
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn datafusion::datasource::file_format::FileFormatFactory>> {
+        self.default_codec.try_decode_file_format(buf, ctx)
+    }
+
+    fn try_encode_file_format(
+        &self,
+        buf: &mut Vec<u8>,
+        node: Arc<dyn datafusion::datasource::file_format::FileFormatFactory>,
+    ) -> Result<()> {
+        self.default_codec.try_encode_file_format(buf, node)
+    }
+}
+
+/// Installs a Hudi provider codec while retaining Ballista's defaults.
+pub fn register_hudi_codec(
+    config: SessionConfig,
+    provider_codec: Arc<dyn HudiProviderCodec>,
+) -> SessionConfig {
+    config.with_ballista_logical_extension_codec(Arc::new(
+        HudiLogicalExtensionCodec::new(provider_codec),
+    ))
+}

--- a/ballista/client/src/lib.rs
+++ b/ballista/client/src/lib.rs
@@ -20,6 +20,9 @@
 
 /// Extension traits for integrating DataFusion with Ballista distributed execution.
 pub mod extension;
+/// Build-gated Apache Hudi integration.
+#[cfg(feature = "contrib-hudi")]
+pub mod hudi;
 /// Prelude module providing commonly used imports for Ballista client applications.
 pub mod prelude;
 /// Re-export of the DataFusion crate for convenience.


### PR DESCRIPTION
## Which issue does this PR close?

Part of #1241.

## Rationale for this change

Ballista already supports replacing its logical extension codec, so this PR no longer adds another format-neutral codec seam. Instead, it follows the contrib build-gate pattern used by Comet: establish a narrow Hudi wire boundary without adding Hudi to Ballista's dependency or release graph.

## What changes are included?

- Adds the opt-in `contrib-hudi` Cargo feature to the `ballista` crate.
- Defines the typed Hudi provider payload (`base_uri` and caller-supplied options).
- Defines `HudiProviderCodec`, implemented by an integration outside Ballista's release graph.
- Adds `HudiLogicalExtensionCodec`, which handles only the Hudi provider payload and delegates every other logical node, provider, and file format to Ballista's existing codec.
- Adds no `hudi-rs` dependency and changes no default runtime behavior.

The follow-up #2389 implements the boundary with hudi-rs in an independently built crate excluded from the main workspace.

## How are these changes tested?

- `cargo check -p ballista --no-default-features --locked`
- `cargo check -p ballista --no-default-features --features contrib-hudi --locked`
- `cargo clippy -p ballista --lib --features contrib-hudi --locked -- -D warnings`
- `cargo package -p ballista --allow-dirty --no-verify`
- Verified with `cargo tree` that neither the default build nor the `contrib-hudi` gate contains a Hudi crate.
- `cargo fmt --all -- --check`
- `git diff --check`

No runtime Hudi test is added here because this PR deliberately contains no Hudi implementation.
