### PR TITLE
feat: add build-gated Hudi read integration

### DIFF
--- a/.github/workflows/hudi.yml
+++ b/.github/workflows/hudi.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Hudi
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/hudi.yml"
+      - "ballista/client/Cargo.toml"
+      - "ballista/client/src/hudi.rs"
+      - "integrations/hudi/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hudi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: protoc
+      - uses: Swatinem/rust-cache@v2
+      - name: Test build-gated Hudi read
+        run: cargo test --manifest-path integrations/hudi/Cargo.toml --test distributed_read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "datafusion-proto",
  "env_logger",
  "log",
+ "prost",
  "rstest",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [workspace]
-exclude = ["dev/msrvcheck", "python"]
+exclude = ["dev/msrvcheck", "integrations/hudi", "python"]
 members = [
     "ballista-cli",
     "ballista/api-types",

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -35,7 +35,9 @@ ballista-executor = { path = "../executor", version = "54.0.0", optional = true,
 ] }
 ballista-scheduler = { path = "../scheduler", version = "54.0.0", optional = true, default-features = false }
 datafusion = { workspace = true }
+datafusion-proto = { workspace = true, optional = true }
 log = { workspace = true }
+prost = { workspace = true, optional = true }
 
 tokio = { workspace = true }
 url = { workspace = true }
@@ -53,6 +55,10 @@ uuid = { workspace = true }
 
 [features]
 default = ["standalone"]
+contrib-hudi = [
+    "dep:datafusion-proto",
+    "dep:prost",
+]
 standalone = ["ballista-executor", "ballista-scheduler"]
 # tests which need change of RUST_MIN_STACK in order for 
 # tests to run. 

--- a/ballista/client/src/hudi.rs
+++ b/ballista/client/src/hudi.rs
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Build gate for optional Apache Hudi support.
+//!
+//! The gate defines the Hudi wire contract and delegates provider construction
+//! to an implementation supplied by an integration crate.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use ballista_core::extension::SessionConfigExt;
+use ballista_core::serde::BallistaLogicalExtensionCodec;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::TableProvider;
+use datafusion::common::{DataFusionError, Result, TableReference};
+use datafusion::execution::TaskContext;
+use datafusion::execution::context::SessionConfig;
+use datafusion::logical_expr::Extension;
+use datafusion_proto::logical_plan::LogicalExtensionCodec;
+use prost::Message;
+
+const HUDI_PROVIDER_PREFIX: &[u8] = b"ballista-contrib-hudi-v1\0";
+
+/// Data needed to reconstruct a Hudi table provider on another Ballista node.
+#[derive(Clone, PartialEq, Message)]
+pub struct HudiProvider {
+    /// Hudi table location.
+    #[prost(string, tag = 1)]
+    pub base_uri: String,
+    /// Caller-supplied Hudi and object-store options.
+    #[prost(map = "string, string", tag = 2)]
+    pub options: HashMap<String, String>,
+}
+
+/// Hudi-specific provider serialization implemented outside Ballista's release graph.
+pub trait HudiProviderCodec: Debug + Send + Sync {
+    /// Returns the Hudi wire descriptor when this codec owns the provider.
+    fn try_encode(&self, provider: &dyn TableProvider) -> Result<Option<HudiProvider>>;
+
+    /// Reconstructs a Hudi table provider from its wire descriptor.
+    fn decode(
+        &self,
+        provider: HudiProvider,
+        schema: SchemaRef,
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn TableProvider>>;
+}
+
+/// Logical codec that combines Ballista's defaults with a Hudi provider codec.
+#[derive(Debug)]
+pub struct HudiLogicalExtensionCodec {
+    default_codec: BallistaLogicalExtensionCodec,
+    provider_codec: Arc<dyn HudiProviderCodec>,
+}
+
+impl HudiLogicalExtensionCodec {
+    /// Creates a logical codec backed by the supplied Hudi provider codec.
+    pub fn new(provider_codec: Arc<dyn HudiProviderCodec>) -> Self {
+        Self {
+            default_codec: BallistaLogicalExtensionCodec::default(),
+            provider_codec,
+        }
+    }
+}
+
+impl LogicalExtensionCodec for HudiLogicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[datafusion::logical_expr::LogicalPlan],
+        ctx: &TaskContext,
+    ) -> Result<Extension> {
+        self.default_codec.try_decode(buf, inputs, ctx)
+    }
+
+    fn try_encode(&self, node: &Extension, buf: &mut Vec<u8>) -> Result<()> {
+        self.default_codec.try_encode(node, buf)
+    }
+
+    fn try_decode_table_provider(
+        &self,
+        buf: &[u8],
+        table_ref: &TableReference,
+        schema: SchemaRef,
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let Some(payload) = buf.strip_prefix(HUDI_PROVIDER_PREFIX) else {
+            return self
+                .default_codec
+                .try_decode_table_provider(buf, table_ref, schema, ctx);
+        };
+        let provider = HudiProvider::decode(payload).map_err(|error| {
+            DataFusionError::Internal(format!("failed to decode Hudi provider: {error}"))
+        })?;
+        self.provider_codec.decode(provider, schema, ctx)
+    }
+
+    fn try_encode_table_provider(
+        &self,
+        table_ref: &TableReference,
+        node: Arc<dyn TableProvider>,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        let Some(provider) = self.provider_codec.try_encode(node.as_ref())? else {
+            return self
+                .default_codec
+                .try_encode_table_provider(table_ref, node, buf);
+        };
+        buf.extend_from_slice(HUDI_PROVIDER_PREFIX);
+        provider.encode(buf).map_err(|error| {
+            DataFusionError::Internal(format!("failed to encode Hudi provider: {error}"))
+        })
+    }
+
+    fn try_decode_file_format(
+        &self,
+        buf: &[u8],
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn datafusion::datasource::file_format::FileFormatFactory>> {
+        self.default_codec.try_decode_file_format(buf, ctx)
+    }
+
+    fn try_encode_file_format(
+        &self,
+        buf: &mut Vec<u8>,
+        node: Arc<dyn datafusion::datasource::file_format::FileFormatFactory>,
+    ) -> Result<()> {
+        self.default_codec.try_encode_file_format(buf, node)
+    }
+}
+
+/// Installs a Hudi provider codec while retaining Ballista's defaults.
+pub fn register_hudi_codec(
+    config: SessionConfig,
+    provider_codec: Arc<dyn HudiProviderCodec>,
+) -> SessionConfig {
+    config.with_ballista_logical_extension_codec(Arc::new(
+        HudiLogicalExtensionCodec::new(provider_codec),
+    ))
+}

--- a/ballista/client/src/lib.rs
+++ b/ballista/client/src/lib.rs
@@ -20,6 +20,9 @@
 
 /// Extension traits for integrating DataFusion with Ballista distributed execution.
 pub mod extension;
+/// Build-gated Apache Hudi integration.
+#[cfg(feature = "contrib-hudi")]
+pub mod hudi;
 /// Prelude module providing commonly used imports for Ballista client applications.
 pub mod prelude;
 /// Re-export of the DataFusion crate for convenience.

--- a/integrations/hudi/Cargo.toml
+++ b/integrations/hudi/Cargo.toml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "hudi-ballista"
+version = "54.0.0"
+edition = "2024"
+rust-version = "1.94.0"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+ballista = { path = "../../ballista/client", version = "54.0.0", features = ["contrib-hudi", "standalone"] }
+hudi-datafusion = { git = "https://github.com/wirybeaver/hudi-rs.git", rev = "c3e4009136443057be564b717c41c99420ae821c", default-features = false }
+hudi-test = { git = "https://github.com/wirybeaver/hudi-rs.git", rev = "c3e4009136443057be564b717c41c99420ae821c" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[workspace]

--- a/integrations/hudi/src/lib.rs
+++ b/integrations/hudi/src/lib.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use ballista::datafusion::arrow::datatypes::SchemaRef;
+use ballista::datafusion::catalog::TableProvider;
+use ballista::datafusion::common::Result;
+use ballista::datafusion::execution::TaskContext;
+use ballista::datafusion::execution::context::SessionConfig;
+use ballista::datafusion::prelude::SessionContext;
+use ballista::hudi::{
+    HudiProvider, HudiProviderCodec, register_hudi_codec as register_codec,
+};
+use hudi_datafusion::HudiDataSource;
+
+#[derive(Debug)]
+struct HudiDataSourceCodec;
+
+impl HudiProviderCodec for HudiDataSourceCodec {
+    fn try_encode(&self, provider: &dyn TableProvider) -> Result<Option<HudiProvider>> {
+        Ok(provider.downcast_ref::<HudiDataSource>().map(|provider| {
+            HudiProvider {
+                base_uri: provider.base_uri(),
+                options: provider.options().clone(),
+            }
+        }))
+    }
+
+    fn decode(
+        &self,
+        provider: HudiProvider,
+        _schema: SchemaRef,
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let provider = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(HudiDataSource::new_with_options(
+                &provider.base_uri,
+                provider.options,
+            ))
+        })?;
+        Ok(Arc::new(provider))
+    }
+}
+
+/// Installs the Hudi provider codec for a Ballista session.
+pub fn register_hudi_codec(config: SessionConfig) -> SessionConfig {
+    register_codec(config, Arc::new(HudiDataSourceCodec))
+}
+
+/// Creates and registers a Hudi table provider.
+pub async fn register_hudi_table<I, K, V>(
+    ctx: &SessionContext,
+    name: &str,
+    base_uri: &str,
+    options: I,
+) -> Result<()>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: Into<String>,
+{
+    let provider = HudiDataSource::new_with_options(base_uri, options).await?;
+    ctx.register_table(name, Arc::new(provider))?;
+    Ok(())
+}

--- a/integrations/hudi/tests/distributed_read.rs
+++ b/integrations/hudi/tests/distributed_read.rs
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ballista::datafusion::arrow::array::{Int32Array, StringArray};
+use ballista::datafusion::execution::SessionStateBuilder;
+use ballista::datafusion::prelude::{SessionConfig, SessionContext};
+use ballista::prelude::{SessionConfigExt, SessionContextExt};
+use hudi_ballista::{register_hudi_codec, register_hudi_table};
+use hudi_test::SampleTable;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reads_projected_hudi_cow_rows_through_ballista() {
+    let config = register_hudi_codec(
+        SessionConfig::new_with_ballista()
+            .with_target_partitions(2)
+            .with_ballista_standalone_parallelism(2),
+    );
+    let state = SessionStateBuilder::new()
+        .with_config(config)
+        .with_default_features()
+        .build();
+    let ctx = SessionContext::standalone_with_state(state).await.unwrap();
+    let table = SampleTable::V6Nonpartitioned.url_to_cow();
+    register_hudi_table(
+        &ctx,
+        "users",
+        table.as_str(),
+        std::iter::empty::<(&str, &str)>(),
+    )
+    .await
+    .unwrap();
+
+    let batches = ctx
+        .sql("SELECT id, name FROM users WHERE \"isActive\" ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let names = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+
+    assert_eq!(
+        (0..ids.len())
+            .map(|row| (ids.value(row), names.value(row)))
+            .collect::<Vec<_>>(),
+        vec![(3, "Carol"), (4, "Diana")]
+    );
+}


### PR DESCRIPTION
## Dependencies

- Stacked on #2388; review the second commit (`feat: add build-gated Hudi read integration`) for this PR's own diff.
- Uses the DataFusion 55 compatibility work in apache/hudi-rs#698, pinned to commit `c3e4009136443057be564b717c41c99420ae821c` until that change is released.

## Which issue does this PR close?

Proves the build-gated provider boundary proposed for #1241 with a real open-table-format read.

## What changes are included?

- Adds an independently built `integrations/hudi` crate excluded from Ballista's workspace.
- Implements `HudiProviderCodec` for hudi-rs `HudiDataSource`.
- Transports only the table base URI and caller-supplied options, then reconstructs the provider on the scheduler.
- Uses hudi-rs's standard Parquet `DataSourceExec` path for copy-on-write reads.
- Adds a focused workflow for the excluded integration crate.

The hudi-rs dependency remains outside Ballista's root `Cargo.lock`, default dependency tree, published package, and release graph. Scope remains read-only Parquet copy-on-write; MOR custom execution, writes, and dynamic loading are intentionally excluded.

## How are these changes tested?

- `cargo check -p ballista --no-default-features --locked`
- `cargo check -p ballista --no-default-features --features contrib-hudi --locked`
- `cargo test --manifest-path integrations/hudi/Cargo.toml --test distributed_read`
- `cargo clippy --manifest-path integrations/hudi/Cargo.toml --all-targets --no-deps -- -D warnings`
- `cargo package -p ballista --allow-dirty --no-verify`
- Verified with `cargo tree` that neither the default Ballista build nor the build-gate feature contains a Hudi crate.
- `cargo fmt --all -- --check`
- `git diff --check`

The focused test runs a projected and filtered Hudi COW query through a two-worker standalone Ballista cluster and verifies the returned rows.
