### PR TITLE
fix(ci): resolve datafusion.proto from datafusion-proto-models

### DIFF
--- a/ballista/core/proto/datafusion.proto
+++ b/ballista/core/proto/datafusion.proto
@@ -92,8 +92,8 @@ message ListingTableScanNode {
   datafusion_common.Schema schema = 5;
   repeated LogicalExprNode filters = 6;
   repeated PartitionColumn table_partition_cols = 7;
-  bool collect_stat = 8;
-  uint32 target_partitions = 9;
+  reserved 8; // was bool collect_stat
+  reserved 9; // was uint32 target_partitions
   oneof FileFormatType {
     datafusion_common.CsvFormat csv = 10;
     datafusion_common.ParquetFormat parquet = 11;
@@ -148,7 +148,17 @@ message RepartitionNode {
   oneof partition_method {
     uint64 round_robin = 2;
     HashRepartition hash = 3;
+    RangeRepartition range = 4;
   }
+}
+
+message RangeSplitPoint {
+  repeated datafusion_common.ScalarValue value = 1;
+}
+
+message RangeRepartition {
+  repeated SortExprNode sort_expr = 1;
+  repeated RangeSplitPoint split_point = 2;
 }
 
 message HashRepartition {
@@ -163,7 +173,8 @@ message EmptyRelationNode {
 message CreateExternalTableNode {
   reserved 1; // was string name
   TableReference name = 9;
-  string location = 2;
+  string location = 2; // deprecated; use repeated locations
+  repeated string locations = 16;
   string file_type = 3;
   datafusion_common.DfSchema schema = 4;
   repeated string table_partition_cols = 5;
@@ -224,12 +235,22 @@ message ValuesNode {
 message AnalyzeNode {
   LogicalPlanNode input = 1;
   bool verbose = 2;
+  // Statement-level override for `datafusion.explain.analyze_level`.
+  // Absent means "fall back to session config".
+  optional datafusion_common.MetricType analyze_level = 3;
+  // Statement-level override for `datafusion.explain.analyze_categories`.
+  // Absent means "fall back to session config".
+  optional datafusion_common.ExplainAnalyzeCategoriesNode analyze_categories = 4;
+  datafusion_common.ExplainFormat format = 5;
 }
 
 message ExplainNode {
   LogicalPlanNode input = 1;
   bool verbose = 2;
   datafusion_common.ExplainFormat format = 3;
+  // Statement-level override for `datafusion.explain.show_statistics`.
+  // Absent means "fall back to session config".
+  optional bool show_statistics = 4;
 }
 
 message AggregateNode {
@@ -293,7 +314,7 @@ message FileFormatProto {
 }
 
 message DmlNode{
-   enum Type {
+  enum Type {
     UPDATE = 0;
     DELETE = 1;
     CTAS = 2;
@@ -301,12 +322,62 @@ message DmlNode{
     INSERT_OVERWRITE = 4;
     INSERT_REPLACE = 5;
     TRUNCATE = 6;
+    MERGE_INTO = 7;
   }
   Type dml_type = 1;
   LogicalPlanNode input = 2;
   TableReference table_name = 3;
   LogicalPlanNode target = 5;
+  // Populated only when dml_type == MERGE_INTO.
+  MergeIntoOpNode merge_into = 6;
 }
+
+// Carries the ON condition and WHEN clauses of a MERGE INTO operation.
+message MergeIntoOpNode {
+  LogicalExprNode on = 1;
+  repeated MergeIntoClauseNode clauses = 2;
+}
+
+// A single WHEN clause within a MERGE INTO statement.
+message MergeIntoClauseNode {
+  enum Kind {
+    MATCHED = 0;
+    NOT_MATCHED = 1;
+    NOT_MATCHED_BY_TARGET = 2;
+    NOT_MATCHED_BY_SOURCE = 3;
+  }
+  Kind kind = 1;
+  // Optional `AND <expr>` predicate. Absent when the clause has no predicate.
+  LogicalExprNode predicate = 2;
+  MergeIntoActionNode action = 3;
+}
+
+// The action for a single WHEN clause.
+message MergeIntoActionNode {
+  oneof action {
+    MergeUpdateAction update = 1;
+    MergeInsertAction insert = 2;
+    MergeDeleteAction delete = 3;
+  }
+}
+
+message MergeUpdateAction {
+  repeated MergeAssignment assignments = 1;
+}
+
+message MergeAssignment {
+  string column = 1;
+  LogicalExprNode value = 2;
+}
+
+message MergeInsertAction {
+  // May be empty (meaning all columns).
+  repeated string columns = 1;
+  // One expression per inserted column.
+  repeated LogicalExprNode values = 2;
+}
+
+message MergeDeleteAction {}
 
 message UnnestNode {
   LogicalPlanNode input = 1;
@@ -332,7 +403,22 @@ message ColumnUnnestListRecursion {
 }
 
 message UnnestOptions {
-  bool preserve_nulls = 1;
+  // Reserved for the historical `bool preserve_nulls = 1;` field.
+  // Use `null_handling` instead.
+  reserved 1;
+  reserved "preserve_nulls";
+
+  enum NullHandling {
+    // Preserve nulls; empty lists produce no rows. The historical default.
+    PRESERVE = 0;
+    // Drop both null and empty lists from the output.
+    DROP = 1;
+    // Preserve nulls, and additionally expand empty lists into a single
+    // NULL output row (outer-unnest semantics).
+    PRESERVE_AND_EXPAND_EMPTY = 2;
+  }
+
+  NullHandling null_handling = 3;
   repeated RecursionUnnestOption recursions = 2;
 }
 
@@ -431,6 +517,10 @@ message LogicalExprNode {
 
     // Subquery expressions
     ScalarSubqueryExprNode scalar_subquery_expr = 36;
+
+    HigherOrderUDFExprNode higher_order_udf_expr = 37;
+    Lambda lambda = 38;
+    LambdaVariable lambda_variable = 39;
   }
 }
 
@@ -543,6 +633,9 @@ message NegativeNode {
 
 message Unnest {
   repeated LogicalExprNode exprs = 1;
+  // When true, this Unnest expression has outer-unnest semantics: NULL and
+  // empty input lists both produce a single NULL output row.
+  bool outer = 2;
 }
 
 message InListNode {
@@ -566,6 +659,22 @@ message ScalarUDFExprNode {
   string fun_name = 1;
   repeated LogicalExprNode args = 2;
   optional bytes fun_definition = 3;
+}
+
+message HigherOrderUDFExprNode {
+  string fun_name = 1;
+  repeated LogicalExprNode args = 2;
+  optional bytes fun_definition = 3;
+}
+
+message Lambda {
+  repeated string params = 1;
+  LogicalExprNode body = 2;
+}
+
+message LambdaVariable {
+  string name = 1;
+  datafusion_common.Field field = 2;
 }
 
 message WindowExprNode {
@@ -937,6 +1046,11 @@ message PhysicalExprNode {
     PhysicalScalarSubqueryExprNode scalar_subquery = 22;
 
     PhysicalDynamicFilterNode dynamic_filter = 23;
+
+    PhysicalHigherOrderUdfNode higher_order_udf = 24;
+    PhysicalLambdaExprNode lambda = 25;
+    PhysicalLambdaVariableExprNode lambda_variable = 26;
+    PhysicalRangeExprNode range_expr = 27;
   }
 }
 
@@ -957,6 +1071,22 @@ message PhysicalScalarUdfNode {
   string return_field_name = 6;
 }
 
+message PhysicalHigherOrderUdfNode {
+  string name = 1;
+  repeated PhysicalExprNode args = 2;
+  optional bytes fun_definition = 3;
+}
+
+message PhysicalLambdaExprNode {
+  repeated string params = 1;
+  PhysicalExprNode body = 2;
+}
+
+message PhysicalLambdaVariableExprNode {
+  uint32 index = 1;
+  datafusion_common.Field field = 2;
+}
+
 message PhysicalAggregateExprNode {
   oneof AggregateFunction {
     string user_defined_aggr_function = 4;
@@ -967,6 +1097,7 @@ message PhysicalAggregateExprNode {
   bool ignore_nulls = 6;
   optional bytes fun_definition = 7;
   string human_display = 8;
+  bool is_reversed = 9;
 }
 
 message PhysicalWindowExprNode {
@@ -1072,6 +1203,11 @@ message PhysicalHashExprNode {
   string description = 6;
 }
 
+message PhysicalRangeExprNode {
+  repeated PhysicalSortExprNode sort_expr = 1;
+  repeated PhysicalRangeSplitPoint split_point = 2;
+}
+
 message FilterExecNode {
   PhysicalPlanNode input = 1;
   PhysicalExprNode expr = 2;
@@ -1120,6 +1256,10 @@ message FileScanExecConf {
   optional uint64 batch_size = 12;
 
   optional ProjectionExprs projection_exprs = 13;
+  // Was optional bool partitioned_by_file_group = 14.
+  reserved 14;
+  reserved "partitioned_by_file_group";
+  optional Partitioning output_partitioning = 15;
 }
 
 message ParquetScanExecNode {
@@ -1191,6 +1331,14 @@ message HashJoinExecNode {
   bool null_aware = 10;
   // Optional dynamic filter expression for pushing down to the probe side.
   PhysicalExprNode dynamic_filter = 11;
+  // Optional row limit pushed into the join by the `limit_pushdown` rule.
+  //
+  // This is presence-tracked (`optional`) on purpose: messages produced by
+  // versions predating this field carry no `fetch` at all, and a plain proto3
+  // scalar would decode that absence as `0`, i.e. "fetch 0 rows", silently
+  // turning old plans into empty results. With `optional`, absent decodes to
+  // `None`, which is the correct reading of an older message.
+  optional uint64 fetch = 12;
 }
 
 enum StreamPartitionMode {
@@ -1233,6 +1381,7 @@ message AnalyzeExecNode {
   // Empty means "plan only". Absent (has_metric_categories=false) means "all".
   bool has_metric_categories = 5;
   repeated string metric_categories = 6;
+  datafusion_common.ExplainFormat format = 7;
 }
 
 message CrossJoinExecNode {
@@ -1256,10 +1405,16 @@ message JoinOn {
 
 message EmptyExecNode {
   datafusion_common.Schema schema = 1;
+  // Number of output partitions. Absent (0) means a single partition, so that
+  // plans encoded before this field existed decode to the previous default.
+  uint32 partitions = 2;
 }
 
 message PlaceholderRowExecNode {
   datafusion_common.Schema schema = 1;
+  // Number of output partitions. Absent (0) means a single partition, so that
+  // plans encoded before this field existed decode to the previous default.
+  uint32 partitions = 2;
 }
 
 message ProjectionExecNode {
@@ -1324,6 +1479,8 @@ message AggregateExecNode {
   bool has_grouping_set = 12;
   // Optional dynamic filter expression for pushing down to the child.
   PhysicalExprNode dynamic_filter = 13;
+  // Output schema preserved by physical optimizer rewrites.
+  datafusion_common.Schema schema = 14;
 }
 
 message GlobalLimitExecNode {
@@ -1332,11 +1489,15 @@ message GlobalLimitExecNode {
   uint32 skip = 2;
   // Maximum number of rows to fetch; negative means no limit
   int64 fetch = 3;
+  // Ordering the limit must preserve; empty means none
+  repeated PhysicalSortExprNode required_ordering = 4;
 }
 
 message LocalLimitExecNode {
   PhysicalPlanNode input = 1;
   uint32 fetch = 2;
+  // Ordering the limit must preserve; empty means none
+  repeated PhysicalSortExprNode required_ordering = 3;
 }
 
 message SortExecNode {
@@ -1380,13 +1541,22 @@ message PhysicalHashRepartition {
   uint64 partition_count = 2;
 }
 
+message PhysicalRangePartitioning {
+  repeated PhysicalSortExprNode sort_expr = 1;
+  repeated PhysicalRangeSplitPoint split_point = 2;
+}
+
+message PhysicalRangeSplitPoint {
+  repeated datafusion_common.ScalarValue value = 1;
+}
+
 message RepartitionExecNode{
   PhysicalPlanNode input = 1;
-  // oneof partition_method {
+  // Legacy direct partitioning fields:
   //   uint64 round_robin = 2;
   //   PhysicalHashRepartition hash = 3;
   //   uint64 unknown = 4;
-  // }
+  // New partitioning variants are stored in `partitioning`.
   Partitioning partitioning = 5;
   bool preserve_order = 6;
 }
@@ -1396,6 +1566,7 @@ message Partitioning {
     uint64 round_robin = 1;
     PhysicalHashRepartition hash = 2;
     uint64 unknown = 3;
+    PhysicalRangePartitioning range = 4;
   }
 }
 
@@ -1417,6 +1588,7 @@ message PartitionedFile {
   repeated datafusion_common.ScalarValue partition_values = 4;
   FileRange range = 5;
   datafusion_common.Statistics statistics = 6;
+  datafusion_common.Schema arrow_schema = 7;
 }
 
 message FileRange {
@@ -1439,15 +1611,15 @@ message RecursiveQueryNode {
 }
 
 message CteWorkTableScanNode {
-    string name = 1;
-    datafusion_common.Schema schema = 2;
+  string name = 1;
+  datafusion_common.Schema schema = 2;
 }
 
 message EmptyTableScanNode {
-    TableReference table_name = 1;
-    datafusion_common.Schema schema = 2;
-    ProjectionColumns projection = 3;
-    repeated LogicalExprNode filters = 4;
+  TableReference table_name = 1;
+  datafusion_common.Schema schema = 2;
+  ProjectionColumns projection = 3;
+  repeated LogicalExprNode filters = 4;
 }
 
 enum GenerateSeriesName {
@@ -1456,44 +1628,44 @@ enum GenerateSeriesName {
 }
 
 message GenerateSeriesArgsContainsNull {
-    GenerateSeriesName name = 1;
+  GenerateSeriesName name = 1;
 }
 
 message GenerateSeriesArgsInt64 {
-    int64 start = 1;
-    int64 end = 2;
-    int64 step = 3;
-    bool include_end = 4;
-    GenerateSeriesName name = 5;
+  int64 start = 1;
+  int64 end = 2;
+  int64 step = 3;
+  bool include_end = 4;
+  GenerateSeriesName name = 5;
 }
 
 message GenerateSeriesArgsTimestamp {
-    int64 start = 1;
-    int64 end = 2;
-    datafusion_common.IntervalMonthDayNanoValue step = 3;
-    optional string tz = 4;
-    bool include_end = 5;
-    GenerateSeriesName name = 6;
+  int64 start = 1;
+  int64 end = 2;
+  datafusion_common.IntervalMonthDayNanoValue step = 3;
+  optional string tz = 4;
+  bool include_end = 5;
+  GenerateSeriesName name = 6;
 }
 
 message GenerateSeriesArgsDate {
-    int64 start = 1;
-    int64 end = 2;
-    datafusion_common.IntervalMonthDayNanoValue step = 3;
-    bool include_end = 4;
-    GenerateSeriesName name = 5;
+  int64 start = 1;
+  int64 end = 2;
+  datafusion_common.IntervalMonthDayNanoValue step = 3;
+  bool include_end = 4;
+  GenerateSeriesName name = 5;
 }
 
 message GenerateSeriesNode {
-    datafusion_common.Schema schema = 1;
-    uint32 target_batch_size = 2;
+  datafusion_common.Schema schema = 1;
+  uint32 target_batch_size = 2;
 
-    oneof args {
-        GenerateSeriesArgsContainsNull contains_null = 3;
-        GenerateSeriesArgsInt64 int64_args = 4;
-        GenerateSeriesArgsTimestamp timestamp_args = 5;
-        GenerateSeriesArgsDate date_args = 6;
-    }
+  oneof args {
+    GenerateSeriesArgsContainsNull contains_null = 3;
+    GenerateSeriesArgsInt64 int64_args = 4;
+    GenerateSeriesArgsTimestamp timestamp_args = 5;
+    GenerateSeriesArgsDate date_args = 6;
+  }
 }
 
 message SortMergeJoinExecNode {

--- a/dev/update_datafusion_proto.py
+++ b/dev/update_datafusion_proto.py
@@ -48,14 +48,31 @@ REPO_ROOT = Path(__file__).parent.parent.absolute()
 VENDOR_DIR = REPO_ROOT / "ballista" / "core" / "proto"
 
 # vendored file name -> (crate name, file name within the crate's `proto/` dir)
+#
+# DataFusion 55 moved the logical-plan proto out of `datafusion-proto` into the
+# new `datafusion-proto-models` crate.  We list both names so the script keeps
+# working on v54 (datafusion-proto) and v55+ (datafusion-proto-models).
 FILES = {
-    "datafusion.proto": ("datafusion-proto", "datafusion.proto"),
-    "datafusion_common.proto": ("datafusion-proto-common", "datafusion_common.proto"),
+    "datafusion.proto": (
+        ["datafusion-proto-models", "datafusion-proto"],
+        "datafusion.proto",
+    ),
+    "datafusion_common.proto": (
+        ["datafusion-proto-common"],
+        "datafusion_common.proto",
+    ),
+}
+
+# Every crate that might be referenced in FILES must be looked up.
+_ALL_CRATES = {
+    crate
+    for crate_list, _ in FILES.values()
+    for crate in crate_list
 }
 
 
 def crate_source_dirs():
-    """Map crate name -> source directory, as resolved in Cargo.lock."""
+    """Map crate name -> (source directory, version), as resolved in Cargo.lock."""
     out = subprocess.run(
         ["cargo", "metadata", "--format-version", "1", "--locked"],
         cwd=REPO_ROOT,
@@ -66,10 +83,12 @@ def crate_source_dirs():
     metadata = json.loads(out.stdout)
     dirs = {}
     for pkg in metadata["packages"]:
-        if pkg["name"] in ("datafusion-proto", "datafusion-proto-common"):
+        if pkg["name"] in _ALL_CRATES:
             # manifest_path points at the crate's Cargo.toml; protos sit alongside it.
             dirs[pkg["name"]] = (Path(pkg["manifest_path"]).parent, pkg["version"])
-    missing = {"datafusion-proto", "datafusion-proto-common"} - dirs.keys()
+    # At least one crate per FILES entry must be present.
+    required = {"datafusion-proto-common"}
+    missing = required - dirs.keys()
     if missing:
         sys.exit(f"could not resolve crate(s) from cargo metadata: {sorted(missing)}")
     return dirs
@@ -100,19 +119,35 @@ def main():
 
     dirs = crate_source_dirs()
     stale = []
-    for vendor_name, (crate, src_name) in FILES.items():
-        crate_dir, version = dirs[crate]
-        src = crate_dir / "proto" / src_name
-        if not src.exists():
-            # Some releases don't publish the `.proto` file (e.g. datafusion-proto-common
-            # only started shipping it in v54). Nothing to sync against, so leave the
-            # vendored copy as-is rather than failing.
-            print(
-                f"note: {crate}@{version} does not ship proto/{src_name}; "
-                f"leaving vendored {vendor_name} unchanged",
-                file=sys.stderr,
+    for vendor_name, (crate_list, src_name) in FILES.items():
+        # Try each crate in preference order; use the first one that ships the file.
+        src = None
+        chosen_crate = None
+        chosen_version = None
+        for crate in crate_list:
+            if crate not in dirs:
+                continue
+            crate_dir, version = dirs[crate]
+            candidate = crate_dir / "proto" / src_name
+            if candidate.exists():
+                src = candidate
+                chosen_crate = crate
+                chosen_version = version
+                break
+
+        if src is None:
+            # None of the candidate crates ship the expected file.  This is
+            # always an error: a missing source means the check cannot run and
+            # proto drift would go undetected.
+            tried = ", ".join(
+                f"{c}@{dirs[c][1]}" if c in dirs else f"{c} (not in Cargo.lock)"
+                for c in crate_list
             )
-            continue
+            sys.exit(
+                f"error: could not find proto/{src_name} in any of: {tried}\n"
+                f"  Update FILES in this script if the crate was renamed."
+            )
+
         expected = rewrite(src.read_text())
         dest = VENDOR_DIR / vendor_name
 
@@ -124,12 +159,15 @@ def main():
                     current.splitlines(keepends=True),
                     expected.splitlines(keepends=True),
                     fromfile=f"vendored/{vendor_name}",
-                    tofile=f"{crate}@{version}/proto/{src_name}",
+                    tofile=f"{chosen_crate}@{chosen_version}/proto/{src_name}",
                 )
                 sys.stderr.writelines(diff)
         else:
             dest.write_text(expected)
-            print(f"updated {dest.relative_to(REPO_ROOT)} from {crate}@{version}")
+            print(
+                f"updated {dest.relative_to(REPO_ROOT)} "
+                f"from {chosen_crate}@{chosen_version}"
+            )
 
     if args.check and stale:
         sys.exit(

--- a/dev/update_datafusion_proto.py
+++ b/dev/update_datafusion_proto.py
@@ -86,11 +86,6 @@ def crate_source_dirs():
         if pkg["name"] in _ALL_CRATES:
             # manifest_path points at the crate's Cargo.toml; protos sit alongside it.
             dirs[pkg["name"]] = (Path(pkg["manifest_path"]).parent, pkg["version"])
-    # At least one crate per FILES entry must be present.
-    required = {"datafusion-proto-common"}
-    missing = required - dirs.keys()
-    if missing:
-        sys.exit(f"could not resolve crate(s) from cargo metadata: {sorted(missing)}")
     return dirs
 
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2377.

# Rationale for this change

`dev/update_datafusion_proto.py` was silently passing CI without actually checking `datafusion.proto`. In DataFusion 55 the logical-plan proto moved from the `datafusion-proto` crate into a new `datafusion-proto-models` crate. The script still targeted `datafusion-proto`, hit a broad "crate doesn't ship this file" escape hatch, printed a `note:` to stderr, and **exited 0** — so the CI job could remain green while validating nothing for `datafusion.proto`.

Reproducer (before this fix):

```text
$ python3 dev/update_datafusion_proto.py --check
note: datafusion-proto@55.0.0 does not ship proto/datafusion.proto; leaving vendored datafusion.proto unchanged
$ echo $?
0
```

# What changes are included in this PR?

**`dev/update_datafusion_proto.py`**

* `FILES` values are now `([ordered crate list], filename)`. For `datafusion.proto` the list is `["datafusion-proto-models", "datafusion-proto"]` — the script tries each in order and uses the first one that actually ships the file. This keeps the script working on both v55+ (`datafusion-proto-models`) and v54 (`datafusion-proto`) without a separate code path.
* `_ALL_CRATES` is derived automatically from `FILES`, so `crate_source_dirs()` always looks up every candidate without a separate maintenance step.
* The silent-skip path (`if not src.exists(): continue`) is **removed**. If none of the candidate crates ships the expected file, the script now exits with a diagnostic listing which crates were tried, so a future rename fails loudly instead of silently passing CI.
* The crate lookup no longer relies on a separate hard-coded list of required crates; validation is derived from the entries in `FILES`.

**`ballista/core/proto/datafusion.proto`**

Re-vendored from `datafusion-proto-models@55.0.0` (211 insertions, 39 deletions vs the previously stale copy). Key additions:

* `reserved 8/9` annotations on `ListingTableScanNode` (was `collect_stat` / `target_partitions`)
* `RangeRepartition` variant on `RepartitionNode` + new `RangeSplitPoint` message
* `repeated string locations = 16` on `CreateExternalTableNode`
* `AnalyzeNode` gains `analyze_level`, `analyze_categories`, `format` fields
* `ExplainNode` gains `show_statistics` field
* `MERGE_INTO` added to `DmlNode.Type` enum

# Are there any user-facing changes?

No. The vendored `.proto` files are build-time stubs only — `ballista/core/build.rs` maps their packages to the real DataFusion crates via `extern_path`, so no Rust code is generated from them in Ballista. This change only makes the CI guard actually guard.
