### PR TITLE
ci: assign issues via take/untake comments

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+name: "Assign/unassign the issue via `take` or `untake` comment"
+
+on:
+  issue_comment:
+    types: created
+
+permissions:
+  issues: write
+
+jobs:
+  issue_assign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: (!github.event.issue.pull_request) && (github.event.comment.body == 'take' || github.event.comment.body == 'untake')
+    concurrency:
+      group: ${{ github.actor }}-issue-assign
+    steps:
+      - name: Take or untake issue
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          USER_LOGIN: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$COMMENT_BODY" == "take" ]
+          then
+            CODE=$(curl -H "Authorization: token $TOKEN" -LI https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees/$USER_LOGIN -o /dev/null -w '%{http_code}\n' -s)
+            if [ "$CODE" -eq "204" ]
+            then
+              echo "Assigning issue $ISSUE_NUMBER to $USER_LOGIN"
+              curl -X POST -H "Authorization: token $TOKEN" -H "Content-Type: application/json" -d "{\"assignees\": [\"$USER_LOGIN\"]}" https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
+            else
+              echo "Cannot assign issue $ISSUE_NUMBER to $USER_LOGIN"
+            fi
+          elif [ "$COMMENT_BODY" == "untake" ]
+          then
+            echo "Unassigning issue $ISSUE_NUMBER from $USER_LOGIN"
+            curl -X DELETE -H "Authorization: token $TOKEN" -H "Content-Type: application/json" -d "{\"assignees\": [\"$USER_LOGIN\"]}" https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,18 @@ You can find a curated
 [good-first-issue](https://github.com/apache/datafusion-ballista/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 list to help you get started.
 
+## Claiming an issue
+
+If you want to work on an issue, comment `take` on it and the
+[`take` workflow](.github/workflows/take.yml) will assign it to you. Comment
+`untake` to unassign yourself again if you no longer plan to work on it. The
+comment has to be exactly `take` or `untake` with nothing else in it.
+
+Assigning an issue to yourself is not required to open a PR, but it lets others
+know that the issue is being worked on. If an issue is already assigned and has
+seen no activity for a while, feel free to ask on the issue whether it is still
+being worked on before picking it up.
+
 # Developer's Guide
 
 This section describes how you can get started with Ballista development.


### PR DESCRIPTION
# Which issue does this PR close?

<!-- No issue filed for this. -->

N/A

# Rationale for this change

Commenting `take` on an issue is how contributors claim an issue in
apache/datafusion and apache/datafusion-comet, so people coming from those
repos naturally try the same thing here. Ballista has no such workflow, so
the comment silently does nothing and the issue stays unassigned.

# What changes are included in this PR?

- Add `.github/workflows/take.yml`, a copy of the DataFusion workflow adapted
  to this repo's runner and style. On an issue comment of exactly `take` it
  assigns the commenter (after checking they are assignable), and on `untake`
  it unassigns them. It uses only `curl` and `secrets.GITHUB_TOKEN`, with no
  third-party actions, so it does not add anything to the ASF actions
  allowlist.
- Document `take`/`untake` in a new "Claiming an issue" section in
  `CONTRIBUTING.md`.

Note that the workflow only takes effect once merged, since `issue_comment`
events always run the version of the workflow on the default branch.

# Are there any user-facing changes?

No code changes. Contributors can self-assign issues by commenting `take`.
