### PR TITLE
chore: require an approving review before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,6 +39,22 @@ github:
     rebase: false
   features:
     issues: true
+  # Require at least one approving review before a pull request can be merged,
+  # matching apache/datafusion and apache/datafusion-comet.
+  #
+  # .asf.yaml does not support wildcards here, so each release branch has to be
+  # listed by name. Add the new branch as part of the release process.
+  # https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#branch-protection
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+    branch-53:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+    branch-54:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
   # publishes the content of the `asf-site` branch to
   # https://datafusion.apache.org/ballista/
   rulesets:


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

`main` in this repo can currently be merged into without any approving review, which is different from `apache/datafusion` and `apache/datafusion-comet`, where both require one approval.

The reason is that Ballista never had review requirements configured. The only protection on `main` today comes from the ruleset that ASF Infra added in c4336a83d ("Set up default protection ruleset for default and release branches"), which is a fleet-wide default that only sets `restrict_deletion` and `restrict_force_push`. Checking the live repository settings confirms this:

- `GET /repos/apache/datafusion-ballista/rulesets/16498601` lists exactly two rules, `deletion` and `non_fast_forward`
- `GET /repos/apache/datafusion-ballista/branches/main/protection` returns 404, so there is no classic branch protection at all

DataFusion and Comet get their approval requirement from a `protected_branches` block in `.asf.yaml`, which Ballista does not have.

# What changes are included in this PR?

Adds a `protected_branches` block to `.asf.yaml` setting `required_approving_review_count: 1` on `main`, `branch-53` and `branch-54`. This is the same mechanism `apache/datafusion-comet` uses.

A few notes for reviewers:

- The existing Infra-managed ruleset is left in place. Legacy `protected_branches` and the newer `rulesets` are separate mechanisms and apply cumulatively, so deletion and force-push stay restricted. `apache/airflow` runs both side by side today.
- `.asf.yaml` does not support wildcards in `protected_branches`, so release branches have to be listed by name. I only listed the two active ones rather than every historical `branch-*`. Happy to add more if people would prefer to match Comet's approach of listing all of them.
- No `required_status_checks` are added here, so this only requires an approval, not a green CI run. Comet does the same. That can be a follow-up if there is appetite for it.
- This does mean committers can no longer merge their own PRs unreviewed, including small dependency bumps, so it is worth a quick sanity check that people are happy with that tradeoff. `allow_auto_merge` is already enabled, which takes some of the sting out of it.

# Are there any user-facing changes?

No.
