### PR TITLE
fix(core): stop forwarding BallistaConfig defaults to the scheduler

### DIFF
--- a/ballista/core/src/config.rs
+++ b/ballista/core/src/config.rs
@@ -889,15 +889,15 @@ impl datafusion::config::ExtensionOptions for BallistaConfig {
     }
 
     fn entries(&self) -> Vec<datafusion::config::ConfigEntry> {
+        // Emit only keys the user explicitly set; absent keys produce value: None.
+        // The receiving side (scheduler/executor) skips None entries and applies
+        // its own current defaults, so a client built against an older release
+        // cannot silently override newer scheduler defaults with stale values.
         Self::valid_entries()
             .iter()
             .map(|(key, value)| datafusion::config::ConfigEntry {
                 key: key.clone(),
-                value: self
-                    .settings
-                    .get(key)
-                    .cloned()
-                    .or(value.default_value.clone()),
+                value: self.settings.get(key).cloned(),
                 description: &value.description,
             })
             .collect()
@@ -1055,5 +1055,41 @@ mod tests {
             .get(BALLISTA_SHUFFLE_SORT_BASED_BATCH_SIZE)
             .expect("entry is registered");
         assert_eq!(batch_size.doc_default(), Some("8192"));
+    }
+
+    // A default BallistaConfig must not emit any key with a concrete value.
+    // Stale client defaults must not override the scheduler's current defaults.
+    #[test]
+    fn default_ballista_config_emits_no_values_over_wire() {
+        let config = BallistaConfig::default();
+        let entries = datafusion::config::ExtensionOptions::entries(&config);
+        for entry in &entries {
+            assert!(
+                entry.value.is_none(),
+                "BallistaConfig::default() should not emit a value for `{}` \
+                 (got {:?}); only explicitly-set keys should be sent to the scheduler",
+                entry.key,
+                entry.value,
+            );
+        }
+    }
+
+    // An explicitly configured key must still be forwarded to the scheduler.
+    #[test]
+    fn explicitly_set_key_is_present_in_entries() {
+        use datafusion::config::ExtensionOptions;
+        let mut config = BallistaConfig::default();
+        config.set("planner.adaptive.enabled", "false").unwrap();
+
+        let entries = datafusion::config::ExtensionOptions::entries(&config);
+        let adaptive = entries
+            .iter()
+            .find(|e| e.key == BALLISTA_ADAPTIVE_PLANNER_ENABLED)
+            .expect("adaptive planner key must be present after explicit set");
+        assert_eq!(
+            adaptive.value.as_deref(),
+            Some("false"),
+            "explicitly-set value must be forwarded to the scheduler"
+        );
     }
 }

--- a/python/python/tests/test_context.py
+++ b/python/python/tests/test_context.py
@@ -117,6 +117,33 @@ def test_cluster_config_accepts_ballista_namespaced_keys():
     assert len(df.collect()) == 1
 
 
+def test_unset_ballista_config_does_not_override_scheduler_defaults():
+    """A client that never explicitly sets ballista.planner.adaptive.enabled
+    must not send that key to the scheduler.  Before the fix for #2371 the
+    Rust BallistaConfig::entries() always included all registered keys with
+    their client-side defaults, so a Python client built against an older
+    release would silently force the static planner on any cluster.
+    """
+    (address, port) = setup_test_cluster()
+    # No cluster_config — the user has not set anything.
+    ctx = BallistaSessionContext(address=f"df://{address}:{port}")
+
+    # Query the scheduler-side session value.  If the client forwarded its
+    # own default the scheduler would echo it back; if the fix is correct
+    # the scheduler uses its own default (true) regardless of the client version.
+    rows = ctx.sql(
+        "SELECT value FROM information_schema.df_settings "
+        "WHERE name = 'ballista.planner.adaptive.enabled'"
+    ).collect()
+
+    assert len(rows) == 1, "setting must appear in df_settings"
+    value = rows[0].column(0)[0].as_py()
+    assert value == "true", (
+        f"scheduler should default adaptive planner to true, got {value!r}; "
+        "a client sending its stale default would override this to false"
+    )
+
+
 def test_write_csv(ctx, tmp_path):
     df = ctx.read_csv("testdata/test.csv", has_header=True)
     out_dir = str(tmp_path / "out")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2371.

# Rationale for this change

`BallistaConfig::entries()` currently emits every registered configuration key with its default value, even when the user has not explicitly configured that key.

These defaults come from the client's version of the configuration registry. When a client and scheduler run different Ballista versions, the client can therefore send stale defaults that override the scheduler's current defaults.

For example, a Python client built against an older Ballista version can send:

```text
ballista.planner.adaptive.enabled = false
```

during session creation even though the user never configured this setting. A newer scheduler whose default is `true` receives this as an explicitly provided value and applies `false`, silently changing the planner behaviour.

This means that a configuration default changing between releases can be unintentionally overridden by an older client, without any explicit user configuration.

# What changes are included in this PR?

### `ballista/core/src/config.rs`

`BallistaConfig::entries()` now only emits values that are present in `self.settings`, meaning values that were explicitly configured by the user.

Previously, the method used the registered default value when a key was absent from `self.settings`. It now returns `None` for unset keys.

The receiving side already skips `None`-valued configuration entries, so unset settings are left to the scheduler/executor to resolve using their own current defaults.

This also preserves the existing behaviour for local configuration reads. Methods such as `get_bool_setting` and `get_usize_setting` continue to fall back to `CONFIG_ENTRIES` when a setting has not been explicitly configured.

Two Rust unit tests were added:

* `default_ballista_config_emits_no_values_over_wire` — verifies that a default `BallistaConfig` does not emit concrete values for unset configuration keys.
* `explicitly_set_key_is_present_in_entries` — verifies that explicitly configured values are still included and forwarded correctly.

### `python/python/tests/test_context.py`

A Python integration regression test was added:

* `test_unset_ballista_config_does_not_override_scheduler_defaults` — starts a test cluster with no client-side `cluster_config`, queries `information_schema.df_settings` for `ballista.planner.adaptive.enabled`, and verifies that the scheduler's own default (`true`) is preserved.

This covers the cross-version behaviour described in #2371.

# Are there any user-facing changes?

Yes. This is a behavioural fix to configuration propagation.

When a client has not explicitly configured a Ballista setting, the setting is no longer sent with the client's potentially stale default. The scheduler/executor can therefore apply its own current default.

In particular, this prevents an older Python client from unintentionally overriding a newer scheduler's `ballista.planner.adaptive.enabled` default.

Explicitly configured values continue to be forwarded unchanged, so user-specified configuration retains the same behaviour.
