### PR TITLE
feat: use object store for history server persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ version = "54.0.0"
 dependencies = [
  "ballista-api-types",
  "log",
+ "object_store",
  "serde",
  "serde_json",
  "tempfile",

--- a/ballista/history/Cargo.toml
+++ b/ballista/history/Cargo.toml
@@ -29,9 +29,10 @@ rust-version = { workspace = true }
 [dependencies]
 ballista-api-types = { workspace = true }
 log = { workspace = true }
+object_store = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
-tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "sync"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/ballista/history/src/lib.rs
+++ b/ballista/history/src/lib.rs
@@ -46,12 +46,21 @@
 //!
 //! # Durability
 //!
-//! [`writer::EventLogWriter`] does all file I/O on a background task, so the
-//! scheduler's event loop never waits on a disk write. Timeline events are
-//! dropped rather than allowed to block if the queue backs up, on the grounds
-//! that losing a progress record is better than stalling scheduling. The
-//! terminal `JobEnd` is the exception: it waits for queue capacity, because a
-//! job missing its `JobEnd` is invisible to the history server.
+//! [`writer::EventLogWriter`] does all persistence on a background task, so the
+//! scheduler's event loop never waits on I/O. Timeline events are dropped rather
+//! than allowed to block if the queue backs up, on the grounds that losing a
+//! progress record is better than stalling scheduling. The terminal `JobEnd` is
+//! the exception: it waits for queue capacity, because a job missing its
+//! `JobEnd` is invisible to the history server.
+//!
+//! Persistence goes through the `object_store` abstraction. The default backend
+//! is a local filesystem store rooted at the configured directory; a caller can
+//! supply any other store via [`writer::EventLogWriter::with_object_store`] (the
+//! scheduler exposes this as `SchedulerConfig::with_event_log_store`). Because
+//! an object store has no append, each running job's log is accumulated in
+//! memory and the whole `<job_id>.eventlog` object is written on
+//! [`writer::EventLogWriter::flush_job`] and on the terminal
+//! [`writer::EventLogWriter::finish_job`].
 
 pub mod event;
 pub mod reader;

--- a/ballista/history/src/writer.rs
+++ b/ballista/history/src/writer.rs
@@ -15,14 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Async, buffered event-log writer. Each job's events append to
-//! `<log_dir>/<job_id>.eventlog` as JSONL. Appends are non-blocking; a background
-//! task performs the file I/O so the scheduler hot path never waits on disk.
+//! Async, buffered event-log writer. Each job's events accumulate in memory and
+//! are persisted as a single `<job_id>.eventlog` JSONL object through the
+//! [`ObjectStore`] abstraction. Appends are non-blocking; a background task owns
+//! the store so the scheduler hot path never waits on I/O.
+//!
+//! Persistence goes through `object_store` rather than the local filesystem
+//! directly, so an event log can live on any supported backend. The default is a
+//! [`LocalFileSystem`] rooted at the configured directory; a caller can supply
+//! its own store with [`EventLogWriter::with_object_store`].
+//!
+//! An object store has no append: `put` replaces a whole object. The writer
+//! therefore keeps each running job's full serialized log in memory and writes
+//! it out once, on [`EventLogWriter::flush_job`] and on the terminal
+//! [`EventLogWriter::finish_job`]. Individual timeline events never touch the
+//! store on their own. A scheduler that dies mid-job loses that job's buffered
+//! timeline, but the history server needs the terminal `JobEnd` record to serve
+//! a job at all, so nothing servable is lost.
 
 use crate::event::HistoryEvent;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt};
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use tokio::io::AsyncWriteExt;
+use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
 enum WriterMsg {
@@ -50,13 +67,40 @@ pub struct EventLogWriter {
 }
 
 impl EventLogWriter {
-    /// Spawn the writer task, appending logs under `log_dir`.
+    /// Spawn the writer task, persisting logs to a [`LocalFileSystem`] store
+    /// rooted at `log_dir`. The directory is created if it does not exist.
     ///
     /// `buffer` bounds the in-flight event queue; beyond it, timeline events are
     /// dropped rather than allowed to stall the caller.
     pub fn new(log_dir: PathBuf, buffer: usize) -> EventLogWriter {
+        let _ = std::fs::create_dir_all(&log_dir);
+        let store: Arc<dyn ObjectStore> = match LocalFileSystem::new_with_prefix(&log_dir)
+        {
+            Ok(store) => Arc::new(store),
+            Err(e) => {
+                log::warn!(
+                    "event-log writer: cannot root a store at {}: {e}",
+                    log_dir.display()
+                );
+                Arc::new(LocalFileSystem::new())
+            }
+        };
+        Self::with_object_store(store, Path::default(), buffer)
+    }
+
+    /// Spawn the writer task, persisting each `<job_id>.eventlog` object under
+    /// `prefix` in `store`.
+    ///
+    /// This is the extension point for backends other than the local
+    /// filesystem: hand in any `object_store` implementation and the writer will
+    /// `put` completed job logs through it.
+    pub fn with_object_store(
+        store: Arc<dyn ObjectStore>,
+        prefix: Path,
+        buffer: usize,
+    ) -> EventLogWriter {
         let (tx, rx) = mpsc::channel(buffer.max(1));
-        tokio::spawn(run(log_dir, rx));
+        tokio::spawn(run(store, prefix, rx));
         EventLogWriter { tx }
     }
 
@@ -74,7 +118,8 @@ impl EventLogWriter {
         }
     }
 
-    /// Await all currently-enqueued writes for `job_id` (best effort).
+    /// Persist everything enqueued for `job_id` so far as its `<job_id>.eventlog`
+    /// object (best effort). Awaits the write.
     pub async fn flush_job(&self, job_id: &str) {
         let (done, wait) = oneshot::channel();
         if self
@@ -107,10 +152,10 @@ impl EventLogWriter {
         }
     }
 
-    /// Flush and close the per-job file handle for `job_id`. Must be called after
-    /// the terminal event has been enqueued (e.g. via `append_final`) so it is
-    /// ordered after it on the single-consumer FIFO channel. Best effort: if the
-    /// channel is closed this logs and returns.
+    /// Persist `job_id`'s log a final time and drop its in-memory buffer. Must be
+    /// called after the terminal event has been enqueued (e.g. via
+    /// `append_final`) so it is ordered after it on the single-consumer FIFO
+    /// channel. Best effort: if the channel is closed this logs and returns.
     pub async fn finish_job(&self, job_id: &str) {
         let (done, wait) = oneshot::channel();
         if self
@@ -131,43 +176,37 @@ impl EventLogWriter {
     }
 }
 
-async fn run(log_dir: PathBuf, mut rx: mpsc::Receiver<WriterMsg>) {
-    if let Err(e) = tokio::fs::create_dir_all(&log_dir).await {
-        log::warn!("event-log writer: cannot create {}: {e}", log_dir.display());
-        return;
-    }
-    // One open append handle per job for the life of the process.
-    let mut handles: HashMap<String, tokio::fs::File> = HashMap::new();
+async fn run(
+    store: Arc<dyn ObjectStore>,
+    prefix: Path,
+    mut rx: mpsc::Receiver<WriterMsg>,
+) {
+    // The full serialized JSONL log for each still-running job, held in memory
+    // until it is persisted whole on flush/finish. An object store has no
+    // append, so there is no per-job handle to keep open.
+    let mut logs: HashMap<String, Vec<u8>> = HashMap::new();
 
     while let Some(msg) = rx.recv().await {
         match msg {
             WriterMsg::Event { job_id, event } => {
-                let file = match open_for(&log_dir, &mut handles, &job_id).await {
-                    Some(f) => f,
-                    None => continue,
-                };
                 match event.to_record().and_then(|r| serde_json::to_string(&r)) {
-                    Ok(mut line) => {
-                        line.push('\n');
-                        if let Err(e) = file.write_all(line.as_bytes()).await {
-                            log::warn!(
-                                "event-log writer: write failed for {job_id}: {e}"
-                            );
-                        }
+                    Ok(line) => {
+                        let buf = logs.entry(job_id).or_default();
+                        buf.extend_from_slice(line.as_bytes());
+                        buf.push(b'\n');
                     }
                     Err(e) => log::warn!("event-log writer: serialize failed: {e}"),
                 }
             }
             WriterMsg::Flush { job_id, done } => {
-                if let Some(file) = handles.get_mut(&job_id) {
-                    let _ = file.flush().await;
+                if let Some(buf) = logs.get(&job_id) {
+                    persist(&*store, &prefix, &job_id, buf).await;
                 }
                 let _ = done.send(());
             }
             WriterMsg::Finish { job_id, done } => {
-                if let Some(mut file) = handles.remove(&job_id) {
-                    let _ = file.flush().await;
-                    // Dropping `file` here closes the fd.
+                if let Some(buf) = logs.remove(&job_id) {
+                    persist(&*store, &prefix, &job_id, &buf).await;
                 }
                 let _ = done.send(());
             }
@@ -175,29 +214,13 @@ async fn run(log_dir: PathBuf, mut rx: mpsc::Receiver<WriterMsg>) {
     }
 }
 
-async fn open_for<'a>(
-    log_dir: &Path,
-    handles: &'a mut HashMap<String, tokio::fs::File>,
-    job_id: &str,
-) -> Option<&'a mut tokio::fs::File> {
-    if !handles.contains_key(job_id) {
-        let path = log_dir.join(format!("{job_id}.eventlog"));
-        match tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .await
-        {
-            Ok(f) => {
-                handles.insert(job_id.to_string(), f);
-            }
-            Err(e) => {
-                log::warn!("event-log writer: cannot open {}: {e}", path.display());
-                return None;
-            }
-        }
+/// Write a job's accumulated log out as a single object. Best effort: a failure
+/// is logged and the buffer is left in place for a later flush/finish to retry.
+async fn persist(store: &dyn ObjectStore, prefix: &Path, job_id: &str, buf: &[u8]) {
+    let location = prefix.clone().join(format!("{job_id}.eventlog"));
+    if let Err(e) = store.put(&location, buf.to_vec().into()).await {
+        log::warn!("event-log writer: put failed for {job_id}: {e}");
     }
-    handles.get_mut(job_id)
 }
 
 #[cfg(test)]
@@ -262,7 +285,7 @@ mod tests {
         writer.finish_job("job-1").await;
 
         let path = dir.path().join("job-1.eventlog");
-        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = contents.lines().collect();
         assert!(
             lines.iter().any(|l| l.contains("\"ev\":\"JobEnd\"")),
@@ -300,10 +323,65 @@ mod tests {
         writer.flush_job("job-1").await;
 
         let path = dir.path().join("job-1.eventlog");
-        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = contents.lines().collect();
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("\"ev\":\"JobStart\""));
         assert!(lines[1].contains("\"ev\":\"StageStart\""));
+    }
+
+    #[tokio::test]
+    async fn with_object_store_persists_to_a_custom_store() {
+        let store = Arc::new(object_store::memory::InMemory::new());
+        let writer =
+            EventLogWriter::with_object_store(store.clone(), Path::from("logs"), 16);
+
+        writer.append(
+            "job-1",
+            HistoryEvent::JobStart(JobStart {
+                job_id: "job-1".into(),
+                job_name: "q1".into(),
+                queued_at: 1,
+                submitted_at: 2,
+                logical_plan: None,
+                physical_plan: None,
+            }),
+        );
+        let job_end = HistoryEvent::JobEnd(Box::new(JobEnd {
+            status: JobEndStatus::Succeeded,
+            queued_at: 1,
+            started_at: 2,
+            completed_at: 20,
+            index: JobIndex {
+                job_id: "job-1".into(),
+                job_name: "q1".into(),
+                status: "Completed".into(),
+                job_status: "COMPLETED".into(),
+                start_time: 10,
+                end_time: 20,
+                num_stages: 1,
+                completed_stages: 1,
+                percent_complete: 100,
+            },
+            job: RawValue::from_string(r#"{"job_id":"job-1"}"#.to_string()).unwrap(),
+            stages: RawValue::from_string(r#"{"stages":[]}"#.to_string()).unwrap(),
+            config: BTreeMap::new(),
+            dot: "digraph {}".into(),
+        }));
+        writer.append_final("job-1", job_end).await;
+        writer.finish_job("job-1").await;
+
+        let bytes = store
+            .get(&Path::from("logs/job-1.eventlog"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let contents = String::from_utf8(bytes.to_vec()).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"ev\":\"JobStart\""));
+        assert!(lines[1].contains("\"ev\":\"JobEnd\""));
     }
 }

--- a/ballista/scheduler/src/config.rs
+++ b/ballista/scheduler/src/config.rs
@@ -33,6 +33,7 @@ use ballista_core::{ConfigProducer, JobId, config::TaskSchedulingPolicy};
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use log::{info, warn};
+use object_store::ObjectStore;
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -408,6 +409,11 @@ pub struct SchedulerConfig {
     pub cors_allowed_methods: String,
     /// Directory to write per-job event logs to. `None` disables event logging.
     pub event_log_dir: Option<String>,
+    /// Object store to persist per-job event logs to. When `None` (the
+    /// default), [`Self::event_log_dir`] is written to the local filesystem;
+    /// when set, `event_log_dir` is used as the key prefix within this store.
+    /// `event_log_dir` must still be set for event logging to be enabled.
+    pub event_log_store: Option<Arc<dyn ObjectStore>>,
     #[cfg(feature = "rest-api")]
     /// The HTTP path that will redirect to the WebTUI app at `https://nightlies.apache.org`
     pub web_tui_route: String,
@@ -459,6 +465,7 @@ impl Default for SchedulerConfig {
             #[cfg(feature = "rest-api")]
             cors_allowed_methods: String::default(),
             event_log_dir: None,
+            event_log_store: None,
             #[cfg(feature = "rest-api")]
             web_tui_route: String::from("/"),
             on_work_available: None,
@@ -687,6 +694,17 @@ impl SchedulerConfig {
         self
     }
 
+    /// Sets the object store to persist per-job event logs to. With a store set,
+    /// [`Self::with_event_log_dir`] supplies the key prefix within it instead of
+    /// a local filesystem path.
+    pub fn with_event_log_store(
+        mut self,
+        event_log_store: Option<Arc<dyn ObjectStore>>,
+    ) -> Self {
+        self.event_log_store = event_log_store;
+        self
+    }
+
     /// Sets whether TLS should be used when connecting to executors (for flight proxy).
     pub fn with_use_tls(mut self, use_tls: bool) -> Self {
         self.use_tls = use_tls;
@@ -833,6 +851,7 @@ impl TryFrom<Config> for SchedulerConfig {
             #[cfg(feature = "rest-api")]
             cors_allowed_methods: opt.cors_allowed_methods,
             event_log_dir: opt.event_log_dir,
+            event_log_store: None,
             #[cfg(feature = "rest-api")]
             web_tui_route: opt.web_tui_route,
             on_work_available: None,

--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -161,10 +161,20 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         ));
         #[cfg(feature = "rest-api")]
         let event_log = config.event_log_dir.as_ref().map(|dir| {
-            ballista_history::writer::EventLogWriter::new(
-                std::path::PathBuf::from(dir),
-                config.event_loop_buffer_size as usize,
-            )
+            let buffer = config.event_loop_buffer_size as usize;
+            match &config.event_log_store {
+                Some(store) => {
+                    ballista_history::writer::EventLogWriter::with_object_store(
+                        store.clone(),
+                        object_store::path::Path::from(dir.as_str()),
+                        buffer,
+                    )
+                }
+                None => ballista_history::writer::EventLogWriter::new(
+                    std::path::PathBuf::from(dir),
+                    buffer,
+                ),
+            }
         });
         let query_stage_scheduler = Arc::new(QueryStageScheduler::new(
             state.clone(),
@@ -215,10 +225,20 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> SchedulerServer<T
         ));
         #[cfg(feature = "rest-api")]
         let event_log = config.event_log_dir.as_ref().map(|dir| {
-            ballista_history::writer::EventLogWriter::new(
-                std::path::PathBuf::from(dir),
-                config.event_loop_buffer_size as usize,
-            )
+            let buffer = config.event_loop_buffer_size as usize;
+            match &config.event_log_store {
+                Some(store) => {
+                    ballista_history::writer::EventLogWriter::with_object_store(
+                        store.clone(),
+                        object_store::path::Path::from(dir.as_str()),
+                        buffer,
+                    )
+                }
+                None => ballista_history::writer::EventLogWriter::new(
+                    std::path::PathBuf::from(dir),
+                    buffer,
+                ),
+            }
         });
         let query_stage_scheduler = Arc::new(QueryStageScheduler::new(
             state.clone(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2267.

# Rationale for this change

# What changes are included in this PR?

- [x] configurable object store endpoint
- [  ] ( consider) temporary write events to local FS before move them to OS

update to history server will be separate RP 

# Are there any user-facing changes?
