### PR TITLE
feat(scheduler): document REST API with OpenAPI and serve /api/openapi.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ name = "ballista-api-types"
 version = "54.0.0"
 dependencies = [
  "serde",
+ "utoipa",
 ]
 
 [[package]]
@@ -1259,6 +1260,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "url-escape",
+ "utoipa",
  "uuid",
 ]
 
@@ -7780,6 +7782,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
 name = "ballista-api-types"
 version = "54.0.0"
 dependencies = [
+ "ballista-api-types",
  "serde",
  "serde_json",
  "utoipa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ name = "ballista-api-types"
 version = "54.0.0"
 dependencies = [
  "serde",
+ "serde_json",
  "utoipa",
 ]
 
@@ -1142,6 +1143,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "url",
+ "utoipa",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ tokio = { version = "1" }
 tokio-stream = { version = "0.1" }
 url = { version = "2.5" }
 url-escape = { version = "0.1.2" }
+utoipa = { version = "5.5", default-features = false, features = ["macros"] }
 uuid = { version = "1.23", features = ["v4", "v7"] }
 
 # cargo build --profile release-lto

--- a/ballista/api-types/Cargo.toml
+++ b/ballista/api-types/Cargo.toml
@@ -35,4 +35,5 @@ serde = { workspace = true, features = ["derive"] }
 utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
+ballista-api-types = { path = ".", features = ["utoipa"] }
 serde_json = { workspace = true }

--- a/ballista/api-types/Cargo.toml
+++ b/ballista/api-types/Cargo.toml
@@ -33,3 +33,6 @@ utoipa = ["dep:utoipa"]
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 utoipa = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/ballista/api-types/Cargo.toml
+++ b/ballista/api-types/Cargo.toml
@@ -26,5 +26,10 @@ authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = []
+utoipa = ["dep:utoipa"]
+
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
+utoipa = { workspace = true, optional = true }

--- a/ballista/api-types/src/dto.rs
+++ b/ballista/api-types/src/dto.rs
@@ -187,7 +187,26 @@ pub type JobConfig = BTreeMap<String, String>;
 #[cfg(all(test, feature = "utoipa"))]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use utoipa::ToSchema;
+
+    fn get_schema_property_names<T: ToSchema>() -> BTreeSet<String> {
+        let schema_ref = T::schema();
+        match schema_ref {
+            utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(obj)) => {
+                obj.properties.keys().cloned().collect()
+            }
+            _ => panic!("Expected Object schema"),
+        }
+    }
+
+    fn get_json_property_names<T: Serialize>(value: &T) -> BTreeSet<String> {
+        let json = serde_json::to_value(value).expect("serialize to value");
+        match json {
+            serde_json::Value::Object(map) => map.keys().cloned().collect(),
+            _ => panic!("Expected JSON Object"),
+        }
+    }
 
     #[test]
     fn test_dto_schemas() {
@@ -198,5 +217,41 @@ mod tests {
         assert_eq!(QueryStageSummary::name(), "QueryStageSummary");
         assert_eq!(QueryStagesResponse::name(), "QueryStagesResponse");
         assert_eq!(PlanFormat::name(), "PlanFormat");
+
+        let task_summary = TaskSummary {
+            id: 1,
+            status: TaskStatus::Running,
+            partition_id: vec![0],
+            scheduled_time: 100,
+            launch_time: 100,
+            start_exec_time: 100,
+            end_exec_time: 200,
+            exec_duration: 100,
+            finish_time: 200,
+            input_rows: 10,
+            output_rows: 10,
+        };
+        assert_eq!(
+            get_schema_property_names::<TaskSummary>(),
+            get_json_property_names(&task_summary)
+        );
+
+        let percentiles = Percentiles {
+            min: 1,
+            p25: 2,
+            median: 3,
+            p75: 4,
+            max: 5,
+        };
+        assert_eq!(
+            get_schema_property_names::<Percentiles>(),
+            get_json_property_names(&percentiles)
+        );
+
+        let query_stages = QueryStagesResponse { stages: vec![] };
+        assert_eq!(
+            get_schema_property_names::<QueryStagesResponse>(),
+            get_json_property_names(&query_stages)
+        );
     }
 }

--- a/ballista/api-types/src/dto.rs
+++ b/ballista/api-types/src/dto.rs
@@ -23,6 +23,7 @@ use std::collections::BTreeMap;
 
 /// Summary of one job, served by `GET /api/jobs` and `GET /api/job/{job_id}`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct JobResponse {
     /// A `String` rather than `ballista_core::JobId` so this crate stays a
     /// serde-only leaf. `JobId` is `#[serde(transparent)]` over `String`, so
@@ -57,6 +58,7 @@ pub struct JobResponse {
 
 /// Terminal or in-flight state of a single task.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum TaskStatus {
     /// Task is currently executing.
     Running,
@@ -73,6 +75,7 @@ pub enum TaskStatus {
 
 /// Per-task detail within a stage.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct TaskSummary {
     /// task id
     pub id: usize,
@@ -105,6 +108,7 @@ pub struct TaskSummary {
 
 /// Five-number summary over a stage's tasks, used to spot skew.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct Percentiles {
     /// Smallest observed value.
     pub min: u64,
@@ -120,6 +124,7 @@ pub struct Percentiles {
 
 /// Summary of one query stage, served by `GET /api/job/{job_id}/stages`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct QueryStageSummary {
     /// Stage id, as a string.
     pub stage_id: String,
@@ -150,6 +155,7 @@ pub struct QueryStageSummary {
 
 /// Response body for `GET /api/job/{job_id}/stages`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct QueryStagesResponse {
     /// One summary per stage, in stage order.
     pub stages: Vec<QueryStageSummary>,
@@ -159,6 +165,7 @@ pub struct QueryStagesResponse {
 /// parameter, and part of the REST contract, so it lives alongside the
 /// response types rather than with the HTTP handlers.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum PlanFormat {
     /// `?plan_format=default` => plain indent, no metrics
@@ -176,3 +183,20 @@ pub enum PlanFormat {
 /// A `BTreeMap` so key order is deterministic: the same job must serialize
 /// identically whether it is served live or replayed from a stored log.
 pub type JobConfig = BTreeMap<String, String>;
+
+#[cfg(all(test, feature = "utoipa"))]
+mod tests {
+    use super::*;
+    use utoipa::ToSchema;
+
+    #[test]
+    fn test_dto_schemas() {
+        assert_eq!(JobResponse::name(), "JobResponse");
+        assert_eq!(TaskStatus::name(), "TaskStatus");
+        assert_eq!(TaskSummary::name(), "TaskSummary");
+        assert_eq!(Percentiles::name(), "Percentiles");
+        assert_eq!(QueryStageSummary::name(), "QueryStageSummary");
+        assert_eq!(QueryStagesResponse::name(), "QueryStagesResponse");
+        assert_eq!(PlanFormat::name(), "PlanFormat");
+    }
+}

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -42,6 +42,7 @@ docsrs = []
 # Used for testing ONLY: causes all values to hash to the same value (test for collisions)
 force_hash_collisions = ["datafusion/force_hash_collisions"]
 spark-compat = ["dep:datafusion-spark"]
+utoipa = ["dep:utoipa"]
 
 [dependencies]
 arrow-flight = { workspace = true }
@@ -65,6 +66,7 @@ tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 url = { workspace = true }
+utoipa = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/ballista/core/src/serde/scheduler/mod.rs
+++ b/ballista/core/src/serde/scheduler/mod.rs
@@ -204,6 +204,7 @@ pub struct ExecutorMetadata {
 
 /// Specification of an executor, indicating its runtime-assigned vcore count.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ExecutorSpecification {
     /// Virtual cores assigned to this executor at runtime — analogous to YARN
     /// vcores (`yarn.nodemanager.resource.cpu-vcores`) or Spark's
@@ -241,6 +242,7 @@ impl ExecutorSpecification {
 
 /// Operating system level specification of an executor
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ExecutorOperatingSystemSpecification {
     /// System name
     pub system_name: String,

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -54,7 +54,13 @@ disable-stage-plan-cache = []
 graphviz-support = ["dep:graphviz-rust"]
 keda-scaler = ["dep:tonic-prost-build", "dep:tonic-prost"]
 prometheus-metrics = ["prometheus", "once_cell"]
-rest-api = ["dep:ballista-api-types", "dep:ballista-history", "dep:serde_json"]
+rest-api = [
+    "ballista-api-types?/utoipa",
+    "dep:ballista-api-types",
+    "dep:ballista-history",
+    "dep:serde_json",
+    "dep:utoipa",
+]
 spark-compat = ["ballista-core/spark-compat"]
 substrait = ["dep:datafusion-substrait"]
 
@@ -93,6 +99,7 @@ tracing = { workspace = true, optional = true }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 url-escape = { workspace = true }
+utoipa = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [[test]]

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -56,6 +56,7 @@ keda-scaler = ["dep:tonic-prost-build", "dep:tonic-prost"]
 prometheus-metrics = ["prometheus", "once_cell"]
 rest-api = [
     "ballista-api-types?/utoipa",
+    "ballista-core/utoipa",
     "dep:ballista-api-types",
     "dep:ballista-history",
     "dep:serde_json",

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -21,7 +21,7 @@ use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},
 };
-use ballista_api_types::dto::{JobResponse, PlanFormat};
+use ballista_api_types::dto::{JobResponse, PlanFormat, QueryStagesResponse};
 use ballista_core::BALLISTA_VERSION;
 use ballista_core::serde::protobuf::job_status::Status;
 use ballista_core::serde::protobuf::{ExecutorMetric, executor_metric::Metric};
@@ -42,40 +42,62 @@ use http::{HeaderMap, StatusCode, header::CONTENT_TYPE};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Debug, serde::Serialize)]
-struct SchedulerStateResponse {
-    started: u128,
-    version: &'static str,
-    datafusion_version: &'static str,
-    substrait_support: bool,
-    keda_support: bool,
-    prometheus_support: bool,
-    graphviz_support: bool,
-    spark_support: bool,
-    scheduling_policy: String,
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct SchedulerStateResponse {
+    pub started: u128,
+    pub version: &'static str,
+    pub datafusion_version: &'static str,
+    pub substrait_support: bool,
+    pub keda_support: bool,
+    pub prometheus_support: bool,
+    pub graphviz_support: bool,
+    pub spark_support: bool,
+    pub scheduling_policy: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    advertise_flight_endpoint: Option<String>,
-    enable_embedded_flight_proxy: bool,
+    pub advertise_flight_endpoint: Option<String>,
+    pub enable_embedded_flight_proxy: bool,
 }
 
-#[derive(Debug, serde::Serialize)]
-struct SchedulerVersionResponse {
-    version: &'static str,
-    datafusion_version: &'static str,
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct SchedulerVersionResponse {
+    pub version: &'static str,
+    pub datafusion_version: &'static str,
 }
 
-#[derive(Debug, serde::Serialize)]
+/// Specification of an executor, indicating its runtime-assigned vcore count.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+#[schema(as = ExecutorSpecification)]
+pub struct ExecutorSpecificationSchema {
+    /// Virtual cores assigned to this executor at runtime
+    pub vcores: u32,
+}
+
+/// Operating system level specification of an executor.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+#[schema(as = ExecutorOperatingSystemSpecification)]
+pub struct ExecutorOperatingSystemSpecificationSchema {
+    /// System name
+    pub system_name: String,
+    /// Kernel version
+    pub kernel_ver: String,
+    /// OS version
+    pub os_ver: String,
+}
+
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 pub struct ExecutorResponse {
     pub id: String,
     pub host: String,
     pub port: u16,
     pub last_seen: Option<u128>,
+    #[schema(value_type = ExecutorSpecificationSchema)]
     pub specification: ExecutorSpecification,
     pub metrics: Vec<ExecutorMetricResponse>,
+    #[schema(value_type = ExecutorOperatingSystemSpecificationSchema)]
     pub os_info: ExecutorOperatingSystemSpecification,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum ExecutorMetricResponse {
@@ -102,14 +124,15 @@ impl ExecutorMetricResponse {
     }
 }
 
-#[derive(Debug, serde::Serialize)]
-struct CancelJobResponse {
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct CancelJobResponse {
     pub cancelled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
 
-#[derive(Debug, serde::Deserialize, Default)]
+#[derive(Debug, serde::Deserialize, Default, utoipa::IntoParams, utoipa::ToSchema)]
+#[into_params(parameter_in = Query)]
 pub struct JobQueryParams {
     /// Controls plan format
     pub plan_format: Option<PlanFormat>,
@@ -167,6 +190,14 @@ pub async fn get_webtui<
     Ok(Redirect::to(&target))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/state",
+    tag = "state",
+    responses(
+        (status = 200, description = "Scheduler state and feature configuration", body = SchedulerStateResponse)
+    )
+)]
 pub async fn get_scheduler_state<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -196,6 +227,14 @@ pub async fn get_scheduler_state<
     Json(response)
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/version",
+    tag = "version",
+    responses(
+        (status = 200, description = "Scheduler and DataFusion version information", body = SchedulerVersionResponse)
+    )
+)]
 pub async fn get_scheduler_version() -> impl IntoResponse {
     let response = SchedulerVersionResponse {
         version: BALLISTA_VERSION,
@@ -204,6 +243,14 @@ pub async fn get_scheduler_version() -> impl IntoResponse {
     Json(response)
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/executors",
+    tag = "executors",
+    responses(
+        (status = 200, description = "List of registered executors", body = Vec<ExecutorResponse>)
+    )
+)]
 pub async fn get_executors<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -234,6 +281,18 @@ pub async fn get_executors<
     Json(executors)
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/executor/{executor_id}",
+    tag = "executors",
+    params(
+        ("executor_id" = String, Path, description = "Unique executor identifier")
+    ),
+    responses(
+        (status = 200, description = "Executor details", body = ExecutorResponse),
+        (status = 404, description = "Executor not found", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_executor_info<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -267,6 +326,15 @@ pub async fn get_executor_info<
         .ok_or(SchedulerErrorResponse::new(StatusCode::NOT_FOUND))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/jobs",
+    tag = "jobs",
+    responses(
+        (status = 200, description = "List of all jobs", body = Vec<JobResponse>),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_jobs<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -288,6 +356,20 @@ pub async fn get_jobs<
     Ok(Json(jobs))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/job/{job_id}",
+    tag = "jobs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier"),
+        JobQueryParams
+    ),
+    responses(
+        (status = 200, description = "Job details", body = JobResponse),
+        (status = 404, description = "Job not found", body = SchedulerErrorResponse),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_job<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -313,6 +395,20 @@ pub async fn get_job<
     )))
 }
 
+#[utoipa::path(
+    patch,
+    path = "/api/job/{job_id}",
+    tag = "jobs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier")
+    ),
+    responses(
+        (status = 200, description = "Job cancellation accepted", body = CancelJobResponse),
+        (status = 404, description = "Job not found", body = SchedulerErrorResponse),
+        (status = 409, description = "Job is in terminal state", body = CancelJobResponse),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn cancel_job<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -380,6 +476,20 @@ pub async fn cancel_job<
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/job/{job_id}/stages",
+    tag = "jobs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier"),
+        JobQueryParams
+    ),
+    responses(
+        (status = 200, description = "Query stages summary", body = QueryStagesResponse),
+        (status = 404, description = "Job not found", body = SchedulerErrorResponse),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_query_stages<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -411,6 +521,19 @@ pub async fn get_query_stages<
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/job/{job_id}/dot",
+    tag = "graphs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier")
+    ),
+    responses(
+        (status = 200, description = "Job execution graph in Graphviz DOT format", content_type = "text/plain", body = String),
+        (status = 404, description = "Job not found", body = SchedulerErrorResponse),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_job_dot_graph<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -438,6 +561,20 @@ pub async fn get_job_dot_graph<
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/job/{job_id}/stage/{stage_id}/dot",
+    tag = "graphs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier"),
+        ("stage_id" = usize, Path, description = "Stage identifier")
+    ),
+    responses(
+        (status = 200, description = "Query stage graph in Graphviz DOT format", content_type = "text/plain", body = String),
+        (status = 404, description = "Job or stage not found", body = SchedulerErrorResponse),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_query_stage_dot_graph<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -459,6 +596,20 @@ pub async fn get_query_stage_dot_graph<
     }
 }
 #[cfg(feature = "graphviz-support")]
+#[utoipa::path(
+    get,
+    path = "/api/job/{job_id}/dot_svg",
+    tag = "graphs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier")
+    ),
+    responses(
+        (status = 200, description = "Job execution graph rendered as SVG", content_type = "image/svg+xml", body = String),
+        (status = 400, description = "DOT parsing or graphviz execution error", body = SchedulerErrorResponse),
+        (status = 404, description = "Job not found", body = SchedulerErrorResponse),
+        (status = 500, description = "Internal server error", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_job_svg_graph<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -492,6 +643,16 @@ pub async fn get_job_svg_graph<
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/metrics",
+    tag = "metrics",
+    responses(
+        (status = 200, description = "Prometheus text metrics", content_type = "text/plain; version=0.0.4; charset=utf-8", body = String),
+        (status = 204, description = "No metrics collected"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub async fn get_scheduler_metrics<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
@@ -514,6 +675,18 @@ pub async fn get_scheduler_metrics<
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/job/{job_id}/config",
+    tag = "jobs",
+    params(
+        ("job_id" = String, Path, description = "Unique job identifier")
+    ),
+    responses(
+        (status = 200, description = "Job session configuration properties", body = std::collections::BTreeMap<String, String>),
+        (status = 404, description = "Job not found", body = SchedulerErrorResponse)
+    )
+)]
 pub async fn get_job_config<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,

--- a/ballista/scheduler/src/api/handlers.rs
+++ b/ballista/scheduler/src/api/handlers.rs
@@ -64,36 +64,14 @@ pub struct SchedulerVersionResponse {
     pub datafusion_version: &'static str,
 }
 
-/// Specification of an executor, indicating its runtime-assigned vcore count.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
-#[schema(as = ExecutorSpecification)]
-pub struct ExecutorSpecificationSchema {
-    /// Virtual cores assigned to this executor at runtime
-    pub vcores: u32,
-}
-
-/// Operating system level specification of an executor.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
-#[schema(as = ExecutorOperatingSystemSpecification)]
-pub struct ExecutorOperatingSystemSpecificationSchema {
-    /// System name
-    pub system_name: String,
-    /// Kernel version
-    pub kernel_ver: String,
-    /// OS version
-    pub os_ver: String,
-}
-
 #[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 pub struct ExecutorResponse {
     pub id: String,
     pub host: String,
     pub port: u16,
     pub last_seen: Option<u128>,
-    #[schema(value_type = ExecutorSpecificationSchema)]
     pub specification: ExecutorSpecification,
     pub metrics: Vec<ExecutorMetricResponse>,
-    #[schema(value_type = ExecutorOperatingSystemSpecificationSchema)]
     pub os_info: ExecutorOperatingSystemSpecification,
 }
 

--- a/ballista/scheduler/src/api/health.rs
+++ b/ballista/scheduler/src/api/health.rs
@@ -55,11 +55,34 @@ pub(crate) fn health_routes<
         .with_state(scheduler_server)
 }
 
-async fn healthz() -> Response {
+#[cfg_attr(
+    feature = "rest-api",
+    utoipa::path(
+        get,
+        path = "/healthz",
+        tag = "health",
+        responses(
+            (status = 200, description = "Scheduler liveness probe", content_type = "text/plain", body = String)
+        )
+    )
+)]
+pub(crate) async fn healthz() -> Response {
     (StatusCode::OK, "ok").into_response()
 }
 
-async fn readyz<
+#[cfg_attr(
+    feature = "rest-api",
+    utoipa::path(
+        get,
+        path = "/readyz",
+        tag = "health",
+        responses(
+            (status = 200, description = "Scheduler is ready to accept queries", content_type = "text/plain", body = String),
+            (status = 503, description = "Scheduler is not ready (insufficient executors)", content_type = "text/plain", body = String)
+        )
+    )
+)]
+pub(crate) async fn readyz<
     T: AsLogicalPlan + Clone + Send + Sync + 'static,
     U: AsExecutionPlan + Send + Sync + 'static,
 >(

--- a/ballista/scheduler/src/api/mod.rs
+++ b/ballista/scheduler/src/api/mod.rs
@@ -18,8 +18,12 @@ pub(crate) mod dto_build;
 mod handlers;
 mod health;
 #[cfg(feature = "rest-api")]
+pub mod openapi;
+#[cfg(feature = "rest-api")]
 mod routes;
 pub(super) use health::health_routes;
+#[cfg(feature = "rest-api")]
+pub use openapi::{ApiDoc, openapi_spec};
 #[cfg(feature = "rest-api")]
 pub use routes::get_routes;
 
@@ -37,6 +41,7 @@ pub(super) fn route_disabled(reason: String) -> Router {
 }
 
 #[derive(Debug, serde::Serialize)]
+#[cfg_attr(feature = "rest-api", derive(utoipa::ToSchema))]
 pub(crate) struct SchedulerErrorResponse {
     #[serde(skip)]
     status_code: StatusCode,

--- a/ballista/scheduler/src/api/openapi.rs
+++ b/ballista/scheduler/src/api/openapi.rs
@@ -1,0 +1,256 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! OpenAPI specification for the Ballista scheduler REST API.
+
+use crate::api::SchedulerErrorResponse;
+use crate::api::handlers::{
+    CancelJobResponse, ExecutorMetricResponse,
+    ExecutorOperatingSystemSpecificationSchema, ExecutorResponse,
+    ExecutorSpecificationSchema, JobQueryParams, SchedulerStateResponse,
+    SchedulerVersionResponse,
+};
+use axum::Json;
+use axum::response::IntoResponse;
+use ballista_api_types::dto::{
+    JobResponse, Percentiles, PlanFormat, QueryStageSummary, QueryStagesResponse,
+    TaskStatus, TaskSummary,
+};
+use utoipa::OpenApi;
+
+/// OpenAPI documentation structure for the Ballista scheduler REST API.
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Apache DataFusion Ballista Scheduler REST API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "REST API for Apache DataFusion Ballista Scheduler",
+        license(
+            name = "Apache-2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    ),
+    paths(
+        crate::api::handlers::get_scheduler_state,
+        crate::api::handlers::get_scheduler_version,
+        crate::api::handlers::get_executors,
+        crate::api::handlers::get_executor_info,
+        crate::api::handlers::get_jobs,
+        crate::api::handlers::get_job,
+        crate::api::handlers::cancel_job,
+        crate::api::handlers::get_job_config,
+        crate::api::handlers::get_query_stages,
+        crate::api::handlers::get_job_dot_graph,
+        crate::api::handlers::get_query_stage_dot_graph,
+        crate::api::handlers::get_scheduler_metrics,
+        crate::api::openapi::get_openapi_spec,
+    ),
+    components(
+        schemas(
+            SchedulerStateResponse,
+            SchedulerVersionResponse,
+            ExecutorResponse,
+            ExecutorMetricResponse,
+            ExecutorSpecificationSchema,
+            ExecutorOperatingSystemSpecificationSchema,
+            CancelJobResponse,
+            JobQueryParams,
+            SchedulerErrorResponse,
+            JobResponse,
+            TaskStatus,
+            TaskSummary,
+            Percentiles,
+            QueryStageSummary,
+            QueryStagesResponse,
+            PlanFormat,
+        )
+    ),
+    tags(
+        (name = "state", description = "Scheduler state and feature configuration"),
+        (name = "version", description = "Version information"),
+        (name = "executors", description = "Executor management and metrics"),
+        (name = "jobs", description = "Job execution, monitoring, and cancellation"),
+        (name = "graphs", description = "Execution graph visualization"),
+        (name = "metrics", description = "Prometheus cluster metrics"),
+        (name = "openapi", description = "OpenAPI specification"),
+    )
+)]
+pub struct ApiDoc;
+
+#[cfg(feature = "graphviz-support")]
+#[derive(OpenApi)]
+#[openapi(paths(crate::api::handlers::get_job_svg_graph))]
+struct GraphvizApiDoc;
+
+/// Generate the OpenAPI specification for the scheduler REST API.
+pub fn openapi_spec() -> utoipa::openapi::OpenApi {
+    #[allow(unused_mut)]
+    let mut spec = ApiDoc::openapi();
+    #[cfg(feature = "graphviz-support")]
+    spec.merge(GraphvizApiDoc::openapi());
+    spec
+}
+
+/// Handler for `GET /api/openapi.json`.
+#[utoipa::path(
+    get,
+    path = "/api/openapi.json",
+    tag = "openapi",
+    responses(
+        (status = 200, description = "OpenAPI specification document in JSON format", body = Object)
+    )
+)]
+pub async fn get_openapi_spec() -> impl IntoResponse {
+    Json(openapi_spec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SchedulerConfig;
+    use crate::metrics::default_metrics_collector;
+    use crate::scheduler_server::SchedulerServer;
+    use crate::test_utils::test_cluster_context;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ballista_core::serde::BallistaCodec;
+    use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    #[test]
+    fn test_openapi_spec_serialization() {
+        let spec = openapi_spec();
+        let json = serde_json::to_string_pretty(&spec)
+            .expect("OpenAPI spec must serialize to JSON");
+        assert!(!json.is_empty());
+
+        let value: serde_json::Value = serde_json::from_str(&json)
+            .expect("Serialized OpenAPI spec must be valid JSON");
+        assert_eq!(
+            value["info"]["title"],
+            "Apache DataFusion Ballista Scheduler REST API"
+        );
+    }
+
+    #[test]
+    fn test_openapi_spec_contains_all_registered_paths() {
+        let spec = openapi_spec();
+        let paths: Vec<&str> = spec.paths.paths.keys().map(|k| k.as_str()).collect();
+
+        let expected_paths = [
+            "/api/openapi.json",
+            "/api/state",
+            "/api/version",
+            "/api/executors",
+            "/api/executor/{executor_id}",
+            "/api/jobs",
+            "/api/job/{job_id}",
+            "/api/job/{job_id}/config",
+            "/api/job/{job_id}/stages",
+            "/api/job/{job_id}/dot",
+            "/api/job/{job_id}/stage/{stage_id}/dot",
+            "/api/metrics",
+        ];
+
+        for path in expected_paths {
+            assert!(
+                paths.contains(&path),
+                "OpenAPI spec is missing registered path: {path}. Found paths: {paths:?}"
+            );
+        }
+
+        #[cfg(feature = "graphviz-support")]
+        assert!(
+            paths.contains(&"/api/job/{job_id}/dot_svg"),
+            "OpenAPI spec is missing graphviz path: /api/job/{{job_id}}/dot_svg"
+        );
+    }
+
+    #[test]
+    fn test_openapi_spec_contains_all_schemas() {
+        let spec = openapi_spec();
+        let components = spec.components.expect("OpenAPI components must be present");
+        let schemas = components.schemas;
+
+        let expected_schemas = [
+            "SchedulerStateResponse",
+            "SchedulerVersionResponse",
+            "ExecutorResponse",
+            "ExecutorMetricResponse",
+            "ExecutorSpecification",
+            "ExecutorOperatingSystemSpecification",
+            "CancelJobResponse",
+            "JobQueryParams",
+            "SchedulerErrorResponse",
+            "JobResponse",
+            "TaskStatus",
+            "TaskSummary",
+            "Percentiles",
+            "QueryStageSummary",
+            "QueryStagesResponse",
+            "PlanFormat",
+        ];
+
+        for schema_name in expected_schemas {
+            assert!(
+                schemas.contains_key(schema_name),
+                "OpenAPI spec is missing schema: {schema_name}. Found schemas: {:?}",
+                schemas.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_openapi_json_endpoint() {
+        let config = SchedulerConfig::default();
+        let server = SchedulerServer::new(
+            "localhost:50050".to_owned(),
+            test_cluster_context(),
+            BallistaCodec::default(),
+            Arc::new(config),
+            default_metrics_collector().unwrap(),
+        );
+        let router =
+            crate::api::get_routes::<LogicalPlanNode, PhysicalPlanNode>(Arc::new(server));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/openapi.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router oneshot");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let spec_value: serde_json::Value = serde_json::from_slice(&body_bytes)
+            .expect("Response body must be valid JSON");
+
+        assert_eq!(
+            spec_value["info"]["title"],
+            "Apache DataFusion Ballista Scheduler REST API"
+        );
+        assert!(spec_value["paths"]["/api/state"].is_object());
+        assert!(spec_value["paths"]["/api/jobs"].is_object());
+    }
+}

--- a/ballista/scheduler/src/api/openapi.rs
+++ b/ballista/scheduler/src/api/openapi.rs
@@ -19,10 +19,8 @@
 
 use crate::api::SchedulerErrorResponse;
 use crate::api::handlers::{
-    CancelJobResponse, ExecutorMetricResponse,
-    ExecutorOperatingSystemSpecificationSchema, ExecutorResponse,
-    ExecutorSpecificationSchema, JobQueryParams, SchedulerStateResponse,
-    SchedulerVersionResponse,
+    CancelJobResponse, ExecutorMetricResponse, ExecutorResponse, JobQueryParams,
+    SchedulerStateResponse, SchedulerVersionResponse,
 };
 use axum::Json;
 use axum::response::IntoResponse;
@@ -30,6 +28,10 @@ use ballista_api_types::dto::{
     JobResponse, Percentiles, PlanFormat, QueryStageSummary, QueryStagesResponse,
     TaskStatus, TaskSummary,
 };
+use ballista_core::serde::scheduler::{
+    ExecutorOperatingSystemSpecification, ExecutorSpecification,
+};
+use std::sync::LazyLock;
 use utoipa::OpenApi;
 
 /// OpenAPI documentation structure for the Ballista scheduler REST API.
@@ -45,6 +47,8 @@ use utoipa::OpenApi;
         )
     ),
     paths(
+        crate::api::health::healthz,
+        crate::api::health::readyz,
         crate::api::handlers::get_scheduler_state,
         crate::api::handlers::get_scheduler_version,
         crate::api::handlers::get_executors,
@@ -65,8 +69,8 @@ use utoipa::OpenApi;
             SchedulerVersionResponse,
             ExecutorResponse,
             ExecutorMetricResponse,
-            ExecutorSpecificationSchema,
-            ExecutorOperatingSystemSpecificationSchema,
+            ExecutorSpecification,
+            ExecutorOperatingSystemSpecification,
             CancelJobResponse,
             JobQueryParams,
             SchedulerErrorResponse,
@@ -80,6 +84,7 @@ use utoipa::OpenApi;
         )
     ),
     tags(
+        (name = "health", description = "Kubernetes liveness and readiness probes"),
         (name = "state", description = "Scheduler state and feature configuration"),
         (name = "version", description = "Version information"),
         (name = "executors", description = "Executor management and metrics"),
@@ -96,13 +101,17 @@ pub struct ApiDoc;
 #[openapi(paths(crate::api::handlers::get_job_svg_graph))]
 struct GraphvizApiDoc;
 
-/// Generate the OpenAPI specification for the scheduler REST API.
-pub fn openapi_spec() -> utoipa::openapi::OpenApi {
+static OPENAPI_SPEC: LazyLock<utoipa::openapi::OpenApi> = LazyLock::new(|| {
     #[allow(unused_mut)]
     let mut spec = ApiDoc::openapi();
     #[cfg(feature = "graphviz-support")]
     spec.merge(GraphvizApiDoc::openapi());
     spec
+});
+
+/// Generate or retrieve the cached OpenAPI specification for the scheduler REST API.
+pub fn openapi_spec() -> utoipa::openapi::OpenApi {
+    OPENAPI_SPEC.clone()
 }
 
 /// Handler for `GET /api/openapi.json`.
@@ -129,8 +138,28 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use ballista_core::serde::BallistaCodec;
     use datafusion_proto::protobuf::{LogicalPlanNode, PhysicalPlanNode};
+    use std::collections::BTreeSet;
     use std::sync::Arc;
     use tower::ServiceExt;
+    use utoipa::ToSchema;
+
+    fn get_schema_property_names<T: ToSchema>() -> BTreeSet<String> {
+        let schema_ref = T::schema();
+        match schema_ref {
+            utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(obj)) => {
+                obj.properties.keys().cloned().collect()
+            }
+            _ => panic!("Expected Object schema"),
+        }
+    }
+
+    fn get_json_property_names<T: serde::Serialize>(value: &T) -> BTreeSet<String> {
+        let json = serde_json::to_value(value).expect("serialize to value");
+        match json {
+            serde_json::Value::Object(map) => map.keys().cloned().collect(),
+            _ => panic!("Expected JSON Object"),
+        }
+    }
 
     #[test]
     fn test_openapi_spec_serialization() {
@@ -153,6 +182,8 @@ mod tests {
         let paths: Vec<&str> = spec.paths.paths.keys().map(|k| k.as_str()).collect();
 
         let expected_paths = [
+            "/healthz",
+            "/readyz",
             "/api/openapi.json",
             "/api/state",
             "/api/version",
@@ -215,6 +246,37 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_schema_property_alignment_with_serde() {
+        assert_eq!(
+            get_schema_property_names::<ExecutorOperatingSystemSpecification>(),
+            get_json_property_names(&ExecutorOperatingSystemSpecification::default())
+        );
+
+        assert_eq!(
+            get_schema_property_names::<ExecutorSpecification>(),
+            get_json_property_names(&ExecutorSpecification::default())
+        );
+
+        let version_response = SchedulerVersionResponse {
+            version: "1.0",
+            datafusion_version: "1.0",
+        };
+        assert_eq!(
+            get_schema_property_names::<SchedulerVersionResponse>(),
+            get_json_property_names(&version_response)
+        );
+
+        let cancel_response = CancelJobResponse {
+            cancelled: true,
+            reason: Some("cancelled by user".to_string()),
+        };
+        assert_eq!(
+            get_schema_property_names::<CancelJobResponse>(),
+            get_json_property_names(&cancel_response)
+        );
+    }
+
     #[tokio::test]
     async fn test_openapi_json_endpoint() {
         let config = SchedulerConfig::default();
@@ -252,5 +314,7 @@ mod tests {
         );
         assert!(spec_value["paths"]["/api/state"].is_object());
         assert!(spec_value["paths"]["/api/jobs"].is_object());
+        assert!(spec_value["paths"]["/healthz"].is_object());
+        assert!(spec_value["paths"]["/readyz"].is_object());
     }
 }

--- a/ballista/scheduler/src/api/routes.rs
+++ b/ballista/scheduler/src/api/routes.rs
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::api::handlers;
+use crate::api::{handlers, openapi};
 use crate::config::SchedulerConfig;
 use crate::scheduler_server::SchedulerServer;
 use axum::{Router, routing::get};
@@ -31,6 +31,7 @@ pub fn get_routes<
 
     let router = Router::new()
         .route(&web_tui_route, get(handlers::get_webtui))
+        .route("/api/openapi.json", get(openapi::get_openapi_spec))
         .route("/api/state", get(handlers::get_scheduler_state::<T, U>))
         .route("/api/version", get(handlers::get_scheduler_version))
         .route("/api/executors", get(handlers::get_executors::<T, U>))

--- a/docs/source/user-guide/scheduler.md
+++ b/docs/source/user-guide/scheduler.md
@@ -75,6 +75,7 @@ The scheduler also provides a REST API that allows jobs to be monitored.
 
 | API                                    | Method | Description                                                       |
 | -------------------------------------- | ------ | ----------------------------------------------------------------- |
+| /api/openapi.json                      | GET    | Return OpenAPI v3 specification document for the REST API.        |
 | /api/jobs                              | GET    | Get a list of jobs that have been submitted to the cluster.       |
 | /api/job/{job_id}                      | GET    | Get a summary of a submitted job.                                 |
 | /api/job/{job_id}/dot                  | GET    | Produce a query plan in DOT (graphviz) format.                    |


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2351

# Rationale for this change

Ballista's public REST interfaces currently lack a machine-readable OpenAPI specification. As proposed in #2351, this PR addresses Phase 1 by using `utoipa` to generate OpenAPI documentation directly from our Rust DTO types and serving the spec at `GET /api/openapi.json`.

# What changes are included in this PR?

- Added `utoipa` (5.5) as a workspace dependency with `macros` enabled.
- Added an optional `utoipa` feature to `ballista-api-types` and derived `utoipa::ToSchema` on shared DTO types (`JobResponse`, `TaskStatus`, `TaskSummary`, `Percentiles`, `QueryStageSummary`, `QueryStagesResponse`, `PlanFormat`).
- Added `#[utoipa::path(...)]` annotations to all public scheduler endpoints in `ballista-scheduler` (`/api/state`, `/api/version`, `/api/executors`, `/api/executor/{executor_id}`, `/api/jobs`, `/api/job/{job_id}`, `/api/job/{job_id}/config`, `/api/job/{job_id}/stages`, `/api/job/{job_id}/dot`, `/api/job/{job_id}/stage/{stage_id}/dot`, `/api/metrics`, and `/api/job/{job_id}/dot_svg` when `graphviz-support` is enabled).
- Added `ballista_scheduler::api::openapi` defining the `ApiDoc` structure and `GET /api/openapi.json` route handler.
- Added comprehensive unit tests in `ballista_scheduler` and `ballista_api_types` asserting schema registration, path coverage, serialization, and endpoint response.

# Are there any user-facing changes?

The scheduler REST API now exposes `GET /api/openapi.json` returning the OpenAPI v3 JSON specification. No existing endpoints or serialization schemas were modified.
