### PR TITLE
feat(history): mark running event logs with a .running suffix until job completion

### DIFF
--- a/ballista/history/src/lib.rs
+++ b/ballista/history/src/lib.rs
@@ -20,9 +20,13 @@
 //! Durable event logs for completed Ballista jobs.
 //!
 //! The scheduler appends one JSONL record per event to
-//! `<event_log_dir>/<job_id>.eventlog` while a job runs. The history server
-//! reads those files back and serves the same `/api/*` responses the live
-//! scheduler does, long after the scheduler has forgotten the job.
+//! `<event_log_dir>/<job_id>.eventlog.running` while a job runs, then renames
+//! the file to `<event_log_dir>/<job_id>.eventlog` once the job reaches a
+//! terminal state. The history server only ever looks at `.eventlog` files,
+//! so the `.running` suffix alone marks a job as not yet ready to read,
+//! without opening it. The history server reads finished files back and
+//! serves the same `/api/*` responses the live scheduler does, long after the
+//! scheduler has forgotten the job.
 //!
 //! # Write once, replay verbatim
 //!
@@ -52,6 +56,12 @@
 //! that losing a progress record is better than stalling scheduling. The
 //! terminal `JobEnd` is the exception: it waits for queue capacity, because a
 //! job missing its `JobEnd` is invisible to the history server.
+//!
+//! Completion is signaled twice, deliberately redundantly: by the file's
+//! name (`.eventlog` vs `.eventlog.running`), which a directory scan can act
+//! on without opening the file, and by the `JobEnd` record's presence in the
+//! content, which guards against a file that was renamed but is otherwise
+//! corrupt.
 
 pub mod event;
 pub mod reader;

--- a/ballista/history/src/writer.rs
+++ b/ballista/history/src/writer.rs
@@ -23,6 +23,12 @@
 //! `<log_dir>/<job_id>.eventlog` — so the `.running` suffix alone marks a job
 //! as still running (or abandoned by a crashed scheduler), without reading
 //! the file.
+//!
+//! Once a job has been finalized, a late event for it (e.g. a straggler
+//! terminal task status arriving after the job was cancelled or failed) is
+//! dropped rather than reopening the log: recreating an orphan `.running` file
+//! that nothing would ever rename would make that job read as crashed. See
+//! `open_for`.
 
 use crate::event::HistoryEvent;
 use std::collections::HashMap;
@@ -208,6 +214,27 @@ async fn open_for<'a>(
     job_id: &str,
 ) -> Option<&'a mut tokio::fs::File> {
     if !handles.contains_key(job_id) {
+        // The job's log has already been finalized and renamed. A late event
+        // (a straggler terminal task status arriving after JobCancel or
+        // JobRunningFailed) must not recreate an orphan `.running` file that
+        // nothing will ever rename — that filename is the "still running /
+        // crashed" signal a directory scan relies on. `unwrap_or(false)` lets a
+        // transient stat error fall through to the normal open path rather than
+        // silently dropping a real event.
+        //
+        // A job that finished without a `JobEnd` and without an open handle
+        // leaves no `.eventlog`, so a straggler for it is not covered here; that
+        // job could not be recorded in the first place and the history server
+        // skips it either way.
+        if tokio::fs::try_exists(final_path(log_dir, job_id))
+            .await
+            .unwrap_or(false)
+        {
+            log::debug!(
+                "event-log writer: dropping late event for {job_id}; its log is already finalized"
+            );
+            return None;
+        }
         let path = running_path(log_dir, job_id);
         match tokio::fs::OpenOptions::new()
             .create(true)
@@ -231,10 +258,38 @@ async fn open_for<'a>(
 mod tests {
     use super::*;
     use crate::event::{
-        HistoryEvent, JobEnd, JobEndStatus, JobIndex, JobStart, StageStart,
+        HistoryEvent, JobEnd, JobEndStatus, JobIndex, JobStart, StageStart, TaskEnd,
+        TaskEndMetrics,
     };
+    use ballista_api_types::dto::TaskStatus;
     use serde_json::value::RawValue;
     use std::collections::BTreeMap;
+
+    /// A minimal succeeded `JobEnd` for `job_id`; the payloads are placeholders,
+    /// only the record's presence and the file lifecycle matter to these tests.
+    fn succeeded_job_end(job_id: &str) -> HistoryEvent {
+        HistoryEvent::JobEnd(Box::new(JobEnd {
+            status: JobEndStatus::Succeeded,
+            queued_at: 1,
+            started_at: 2,
+            completed_at: 20,
+            index: JobIndex {
+                job_id: job_id.into(),
+                job_name: "q1".into(),
+                status: "Completed".into(),
+                job_status: "COMPLETED".into(),
+                start_time: 10,
+                end_time: 20,
+                num_stages: 1,
+                completed_stages: 1,
+                percent_complete: 100,
+            },
+            job: RawValue::from_string(format!(r#"{{"job_id":"{job_id}"}}"#)).unwrap(),
+            stages: RawValue::from_string(r#"{"stages":[]}"#.to_string()).unwrap(),
+            config: BTreeMap::new(),
+            dot: "digraph {}".into(),
+        }))
+    }
 
     #[tokio::test]
     async fn terminal_job_end_is_not_dropped_on_a_saturated_channel() {
@@ -346,5 +401,64 @@ mod tests {
 
         assert!(!dir.path().join("never-appended.eventlog.running").exists());
         assert!(!dir.path().join("never-appended.eventlog").exists());
+    }
+
+    #[tokio::test]
+    async fn late_event_after_finish_does_not_recreate_the_running_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = EventLogWriter::new(dir.path().to_path_buf(), 16);
+
+        writer.append(
+            "job-1",
+            HistoryEvent::JobStart(JobStart {
+                job_id: "job-1".into(),
+                job_name: "q1".into(),
+                queued_at: 1,
+                submitted_at: 2,
+                logical_plan: None,
+                physical_plan: None,
+            }),
+        );
+        writer
+            .append_final("job-1", succeeded_job_end("job-1"))
+            .await;
+        writer.finish_job("job-1").await;
+
+        let running = dir.path().join("job-1.eventlog.running");
+        let final_path = dir.path().join("job-1.eventlog");
+        assert!(!running.exists());
+        assert!(final_path.exists());
+        let finalized = tokio::fs::read_to_string(&final_path).await.unwrap();
+
+        // A straggler terminal task status for the same job, arriving after the
+        // log was finalized (e.g. a task completing just after JobCancel).
+        writer.append(
+            "job-1",
+            HistoryEvent::TaskEnd(TaskEnd {
+                stage_id: 1,
+                task_id: 7,
+                executor_id: "exec-1".into(),
+                status: TaskStatus::Successful,
+                launch_time: 1,
+                start_exec_time: 2,
+                end_exec_time: 3,
+                metrics: TaskEndMetrics {
+                    input_rows: 0,
+                    output_rows: 0,
+                    elapsed_compute_nanos: 0,
+                },
+            }),
+        );
+        writer.flush_job("job-1").await;
+
+        assert!(
+            !running.exists(),
+            "a late event must not recreate the .running log for a finalized job"
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&final_path).await.unwrap(),
+            finalized,
+            "the finalized .eventlog must be left untouched"
+        );
     }
 }

--- a/ballista/history/src/writer.rs
+++ b/ballista/history/src/writer.rs
@@ -16,8 +16,13 @@
 // under the License.
 
 //! Async, buffered event-log writer. Each job's events append to
-//! `<log_dir>/<job_id>.eventlog` as JSONL. Appends are non-blocking; a background
-//! task performs the file I/O so the scheduler hot path never waits on disk.
+//! `<log_dir>/<job_id>.eventlog.running` as JSONL while the job runs. Appends
+//! are non-blocking; a background task performs the file I/O so the scheduler
+//! hot path never waits on disk. When the job reaches a terminal state,
+//! [`EventLogWriter::finish_job`] flushes, closes, and renames the file to
+//! `<log_dir>/<job_id>.eventlog` — so the `.running` suffix alone marks a job
+//! as still running (or abandoned by a crashed scheduler), without reading
+//! the file.
 
 use crate::event::HistoryEvent;
 use std::collections::HashMap;
@@ -167,12 +172,34 @@ async fn run(log_dir: PathBuf, mut rx: mpsc::Receiver<WriterMsg>) {
             WriterMsg::Finish { job_id, done } => {
                 if let Some(mut file) = handles.remove(&job_id) {
                     let _ = file.flush().await;
-                    // Dropping `file` here closes the fd.
+                    // Must close before renaming: required on Windows, and
+                    // makes the close-before-rename ordering explicit here on
+                    // every platform.
+                    drop(file);
+                    let from = running_path(&log_dir, &job_id);
+                    let to = final_path(&log_dir, &job_id);
+                    if let Err(e) = tokio::fs::rename(&from, &to).await {
+                        log::warn!(
+                            "event-log writer: failed to rename {} to {}: {e}",
+                            from.display(),
+                            to.display()
+                        );
+                    }
                 }
                 let _ = done.send(());
             }
         }
     }
+}
+
+/// Where `job_id`'s log lives while the job is still running.
+fn running_path(log_dir: &Path, job_id: &str) -> PathBuf {
+    log_dir.join(format!("{job_id}.eventlog.running"))
+}
+
+/// Where `job_id`'s log lives once it has reached a terminal state.
+fn final_path(log_dir: &Path, job_id: &str) -> PathBuf {
+    log_dir.join(format!("{job_id}.eventlog"))
 }
 
 async fn open_for<'a>(
@@ -181,7 +208,7 @@ async fn open_for<'a>(
     job_id: &str,
 ) -> Option<&'a mut tokio::fs::File> {
     if !handles.contains_key(job_id) {
-        let path = log_dir.join(format!("{job_id}.eventlog"));
+        let path = running_path(log_dir, job_id);
         match tokio::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -261,7 +288,9 @@ mod tests {
         writer.append_final("job-1", job_end).await;
         writer.finish_job("job-1").await;
 
+        assert!(!dir.path().join("job-1.eventlog.running").exists());
         let path = dir.path().join("job-1.eventlog");
+        assert!(path.exists());
         let contents = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = contents.lines().collect();
         assert!(
@@ -299,11 +328,23 @@ mod tests {
         );
         writer.flush_job("job-1").await;
 
-        let path = dir.path().join("job-1.eventlog");
+        // Not finished yet, so still under the `.running` name.
+        let path = dir.path().join("job-1.eventlog.running");
         let contents = tokio::fs::read_to_string(&path).await.unwrap();
         let lines: Vec<&str> = contents.lines().collect();
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("\"ev\":\"JobStart\""));
         assert!(lines[1].contains("\"ev\":\"StageStart\""));
+    }
+
+    #[tokio::test]
+    async fn finish_job_is_a_noop_for_a_job_with_no_open_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = EventLogWriter::new(dir.path().to_path_buf(), 16);
+
+        writer.finish_job("never-appended").await;
+
+        assert!(!dir.path().join("never-appended.eventlog.running").exists());
+        assert!(!dir.path().join("never-appended.eventlog").exists());
     }
 }

--- a/ballista/scheduler/src/history/mod.rs
+++ b/ballista/scheduler/src/history/mod.rs
@@ -44,7 +44,9 @@ use std::time::{Duration, SystemTime};
 struct JobEntry {
     /// Frozen summary, everything `GET /api/jobs` reports.
     index: JobIndex,
-    /// The `<job_id>.eventlog` the rest of the job is read back from.
+    /// The `<job_id>.eventlog` the rest of the job is read back from. A job
+    /// still running is named `<job_id>.eventlog.running` and has no entry
+    /// here yet.
     path: PathBuf,
 }
 
@@ -70,10 +72,11 @@ struct FileStamp {
 struct Index {
     /// Completed jobs keyed by job id.
     jobs: HashMap<String, JobEntry>,
-    /// Every `.eventlog` seen so far and the job id it produced, if any. Logs
-    /// that are still running (no terminal record yet) or unreadable are kept
-    /// here with `None` so a rescan can tell "already looked at, unchanged"
-    /// from "never seen".
+    /// Every `.eventlog` seen so far and the job id it produced, if any.
+    /// Logs still running are named `.eventlog.running` and never reach this
+    /// map at all (see `scan_dir`); an entry with `None` here means an
+    /// `.eventlog` file that was unreadable or lacked its terminal record,
+    /// so a rescan can tell "already looked at, unchanged" from "never seen".
     seen: HashMap<PathBuf, (FileStamp, Option<String>)>,
 }
 
@@ -273,6 +276,10 @@ impl HistoryStore {
         for entry in std::fs::read_dir(&self.dir)? {
             let entry = entry?;
             let path = entry.path();
+            // A job still running (or abandoned by a crashed scheduler) is
+            // named `<job_id>.eventlog.running`, whose extension is
+            // "running", not "eventlog" — this check relies on that to skip
+            // it without ever opening it.
             if path.extension().and_then(|e| e.to_str()) != Some("eventlog") {
                 continue;
             }
@@ -913,23 +920,27 @@ mod tests {
         assert_eq!(store.len(), 1);
     }
 
-    /// A log with no terminal record yet is a job still running. It is not
-    /// listed, but it must not be written off either: the next rescan after
-    /// the job ends has to pick it up.
+    /// A job still running is named `.eventlog.running` and is invisible to a
+    /// scan; it must not be written off, though: the next rescan after the
+    /// job ends and the writer renames the file has to pick it up.
     #[test]
     fn refresh_indexes_a_log_that_gains_its_terminal_record() {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("job-1.eventlog");
+        let running_path = dir.path().join("job-1.eventlog.running");
+        let final_path = dir.path().join("job-1.eventlog");
         std::fs::write(
-            &path,
+            &running_path,
             "{\"ev\":\"StageStart\",\"version\":1,\"data\":{\"stage_id\":1}}\n",
         )
         .unwrap();
 
         let store = HistoryStore::load(dir.path()).unwrap();
-        assert!(store.is_empty());
+        assert!(store.is_empty(), "a .running file must not be indexed");
 
-        write_job_end_log(&path, "job-1");
+        // Simulate what EventLogWriter::finish_job does on completion: write
+        // the real terminal content, then rename into place.
+        write_job_end_log(&running_path, "job-1");
+        std::fs::rename(&running_path, &final_path).unwrap();
 
         assert_eq!(store.refresh().unwrap().added, 1);
         assert_eq!(store.len(), 1);

--- a/ballista/scheduler/src/scheduler_server/event_log.rs
+++ b/ballista/scheduler/src/scheduler_server/event_log.rs
@@ -383,6 +383,7 @@ mod tests {
             job_end_event(&graph, JobEndStatus::Succeeded, 1, 20),
         );
         writer.flush_job(&job_id).await;
+        writer.finish_job(&job_id).await;
 
         let path = dir.path().join(format!("{job_id}.eventlog"));
         let contents = tokio::fs::read_to_string(&path).await.unwrap();
@@ -425,6 +426,7 @@ mod tests {
         let writer = EventLogWriter::new(dir.path().to_path_buf(), 16);
         writer.append(&job_id, event);
         writer.flush_job(&job_id).await;
+        writer.finish_job(&job_id).await;
 
         let store = HistoryStore::load(dir.path()).unwrap();
         let replayed = store.read_job(&job_id).expect("job should be replayed");

--- a/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
+++ b/ballista/scheduler/src/scheduler_server/query_stage_scheduler.rs
@@ -191,7 +191,11 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan>
                 // `finish_job` runs even when no `JobEnd` could be built, so a
                 // job that cannot be recorded still releases its file handle;
                 // such a log has no `JobEnd` line and the history server skips
-                // it rather than serving a half-written job.
+                // it rather than serving a half-written job. `finish_job` also
+                // renames the file from `.eventlog.running` to `.eventlog`, so
+                // a job whose `finish_job` never runs (the scheduler process is
+                // killed first) leaves a `.running`-suffixed file behind
+                // permanently — nothing else will ever rename it.
                 QueryStageSchedulerEvent::JobFinished {
                     job_id,
                     queued_at,

--- a/docs/source/user-guide/history-server.md
+++ b/docs/source/user-guide/history-server.md
@@ -39,9 +39,13 @@ to:
 ballista-scheduler --event-log-dir /var/lib/ballista/history
 ```
 
-The scheduler writes one file per job, `<job_id>.eventlog`, in
-[JSON Lines](https://jsonlines.org/) format. Files are appended as the job runs
-and closed when it reaches a terminal state.
+The scheduler writes one file per job, in
+[JSON Lines](https://jsonlines.org/) format. While the job runs, records are
+appended to `<job_id>.eventlog.running`; when it reaches a terminal state
+(succeeds, fails, or is cancelled) the scheduler flushes, closes, and renames
+the file to `<job_id>.eventlog`. Only `.eventlog` files are ever indexed by
+the history server, so the `.running` suffix alone marks a job as not yet
+ready to read.
 
 Writes happen on a background task, so the scheduler's event loop never waits on
 disk. If the queue backs up, progress records are dropped rather than allowed to
@@ -127,11 +131,18 @@ future UI can show a job progressing rather than only its end state.
 - **Disk is not reclaimed automatically.** Logs accumulate until you remove
   them. Size them against your job volume and prune with whatever you already
   use for log rotation.
-- **A corrupt log is skipped, not fatal.** If the scheduler dies mid-write the
-  affected file simply has no terminal record, so the history server ignores it
-  and still serves every other job. Damage confined to a job's stored responses
-  is only found when that job is opened, and shows up as a failed request for
-  that one job.
+- **A crash mid-job leaves a `.running` file, never listed.** If the scheduler
+  dies (or is killed) before a job finishes, the file stays named
+  `<job_id>.eventlog.running` and the history server excludes it by name alone
+  without ever opening it. A restarted scheduler has no persisted memory of
+  the job and will never write to, rename, or otherwise touch that file again,
+  so a leftover `.running` file is permanently orphaned — safe (and necessary,
+  since nothing does it automatically) to remove during routine log pruning,
+  like any other stale log. This is also a directly visible signal, via `ls`,
+  that a job never finished cleanly, with no need to open and inspect it.
+  Damage confined to a job's stored responses in an already-`.eventlog`-named
+  file is a separate, orthogonal case: it is only found when that job is
+  opened, and shows up as a failed request for that one job.
 - **Deleting a log takes up to one rescan to show.** Until the next pass the
   job is still listed, and opening it fails.
 - **`GET /api/jobs` returns every job in one response.** There is no paging


### PR DESCRIPTION

# Which issue does this PR close?

Relates to #2267
Closes #.

# Rationale for this change

Event logs written by `EventLogWriter` (`ballista/history/src/writer.rs`) now go to `<job_id>.eventlog.running` while a job runs, and are flushed, closed, and renamed to `<job_id>.eventlog` when the job reaches a terminal state (success, failure, or cancellation) via `finish_job`; this lets a directory scan tell running/crashed jobs apart from finished ones by filename alone, since the history server's existing `.eventlog` extension filter (`ballista/scheduler/src/history/mod.rs`) already excludes `.running` files without opening them, avoiding the previous per-tick re-parsing of in-flight logs.


Doc comments in `ballista/history/src/lib.rs`,
`writer.rs`, `history/mod.rs`, and `docs/source/user-guide/history-server.md` were updated to describe the new two-name lifecycle, and tests were adjusted accordingly: writer.rs's tests were updated for the new path and a new no-op-finish test was added, history/mod.rs's `refresh_indexes_a_log_that_gains_its_terminal_record` was rewritten to exercise a real write-then-rename, and two tests in `scheduler_server/event_log.rs` that previously only called flush_job (and would otherwise never see the renamed file) now also call finish_job.

This would enable custom event log handlers (history server) to make difference between finished and running jobs. we can use `inotifiy` listeners to add finished jobs to history server state, or implement external object store synchroniser without reading whole directory every time synchronisation is needed


# What changes are included in this PR?

# Are there any user-facing changes?
