### PR TITLE
feat(core): order shuffle reads round-robin across producers, staggered per consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,6 @@ dependencies = [
  "datafusion-proto-common",
  "datafusion-spark",
  "futures",
- "itertools 0.15.0",
  "log",
  "md-5 0.11.0",
  "object_store",

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -55,7 +55,6 @@ datafusion-proto = { workspace = true }
 datafusion-proto-common = { workspace = true }
 datafusion-spark = { workspace = true, optional = true, features = ["datafusion"] }
 futures = { workspace = true }
-itertools = "0.15"
 log = { workspace = true }
 md-5 = { version = "^0.11.0" }
 object_store = { workspace = true, features = ["aws", "http"], optional = true }

--- a/ballista/core/proto/ballista.proto
+++ b/ballista/core/proto/ballista.proto
@@ -350,6 +350,10 @@ message ShuffleReaderExecNode {
   uint32 upstream_partition_count = 6;
   // Optional coalesce metadata. Absent means "no coalesce" (legacy one-to-one read behavior).
   optional CoalescePlan coalesce = 7;
+  // Index of each local output partition in the unsliced stage, parallel to
+  // `partition`. Absent on a reader that was never sliced; decodes to the
+  // identity mapping.
+  repeated uint32 output_partition_indices = 8;
 }
 
 message ShuffleReaderPartition {

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -49,11 +49,9 @@ use datafusion::physical_plan::{
     PlanProperties, RecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 use datafusion::prelude::SessionConfig;
+use futures::stream::{BoxStream, select};
 use futures::{Stream, StreamExt, TryStreamExt, ready};
-use itertools::Itertools;
 use log::{debug, error, trace};
-use rand::prelude::SliceRandom;
-use rand::rng;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs::File;
@@ -64,7 +62,7 @@ use std::pin::Pin;
 use std::result;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -125,6 +123,10 @@ pub struct ShuffleReaderExec {
     /// is responsible for pre-concatenating the M-shape upstream
     /// `Vec<Vec<PartitionLocation>>` into K-shape before invoking `try_new_coalesced`.
     pub coalesce: Option<CoalescePlan>,
+    /// Index of each local output partition in the unsliced stage, parallel to
+    /// `partition`. Restriction re-indexes `partition` from zero, so this is all
+    /// that tells peers apart. Picks which producer `execute` fetches first.
+    pub output_partition_indices: Vec<usize>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     properties: Arc<PlanProperties>,
@@ -142,6 +144,7 @@ impl ShuffleReaderExec {
         partitioning: Partitioning,
     ) -> Result<Self> {
         let upstream_partition_count = partition.len();
+        let output_partition_indices = (0..partition.len()).collect();
         let properties = Arc::new(PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
             partitioning,
@@ -155,6 +158,7 @@ impl ShuffleReaderExec {
             broadcast: false,
             upstream_partition_count,
             coalesce: None,
+            output_partition_indices,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,    // to be updated at the executor side
@@ -185,6 +189,7 @@ impl ShuffleReaderExec {
             broadcast: true,
             upstream_partition_count,
             coalesce: None,
+            output_partition_indices: vec![0],
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,    // to be updated at the executor side
@@ -223,6 +228,7 @@ impl ShuffleReaderExec {
             "partitioning.partition_count() must equal coalesce.groups.len() (= K)",
         );
         let upstream_partition_count = coalesce.upstream_partition_count as usize;
+        let output_partition_indices = (0..partition.len()).collect();
         let properties = Arc::new(PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(schema.clone()),
             partitioning,
@@ -236,6 +242,7 @@ impl ShuffleReaderExec {
             broadcast: false,
             upstream_partition_count,
             coalesce: Some(coalesce),
+            output_partition_indices,
             metrics: ExecutionPlanMetricsSet::new(),
             properties,
             work_dir: None,    // to be updated at the executor side
@@ -252,6 +259,7 @@ impl ShuffleReaderExec {
             broadcast: self.broadcast,
             upstream_partition_count: self.upstream_partition_count,
             coalesce: self.coalesce.clone(),
+            output_partition_indices: self.output_partition_indices.clone(),
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
             work_dir: Some(work_dir),
@@ -267,11 +275,33 @@ impl ShuffleReaderExec {
             broadcast: self.broadcast,
             upstream_partition_count: self.upstream_partition_count,
             coalesce: self.coalesce.clone(),
+            output_partition_indices: self.output_partition_indices.clone(),
             metrics: self.metrics.clone(),
             properties: self.properties.clone(),
             work_dir: self.work_dir.clone(),
             client_pool: Some(client_pool),
         }
+    }
+
+    /// Stamps each local output partition with its global index. `indices` must
+    /// be parallel to `partition`.
+    pub fn with_output_partition_indices(mut self, indices: Vec<usize>) -> Self {
+        debug_assert_eq!(
+            indices.len(),
+            self.partition.len(),
+            "output_partition_indices must be parallel to partition",
+        );
+        self.output_partition_indices = indices;
+        self
+    }
+
+    /// Producer-ring offset for a local output partition: its stamped global
+    /// index, falling back to the local one if the stamp is somehow short.
+    fn rotation_for(&self, partition: usize) -> u64 {
+        self.output_partition_indices
+            .get(partition)
+            .copied()
+            .unwrap_or(partition) as u64
     }
 }
 
@@ -350,6 +380,7 @@ impl ExecutionPlan for ShuffleReaderExec {
                 broadcast: self.broadcast,
                 upstream_partition_count: self.upstream_partition_count,
                 coalesce: self.coalesce.clone(),
+                output_partition_indices: self.output_partition_indices.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
                 properties: self.properties.clone(),
                 work_dir: self.work_dir.clone(),
@@ -389,22 +420,9 @@ impl ExecutionPlan for ShuffleReaderExec {
             config.ballista_shuffle_reader_maximum_concurrent_requests(),
             config.ballista_grpc_client_max_message_size()
         );
-        let mut partition_locations = HashMap::new();
-        for p in &self.partition[partition] {
-            partition_locations
-                .entry(p.executor_meta.id.clone())
-                .or_insert_with(Vec::new)
-                .push(p.clone());
-        }
-        // Sort partitions for evenly send fetching partition requests to avoid hot executors within one task
-        let mut partition_locations: Vec<PartitionLocation> = partition_locations
-            .into_values()
-            .flat_map(|ps| ps.into_iter().enumerate())
-            .sorted_by(|(p1_idx, _), (p2_idx, _)| Ord::cmp(p1_idx, p2_idx))
-            .map(|(_, p)| p)
-            .collect();
-        // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
-        partition_locations.shuffle(&mut rng());
+        let locations = &self.partition[partition];
+        let partition_locations =
+            interleave_by_executor(locations, self.rotation_for(partition));
 
         let work_dir = self
             .work_dir
@@ -613,23 +631,31 @@ where
     }
 }
 
-/// Adapter for a tokio ReceiverStream that implements the SendableRecordBatchStream interface
+/// One fetched partition, or the failure to fetch it.
+type FetchResult = result::Result<SendableRecordBatchStream, BallistaError>;
+
+/// Adapter for the local and remote fetch lanes that implements the
+/// SendableRecordBatchStream interface.
 struct AbortableReceiverStream {
-    inner: ReceiverStream<result::Result<SendableRecordBatchStream, BallistaError>>,
+    inner: BoxStream<'static, FetchResult>,
 
     #[allow(dead_code)]
     drop_helper: Vec<SpawnedTask<()>>,
 }
 
 impl AbortableReceiverStream {
-    /// Construct a new SendableRecordBatchReceiverStream which will send batches of the specified schema from inner
+    /// Merges the two fetch lanes. `select` alternates, so locals arrive
+    /// interleaved with remotes rather than serialized behind them.
     pub fn create(
-        rx: tokio::sync::mpsc::Receiver<
-            result::Result<SendableRecordBatchStream, BallistaError>,
-        >,
+        local_rx: mpsc::Receiver<FetchResult>,
+        remote_rx: mpsc::Receiver<FetchResult>,
         spawned_tasks: Vec<SpawnedTask<()>>,
     ) -> AbortableReceiverStream {
-        let inner = ReceiverStream::new(rx);
+        let inner = select(
+            ReceiverStream::new(local_rx),
+            ReceiverStream::new(remote_rx),
+        )
+        .boxed();
         Self {
             inner,
             drop_helper: spawned_tasks,
@@ -720,6 +746,44 @@ impl RecordBatchStream for GovernedStream {
     }
 }
 
+/// Orders a task's fetch list round-robin across the executors that produced its
+/// blocks, starting at the one `rotation` selects. The round-robin spreads one
+/// task's in-flight window over many producers; the rotation keeps peers from
+/// agreeing on which producer that is.
+fn interleave_by_executor(
+    locations: &[PartitionLocation],
+    rotation: u64,
+) -> Vec<PartitionLocation> {
+    if locations.is_empty() {
+        return Vec::new();
+    }
+
+    let mut by_executor: HashMap<&str, Vec<&PartitionLocation>> = HashMap::new();
+    for location in locations {
+        by_executor
+            .entry(location.executor_meta.id.as_str())
+            .or_default()
+            .push(location);
+    }
+    // Peers build their lists independently, so the rotation only staggers them
+    // if every peer sees the same producer order.
+    let mut groups: Vec<_> = by_executor.into_iter().collect();
+    groups.sort_unstable_by_key(|(id, _)| *id);
+    let start = (rotation % groups.len() as u64) as usize;
+    groups.rotate_left(start);
+
+    let mut ordered = Vec::with_capacity(locations.len());
+    for round in 0.. {
+        // Drop exhausted producers so a skewed one's tail drains alone.
+        groups.retain(|(_, blocks)| blocks.len() > round);
+        if groups.is_empty() {
+            break;
+        }
+        ordered.extend(groups.iter().map(|(_, blocks)| blocks[round].clone()));
+    }
+    ordered
+}
+
 /// Splits the provided partition locations into local and remote partitions.
 /// Local partitions are read directly from local Arrow IPC files,
 /// while remote partitions are fetched using the Arrow Flight client.
@@ -805,7 +869,12 @@ fn send_fetch_partitions(
         ballista_config.shuffle_reader_max_blocks_in_flight_per_address();
     let default_block_size = ballista_config.shuffle_reader_default_block_size_bytes();
 
-    let (response_sender, response_receiver) = mpsc::channel(max_reqs.max(1));
+    // Separate lanes so the two producers' backpressure never couples. A queued
+    // local pins an open fd and a 256 KB BufReader, hence depth 1. Remotes
+    // mirror `req_sem`, so a full lane means every permit is already held and
+    // blocking on `send` costs no prefetch.
+    let (local_sender, local_receiver) = mpsc::channel(1);
+    let (remote_sender, remote_receiver) = mpsc::channel(max_reqs.max(1));
 
     // Reduce-side in-flight governor. Each remote fetch acquires:
     //   * `byte_sem`  — min(block_size, max_bytes) permits (in-flight-bytes budget)
@@ -839,7 +908,6 @@ fn send_fetch_partitions(
     read_metrics.remote_partitions.add(remote_locations.len());
 
     // keep local shuffle files reading in serial order for memory control.
-    let response_sender_c = response_sender.clone();
     let work_dir = work_dir.to_string();
     let local_read_time = read_metrics.local_read_time.clone();
     spawned_tasks.push(SpawnedTask::spawn_blocking({
@@ -849,8 +917,9 @@ fn send_fetch_partitions(
                     let _timer = local_read_time.timer();
                     fetch_partition_local(&work_dir, &p)
                 };
-                if let Err(e) = response_sender_c.blocking_send(r) {
+                if let Err(e) = local_sender.blocking_send(r) {
                     error!("Fail to send response event to the channel due to {e}");
+                    break;
                 }
             }
         }
@@ -871,82 +940,110 @@ fn send_fetch_partitions(
         Arc::new(c)
     };
 
-    for p in remote_locations.into_iter() {
-        let byte_sem = byte_sem.clone();
-        let req_sem = req_sem.clone();
-        let addr_sems = addr_sems.clone();
-        let response_sender = response_sender.clone();
-        let customize_endpoint = customize_endpoint.clone();
-        let client_grpc_config = client_grpc_config.clone();
-        let client_pool = client_pool.clone();
-        let read_metrics = read_metrics.clone();
+    // One driver rather than a task per block: `buffer_unordered` initiates in
+    // list order, so `interleave_by_executor`'s ordering reaches the wire rather
+    // than depending on how tokio schedules M spawns. Completion stays
+    // unordered, and the governor still binds because `GovernedStream` holds its
+    // permits until the body is drained.
+    //
+    // These are futures, not tasks: one thread polls all of them. Only the
+    // request issue belongs here; `fetch_partition_buffered` spawns the decode.
+    // Every block becomes eligible now. Timing from here instead of from the
+    // buffer constructing its future keeps a queued block's wait whole.
+    let queued_at = Instant::now();
+    spawned_tasks.push(SpawnedTask::spawn(async move {
+        let mut fetches = futures::stream::iter(remote_locations)
+            .map(|p| {
+                let byte_sem = byte_sem.clone();
+                let req_sem = req_sem.clone();
+                let addr_sems = addr_sems.clone();
+                let customize_endpoint = customize_endpoint.clone();
+                let client_grpc_config = client_grpc_config.clone();
+                let client_pool = client_pool.clone();
+                let read_metrics = read_metrics.clone();
 
-        spawned_tasks.push(SpawnedTask::spawn(async move {
-            let addr = p.executor_meta.id.clone();
-            let size = block_size(&p, default_block_size);
+                async move {
+                    let size = block_size(&p, default_block_size);
 
-            // Time spent blocked acquiring the three governor permits (#1951).
-            let (req_permit, addr_permit, byte_permit) = {
-                let _permit_timer = read_metrics.permit_wait_time.timer();
-                let req_permit = req_sem.acquire_owned().await.unwrap();
-                let addr_sem = {
-                    let mut map = addr_sems.lock().unwrap();
-                    map.entry(addr.clone())
-                        .or_insert_with(|| {
-                            Arc::new(Semaphore::new(max_blocks_per_addr.max(1)))
-                        })
-                        .clone()
-                };
-                let addr_permit = addr_sem.acquire_owned().await.unwrap();
-                let byte_permit = byte_sem
-                    .acquire_many_owned(byte_permits_for(size, max_bytes))
-                    .await
-                    .unwrap();
-                (req_permit, addr_permit, byte_permit)
-            };
+                    // Time spent blocked acquiring the three governor permits (#1951).
+                    let (req_permit, addr_permit, byte_permit) = {
+                        let _permit_timer =
+                            read_metrics.permit_wait_time.timer_with(queued_at);
+                        let req_permit = req_sem.acquire_owned().await.unwrap();
+                        let addr_sem = {
+                            let addr = p.executor_meta.id.as_str();
+                            let mut map = addr_sems.lock().unwrap();
+                            // Borrowed lookup first: N executors against M >> N
+                            // blocks, so every block but the first per executor
+                            // takes this arm and allocates nothing.
+                            match map.get(addr) {
+                                Some(sem) => sem.clone(),
+                                None => map
+                                    .entry(addr.to_string())
+                                    .or_insert_with(|| {
+                                        Arc::new(Semaphore::new(
+                                            max_blocks_per_addr.max(1),
+                                        ))
+                                    })
+                                    .clone(),
+                            }
+                        };
+                        let addr_permit = addr_sem.acquire_owned().await.unwrap();
+                        let byte_permit = byte_sem
+                            .acquire_many_owned(byte_permits_for(size, max_bytes))
+                            .await
+                            .unwrap();
+                        (req_permit, addr_permit, byte_permit)
+                    };
 
-            let mut attempts = 0usize;
-            // Cloned (rather than used by reference) to avoid a partial move of
-            // `read_metrics`, which is still needed below for
-            // `fetch_requests`/`fetch_retries`.
-            let decoded_bytes = read_metrics.decoded_bytes.clone();
-            let r = {
-                let _fetch_timer = read_metrics.fetch_time.timer();
-                with_retry(outer_retries, io_wait, is_retriable_fetch_error, || {
-                    attempts += 1;
-                    fetch_partition_buffered(
-                        &p,
-                        client_grpc_config.clone(),
-                        prefer_flight,
-                        customize_endpoint.clone(),
-                        client_pool.clone(),
-                    )
-                })
-                .await
-            }
-            .map(|(schema, batches)| {
-                let bytes: usize =
-                    batches.iter().map(|b| b.get_array_memory_size()).sum();
-                decoded_bytes.add(bytes);
-                Box::pin(GovernedStream::new(
-                    buffered_stream(schema, batches),
-                    byte_permit,
-                    req_permit,
-                    addr_permit,
-                )) as SendableRecordBatchStream
-            });
-            // Total wire attempts (initial + retries), recorded only after
-            // `with_retry` has finished retrying.
-            read_metrics.fetch_requests.add(attempts);
-            read_metrics.fetch_retries.add(attempts.saturating_sub(1));
+                    let mut attempts = 0usize;
+                    let r = {
+                        let _fetch_timer = read_metrics.fetch_time.timer();
+                        with_retry(
+                            outer_retries,
+                            io_wait,
+                            is_retriable_fetch_error,
+                            || {
+                                attempts += 1;
+                                fetch_partition_buffered(
+                                    &p,
+                                    client_grpc_config.clone(),
+                                    prefer_flight,
+                                    customize_endpoint.clone(),
+                                    client_pool.clone(),
+                                )
+                            },
+                        )
+                        .await
+                    }
+                    .map(|(schema, batches, bytes)| {
+                        read_metrics.decoded_bytes.add(bytes);
+                        Box::pin(GovernedStream::new(
+                            buffered_stream(schema, batches),
+                            byte_permit,
+                            req_permit,
+                            addr_permit,
+                        )) as SendableRecordBatchStream
+                    });
+                    // Total wire attempts (initial + retries), recorded only after
+                    // `with_retry` has finished retrying.
+                    read_metrics.fetch_requests.add(attempts);
+                    read_metrics.fetch_retries.add(attempts.saturating_sub(1));
 
-            if let Err(e) = response_sender.send(r).await {
+                    r
+                }
+            })
+            .buffer_unordered(max_reqs.max(1));
+
+        while let Some(r) = fetches.next().await {
+            if let Err(e) = remote_sender.send(r).await {
                 error!("Fail to send response event to the channel due to {e}");
+                break;
             }
-        }));
-    }
+        }
+    }));
 
-    AbortableReceiverStream::create(response_receiver, spawned_tasks)
+    AbortableReceiverStream::create(local_receiver, remote_receiver, spawned_tasks)
 }
 
 /// Retry an idempotent async operation up to `retries` times after the initial
@@ -1010,7 +1107,7 @@ async fn fetch_partition_buffered(
     prefer_flight: bool,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
     client_pool: Option<Arc<dyn BallistaClientPool>>,
-) -> result::Result<(SchemaRef, Vec<RecordBatch>), BallistaError> {
+) -> result::Result<(SchemaRef, Vec<RecordBatch>, usize), BallistaError> {
     let stream = fetch_partition_remote(
         location,
         config,
@@ -1022,15 +1119,43 @@ async fn fetch_partition_buffered(
     let schema = stream.schema();
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
-    let batches = stream.try_collect::<Vec<_>>().await.map_err(|e| {
+    let fetch_failed = |e: String| {
         BallistaError::FetchFailed(
             metadata.id.clone(),
             partition_id.stage_id,
             partition_id.partition_id,
-            e.to_string(),
+            e,
         )
-    })?;
-    Ok((schema, batches))
+    };
+
+    // The request above is issued in the caller's task, so fetch order still
+    // reaches the wire in list order; only the decode moves off it.
+    let (batches, decoded_bytes) =
+        collect_off_task(stream).await.map_err(fetch_failed)?;
+
+    Ok((schema, batches, decoded_bytes))
+}
+
+/// Drains `stream` to completion on a task of its own, returning its batches and
+/// their in-memory footprint.
+///
+/// Draining is IPC decode and decompression: CPU, which holds whichever thread
+/// polls it. The caller drives every concurrent block from one task, so draining
+/// inline would serialize them onto a single worker. Sizing the batches walks
+/// every array, so it rides along here rather than back on the caller.
+/// `SpawnedTask` aborts on drop, so a caller that goes away takes the drain.
+async fn collect_off_task(
+    stream: SendableRecordBatchStream,
+) -> result::Result<(Vec<RecordBatch>, usize), String> {
+    SpawnedTask::spawn(async move {
+        let batches = stream.try_collect::<Vec<_>>().await?;
+        let bytes = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        Ok::<_, DataFusionError>((batches, bytes))
+    })
+    .join()
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())
 }
 
 /// Build an in-memory `SendableRecordBatchStream` from already-buffered batches.
@@ -1075,7 +1200,7 @@ pub(crate) async fn fetch_partition_remote(
     prefer_flight: bool,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
     client_pool: Option<Arc<dyn BallistaClientPool>>,
-) -> result::Result<SendableRecordBatchStream, BallistaError> {
+) -> FetchResult {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
     let file_id = location.file_id;
@@ -1143,7 +1268,7 @@ pub(crate) async fn fetch_range_remote(
     config: Arc<GrpcClientConfig>,
     customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
     client_pool: Option<Arc<dyn BallistaClientPool>>,
-) -> result::Result<SendableRecordBatchStream, BallistaError> {
+) -> FetchResult {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
 
@@ -1181,7 +1306,7 @@ async fn fetch_ranges_with(
     location: &PartitionLocation,
     bound: WidenedBound,
     schema: SchemaRef,
-) -> result::Result<SendableRecordBatchStream, BallistaError> {
+) -> FetchResult {
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
     let (lo, hi) = bound;
@@ -1268,7 +1393,7 @@ fn as_fetch_failed(
 pub(crate) fn fetch_partition_local(
     work_dir: &str,
     location: &PartitionLocation,
-) -> result::Result<SendableRecordBatchStream, BallistaError> {
+) -> FetchResult {
     let path = &location.path(work_dir)?;
     let metadata = &location.executor_meta;
     let partition_id = &location.partition_id;
@@ -1468,6 +1593,8 @@ mod tests {
     use datafusion::physical_plan::common;
     use datafusion::physical_plan::statistics::StatisticsContext;
     use datafusion::prelude::SessionContext;
+    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::time::Instant;
     use tempfile::{TempDir, tempdir};
 
     /// Build an M-shape upstream `Vec<Vec<PartitionLocation>>` with per-partition
@@ -2007,27 +2134,9 @@ mod tests {
     }
 
     async fn test_send_fetch_partitions(max_request_num: usize, partition_num: usize) {
-        let schema = get_test_partition_schema();
-        let data_array = Int32Array::from(vec![1]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
-                .unwrap();
         let tmp_dir = tempdir().unwrap();
         let work_dir = tmp_dir.path();
-
-        for p in 0..partition_num {
-            // job name and stage id are hard-codded
-            let file_path =
-                create_shuffle_path(work_dir, &"job".into(), 1, p, None, false).unwrap();
-            // this unwrap should not be problem as
-            // this function never return root dir
-            std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-            let file: File = File::create(&file_path).unwrap();
-
-            let mut writer = StreamWriter::try_new(file, &schema).unwrap();
-            writer.write(&batch).unwrap();
-            writer.finish().unwrap();
-        }
+        let schema = write_local_shuffle_files(work_dir, partition_num);
 
         let partition_locations = get_test_partition_locations(partition_num, None);
         let config = SessionConfig::new_with_ballista()
@@ -2053,23 +2162,10 @@ mod tests {
 
     #[tokio::test]
     async fn send_fetch_partitions_records_local_metrics() {
-        let schema = get_test_partition_schema();
-        let data_array = Int32Array::from(vec![1]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
-                .unwrap();
         let tmp_dir = tempdir().unwrap();
         let work_dir = tmp_dir.path();
         let partition_num = 3usize;
-        for p in 0..partition_num {
-            let file_path =
-                create_shuffle_path(work_dir, &"job".into(), 1, p, None, false).unwrap();
-            std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-            let file = File::create(&file_path).unwrap();
-            let mut writer = StreamWriter::try_new(file, &schema).unwrap();
-            writer.write(&batch).unwrap();
-            writer.finish().unwrap();
-        }
+        let schema = write_local_shuffle_files(work_dir, partition_num);
         let partition_locations = get_test_partition_locations(partition_num, None);
         let config = SessionConfig::new_with_ballista();
         let metrics_set = ExecutionPlanMetricsSet::new();
@@ -2097,6 +2193,61 @@ mod tests {
         assert!(
             metrics.sum_by_name("local_read_time").is_some(),
             "local_read_time metric should be registered"
+        );
+    }
+
+    /// Shuffle files the reader is still holding open.
+    #[cfg(target_os = "linux")]
+    fn open_shuffle_fds(work_dir: &std::path::Path) -> usize {
+        std::fs::read_dir("/proc/self/fd")
+            .into_iter()
+            .flatten()
+            .filter_map(|e| std::fs::read_link(e.ok()?.path()).ok())
+            .filter(|target| target.starts_with(work_dir))
+            .count()
+    }
+
+    /// The local reader must not run ahead of the consumer. Each queued result
+    /// holds an open fd, so a depth-1 lane leaves two at most: queued, and in hand.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn local_reads_do_not_run_ahead_of_the_consumer() {
+        let tmp_dir = tempdir().unwrap();
+        let work_dir = tmp_dir.path();
+        let partition_num = 8usize;
+        write_local_shuffle_files(work_dir, partition_num);
+
+        // A shared lane this deep is what let the reader run ahead.
+        let config = SessionConfig::new_with_ballista()
+            .with_ballista_shuffle_reader_maximum_concurrent_requests(partition_num);
+        let metrics_set = ExecutionPlanMetricsSet::new();
+
+        // Never polled: the reader gets no backpressure relief from the consumer.
+        let _receiver = send_fetch_partitions(
+            &work_dir.to_string_lossy(),
+            get_test_partition_locations(partition_num, None),
+            &config,
+            None,
+            ShuffleReadMetrics::new(0, &metrics_set),
+        );
+
+        // Wait for the reader to start, so a task that has not run yet cannot
+        // pass by having done nothing.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while open_shuffle_fds(work_dir) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("local reader never opened a file");
+
+        // Room to run further ahead, if it is going to.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let open = open_shuffle_fds(work_dir);
+        assert!(
+            open <= 2,
+            "local reader ran {open} files ahead of an undrained consumer"
         );
     }
 
@@ -2133,6 +2284,151 @@ mod tests {
                 .map(|v| v.as_usize()),
             Some(0)
         );
+    }
+
+    /// A pool that records the order fetches reach the wire, then fails each one
+    /// so nothing but the order is under test.
+    #[derive(Debug, Default)]
+    struct RecordingClientPool {
+        hosts: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl BallistaClientPool for RecordingClientPool {
+        async fn acquire(
+            &self,
+            host: &str,
+            _port: u16,
+            _config: &GrpcClientConfig,
+            _customize_endpoint: Option<Arc<BallistaConfigGrpcEndpoint>>,
+        ) -> result::Result<crate::client_pool::PooledClient, BallistaError> {
+            self.hosts.lock().unwrap().push(host.to_string());
+            // Deliberately not a retriable variant: a retry would record the
+            // same host twice and the order would stop meaning anything.
+            Err(BallistaError::General("recording pool".to_string()))
+        }
+
+        async fn evict_idle(&self) {}
+    }
+
+    /// A stream whose drain holds its thread, the way IPC decode does, until
+    /// `needed` drains run at once. Drains sharing a thread never get there, so
+    /// the wait is deadline-bounded and fails rather than hangs.
+    fn drain_probe(
+        live: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        needed: usize,
+    ) -> SendableRecordBatchStream {
+        let schema: SchemaRef = Arc::new(get_test_partition_schema());
+        let batch = RecordBatch::new_empty(schema.clone());
+        Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::once(async move {
+                peak.fetch_max(live.fetch_add(1, SeqCst) + 1, SeqCst);
+                let deadline = Instant::now() + Duration::from_secs(2);
+                while peak.load(SeqCst) < needed && Instant::now() < deadline {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                live.fetch_sub(1, SeqCst);
+                Ok(batch)
+            }),
+        ))
+    }
+
+    /// Decode must not run on the task driving the fetches: one task polls every
+    /// concurrent block, so an inline drain would serialize them onto one worker.
+    /// These probes only finish if each drain got a thread of its own.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn decode_does_not_run_on_the_callers_task() {
+        let needed = 4usize;
+        let live = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        // One task driving all of them, exactly as `send_fetch_partitions` does.
+        SpawnedTask::spawn({
+            let (live, peak) = (live.clone(), peak.clone());
+            async move {
+                futures::stream::iter(0..needed)
+                    .map(|_| {
+                        collect_off_task(drain_probe(live.clone(), peak.clone(), needed))
+                    })
+                    .buffer_unordered(needed)
+                    .try_collect::<Vec<_>>()
+                    .await
+            }
+        })
+        .join()
+        .await
+        .unwrap()
+        .expect("a drain failed");
+
+        assert_eq!(
+            peak.load(SeqCst),
+            needed,
+            "drains never overlapped, so they are sharing the caller's thread"
+        );
+    }
+
+    /// `interleave_by_executor` only buys anything if its ordering survives to
+    /// the wire. Run on both sides of the governor: a window wide enough to admit
+    /// every block at once, and one narrow enough to be the gate itself.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn remote_fetches_reach_the_wire_in_list_order() {
+        let tmp_dir = tempdir().unwrap();
+        let work_dir = tmp_dir.path();
+        // Nothing on disk, so every location is remote. Hosts are out of sorted
+        // order: what is asserted is list order, not one the path could recover.
+        let locations: Vec<_> = [5usize, 2, 9, 0, 7, 3, 8, 1]
+            .into_iter()
+            .map(|i| loc(&format!("e{i}"), i))
+            .collect();
+        let expected = executors_of(&locations);
+
+        for max_reqs in [locations.len(), 2] {
+            let pool = Arc::new(RecordingClientPool::default());
+            let hosts = pool.hosts.clone();
+            let metrics_set = ExecutionPlanMetricsSet::new();
+
+            let mut rx = send_fetch_partitions(
+                &work_dir.to_string_lossy(),
+                locations.clone(),
+                &SessionConfig::new_with_ballista()
+                    .with_ballista_shuffle_reader_maximum_concurrent_requests(max_reqs),
+                Some(pool),
+                ShuffleReadMetrics::new(0, &metrics_set),
+            );
+
+            // Drain, or a lane narrower than the fetch list stops admitting
+            // partway and the tail never reaches the pool.
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while rx.next().await.is_some() {}
+            })
+            .await
+            .unwrap_or_else(|_| panic!("max_reqs={max_reqs}: fetches never finished"));
+
+            assert_eq!(*hosts.lock().unwrap(), expected, "max_reqs={max_reqs}");
+        }
+    }
+
+    /// Writes `n` single-row local shuffle files under `work_dir`, returning
+    /// the schema they share.
+    fn write_local_shuffle_files(work_dir: &std::path::Path, n: usize) -> Schema {
+        let schema = get_test_partition_schema();
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )
+        .unwrap();
+        for p in 0..n {
+            let path =
+                create_shuffle_path(work_dir, &"job".into(), 1, p, None, false).unwrap();
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let mut writer =
+                StreamWriter::try_new(File::create(&path).unwrap(), &schema).unwrap();
+            writer.write(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        schema
     }
 
     fn get_test_partition_locations(
@@ -2519,6 +2815,144 @@ mod tests {
         assert_eq!(90, *stats1.total_byte_size.get_value().unwrap());
         assert_eq!(9, *stats1.num_rows.get_value().unwrap());
         Ok(())
+    }
+
+    fn loc(executor: &str, partition_id: usize) -> PartitionLocation {
+        PartitionLocation {
+            map_partition_id: 0,
+            partition_id: PartitionId {
+                job_id: "job".into(),
+                stage_id: 1,
+                partition_id,
+            },
+            executor_meta: ExecutorMetadata {
+                id: executor.to_string(),
+                host: executor.to_string(),
+                port: 7070,
+                grpc_port: 8080,
+                specification: ExecutorSpecification::default().with_vcores(1),
+                os_info: ExecutorOperatingSystemSpecification::default(),
+            },
+            partition_stats: PartitionStats::default(),
+            file_id: None,
+            is_sort_shuffle: false,
+        }
+    }
+
+    fn executors_of(locations: &[PartitionLocation]) -> Vec<String> {
+        locations
+            .iter()
+            .map(|l| l.executor_meta.id.clone())
+            .collect()
+    }
+
+    /// Each round touches every producer once, so the in-flight window spans all.
+    #[test]
+    fn interleave_visits_every_executor_once_per_round() {
+        let locations: Vec<_> = (0..4)
+            .flat_map(|block| ["a", "b", "c"].map(move |e| loc(e, block)))
+            .collect();
+
+        let order = executors_of(&interleave_by_executor(&locations, 0));
+
+        assert_eq!(order.len(), 12);
+        for round in order.chunks(3) {
+            let mut seen = round.to_vec();
+            seen.sort();
+            assert_eq!(seen, ["a", "b", "c"], "round repeats a producer: {round:?}");
+        }
+    }
+
+    /// Exact round-robin: no two of N consecutive peers open on the same
+    /// producer.
+    #[test]
+    fn stamped_peers_round_robin_across_producers() {
+        let producers = ["a", "b", "c"];
+        let locations: Vec<_> = producers.iter().map(|e| loc(e, 0)).collect();
+
+        let first_fetch: Vec<String> = (0..7)
+            .map(|output_partition_index| {
+                executors_of(&interleave_by_executor(&locations, output_partition_index))
+                    [0]
+                .clone()
+            })
+            .collect();
+
+        assert_eq!(first_fetch, ["a", "b", "c", "a", "b", "c", "a"]);
+    }
+
+    /// Guards the `% groups.len()` divisor: a partition with no upstream blocks.
+    #[test]
+    fn interleave_handles_no_locations() {
+        assert!(interleave_by_executor(&[], 3).is_empty());
+    }
+
+    /// The rotation must come from the stamp, not the local index.
+    #[test]
+    fn rotation_comes_from_the_stamp_not_the_local_index() {
+        let exec = ShuffleReaderExec::try_new(
+            1,
+            vec![vec![], vec![]],
+            Arc::new(get_test_partition_schema()),
+            Partitioning::UnknownPartitioning(2),
+        )
+        .unwrap();
+
+        assert_eq!((exec.rotation_for(0), exec.rotation_for(1)), (0, 1));
+
+        let stamped = exec.with_output_partition_indices(vec![11, 4]);
+        assert_eq!((stamped.rotation_for(0), stamped.rotation_for(1)), (11, 4));
+        // Out of range falls back to the local index rather than panicking.
+        assert_eq!(stamped.rotation_for(7), 7);
+    }
+
+    /// Reordering must not drop, duplicate, or invent a block.
+    #[test]
+    fn interleave_preserves_the_fetch_set() {
+        let locations: Vec<_> = (0..7)
+            .flat_map(|block| ["a", "b"].map(move |e| loc(e, block)))
+            .collect();
+
+        let mut before: Vec<_> = locations
+            .iter()
+            .map(|l| (l.executor_meta.id.clone(), l.partition_id.partition_id))
+            .collect();
+        let mut after: Vec<_> = interleave_by_executor(&locations, 0)
+            .iter()
+            .map(|l| (l.executor_meta.id.clone(), l.partition_id.partition_id))
+            .collect();
+        before.sort();
+        after.sort();
+
+        assert_eq!(before, after);
+    }
+
+    /// Peer lists are built independently, so the producer order must not depend
+    /// on the order a task's locations arrived in.
+    #[test]
+    fn producer_order_is_independent_of_input_order() {
+        let forward: Vec<_> = (0..2)
+            .flat_map(|block| ["a", "b", "c"].map(move |e| loc(e, block)))
+            .collect();
+        let mut reversed = forward.clone();
+        reversed.reverse();
+
+        assert_eq!(
+            executors_of(&interleave_by_executor(&forward, 1)),
+            executors_of(&interleave_by_executor(&reversed, 1)),
+        );
+    }
+
+    /// A skewed producer keeps its turn every round, then drains alone.
+    #[test]
+    fn interleave_drains_a_skewed_producer_last() {
+        let mut locations = vec![loc("small", 0)];
+        locations.extend((0..4).map(|block| loc("big", block)));
+
+        let order = executors_of(&interleave_by_executor(&locations, 0));
+
+        assert_eq!(order.iter().filter(|e| *e == "big").count(), 4);
+        assert_eq!(order[2..], ["big", "big", "big"]);
     }
 }
 

--- a/ballista/core/src/serde/generated/ballista.rs
+++ b/ballista/core/src/serde/generated/ballista.rs
@@ -446,6 +446,11 @@ pub struct ShuffleReaderExecNode {
     /// Optional coalesce metadata. Absent means "no coalesce" (legacy one-to-one read behavior).
     #[prost(message, optional, tag = "7")]
     pub coalesce: ::core::option::Option<CoalescePlan>,
+    /// Index of each local output partition in the unsliced stage, parallel to
+    /// `partition`. Absent on a reader that was never sliced; decodes to the
+    /// identity mapping.
+    #[prost(uint32, repeated, tag = "8")]
+    pub output_partition_indices: ::prost::alloc::vec::Vec<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShuffleReaderPartition {

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -694,6 +694,11 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                 )?;
                 let partitioning = partitioning
                     .ok_or_else(|| proto_error("missing required partitioning field"))?;
+                let output_partition_indices: Vec<usize> = shuffle_reader
+                    .output_partition_indices
+                    .iter()
+                    .map(|&i| i as usize)
+                    .collect();
                 let exec = if let Some(c) = shuffle_reader.coalesce.as_ref() {
                     ShuffleReaderExec::try_new_coalesced(
                         stage_id,
@@ -722,6 +727,24 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                         schema,
                         partitioning,
                     )?
+                };
+                let exec = match output_partition_indices.len() {
+                    // Encoded before this field existed. The constructor's
+                    // identity mapping is right for a reader never sliced.
+                    0 if !exec.partition.is_empty() => exec,
+                    n if n == exec.partition.len() => {
+                        exec.with_output_partition_indices(output_partition_indices)
+                    }
+                    // Never version skew: both fields ship in one message from
+                    // one encoder. Identity here would look fine and silently
+                    // point every peer at the same producer.
+                    n => {
+                        return Err(proto_error(format!(
+                            "ShuffleReaderExec: output_partition_indices has {n} \
+                             entries, expected {} to be parallel to partition",
+                            exec.partition.len()
+                        )));
+                    }
                 };
                 Ok(Arc::new(exec))
             }
@@ -1171,6 +1194,11 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                         broadcast: exec.broadcast,
                         upstream_partition_count: exec.upstream_partition_count as u32,
                         coalesce: exec.coalesce.as_ref().map(|c| c.into()),
+                        output_partition_indices: exec
+                            .output_partition_indices
+                            .iter()
+                            .map(|&i| i as u32)
+                            .collect(),
                     },
                 )),
             };
@@ -1682,6 +1710,103 @@ mod test {
             decoded_exec.coalesce.is_none(),
             "absent coalesce field must decode to None (codec inertness)"
         );
+    }
+
+    /// The smallest reader whose stamp has something to be parallel to.
+    fn two_partition_reader() -> ShuffleReaderExec {
+        let schema = create_test_schema();
+        let partitioning =
+            Partitioning::Hash(vec![col("id", schema.as_ref()).unwrap()], 2);
+        ShuffleReaderExec::try_new(1, vec![vec![], vec![]], schema, partitioning).unwrap()
+    }
+
+    /// Encodes `exec` and decodes it back, letting `tamper` rewrite the node on
+    /// the wire first. That is the only way to produce the bytes a current
+    /// encoder never would, which is what the back-compat paths exist for.
+    fn stamp_roundtrip(
+        exec: ShuffleReaderExec,
+        tamper: impl FnOnce(&mut protobuf::ShuffleReaderExecNode),
+    ) -> datafusion::error::Result<ShuffleReaderExec> {
+        let codec = BallistaPhysicalExtensionCodec::default();
+        let mut buf: Vec<u8> = vec![];
+        codec
+            .try_encode(Arc::new(exec), &mut buf, &DefaultPhysicalProtoConverter {})
+            .unwrap();
+
+        let mut node =
+            protobuf::BallistaPhysicalPlanNode::decode(buf.as_slice()).unwrap();
+        let Some(PhysicalPlanType::ShuffleReader(reader)) =
+            node.physical_plan_type.as_mut()
+        else {
+            panic!("expected a ShuffleReader node");
+        };
+        tamper(reader);
+        let mut buf: Vec<u8> = vec![];
+        node.encode(&mut buf).unwrap();
+
+        let ctx = SessionContext::new().task_ctx();
+        codec
+            .try_decode(&buf, &[], &ctx, &DefaultPhysicalProtoConverter {})
+            .map(|plan| {
+                plan.downcast_ref::<ShuffleReaderExec>()
+                    .expect("Expected ShuffleReaderExec")
+                    .clone()
+            })
+    }
+
+    #[tokio::test]
+    async fn test_shuffle_reader_exec_output_partition_indices_roundtrip() {
+        let stamped = two_partition_reader().with_output_partition_indices(vec![11, 4]);
+
+        let decoded = stamp_roundtrip(stamped, |_| {}).unwrap();
+
+        assert_eq!(decoded.output_partition_indices, vec![11, 4]);
+    }
+
+    /// A plan encoded before this field existed carries no stamp, and must decode
+    /// back to the identity mapping.
+    #[tokio::test]
+    async fn test_shuffle_reader_exec_absent_output_partition_indices_decode_to_identity()
+    {
+        let reader = two_partition_reader();
+        assert_eq!(reader.output_partition_indices, vec![0, 1]);
+
+        let decoded =
+            stamp_roundtrip(reader, |node| node.output_partition_indices.clear())
+                .unwrap();
+
+        assert_eq!(decoded.output_partition_indices, vec![0, 1]);
+    }
+
+    /// A stamp that is not parallel to `partition` is a bug, never version skew.
+    /// Decoding it back to the identity would look fine and silently point every
+    /// peer at one producer.
+    #[tokio::test]
+    async fn test_shuffle_reader_exec_mismatched_output_partition_indices_are_rejected() {
+        let err = stamp_roundtrip(two_partition_reader(), |node| {
+            node.output_partition_indices = vec![0]
+        })
+        .expect_err("a stamp that is not parallel to partition must not decode");
+
+        assert!(
+            err.to_string().contains("output_partition_indices"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Broadcast is the one path where the stamp is not the identity and decode
+    /// runs a different constructor, so the wire has to carry it there too.
+    #[tokio::test]
+    async fn test_broadcast_shuffle_reader_exec_output_partition_index_roundtrip() {
+        let reader =
+            ShuffleReaderExec::try_new_broadcast(7, Vec::new(), create_test_schema(), 4)
+                .unwrap()
+                .with_output_partition_indices(vec![5]);
+
+        let decoded = stamp_roundtrip(reader, |_| {}).unwrap();
+
+        assert!(decoded.broadcast);
+        assert_eq!(decoded.output_partition_indices, vec![5]);
     }
 
     #[tokio::test]

--- a/ballista/scheduler/src/state/task_builder.rs
+++ b/ballista/scheduler/src/state/task_builder.rs
@@ -79,8 +79,9 @@ fn restrict(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     // Leaves: apply the algebraic partition-projection when we're not
     // under a collapse. Under collapse, leaves keep their full upstream —
-    // the generic recursion below leaves them unchanged.
-    if !under_collect
+    // the generic recursion below leaves them unchanged. A broadcast reader is
+    // the exception; see `is_broadcast_reader`.
+    if (!under_collect || is_broadcast_reader(&plan))
         && let Some(rewritten) = select_output_partitions(&plan, partitions)?
     {
         return Ok(rewritten);
@@ -212,6 +213,14 @@ fn child_scopes(plan: &Arc<dyn ExecutionPlan>, under_collect: bool) -> Vec<bool>
         .collect()
 }
 
+/// A broadcast reader is the build side of a `CollectLeft` join, so it always
+/// lands under the gate that stops leaf restriction. It is safe to route past:
+/// stamping changes fetch order, never which rows are read.
+fn is_broadcast_reader(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    plan.downcast_ref::<ShuffleReaderExec>()
+        .is_some_and(|reader| reader.broadcast)
+}
+
 /// Restrict a plan node to a subset of its output partitions, re-indexed
 /// so position `i` of the result corresponds to input `indices[i]`.
 ///
@@ -248,23 +257,28 @@ fn child_scopes(plan: &Arc<dyn ExecutionPlan>, under_collect: bool) -> Vec<bool>
 ///
 /// This helper is scope-agnostic. The `under_collect` decision (whether
 /// a leaf below a `CoalescePartitionsExec` / `SortPreservingMergeExec` /
-/// join build side must read its full upstream) lives in the walker —
-/// the walker simply doesn't call this function under collapse.
+/// join build side must read its full upstream) lives in the walker, which
+/// under collapse calls this only for a broadcast reader.
 fn select_output_partitions(
     plan: &Arc<dyn ExecutionPlan>,
     indices: &[usize],
 ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
     // ShuffleReaderExec: cross-stage inputs.
     if let Some(reader) = plan.downcast_ref::<ShuffleReaderExec>() {
-        // Broadcast readers serve everything from partition[0] for every
-        // consumer — slicing would drop the payload. Leave intact.
         if reader.broadcast {
-            return Ok(Some(plan.clone()));
+            // Never sliced, since every consumer is served from `partition[0]`,
+            // but still stamped, or the whole stage fetches from one producer.
+            let index = indices.first().copied().unwrap_or(0);
+            return Ok(Some(Arc::new(
+                reader.clone().with_output_partition_indices(vec![index]),
+            )));
         }
-        let kept: Vec<Vec<_>> = indices
+        // Carry each global index alongside the slice it selects: `kept` is
+        // re-indexed from zero, which would leave every peer looking identical.
+        let (output_partition_indices, kept): (Vec<usize>, Vec<Vec<_>>) = indices
             .iter()
-            .filter_map(|&p| reader.partition.get(p).cloned())
-            .collect();
+            .filter_map(|&p| reader.partition.get(p).cloned().map(|locs| (p, locs)))
+            .unzip();
         let partitioning = match reader.properties().output_partitioning() {
             Partitioning::Hash(exprs, _) => Partitioning::Hash(exprs.clone(), kept.len()),
             Partitioning::RoundRobinBatch(_) => Partitioning::RoundRobinBatch(kept.len()),
@@ -295,7 +309,9 @@ fn select_output_partitions(
         ) else {
             return Ok(None);
         };
-        return Ok(Some(Arc::new(restricted)));
+        return Ok(Some(Arc::new(
+            restricted.with_output_partition_indices(output_partition_indices),
+        )));
     }
 
     // RangeShuffleReaderExec: cross-stage inputs, ordering-preserving. Same
@@ -435,17 +451,23 @@ mod tests {
         }
     }
 
+    /// A `ShuffleReaderExec` over `n` single-location partitions.
+    fn shuffle_reader(n: usize) -> Arc<dyn ExecutionPlan> {
+        let partitions = (0..n).map(|i| vec![create_partition(i)]).collect();
+        Arc::new(
+            ShuffleReaderExec::try_new(
+                1,
+                partitions,
+                Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
+                Partitioning::UnknownPartitioning(n),
+            )
+            .unwrap(),
+        )
+    }
+
     #[test]
     fn keeps_only_the_wanted_partition() {
-        let partitions = (0..4).map(|i| vec![create_partition(i)]).collect();
-        let reader = ShuffleReaderExec::try_new(
-            1,
-            partitions,
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            Partitioning::UnknownPartitioning(4),
-        )
-        .unwrap();
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(reader);
+        let plan = shuffle_reader(4);
         let pruned = restrict_plan_to_partitions(plan, &[1]).unwrap();
         let r = pruned
             .downcast_ref::<ShuffleReaderExec>()
@@ -459,15 +481,7 @@ mod tests {
 
     #[test]
     fn keeps_multiple_wanted_partitions_in_request_order() {
-        let partitions = (0..4).map(|i| vec![create_partition(i)]).collect();
-        let reader = ShuffleReaderExec::try_new(
-            1,
-            partitions,
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            Partitioning::UnknownPartitioning(4),
-        )
-        .unwrap();
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(reader);
+        let plan = shuffle_reader(4);
         let pruned = restrict_plan_to_partitions(plan, &[0, 3]).unwrap();
         let r = pruned
             .downcast_ref::<ShuffleReaderExec>()
@@ -475,6 +489,70 @@ mod tests {
         assert_eq!(r.partition.len(), 2);
         assert_eq!(r.partition[0][0].partition_id.partition_id, 0);
         assert_eq!(r.partition[1][0].partition_id.partition_id, 3);
+    }
+
+    /// The kept slice is re-indexed from zero, so the global indices have to be
+    /// stamped alongside it.
+    #[test]
+    fn restriction_stamps_the_global_output_partition_indices() {
+        let plan = shuffle_reader(4);
+        let pruned = restrict_plan_to_partitions(plan, &[3, 1]).unwrap();
+        let r = pruned
+            .downcast_ref::<ShuffleReaderExec>()
+            .expect("expected a ShuffleReaderExec");
+
+        assert_eq!(r.output_partition_indices, vec![3, 1]);
+    }
+
+    /// A dropped out-of-range index must drop from the stamp too, or the two
+    /// stop being parallel.
+    #[test]
+    fn stamp_stays_parallel_when_an_index_is_out_of_range() {
+        let plan = shuffle_reader(2);
+        let pruned = restrict_plan_to_partitions(plan, &[1, 9]).unwrap();
+        let r = pruned
+            .downcast_ref::<ShuffleReaderExec>()
+            .expect("expected a ShuffleReaderExec");
+
+        assert_eq!(r.partition.len(), 1);
+        assert_eq!(r.output_partition_indices, vec![1]);
+    }
+
+    /// A broadcast reader sits under `under_collect`, where leaf restriction is
+    /// skipped, and must still come back stamped.
+    #[test]
+    fn broadcast_reader_under_a_collected_join_is_still_stamped() {
+        use datafusion::physical_plan::joins::CrossJoinExec;
+
+        let reader: Arc<dyn ExecutionPlan> = Arc::new(
+            ShuffleReaderExec::try_new_broadcast(
+                1,
+                (0..4).map(create_partition).collect(),
+                Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
+                4,
+            )
+            .unwrap(),
+        );
+        let join: Arc<dyn ExecutionPlan> =
+            Arc::new(CrossJoinExec::new(reader, scan_with_file_groups(4)));
+
+        assert!(
+            matches!(
+                join.input_distribution_requirements().child_distribution(0),
+                Some(Distribution::SinglePartition)
+            ),
+            "the collected side must declare SinglePartition"
+        );
+
+        let restricted = restrict_plan_to_partitions(join, &[2]).unwrap();
+        let build = restricted.children()[0]
+            .downcast_ref::<ShuffleReaderExec>()
+            .expect("expected the build side to still be a ShuffleReaderExec");
+
+        assert!(build.broadcast);
+        assert_eq!(build.partition.len(), 1);
+        assert_eq!(build.partition[0].len(), 4);
+        assert_eq!(build.output_partition_indices, vec![2]);
     }
 
     #[test]
@@ -542,15 +620,7 @@ mod tests {
 
     #[test]
     fn restricting_to_every_partition_is_a_no_op() {
-        let partitions = (0..3).map(|i| vec![create_partition(i)]).collect();
-        let reader = ShuffleReaderExec::try_new(
-            1,
-            partitions,
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            Partitioning::UnknownPartitioning(3),
-        )
-        .unwrap();
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(reader);
+        let plan = shuffle_reader(3);
         let pruned = restrict_plan_to_partitions(plan, &[0, 1, 2]).unwrap();
         let r = pruned
             .downcast_ref::<ShuffleReaderExec>()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2403 

 # Rationale for this change

This PR should optimally distribute consumers across producers deterministically. 
Previously we relied on a RNG distribution, which could land several consumers on the same producers. `req_sem` caps how many blocks are in flight but not how many of them share an address, so nothing today stops all 64 targeting one executor. Round-robin gives the exact spread the original sort was reaching for, and makes fetch order a pure function of the block list and the consumer's index. Remaining variance comes from block skew and executor load rather than from the draw, so it is attributable. 

The order is also assertable, which several tests here rely on and an RNG made impossible.

Primary benefits:
- **More predictable query times.** 

- **Less chance of a hot producer:** This in theory should improve the stability of Ballista at higher cluster sizes.

- **Potentially faster (unproven see below).** If every consumers is optimally distributed, this may lead to performance gains due to lack of contention.

Side benefits:
- **We can drop the itertools dependency**
- **A bound on open files and buffered data.** Every local result waiting to be
  consumed holds an open file descriptor and a 256 KB buffer. The old shared
  channel let a stalled consumer pin `max_requests` of them; the split lane caps
  it at two. This predates the PR and was found while investigating the stall.
- **Less per-block overhead.** The per-address semaphore map is now touched only
  by the driver instead of contended across M tasks, and the executor id is no
  longer cloned twice per block. 



# Performance improvements + AI Benchmarking:

**Fetch ordering is cheaper than what it replaces.** The old path sorted all M blocks and then ran an O(M) shuffle over them. `interleave_by_executor` sorts only the N producers. Per `execute()` call, on the synchronous setup path before any fetch is issued:

| M | N | old (sort + shuffle) | new (round-robin) |
|---|---|---|---|
| 1000 | 20 | 837 us | 285 us |
| 5000 | 50 | 2.59 ms | 1.45 ms |
| 20000 | 200 | 16.96 ms | 6.11 ms |




## Help wanted 
The ordering benefit itself is unmeasured. I don't have a multi-executor cluster to test this on.

The numbers I would find most useful, against `main` on a shuffle-heavy query such as TPC-H q4 or q18:

- `ShuffleReaderExec`'s `permit_wait_time` and `fetch_time` metrics, which is
  where converging on one producer shows up
- reduce-stage wall time, especially its spread across tasks: the change is
  aimed at tail latency more than the mean
- whether more executors widens or narrows the gap, since N is what the
  round-robin has to spread across

A confirmation that nothing regresses would be just as valuable as a win.


# What changes are included in this PR?

**Ordering.** `interleave_by_executor` replaces the sort-then-shuffle. Blocks
are round-robined across the executors that produced them, starting at the
producer the consumer's own index selects. A skewed producer keeps its turn
each round, then drains alone.

**Peer identity.** New `ShuffleReaderExecNode.output_partition_indices`
(proto field 8), stamped by `restrict_plan_to_partitions` alongside the slice
it selects. Absent on the wire decodes to the identity mapping, so a plan from
an older encoder is unaffected; a stamp that is not parallel to `partition` is
a decode error rather than a silent fallback.

**One fetch driver instead of a task per block.** Ordering only matters if it
survives to the wire. With a task per block, M tasks race to acquire `req_sem`
and the admitted subset is up to the runtime, so the round-robin is computed
and then discarded. A single driver over `buffer_unordered` initiates in list
order; completion stays unordered.

**Decode off the driver.** One driver polling every block would decode them all
on a single thread, since IPC decode and decompression happen in `poll_next` and
hold whatever thread polls them. So the driver issues the request and hands the
drain to its own task (`collect_off_task`). Measured on 24 blocks of
ZSTD-compressed Arrow IPC, 337 KiB per block:

| where the block is drained | wall time (4 runs) |
|---|---|
| inside the driver | 58.8, 61.0, 61.5, 63.2 ms |
| on its own task (this PR) | 11.5, 12.5, 14.4, 19.1 ms |

`main` spawns a task per block, so its decode is already parallel. This keeps
that property rather than improving on it. Fetch order is unaffected: the
request is still issued from the driver, in list order.

**Separate local and remote lanes.** A queued local result pins an open fd and
a 256 KB buffer, so locals get a depth-1 lane; remotes mirror `req_sem`. The
two are merged with `select`, so locals arrive interleaved rather than
serialized behind remotes.

`permit_wait_time` now times from when a block becomes eligible rather than
from when the buffer constructs its future, keeping the metric comparable with
the previous task-per-block version. 

# Tests

Ordering: `interleave_visits_every_executor_once_per_round`,
`interleave_drains_a_skewed_producer_last`, `interleave_preserves_the_fetch_set`,
`producer_order_is_independent_of_input_order`, `interleave_handles_no_locations`,
`stamped_peers_round_robin_across_producers`,
`rotation_comes_from_the_stamp_not_the_local_index`.

Reaching the wire: `remote_fetches_reach_the_wire_in_list_order` records fetch
order through a stub client pool, on both sides of the governor window.

Concurrency: `decode_does_not_run_on_the_callers_task` fails unless the drains
run on threads of their own; `local_reads_do_not_run_ahead_of_the_consumer`
counts open descriptors under the work dir.

Stamping: `restriction_stamps_the_global_output_partition_indices`,
`stamp_stays_parallel_when_an_index_is_out_of_range`,
`broadcast_reader_under_a_collected_join_is_still_stamped`, plus codec
roundtrips for the stamped, absent, mismatched, and broadcast cases.

Every test above was checked by mutation: reverting the behavior it covers
fails that test and no other.


# How Spark handles the same problem

**Spark randomizes too**, exactly as Ballista did before this PR:
`fetchRequests ++= Utils.randomize(remoteRequests)`.

**Its producer spread comes from request sizing, not ordering.** Spark's fetch
unit is a batch of blocks from one address, capped at `maxBytesInFlight / 5`:

> the reason to keep them smaller than `maxBytesInFlight` is to allow multiple,
> parallel fetches from up to 5 nodes, rather than blocking on reading output
> from one node.

The byte budget itself forces several distinct sources in flight, whatever the
queue order. Randomization is only tie-breaking.

**This PR does not copy that** because it needs a batched multi-block request.
Ballista fetches one partition per Flight call, and `req_sem` bounds the fetch
*count*, which says nothing about address diversity: all 64 can be one executor.
Ordering is the cheaper lever on the existing design, and the two compose.

**Spark has no per-consumer stagger.** Nothing keys fetch order to the reducer's
own index. `output_partition_indices` has no Spark analog, which cuts both ways:
stronger than the state of the art, and unproven.

Source: [ShuffleBlockFetcherIterator.scala](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala)



# Are there any user-facing changes?
No
