### PR TITLE
chore(deps): drop unused md-5, move insta to dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,6 @@ dependencies = [
  "futures",
  "itertools 0.15.0",
  "log",
- "md-5 0.11.0",
  "object_store",
  "parking_lot",
  "pastey",

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -57,7 +57,6 @@ datafusion-spark = { workspace = true, optional = true, features = ["datafusion"
 futures = { workspace = true }
 itertools = "0.15"
 log = { workspace = true }
-md-5 = { version = "^0.11.0" }
 object_store = { workspace = true, features = ["aws", "http"], optional = true }
 parking_lot = { workspace = true }
 pastey = { workspace = true }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -66,7 +66,6 @@ ferroid = { version = "2.0", features = ["alloc", "std", "snowflake", "atomic", 
 futures = { workspace = true }
 graphviz-rust = { version = "0.9", optional = true }
 http = "1.4"
-insta = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true }
@@ -94,6 +93,7 @@ name = "tpch_plan_stability"
 path = "tests/tpch_plan_stability/main.rs"
 
 [dev-dependencies]
+insta = { workspace = true }
 regex = "1"
 rstest = { workspace = true }
 serde_json = "1"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Two dependency fixes, no behavior change.

- **md-5**: added in #830 for `consistent_hash`, which #1526 deleted. Unused
  since. Note this drops no build unit (datafusion-functions and object_store
  still pull 0.11 / 0.10), only a dead declaration.
- **insta**: test-only (every call site is `#[cfg(test)]`), but in
  `[dependencies]` since #1372, so it linked into the scheduler binary and into
  anything using `ballista`'s default `standalone` feature.

Verified: workspace `cargo check --all-targets --locked` clean; 213 `state::aqe`
and 375 core tests pass; clippy `-D warnings` clean; `cargo tree -e normal` no
longer shows insta for `ballista-scheduler` or `ballista`.
# Are there any user-facing changes?
no