### PR TITLE
ci: share one cluster harness across the tpch, tpcds and h2o jobs

### DIFF
--- a/.github/actions/setup-benchmark-builder/action.yaml
+++ b/.github/actions/setup-benchmark-builder/action.yaml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Setup Ballista benchmark builder
+description: >
+  Installs the build dependencies and Rust toolchain, then builds the scheduler,
+  executor and benchmark binaries the benchmark CI jobs run against. Expects the
+  repository checked out on a Linux runner.
+inputs:
+  shared-key:
+    description: rust-cache key, shared across the matrix legs of one workflow.
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # `nc` backs the port readiness probes in ci/scripts/ballista_cluster.sh.
+    - name: Install netcat
+      shell: bash
+      run: |
+        apt-get update
+        apt-get install -y netcat-traditional
+    - name: Setup Rust toolchain
+      uses: ./.github/actions/setup-builder
+    - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #2.9.2
+      with:
+        shared-key: ${{ inputs.shared-key }}
+    - name: Build Ballista binaries
+      shell: bash
+      run: |
+        cargo build --profile tpch-ci --locked \
+          -p ballista-scheduler \
+          -p ballista-executor \
+          -p ballista-benchmarks

--- a/.github/workflows/h2o.yml
+++ b/.github/workflows/h2o.yml
@@ -39,6 +39,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/h2o.yml"
       - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-benchmark-builder/**"
+      - "ci/scripts/ballista_cluster.sh"
       # docs-only changes cannot affect this job; exclusions are applied last
       - "!**/*.md"
   pull_request:
@@ -50,6 +52,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/h2o.yml"
       - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-benchmark-builder/**"
+      - "ci/scripts/ballista_cluster.sh"
       # docs-only changes cannot affect this job; exclusions are applied last
       - "!**/*.md"
   workflow_dispatch:
@@ -60,31 +64,18 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
+    # A passing run takes ~21-23 minutes, mostly the cold-cache build. Cap it
+    # well under the 6-hour default so a hang frees the runner instead.
+    timeout-minutes: 45
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y netcat-traditional
-
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #2.9.2
+      - name: Setup toolchain and build Ballista binaries
+        uses: ./.github/actions/setup-benchmark-builder
         with:
           shared-key: h2o-window-small
-
-      - name: Build Ballista binaries
-        run: |
-          cargo build --profile tpch-ci --locked \
-            -p ballista-scheduler \
-            -p ballista-executor \
-            -p ballista-benchmarks
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -101,62 +92,20 @@ jobs:
           cd benchmarks
           uv run falsa join --path-prefix "$H2O_DIR" --size SMALL --data-format PARQUET
 
+      - name: Start Ballista cluster
+        # Same expression the log-upload step globs, so the two cannot drift.
+        env:
+          CLUSTER_DIR: ${{ runner.temp }}
+        run: ci/scripts/ballista_cluster.sh start
+
       - name: Run h2o window suite against Ballista cluster
+        # On the step rather than the job so a hang still runs teardown and
+        # the log upload. The suite itself runs ~5 minutes.
+        timeout-minutes: 30
         env:
           H2O_DIR: ${{ runner.temp }}/h2o-data
-          WORK_DIR: ${{ runner.temp }}/work
-          SCHEDULER_LOG: ${{ runner.temp }}/scheduler.log
-          EXECUTOR_LOG: ${{ runner.temp }}/executor.log
         run: |
           set -euo pipefail
-
-          mkdir -p "$WORK_DIR"
-
-          ./target/tpch-ci/ballista-scheduler \
-            --bind-host 127.0.0.1 \
-            > "$SCHEDULER_LOG" 2>&1 &
-          SCHEDULER_PID=$!
-
-          ./target/tpch-ci/ballista-executor \
-            --bind-host 127.0.0.1 \
-            --bind-port 50051 \
-            --scheduler-host 127.0.0.1 \
-            --scheduler-connect-timeout-seconds 10 \
-            --vcores 4 \
-            --memory-pool-size 2GB \
-            --work-dir "$WORK_DIR" \
-            > "$EXECUTOR_LOG" 2>&1 &
-          EXECUTOR_PID=$!
-
-          cleanup() {
-            echo "::group::scheduler log (tail)"
-            tail -n 200 "$SCHEDULER_LOG" || true
-            echo "::endgroup::"
-            echo "::group::executor log (tail)"
-            tail -n 200 "$EXECUTOR_LOG" || true
-            echo "::endgroup::"
-            kill "$SCHEDULER_PID" "$EXECUTOR_PID" 2>/dev/null || true
-            wait "$SCHEDULER_PID" "$EXECUTOR_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
-          echo "Waiting for scheduler on 127.0.0.1:50050..."
-          for _ in $(seq 1 30); do
-            if nc -z 127.0.0.1 50050; then
-              break
-            fi
-            sleep 1
-          done
-          nc -z 127.0.0.1 50050 || { echo "scheduler did not start"; exit 1; }
-
-          echo "Waiting for executor on 127.0.0.1:50051..."
-          for _ in $(seq 1 30); do
-            if nc -z 127.0.0.1 50051; then
-              break
-            fi
-            sleep 1
-          done
-          nc -z 127.0.0.1 50051 || { echo "executor did not start"; exit 1; }
 
           JOIN_PATHS="$H2O_DIR/J1_1e7_NA_0.parquet,$H2O_DIR/J1_1e7_1e1_0.parquet,$H2O_DIR/J1_1e7_1e4_0.parquet,$H2O_DIR/J1_1e7_1e7_NA.parquet"
 
@@ -176,8 +125,18 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Stop Ballista cluster
+        # `always()`: still reap the processes and print the log tails when the
+        # suite times out or the run is cancelled.
+        if: always()
+        env:
+          CLUSTER_DIR: ${{ runner.temp }}
+        run: ci/scripts/ballista_cluster.sh stop
+
       - name: Upload cluster logs on failure
-        if: failure()
+        # `!success()` rather than `failure()` so timed-out and cancelled runs
+        # still surface their logs.
+        if: ${{ !success() }}
         uses: actions/upload-artifact@v7
         with:
           name: h2o-window-small-cluster-logs

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -35,6 +35,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpcds.yml"
       - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-benchmark-builder/**"
+      - "ci/scripts/ballista_cluster.sh"
       # docs-only changes cannot affect this job; exclusions are applied last
       - "!**/*.md"
   pull_request:
@@ -46,6 +48,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpcds.yml"
       - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-benchmark-builder/**"
+      - "ci/scripts/ballista_cluster.sh"
       # docs-only changes cannot affect this job; exclusions are applied last
       - "!**/*.md"
   workflow_dispatch:
@@ -71,38 +75,22 @@ jobs:
             slug: "mpt1"
           # 4 rather than a larger cap because the scheduler clamps the slice to
           # the executor's free vcores (`budget.vcores.min(cap)`), and the
-          # executor below runs `--concurrent-tasks 4`. A higher cap would be
-          # unreachable and the label would overstate what is covered.
+          # executor runs with `--vcores 4`. A higher cap would be unreachable
+          # and the label would overstate what is covered.
           - label: "4 partitions per task"
             task_args: "-c ballista.scheduler.max_partitions_per_task=4"
             slug: "mpt4"
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y netcat-traditional
-
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #2.9.2
+      - name: Setup toolchain and build Ballista binaries
+        uses: ./.github/actions/setup-benchmark-builder
         with:
           # Share the build cache across all matrix legs — the compiled
           # binaries are identical; only the per-suite CLI args differ.
           shared-key: tpcds-sf1
-
-      - name: Build Ballista binaries
-        run: |
-          cargo build --profile tpch-ci --locked \
-            -p ballista-scheduler \
-            -p ballista-executor \
-            -p ballista-benchmarks
 
       - name: Install tpcgen-cli
         run: |
@@ -116,66 +104,20 @@ jobs:
             --scale-factor 1 \
             --output-dir "$RUNNER_TEMP/tpcds-data"
 
+      - name: Start Ballista cluster
+        # Same expression the log-upload step globs, so the two cannot drift.
+        env:
+          CLUSTER_DIR: ${{ runner.temp }}
+        run: ci/scripts/ballista_cluster.sh start
+
       - name: Run TPC-DS queries against Ballista cluster
-        # Primary timeout, on the step rather than the job, so that a hang
-        # still runs the log-upload step below and leaves something to
-        # diagnose. The job-level cap is only a backstop.
+        # On the step rather than the job so a hang still runs teardown and
+        # the log upload.
         timeout-minutes: 30
         env:
           DATA_DIR: ${{ runner.temp }}/tpcds-data
-          WORK_DIR: ${{ runner.temp }}/work
-          SCHEDULER_LOG: ${{ runner.temp }}/scheduler.log
-          EXECUTOR_LOG: ${{ runner.temp }}/executor.log
         run: |
           set -euo pipefail
-
-          mkdir -p "$WORK_DIR"
-
-          ./target/tpch-ci/ballista-scheduler \
-            --bind-host 127.0.0.1 \
-            > "$SCHEDULER_LOG" 2>&1 &
-          SCHEDULER_PID=$!
-
-          ./target/tpch-ci/ballista-executor \
-            --bind-host 127.0.0.1 \
-            --bind-port 50051 \
-            --scheduler-host 127.0.0.1 \
-            --scheduler-connect-timeout-seconds 10 \
-            --concurrent-tasks 4 \
-            --memory-pool-size 2GB \
-            --work-dir "$WORK_DIR" \
-            > "$EXECUTOR_LOG" 2>&1 &
-          EXECUTOR_PID=$!
-
-          cleanup() {
-            echo "::group::scheduler log (tail)"
-            tail -n 200 "$SCHEDULER_LOG" || true
-            echo "::endgroup::"
-            echo "::group::executor log (tail)"
-            tail -n 200 "$EXECUTOR_LOG" || true
-            echo "::endgroup::"
-            kill "$SCHEDULER_PID" "$EXECUTOR_PID" 2>/dev/null || true
-            wait "$SCHEDULER_PID" "$EXECUTOR_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
-          echo "Waiting for scheduler on 127.0.0.1:50050..."
-          for _ in $(seq 1 30); do
-            if nc -z 127.0.0.1 50050; then
-              break
-            fi
-            sleep 1
-          done
-          nc -z 127.0.0.1 50050 || { echo "scheduler did not start"; exit 1; }
-
-          echo "Waiting for executor on 127.0.0.1:50051..."
-          for _ in $(seq 1 30); do
-            if nc -z 127.0.0.1 50051; then
-              break
-            fi
-            sleep 1
-          done
-          nc -z 127.0.0.1 50051 || { echo "executor did not start"; exit 1; }
 
           # This matrix leg runs the suite under the default (static) planner at
           # one task-packing setting. The tpcds binary internally loops all
@@ -193,6 +135,14 @@ jobs:
             -c datafusion.optimizer.prefer_hash_join=false \
             ${{ matrix.task_args }}
           echo "::endgroup::"
+
+      - name: Stop Ballista cluster
+        # `always()`: still reap the processes and print the log tails when the
+        # suite times out or the run is cancelled.
+        if: always()
+        env:
+          CLUSTER_DIR: ${{ runner.temp }}
+        run: ci/scripts/ballista_cluster.sh stop
 
       - name: Upload cluster logs on failure
         # `!success()` rather than `failure()` so a timed-out or cancelled

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -35,6 +35,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpch.yml"
       - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-benchmark-builder/**"
+      - "ci/scripts/ballista_cluster.sh"
       # docs-only changes cannot affect this job; exclusions are applied last
       - "!**/*.md"
   pull_request:
@@ -46,6 +48,8 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/tpch.yml"
       - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-benchmark-builder/**"
+      - "ci/scripts/ballista_cluster.sh"
       # docs-only changes cannot affect this job; exclusions are applied last
       - "!**/*.md"
   workflow_dispatch:
@@ -56,6 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
+    # A passing leg runs 8-19 minutes, mostly the cold-cache build. Cap it well
+    # under the 6-hour default so a hang frees the runner instead.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -70,32 +77,16 @@ jobs:
             planner_args: "-c ballista.planner.adaptive.enabled=true -c ballista.scheduler.max_partitions_per_task=0"
             slug: "aqe-on-mpt"
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y netcat-traditional
-
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: stable
-
-      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #2.9.2
+      - name: Setup toolchain and build Ballista binaries
+        uses: ./.github/actions/setup-benchmark-builder
         with:
           # Share the build cache across all matrix legs — the compiled
           # binaries are identical; only the per-suite CLI args differ.
           shared-key: tpch-sf10
-
-      - name: Build Ballista binaries
-        run: |
-          cargo build --profile tpch-ci --locked \
-            -p ballista-scheduler \
-            -p ballista-executor \
-            -p ballista-benchmarks
 
       - name: Install tpchgen-cli
         uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
@@ -111,62 +102,20 @@ jobs:
             --format=parquet \
             --output-dir "$RUNNER_TEMP/tpch-data"
 
+      - name: Start Ballista cluster
+        # Same expression the log-upload step globs, so the two cannot drift.
+        env:
+          CLUSTER_DIR: ${{ runner.temp }}
+        run: ci/scripts/ballista_cluster.sh start
+
       - name: Run TPC-H queries against Ballista cluster
+        # On the step rather than the job so a hang still runs teardown and
+        # the log upload. The suite itself runs ~1 minute.
+        timeout-minutes: 30
         env:
           DATA_DIR: ${{ runner.temp }}/tpch-data
-          WORK_DIR: ${{ runner.temp }}/work
-          SCHEDULER_LOG: ${{ runner.temp }}/scheduler.log
-          EXECUTOR_LOG: ${{ runner.temp }}/executor.log
         run: |
           set -euo pipefail
-
-          mkdir -p "$WORK_DIR"
-
-          ./target/tpch-ci/ballista-scheduler \
-            --bind-host 127.0.0.1 \
-            > "$SCHEDULER_LOG" 2>&1 &
-          SCHEDULER_PID=$!
-
-          ./target/tpch-ci/ballista-executor \
-            --bind-host 127.0.0.1 \
-            --bind-port 50051 \
-            --scheduler-host 127.0.0.1 \
-            --scheduler-connect-timeout-seconds 10 \
-            --vcores 4 \
-            --memory-pool-size 2GB \
-            --work-dir "$WORK_DIR" \
-            > "$EXECUTOR_LOG" 2>&1 &
-          EXECUTOR_PID=$!
-
-          cleanup() {
-            echo "::group::scheduler log (tail)"
-            tail -n 200 "$SCHEDULER_LOG" || true
-            echo "::endgroup::"
-            echo "::group::executor log (tail)"
-            tail -n 200 "$EXECUTOR_LOG" || true
-            echo "::endgroup::"
-            kill "$SCHEDULER_PID" "$EXECUTOR_PID" 2>/dev/null || true
-            wait "$SCHEDULER_PID" "$EXECUTOR_PID" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
-          echo "Waiting for scheduler on 127.0.0.1:50050..."
-          for _ in $(seq 1 30); do
-            if nc -z 127.0.0.1 50050; then
-              break
-            fi
-            sleep 1
-          done
-          nc -z 127.0.0.1 50050 || { echo "scheduler did not start"; exit 1; }
-
-          echo "Waiting for executor on 127.0.0.1:50051..."
-          for _ in $(seq 1 30); do
-            if nc -z 127.0.0.1 50051; then
-              break
-            fi
-            sleep 1
-          done
-          nc -z 127.0.0.1 50051 || { echo "executor did not start"; exit 1; }
 
           # This matrix leg runs one planner configuration against the whole
           # SF10 dataset. The other legs run in parallel jobs.
@@ -186,8 +135,18 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Stop Ballista cluster
+        # `always()`: still reap the processes and print the log tails when the
+        # suite times out or the run is cancelled.
+        if: always()
+        env:
+          CLUSTER_DIR: ${{ runner.temp }}
+        run: ci/scripts/ballista_cluster.sh stop
+
       - name: Upload cluster logs on failure
-        if: failure()
+        # `!success()` rather than `failure()` so timed-out and cancelled runs
+        # still surface their logs.
+        if: ${{ !success() }}
         uses: actions/upload-artifact@v7
         with:
           name: tpch-sf10-cluster-logs-${{ matrix.slug }}

--- a/ci/scripts/ballista_cluster.sh
+++ b/ci/scripts/ballista_cluster.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Starts and stops the Ballista cluster (one scheduler, one executor) that the
+# benchmark CI jobs run their suites against.
+#
+# Usage:
+#   ci/scripts/ballista_cluster.sh start   # start both, block until ready
+#   ci/scripts/ballista_cluster.sh stop    # dump log tails, then terminate
+#
+# `start` writes the PIDs to a pidfile so `stop` can run as a separate CI step.
+#
+# Settings, all overridable via the environment:
+#   BALLISTA_BIN_DIR    directory holding ballista-scheduler / ballista-executor
+#   CLUSTER_DIR         scratch dir for logs, pidfile and the executor work dir
+#   SCHEDULER_PORT      scheduler bind/connect port
+#   EXECUTOR_PORT       executor bind port
+#   EXECUTOR_VCORES     executor vcore count
+#   EXECUTOR_MEMORY     executor memory pool size
+#   READY_TIMEOUT_SECONDS     how long to wait for each port to open
+#   SHUTDOWN_TIMEOUT_SECONDS  grace period after SIGTERM before SIGKILL
+#   STARTUP_SETTLE_SECONDS    pause before the post-readiness liveness re-check
+
+set -euo pipefail
+
+BALLISTA_BIN_DIR="${BALLISTA_BIN_DIR:-./target/tpch-ci}"
+CLUSTER_DIR="${CLUSTER_DIR:-${RUNNER_TEMP:-/tmp}}"
+SCHEDULER_PORT="${SCHEDULER_PORT:-50050}"
+EXECUTOR_PORT="${EXECUTOR_PORT:-50051}"
+EXECUTOR_VCORES="${EXECUTOR_VCORES:-4}"
+EXECUTOR_MEMORY="${EXECUTOR_MEMORY:-2GB}"
+READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-30}"
+SHUTDOWN_TIMEOUT_SECONDS="${SHUTDOWN_TIMEOUT_SECONDS:-10}"
+STARTUP_SETTLE_SECONDS="${STARTUP_SETTLE_SECONDS:-2}"
+
+SCHEDULER_LOG="${CLUSTER_DIR}/scheduler.log"
+EXECUTOR_LOG="${CLUSTER_DIR}/executor.log"
+WORK_DIR="${CLUSTER_DIR}/work"
+PID_FILE="${CLUSTER_DIR}/ballista-cluster.pids"
+
+dump_logs() {
+    echo "::group::scheduler log (tail)"
+    tail -n 200 "${SCHEDULER_LOG}" 2>/dev/null || true
+    echo "::endgroup::"
+    echo "::group::executor log (tail)"
+    tail -n 200 "${EXECUTOR_LOG}" 2>/dev/null || true
+    echo "::endgroup::"
+}
+
+# Waits for a port to accept connections, failing fast if the process backing it
+# has already exited.
+wait_for_port() {
+    local name=$1 port=$2 pid=$3
+
+    echo "Waiting for ${name} on 127.0.0.1:${port}..."
+    for _ in $(seq 1 "${READY_TIMEOUT_SECONDS}"); do
+        if nc -z 127.0.0.1 "${port}"; then
+            echo "${name} is up"
+            return 0
+        fi
+        if ! kill -0 "${pid}" 2>/dev/null; then
+            echo "${name} exited before opening port ${port}" >&2
+            return 1
+        fi
+        sleep 1
+    done
+
+    echo "${name} did not open port ${port} within ${READY_TIMEOUT_SECONDS}s" >&2
+    return 1
+}
+
+# An open port is not proof of a healthy process: the executor binds its gRPC
+# port before the Arrow Flight server and exits if that later bind fails, and a
+# stale listener from an earlier run can answer the probe too.
+confirm_still_alive() {
+    sleep "${STARTUP_SETTLE_SECONDS}"
+
+    while [ $# -gt 0 ]; do
+        if ! kill -0 "$2" 2>/dev/null; then
+            echo "$1 exited during startup (see log below)" >&2
+            return 1
+        fi
+        shift 2
+    done
+}
+
+start() {
+    mkdir -p "${WORK_DIR}"
+
+    "${BALLISTA_BIN_DIR}/ballista-scheduler" \
+        --bind-host 127.0.0.1 \
+        --bind-port "${SCHEDULER_PORT}" \
+        > "${SCHEDULER_LOG}" 2>&1 &
+    local scheduler_pid=$!
+
+    "${BALLISTA_BIN_DIR}/ballista-executor" \
+        --bind-host 127.0.0.1 \
+        --bind-port "${EXECUTOR_PORT}" \
+        --scheduler-host 127.0.0.1 \
+        --scheduler-port "${SCHEDULER_PORT}" \
+        --scheduler-connect-timeout-seconds 10 \
+        --vcores "${EXECUTOR_VCORES}" \
+        --memory-pool-size "${EXECUTOR_MEMORY}" \
+        --work-dir "${WORK_DIR}" \
+        > "${EXECUTOR_LOG}" 2>&1 &
+    local executor_pid=$!
+
+    printf '%s\n%s\n' "${scheduler_pid}" "${executor_pid}" > "${PID_FILE}"
+
+    if ! wait_for_port scheduler "${SCHEDULER_PORT}" "${scheduler_pid}" ||
+        ! wait_for_port executor "${EXECUTOR_PORT}" "${executor_pid}" ||
+        ! confirm_still_alive scheduler "${scheduler_pid}" executor "${executor_pid}"; then
+        dump_logs
+        return 1
+    fi
+}
+
+stop() {
+    dump_logs
+
+    if [ ! -f "${PID_FILE}" ]; then
+        echo "no pidfile at ${PID_FILE}; nothing to stop"
+        return 0
+    fi
+
+    # These were started by an earlier step's shell and are not our children,
+    # so poll for the PID to go away rather than waiting on it.
+    while read -r pid; do
+        [ -n "${pid}" ] || continue
+        kill -0 "${pid}" 2>/dev/null || continue
+
+        kill "${pid}" 2>/dev/null || true
+        for _ in $(seq 1 "${SHUTDOWN_TIMEOUT_SECONDS}"); do
+            kill -0 "${pid}" 2>/dev/null || break
+            sleep 1
+        done
+
+        if kill -0 "${pid}" 2>/dev/null; then
+            echo "pid ${pid} ignored SIGTERM after ${SHUTDOWN_TIMEOUT_SECONDS}s; sending SIGKILL"
+            kill -9 "${pid}" 2>/dev/null || true
+        fi
+    done < "${PID_FILE}"
+
+    rm -f "${PID_FILE}"
+}
+
+case "${1:-}" in
+    start) start ;;
+    stop) stop ;;
+    *)
+        echo "usage: $0 {start|stop}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

The three benchmark workflows each inlined the same ~60 lines of setup and
cluster lifecycle. This extracts the shared halves into
`.github/actions/setup-benchmark-builder` (deps, toolchain, cache, build) and
`ci/scripts/ballista_cluster.sh` (`start` / `stop`). Workflows drop from ~90
lines of job body to ~40.

`stop` is now its own step under `if: always()`, so teardown and the log dump
also happen on a timeout or cancellation. The old `trap cleanup EXIT` only
fired if the step's own shell exited.

Fixes drift the three copies had accumulated:
- tpch and h2o uploaded logs under `failure()`, discarding them on a hang,
  which is the case they exist for. Now `!success()`, matching tpcds.
- tpch and h2o had no timeouts (6-hour default). All three now 45min job /
  30min step; observed passing jobs are 8-23min.
- tpcds used `--concurrent-tasks`, a deprecated alias that warns. Now `--vcores`.

Also fixes two readiness bugs present in all three copies. A dead process was
waited on for the full 30s instead of failing immediately, and an open port was
treated as proof of health (the executor binds its gRPC port before the Flight
server and exits if that later bind fails).

No new third-party actions,  the composite reuses the rust-cache pin already
used across the repo.