### PR TITLE
chore: consolidate shared manifest metadata into the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,24 @@ members = [
 resolver = "3"
 
 [workspace.package]
+authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 edition = "2024"
+homepage = "https://datafusion.apache.org/ballista/"
+license = "Apache-2.0"
+repository = "https://github.com/apache/datafusion-ballista"
 # we should try to follow datafusion version 
 rust-version = "1.94.0"
+version = "54.0.0"
 
 [workspace.dependencies]
 arrow = { version = "59.2.0", features = ["ipc_compression"] }
 arrow-flight = { version = "59.2.0", features = ["flight-sql-experimental"] }
+ballista = { path = "ballista/client", version = "54.0.0" }
 ballista-api-types = { path = "ballista/api-types", version = "54.0.0" }
+ballista-core = { path = "ballista/core", version = "54.0.0" }
+ballista-executor = { path = "ballista/executor", version = "54.0.0" }
+ballista-history = { path = "ballista/history", version = "54.0.0" }
+ballista-scheduler = { path = "ballista/scheduler", version = "54.0.0" }
 clap = { version = "4.5", features = ["derive", "cargo"] }
 
 # Keep these as minor-version requirements rather than exact patch pins so a
@@ -74,6 +84,8 @@ tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 async-trait = { version = "0.1" }
+axum = "0.8.9"
+chrono = { version = "0.4", default-features = false }
 dashmap = { version = "6.2" }
 env_logger = { version = "0.11" }
 futures = { version = "0.3" }
@@ -81,6 +93,7 @@ log = { version = "0.4" }
 parking_lot = { version = "0.12" }
 rand = { version = "0.10" }
 serde = { version = "1.0" }
+serde_json = { version = "1" }
 tempfile = { version = "3.27" }
 tokio = { version = "1" }
 tokio-stream = { version = "0.1" }

--- a/ballista-cli/Cargo.toml
+++ b/ballista-cli/Cargo.toml
@@ -18,14 +18,14 @@
 [package]
 name = "ballista-cli"
 description = "Command Line Client for Ballista distributed query engine."
-version = "54.0.0"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+version = { workspace = true }
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 keywords = ["ballista", "cli"]
-license = "Apache-2.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
 
 [lib]
@@ -33,7 +33,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # CLI-only deps (DataFusion/Ballista) — gated by `cli` feature
-ballista = { path = "../ballista/client", version = "54.0.0", features = ["standalone"], optional = true }
+ballista = { workspace = true, features = ["standalone"], optional = true }
 datafusion = { workspace = true, optional = true }
 datafusion-cli = { workspace = true, optional = true }
 mimalloc = { workspace = true, optional = true }
@@ -41,25 +41,25 @@ rustyline = { version = "18.0.0", optional = true }
 
 # TUI/web shared deps
 ballista-api-types = { workspace = true, optional = true }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
+chrono = { workspace = true, features = ["std", "clock"], optional = true }
 clap = { workspace = true, features = ["derive", "cargo"] }
 config = { version = "0.15.23", default-features = false, features = ["yaml"], optional = true }
 dirs = "6.0"
 dotparser = { version = "0.3.0", optional = true }
-futures = { version = "0.3.31", optional = true }
+futures = { workspace = true, optional = true }
 prometheus-parse = { version = "0.2", optional = true }
 ratatui = { version = "0.30.1", default-features = false, optional = true }
 reqwest = { version = "0.13.4", features = ["json"], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "local-time"] }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "local-time"] }
 tui-shimmer = { version = "0.1", optional = true }
 url-escape = { workspace = true, optional = true }
 
 # Native-only TUI deps
 crossterm = { version = "0.29.0", features = ["event-stream"], optional = true }
-tracing-appender = { version = "0.2", optional = true }
+tracing-appender = { workspace = true, optional = true }
 
 # Web-only deps (WASM)
 console_error_panic_hook = { version = "0.1", optional = true }

--- a/ballista/api-types/Cargo.toml
+++ b/ballista/api-types/Cargo.toml
@@ -18,11 +18,11 @@
 [package]
 name = "ballista-api-types"
 description = "Wire types for the Ballista scheduler REST API"
-license = "Apache-2.0"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+license = { workspace = true }
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 

--- a/ballista/client/Cargo.toml
+++ b/ballista/client/Cargo.toml
@@ -18,18 +18,18 @@
 [package]
 name = "ballista"
 description = "Ballista Distributed Compute"
-license = "Apache-2.0"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
+license = { workspace = true }
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
-ballista-core = { path = "../core", version = "54.0.0" }
+ballista-core = { workspace = true }
 ballista-executor = { path = "../executor", version = "54.0.0", optional = true, default-features = false, features = [
     "arrow-ipc-optimizations",
 ] }
@@ -41,8 +41,8 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-ballista-executor = { path = "../executor", version = "54.0.0" }
-ballista-scheduler = { path = "../scheduler", version = "54.0.0" }
+ballista-executor = { workspace = true }
+ballista-scheduler = { workspace = true }
 ctor = { workspace = true }
 datafusion-proto = { workspace = true }
 env_logger = { workspace = true }

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -18,12 +18,12 @@
 [package]
 name = "ballista-core"
 description = "Ballista Distributed Compute"
-license = "Apache-2.0"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
+license = { workspace = true }
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 build = "build.rs"
@@ -48,14 +48,14 @@ arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 aws-config = { version = "1.8.18", optional = true }
 aws-credential-types = { version = "1.2.0", optional = true }
-chrono = { version = "0.4", default-features = false }
+chrono = { workspace = true }
 clap = { workspace = true, optional = true }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 datafusion-proto-common = { workspace = true }
 datafusion-spark = { workspace = true, optional = true, features = ["datafusion"] }
 futures = { workspace = true }
-itertools = "0.15"
+itertools = { workspace = true }
 log = { workspace = true }
 md-5 = { version = "^0.11.0" }
 object_store = { workspace = true, features = ["aws", "http"], optional = true }

--- a/ballista/executor/Cargo.toml
+++ b/ballista/executor/Cargo.toml
@@ -18,12 +18,12 @@
 [package]
 name = "ballista-executor"
 description = "Ballista Distributed Compute - Executor"
-license = "Apache-2.0"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
+license = { workspace = true }
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -50,8 +50,8 @@ spark-compat = ["ballista-core/spark-compat"]
 arrow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
-axum = { version = "0.8.9", optional = true }
-ballista-core = { path = "../core", version = "54.0.0" }
+axum = { workspace = true, optional = true }
+ballista-core = { workspace = true }
 bytesize = "2"
 clap = { workspace = true, optional = true }
 dashmap = { workspace = true }
@@ -74,10 +74,6 @@ tracing = { workspace = true, optional = true }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 uuid = { workspace = true }
-
-[dev-dependencies]
-
-[build-dependencies]
 
 # use libc on unix like platforms to set worker priority in DedicatedExecutor
 [target."cfg(unix)".dependencies.libc]

--- a/ballista/history/Cargo.toml
+++ b/ballista/history/Cargo.toml
@@ -18,11 +18,11 @@
 [package]
 name = "ballista-history"
 description = "Event-log schema, writer, and reader for the Ballista history server"
-license = "Apache-2.0"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+license = { workspace = true }
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -30,7 +30,7 @@ rust-version = { workspace = true }
 ballista-api-types = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt", "sync"] }
 
 [dev-dependencies]

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -18,12 +18,12 @@
 [package]
 name = "ballista-scheduler"
 description = "Ballista Distributed Compute - Scheduler"
-license = "Apache-2.0"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
+license = { workspace = true }
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
+authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -53,10 +53,10 @@ substrait = ["dep:datafusion-substrait"]
 [dependencies]
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
-axum = "0.8.9"
+axum = { workspace = true }
 ballista-api-types = { workspace = true, optional = true }
-ballista-core = { path = "../core", version = "54.0.0" }
-ballista-history = { path = "../history", version = "54.0.0", optional = true }
+ballista-core = { workspace = true }
+ballista-history = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 dashmap = { workspace = true }
 datafusion = { workspace = true }
@@ -77,7 +77,7 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { version = "1", optional = true }
+serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true, features = ["router"] }
@@ -96,7 +96,7 @@ path = "tests/tpch_plan_stability/main.rs"
 [dev-dependencies]
 regex = "1"
 rstest = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,12 +18,13 @@
 [package]
 name = "ballista-benchmarks"
 description = "Ballista Benchmarks"
-version = "54.0.0"
-edition = "2024"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
-license = "Apache-2.0"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 publish = false
 
 [features]
@@ -31,10 +32,8 @@ ci = []
 default = ["mimalloc"]
 
 [dependencies]
-ballista = { path = "../ballista/client", version = "54.0.0" }
-ballista-core = { path = "../ballista/core", version = "54.0.0", features = [
-    "build-binary",
-] }
+ballista = { workspace = true }
+ballista-core = { workspace = true, features = ["build-binary"] }
 clap = { workspace = true }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
@@ -43,10 +42,10 @@ futures = { workspace = true }
 mimalloc = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
-serde_json = "1.0.150"
+serde_json = { workspace = true }
 structopt = { version = "0.3", default-features = false }
 tempfile = { workspace = true }
-tokio = { version = "^1.52", features = [
+tokio = { workspace = true, features = [
     "macros",
     "rt",
     "rt-multi-thread",

--- a/chaos-testing/Cargo.toml
+++ b/chaos-testing/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "ballista-chaos"
 description = "Fault-injection harness for testing Ballista high availability"
-license = "Apache-2.0"
+license = { workspace = true }
 version = "0.1.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
@@ -32,16 +32,16 @@ k8s = []
 
 [dependencies]
 arrow = { workspace = true }
-ballista = { path = "../ballista/client" }
-ballista-core = { path = "../ballista/core" }
-ballista-executor = { path = "../ballista/executor" }
-ballista-scheduler = { path = "../ballista/scheduler" }
+ballista = { workspace = true }
+ballista-core = { workspace = true }
+ballista-executor = { workspace = true }
+ballista-scheduler = { workspace = true }
 datafusion = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 nix = { version = "0.31", features = ["fs", "signal"] }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
-serde_json = "1.0"
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "sync", "time"] }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,11 +18,11 @@
 [package]
 name = "ballista-examples"
 description = "Ballista usage examples"
-version = "54.0.0"
-homepage = "https://datafusion.apache.org/ballista/"
-repository = "https://github.com/apache/datafusion-ballista"
-authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
-license = "Apache-2.0"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 keywords = ["arrow", "distributed", "query", "sql"]
 edition = { workspace = true }
 rust-version = { workspace = true }
@@ -57,7 +57,7 @@ rustls = { version = "0.23", features = ["ring"], optional = true }
 
 [dev-dependencies]
 arrow-flight = { workspace = true }
-ballista = { path = "../ballista/client", version = "54.0.0" }
+ballista = { workspace = true }
 ballista-core = { path = "../ballista/core", version = "54.0.0", default-features = false, features = ["build-binary"] }
 ballista-executor = { path = "../ballista/executor", version = "54.0.0", default-features = false }
 ballista-scheduler = { path = "../ballista/scheduler", version = "54.0.0", default-features = false }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -24,8 +24,8 @@ authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 description = "Apache DataFusion Ballista Python Client"
 readme = "README.md"
 license = "Apache-2.0"
-edition = "2021"
-rust-version = "1.82.0"
+edition = "2024"
+rust-version = "1.94.0"
 include = ["/src", "/ballista", "/LICENSE.txt", "pyproject.toml", "Cargo.toml", "Cargo.lock"]
 publish = false
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Manifest-only cleanup. No resolved dependency or feature set changes.

- `[workspace.package]` gains `version`, `authors`, `license`, `homepage`,
  `repository`; all ten members inherit. `readme` stays per-crate (inherited,
  it resolves against the workspace root, not the crate).
- Internal crates moved to `[workspace.dependencies]`, so a release bump
  touches one file. Five use sites keep the explicit `path` + `version` form
  because Cargo rejects `default-features = false` on an inherited dep.
- Third-party stragglers now use the workspace table: `itertools`, `chrono`,
  `axum`, `serde_json` (was declared 5x across 3 version specs), `tokio` in
  benchmarks, and `serde` / `futures` / `tracing*` in ballista-cli. `reqwest`
  is left alone: the CLI wants default TLS, chaos-testing deliberately drops it.
- benchmarks was the only member hardcoding `edition` and omitting
  `rust-version`; both now inherit. Dropped the executor's empty
  `[dev-dependencies]` and `[build-dependencies]`.
- `python/Cargo.toml` moves to edition 2024, which needs Rust 1.85+, so
  `rust-version` goes to 1.94.0. The old 1.82.0 floor was already unreachable
  via `ballista = "=54.0.0"`. It can't inherit; it's in the workspace's
  `exclude` list.

Verified: `cargo tree --all-features` identical across all 557 packages before
and after; no `Cargo.lock` drift; `cargo check --workspace --all-targets
--locked` and the `--no-default-features` check pass; pyballista compiles under
edition 2024; `taplo format --check` clean.