### PR TITLE
perf(core): remove the inert shuffle-read sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,6 @@ dependencies = [
  "datafusion-proto-common",
  "datafusion-spark",
  "futures",
- "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",

--- a/ballista/core/Cargo.toml
+++ b/ballista/core/Cargo.toml
@@ -55,7 +55,6 @@ datafusion-proto = { workspace = true }
 datafusion-proto-common = { workspace = true }
 datafusion-spark = { workspace = true, optional = true, features = ["datafusion"] }
 futures = { workspace = true }
-itertools = { workspace = true }
 log = { workspace = true }
 object_store = { workspace = true, features = ["aws", "http"], optional = true }
 parking_lot = { workspace = true }

--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -50,7 +50,6 @@ use datafusion::physical_plan::{
 };
 use datafusion::prelude::SessionConfig;
 use futures::{Stream, StreamExt, TryStreamExt, ready};
-use itertools::Itertools;
 use log::{debug, error, trace};
 use rand::prelude::SliceRandom;
 use rand::rng;
@@ -389,20 +388,8 @@ impl ExecutionPlan for ShuffleReaderExec {
             config.ballista_shuffle_reader_maximum_concurrent_requests(),
             config.ballista_grpc_client_max_message_size()
         );
-        let mut partition_locations = HashMap::new();
-        for p in &self.partition[partition] {
-            partition_locations
-                .entry(p.executor_meta.id.clone())
-                .or_insert_with(Vec::new)
-                .push(p.clone());
-        }
-        // Sort partitions for evenly send fetching partition requests to avoid hot executors within one task
-        let mut partition_locations: Vec<PartitionLocation> = partition_locations
-            .into_values()
-            .flat_map(|ps| ps.into_iter().enumerate())
-            .sorted_by(|(p1_idx, _), (p2_idx, _)| Ord::cmp(p1_idx, p2_idx))
-            .map(|(_, p)| p)
-            .collect();
+        let mut partition_locations: Vec<PartitionLocation> =
+            self.partition[partition].clone();
         // Shuffle partitions for evenly send fetching partition requests to avoid hot executors within multiple tasks
         partition_locations.shuffle(&mut rng());
 


### PR DESCRIPTION


# Which issue does this PR close?
Closes #2403 

 # Rationale for this change
The shuffle is uniformly random (Durstenfeld's Fisher-Yates) , so sorting before the random shuffle does nothing.


## AI Verification

Confirmed by counting permutations over 4 blocks (24 permutations), 480,000
trials per pipeline. Uniform if chi-square is below 35.17 (5% level, 23 df):

| shape | pipeline | chi-square |
| --- | --- | --- |
| even | sort + shuffle | 24.66 |
| even | shuffle only | 13.38 |
| skewed | sort + shuffle | 27.17 |
| skewed | shuffle only | 19.58 |

All four pass. Every trial also asserted the output is a permutation of the
input, so the set of blocks fetched is unchanged.


# What changes are included in this PR?
- Delete inert sort for partition_locations in shuffle reader.
- Delete now unused itertools crate.

# Are there any user-facing changes?
No
