### PR TITLE
test: dedupe shuffle reader test setup

### DIFF
--- a/ballista/core/src/execution_plans/shuffle_reader.rs
+++ b/ballista/core/src/execution_plans/shuffle_reader.rs
@@ -1966,24 +1966,9 @@ mod tests {
     // qualify all partitions as remote
     #[tokio::test]
     async fn test_remote_local_read() {
-        let schema = get_test_partition_schema();
-        let data_array = Int32Array::from(vec![1]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
-                .unwrap();
         let tmp_dir = tempdir().unwrap();
         let work_dir = tmp_dir.path();
-
-        // job name and stage id are hard-coded
-        let file_path =
-            create_shuffle_path(work_dir, &"job".into(), 1, 0, None, false).unwrap();
-
-        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-
-        let file = File::create(&file_path).unwrap();
-        let mut writer = StreamWriter::try_new(file, &schema).unwrap();
-        writer.write(&batch).unwrap();
-        writer.finish().unwrap();
+        write_local_shuffle_files(work_dir, 1);
 
         let partition_locations = get_test_partition_locations(1, None);
 
@@ -2007,27 +1992,9 @@ mod tests {
     }
 
     async fn test_send_fetch_partitions(max_request_num: usize, partition_num: usize) {
-        let schema = get_test_partition_schema();
-        let data_array = Int32Array::from(vec![1]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
-                .unwrap();
         let tmp_dir = tempdir().unwrap();
         let work_dir = tmp_dir.path();
-
-        for p in 0..partition_num {
-            // job name and stage id are hard-codded
-            let file_path =
-                create_shuffle_path(work_dir, &"job".into(), 1, p, None, false).unwrap();
-            // this unwrap should not be problem as
-            // this function never return root dir
-            std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-            let file: File = File::create(&file_path).unwrap();
-
-            let mut writer = StreamWriter::try_new(file, &schema).unwrap();
-            writer.write(&batch).unwrap();
-            writer.finish().unwrap();
-        }
+        let schema = write_local_shuffle_files(work_dir, partition_num);
 
         let partition_locations = get_test_partition_locations(partition_num, None);
         let config = SessionConfig::new_with_ballista()
@@ -2053,23 +2020,10 @@ mod tests {
 
     #[tokio::test]
     async fn send_fetch_partitions_records_local_metrics() {
-        let schema = get_test_partition_schema();
-        let data_array = Int32Array::from(vec![1]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(data_array)])
-                .unwrap();
         let tmp_dir = tempdir().unwrap();
         let work_dir = tmp_dir.path();
         let partition_num = 3usize;
-        for p in 0..partition_num {
-            let file_path =
-                create_shuffle_path(work_dir, &"job".into(), 1, p, None, false).unwrap();
-            std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
-            let file = File::create(&file_path).unwrap();
-            let mut writer = StreamWriter::try_new(file, &schema).unwrap();
-            writer.write(&batch).unwrap();
-            writer.finish().unwrap();
-        }
+        let schema = write_local_shuffle_files(work_dir, partition_num);
         let partition_locations = get_test_partition_locations(partition_num, None);
         let config = SessionConfig::new_with_ballista();
         let metrics_set = ExecutionPlanMetricsSet::new();
@@ -2133,6 +2087,27 @@ mod tests {
                 .map(|v| v.as_usize()),
             Some(0)
         );
+    }
+
+    /// Writes `n` single-row local shuffle files under `work_dir`, returning
+    /// the schema they share.
+    fn write_local_shuffle_files(work_dir: &std::path::Path, n: usize) -> Schema {
+        let schema = get_test_partition_schema();
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )
+        .unwrap();
+        for p in 0..n {
+            let path =
+                create_shuffle_path(work_dir, &"job".into(), 1, p, None, false).unwrap();
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let mut writer =
+                StreamWriter::try_new(File::create(&path).unwrap(), &schema).unwrap();
+            writer.write(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        schema
     }
 
     fn get_test_partition_locations(

--- a/ballista/scheduler/src/state/task_builder.rs
+++ b/ballista/scheduler/src/state/task_builder.rs
@@ -435,17 +435,23 @@ mod tests {
         }
     }
 
+    /// A `ShuffleReaderExec` over `n` single-location partitions.
+    fn shuffle_reader(n: usize) -> Arc<dyn ExecutionPlan> {
+        let partitions = (0..n).map(|i| vec![create_partition(i)]).collect();
+        Arc::new(
+            ShuffleReaderExec::try_new(
+                1,
+                partitions,
+                Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
+                Partitioning::UnknownPartitioning(n),
+            )
+            .unwrap(),
+        )
+    }
+
     #[test]
     fn keeps_only_the_wanted_partition() {
-        let partitions = (0..4).map(|i| vec![create_partition(i)]).collect();
-        let reader = ShuffleReaderExec::try_new(
-            1,
-            partitions,
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            Partitioning::UnknownPartitioning(4),
-        )
-        .unwrap();
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(reader);
+        let plan = shuffle_reader(4);
         let pruned = restrict_plan_to_partitions(plan, &[1]).unwrap();
         let r = pruned
             .downcast_ref::<ShuffleReaderExec>()
@@ -459,15 +465,7 @@ mod tests {
 
     #[test]
     fn keeps_multiple_wanted_partitions_in_request_order() {
-        let partitions = (0..4).map(|i| vec![create_partition(i)]).collect();
-        let reader = ShuffleReaderExec::try_new(
-            1,
-            partitions,
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            Partitioning::UnknownPartitioning(4),
-        )
-        .unwrap();
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(reader);
+        let plan = shuffle_reader(4);
         let pruned = restrict_plan_to_partitions(plan, &[0, 3]).unwrap();
         let r = pruned
             .downcast_ref::<ShuffleReaderExec>()
@@ -542,15 +540,7 @@ mod tests {
 
     #[test]
     fn restricting_to_every_partition_is_a_no_op() {
-        let partitions = (0..3).map(|i| vec![create_partition(i)]).collect();
-        let reader = ShuffleReaderExec::try_new(
-            1,
-            partitions,
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            Partitioning::UnknownPartitioning(3),
-        )
-        .unwrap();
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(reader);
+        let plan = shuffle_reader(3);
         let pruned = restrict_plan_to_partitions(plan, &[0, 1, 2]).unwrap();
         let r = pruned
             .downcast_ref::<ShuffleReaderExec>()


### PR DESCRIPTION
 # Rationale for this change

Found while working on the ordering PR. There probably are other test cleanups, but these were the only ones I put time into verifying.

Two test setup blocks were copy-pasted three times each.

# What changes are included in this PR?

- `write_local_shuffle_files(work_dir, n)` replaces three copies of the local
  shuffle file writing in `shuffle_reader.rs`.
- `shuffle_reader(n)` replaces three copies of the reader construction in
  `task_builder.rs`.

Tests only. +41 / −76.
