### PR TITLE
fix(ci): pin tinyvec in the MSRV dependency checker

### DIFF
--- a/dev/msrvcheck/Cargo.toml
+++ b/dev/msrvcheck/Cargo.toml
@@ -24,4 +24,5 @@ edition = "2024"
 
 [dependencies]
 cargo = "0.97.1"
-time = "=0.3.47" # time 0.3.48 introduced an associated-type From impl that conflicts with cargo-credential's blanket From impl
+time = "=0.3.47"    # time 0.3.48 introduced an associated-type From impl that conflicts with cargo-credential's blanket From impl
+tinyvec = "=1.12.0" # tinyvec 1.13.0 does not compile: `use alloc::vec::{self, Vec}` shadows the `vec!` macro


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2420.

# Rationale for this change

`msrv dependency check` is failing on every PR that touches a manifest:

```
error: cannot find macro `vec` in this scope
   --> tinyvec-1.13.0/src/tinyvec.rs:710:21
note: `vec` is imported here, but it is a module, not a macro
   --> tinyvec-1.13.0/src/tinyvec.rs:3:18
  3 | use alloc::vec::{self, Vec};
error: could not compile `tinyvec` (lib) due to 1 previous error
```

`tinyvec 1.13.0` shadows its own `vec!` macro with a module import, so it does
not build without `std`. It was published 2026-09-03T21:13:39Z, which is when
the job started failing.

Only that job is affected. `tinyvec` reaches it transitively through the
`cargo` crate, and `dev/msrvcheck/.gitignore` ignores `Cargo.lock`, so
`cargo run` re-resolves from crates.io on every CI run and picked the broken
version up as soon as it appeared. The workspace itself is fine: its
checked-in `Cargo.lock` pins `tinyvec 1.12.0`.

# What changes are included in this PR?

Pins `tinyvec = "=1.12.0"` in `dev/msrvcheck/Cargo.toml`, the same way `time`
is already pinned there for a similar upstream break, with a comment saying
why. The pin can be dropped once upstream ships a fix.

The one-line change to the `time` entry is `taplo` realigning the trailing
comments now that a longer key sits below it.

# Are there any user-facing changes?

No. `dev/msrvcheck` is a CI helper and is not part of the published workspace.
