### PR TITLE
test(chaos): run #2029 executor-loss scenarios on the k8s backend

### DIFF
--- a/chaos-testing/README.md
+++ b/chaos-testing/README.md
@@ -179,11 +179,24 @@ The harness also has an opt-in Kubernetes backend (`K8sCluster`, in
 `src/k8s.rs`) that runs the scheduler and executors as pods in a local
 [kind](https://kind.sigs.k8s.io) cluster rather than as local processes. It is
 gated behind the `k8s` feature _and_ `CHAOS_BACKEND=kind`, so a plain `cargo
-test` never touches a cluster. Today it runs a single baseline scenario — a real
-query whose result must match plain local DataFusion — as a walking skeleton for
-the executor-kill scenarios the
-[#2029](https://github.com/apache/datafusion-ballista/issues/2029) follow-ups
-will add. It needs [Docker](https://docs.docker.com/get-docker/),
+test` never touches a cluster. It runs the scenarios that genuinely need a
+cluster — real pod lifecycle, rescheduling, and the port-forward/flight-proxy
+path — while the backend-agnostic fault-injection scenarios stay on the fast
+process harness:
+
+- **baseline** — a real query whose result must match plain local DataFusion
+  (exercises the mount, port-forward, flight proxy, and shuffle).
+- **G / [#2029](https://github.com/apache/datafusion-ballista/issues/2029)** —
+  every executor is force-killed mid-query and the Deployment is held at zero: a
+  total loss that is neither drained nor rescheduled (a graceful `scale 0` alone
+  lets the executors drain the query to success). The job must fail with an
+  executor-loss error, not hang. Run under both AQE settings, since #2029 had an
+  AQE-on-only hang path.
+- **F** — one executor pod is force-deleted; the Deployment reschedules a
+  replacement with a new id, and the cluster must reabsorb it and keep serving
+  queries. This proves genuine rescheduling, which the process backend cannot.
+
+It needs [Docker](https://docs.docker.com/get-docker/),
 [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), and
 `kubectl`.
 

--- a/chaos-testing/src/cluster.rs
+++ b/chaos-testing/src/cluster.rs
@@ -467,67 +467,23 @@ impl TestCluster {
     /// actually reaping it (rather than just transiently over-counting) needs
     /// to wait for the count to come down to `n` exactly, not merely reach it.
     pub async fn await_executor_count(&self, n: usize) -> Result<(), String> {
-        let deadline = Instant::now() + Duration::from_secs(120);
-        loop {
-            if let Ok(count) = self.registered_executors().await
-                && count == n
-            {
-                return Ok(());
-            }
-            if Instant::now() > deadline {
-                return Err(format!(
-                    "timed out waiting for exactly {n} registered executors"
-                ));
-            }
-            tokio::time::sleep(Duration::from_millis(200)).await;
-        }
+        crate::rest::await_executor_count(&self.rest_url(), n).await
     }
 
     /// How many executors the scheduler currently considers registered.
     pub async fn registered_executors(&self) -> Result<usize, String> {
-        let body: serde_json::Value =
-            reqwest::get(format!("{}/api/executors", self.rest_url()))
-                .await
-                .map_err(|e| e.to_string())?
-                .json()
-                .await
-                .map_err(|e| e.to_string())?;
-        Ok(body.as_array().map(|a| a.len()).unwrap_or(0))
+        crate::rest::registered_executors(&self.rest_url()).await
     }
 
     /// The id of the single job the scheduler currently knows about.
     ///
     /// The harness runs one query at a time, so "the running job" is unambiguous.
     pub async fn running_job_id(&self) -> Result<String, String> {
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            let body: serde_json::Value =
-                reqwest::get(format!("{}/api/jobs", self.rest_url()))
-                    .await
-                    .map_err(|e| e.to_string())?
-                    .json()
-                    .await
-                    .map_err(|e| e.to_string())?;
-
-            if let Some(job) = body.as_array().and_then(|jobs| jobs.first())
-                && let Some(id) = job.get("job_id").and_then(|v| v.as_str())
-            {
-                return Ok(id.to_string());
-            }
-            if Instant::now() > deadline {
-                return Err("timed out waiting for a job to appear".to_string());
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+        crate::rest::running_job_id(&self.rest_url()).await
     }
 
     async fn stages(&self, job_id: &str) -> Result<serde_json::Value, String> {
-        reqwest::get(format!("{}/api/job/{job_id}/stages", self.rest_url()))
-            .await
-            .map_err(|e| e.to_string())?
-            .json()
-            .await
-            .map_err(|e| e.to_string())
+        crate::rest::stages(&self.rest_url(), job_id).await
     }
 
     /// Block until `stage_id` has at least one task in state Running.
@@ -550,35 +506,7 @@ impl TestCluster {
     /// specific stage id we wait until the job is genuinely executing a task
     /// somewhere. Used where the scenario only needs a kill to land mid-flight.
     pub async fn await_any_stage_running(&self, job_id: &str) -> Result<(), String> {
-        let deadline = Instant::now() + Duration::from_secs(60);
-        loop {
-            let stages = self.stages(job_id).await?;
-            let running =
-                stages
-                    .get("stages")
-                    .and_then(|s| s.as_array())
-                    .is_some_and(|stages| {
-                        stages.iter().any(|stage| {
-                            stage.get("tasks").and_then(|t| t.as_array()).is_some_and(
-                                |tasks| {
-                                    tasks.iter().any(|t| {
-                                        t.get("status").and_then(|s| s.as_str())
-                                            == Some("Running")
-                                    })
-                                },
-                            )
-                        })
-                    });
-            if running {
-                return Ok(());
-            }
-            if Instant::now() > deadline {
-                return Err(
-                    "timed out waiting for any stage to start running".to_string()
-                );
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
+        crate::rest::await_any_stage_running(&self.rest_url(), job_id).await
     }
 
     /// Block until every task in `stage_id` is Successful.

--- a/chaos-testing/src/k8s.rs
+++ b/chaos-testing/src/k8s.rs
@@ -259,29 +259,37 @@ impl K8sCluster {
 
     /// How many executors the scheduler currently considers registered.
     pub async fn registered_executors(&self) -> Result<usize, String> {
-        // A short timeout so a stalled port-forward surfaces as a retryable
-        // error in the polling loop rather than hanging the whole wait.
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build()
-            .map_err(|e| e.to_string())?;
-        let body: serde_json::Value = client
-            .get(format!("{}/api/executors", self.rest_url()))
-            .send()
-            .await
-            .map_err(|e| e.to_string())?
-            .json()
-            .await
-            .map_err(|e| e.to_string())?;
-        Ok(body.as_array().map(|a| a.len()).unwrap_or(0))
+        crate::rest::registered_executors(&self.rest_url()).await
     }
 
-    /// Scale the executor Deployment. `0` is a total loss that stays lost (the
-    /// controller does not recreate the pods); scaling back up recovers.
-    ///
-    /// Not yet exercised by a scenario — this is the k8s primitive the executor
-    /// kill/loss scenarios (the #2029 follow-ups) will drive; the baseline test
-    /// only needs a healthy cluster. Kept here so the backend is complete.
+    /// The ids of every executor the scheduler currently lists. A killed
+    /// executor's pod is rescheduled with a fresh id, so a scenario can compare
+    /// this before and after a kill to prove the replacement is genuinely new.
+    pub async fn executor_ids(&self) -> Result<Vec<String>, String> {
+        crate::rest::executor_ids(&self.rest_url()).await
+    }
+
+    /// The id of the single job the scheduler currently knows about.
+    pub async fn running_job_id(&self) -> Result<String, String> {
+        crate::rest::running_job_id(&self.rest_url()).await
+    }
+
+    /// Block until any task in any stage is Running, so a kill lands mid-flight.
+    pub async fn await_any_stage_running(&self, job_id: &str) -> Result<(), String> {
+        crate::rest::await_any_stage_running(&self.rest_url(), job_id).await
+    }
+
+    /// Block until the scheduler considers exactly `n` executors registered
+    /// (i.e. a killed executor has been reaped, or a rescheduled one re-joined).
+    pub async fn await_executor_count(&self, n: usize) -> Result<(), String> {
+        crate::rest::await_executor_count(&self.rest_url(), n).await
+    }
+
+    /// Scale the executor Deployment to `replicas`. Setting `0` stops the
+    /// controller from rescheduling, but it is a *graceful* scale-down: the pods
+    /// receive SIGTERM and the executors drain their in-flight tasks to
+    /// completion before exiting, so a query in flight will still succeed. To
+    /// lose work mid-query, use [`Self::kill_all_executors_hard`].
     pub async fn scale_executors(&self, replicas: usize) -> Result<(), String> {
         kubectl(&[
             "-n",
@@ -289,6 +297,28 @@ impl K8sCluster {
             "scale",
             &format!("deploy/{EXECUTOR_DEPLOYMENT}"),
             &format!("--replicas={replicas}"),
+        ])
+        .await
+        .map(|_| ())
+    }
+
+    /// Total, sustained executor loss *mid-query* (#2029): every executor dies at
+    /// once and none is rescheduled. Scales the Deployment to 0 first so the
+    /// controller will not recreate the pods, then force-deletes them
+    /// (`--grace-period=0 --force`) so they are SIGKILLed without the graceful
+    /// drain that [`Self::scale_executors`] alone allows — otherwise the
+    /// executors would finish the in-flight query and it would succeed.
+    pub async fn kill_all_executors_hard(&self) -> Result<(), String> {
+        self.scale_executors(0).await?;
+        kubectl(&[
+            "-n",
+            &self.namespace,
+            "delete",
+            "pod",
+            "-l",
+            "app=ballista-executor",
+            "--grace-period=0",
+            "--force",
         ])
         .await
         .map(|_| ())

--- a/chaos-testing/src/lib.rs
+++ b/chaos-testing/src/lib.rs
@@ -26,4 +26,5 @@ pub mod fixture;
 #[cfg(feature = "k8s")]
 pub mod k8s;
 pub mod registry;
+pub(crate) mod rest;
 pub mod udf;

--- a/chaos-testing/src/rest.rs
+++ b/chaos-testing/src/rest.rs
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Scheduler REST-API polling shared by both cluster backends.
+//!
+//! [`crate::cluster::TestCluster`] (local processes) and [`crate::k8s`]
+//! (`kind` pods) both drive scenarios by polling the scheduler's REST API —
+//! the same endpoints (`/api/executors`, `/api/jobs`, `/api/job/{id}/stages`)
+//! and the same JSON shape, differing only in the base URL (loopback vs. the
+//! port-forward). These free functions take that base URL so the polling logic
+//! lives in one place; each backend wraps them in thin methods.
+
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+/// Per-request timeout. Short so a stalled connection (e.g. a k8s port-forward
+/// that dropped) surfaces as a retryable error inside a polling loop rather than
+/// hanging the whole wait; harmless for the loopback (process) backend.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+async fn get_json(url: String) -> Result<Value, String> {
+    client()?
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// How many executors the scheduler currently considers registered.
+pub(crate) async fn registered_executors(rest_url: &str) -> Result<usize, String> {
+    let body = get_json(format!("{rest_url}/api/executors")).await?;
+    Ok(body.as_array().map(|a| a.len()).unwrap_or(0))
+}
+
+/// The ids of every executor the scheduler currently lists. Lets a scenario
+/// prove a *new* executor (a fresh id) replaced a killed one after rescheduling.
+/// Only the k8s backend reschedules automatically, so this is k8s-only.
+#[cfg(feature = "k8s")]
+pub(crate) async fn executor_ids(rest_url: &str) -> Result<Vec<String>, String> {
+    let body = get_json(format!("{rest_url}/api/executors")).await?;
+    Ok(body
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.get("id").and_then(|v| v.as_str()).map(String::from))
+        .collect())
+}
+
+/// The id of the single job the scheduler currently knows about.
+///
+/// The harness runs one query at a time, so "the running job" is unambiguous.
+pub(crate) async fn running_job_id(rest_url: &str) -> Result<String, String> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let body = get_json(format!("{rest_url}/api/jobs")).await?;
+        if let Some(job) = body.as_array().and_then(|jobs| jobs.first())
+            && let Some(id) = job.get("job_id").and_then(|v| v.as_str())
+        {
+            return Ok(id.to_string());
+        }
+        if Instant::now() > deadline {
+            return Err("timed out waiting for a job to appear".to_string());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// The stage summary for `job_id`.
+pub(crate) async fn stages(rest_url: &str, job_id: &str) -> Result<Value, String> {
+    get_json(format!("{rest_url}/api/job/{job_id}/stages")).await
+}
+
+/// Block until any task in any stage is Running.
+///
+/// Planner-agnostic sync point: the static and adaptive (AQE) planners number
+/// and materialize stages differently, so rather than target a specific stage id
+/// we wait until the job is genuinely executing a task somewhere. Used where the
+/// scenario only needs a fault to land mid-flight.
+pub(crate) async fn await_any_stage_running(
+    rest_url: &str,
+    job_id: &str,
+) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let stages = stages(rest_url, job_id).await?;
+        let running =
+            stages
+                .get("stages")
+                .and_then(|s| s.as_array())
+                .is_some_and(|stages| {
+                    stages.iter().any(|stage| {
+                        stage.get("tasks").and_then(|t| t.as_array()).is_some_and(
+                            |tasks| {
+                                tasks.iter().any(|t| {
+                                    t.get("status").and_then(|s| s.as_str())
+                                        == Some("Running")
+                                })
+                            },
+                        )
+                    })
+                });
+        if running {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            return Err("timed out waiting for any stage to start running".to_string());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Block until the scheduler considers exactly `n` executors registered.
+///
+/// Unlike an at-least-`n` wait, a killed executor is not dropped from
+/// `/api/executors` the instant it dies — the scheduler keeps listing it until
+/// its heartbeat times out (`executor_timeout_seconds`). A scenario that kills
+/// an executor and wants to observe the scheduler actually reaping it (rather
+/// than transiently over-counting) must wait for the count to come *down* to
+/// `n` exactly, not merely reach it.
+pub(crate) async fn await_executor_count(rest_url: &str, n: usize) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        if let Ok(count) = registered_executors(rest_url).await
+            && count == n
+        {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            return Err(format!(
+                "timed out waiting for exactly {n} registered executors"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}

--- a/chaos-testing/tests/k8s.rs
+++ b/chaos-testing/tests/k8s.rs
@@ -27,16 +27,26 @@
 //! kind load docker-image ballista-chaos:test
 //! CHAOS_BACKEND=kind cargo test -p ballista-chaos --features k8s --test k8s -- --test-threads=1
 //! ```
+//!
+//! These are the scenarios that genuinely need a cluster — real pod lifecycle,
+//! rescheduling, and the port-forward/flight-proxy path — rather than the
+//! fault-injection scenarios in `ha.rs`, which are backend-agnostic and stay on
+//! the fast process harness. Which planner each scenario runs under mirrors
+//! `ha.rs`: both AQE settings only where the planner changes the code path.
 #![cfg(feature = "k8s")]
 
+use std::time::{Duration, Instant};
+
 use ballista::prelude::{SessionConfigExt, SessionContextExt};
+use ballista_core::config::BALLISTA_ADAPTIVE_PLANNER_ENABLED;
 use chaos_testing::fixture::Fixture;
-use chaos_testing::k8s::K8sCluster;
+use chaos_testing::k8s::{K8sCluster, KillMode};
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::prelude::{SessionConfig, SessionContext};
+use rstest::rstest;
 
-/// The k8s scenarios need a running kind cluster with the chaos images loaded;
+/// The k8s scenarios need a running kind cluster with the chaos image loaded;
 /// they are opt-in via `CHAOS_BACKEND=kind` so a plain `cargo test` skips them.
 fn kind_backend_selected() -> bool {
     if std::env::var("CHAOS_BACKEND").as_deref() == Ok("kind") {
@@ -44,70 +54,251 @@ fn kind_backend_selected() -> bool {
     } else {
         eprintln!(
             "skipping k8s scenario: set CHAOS_BACKEND=kind and provide a kind cluster \
-             with the chaos images loaded (see the crate README runbook)"
+             with the chaos image loaded (see the crate README runbook)"
         );
         false
     }
 }
 
-/// The chaos-free baseline query, run on a fresh local DataFusion context. This
-/// is the reference the cluster must reproduce exactly.
-async fn local_baseline(fixture: &Fixture) -> String {
-    let ctx = SessionContext::new();
-    for stmt in fixture.register_sql() {
-        ctx.sql(&stmt).await.unwrap().collect().await.unwrap();
+/// One kind cluster plus its fixture and a connected client, wired for a single
+/// scenario. The k8s counterpart of `ha.rs`'s `ChaosRun`: it centralises the
+/// fixture write, the client connect, and the UDF-after-upgrade registration so
+/// each scenario reads as just its fault and its assertions.
+struct K8sRun {
+    cluster: K8sCluster,
+    fixture: Fixture,
+    ctx: SessionContext,
+}
+
+impl K8sRun {
+    /// Deploy a cluster of `executors`, write the fixture into the shared mount,
+    /// and connect a client with AQE set to `aqe`.
+    async fn start(aqe: bool, executors: usize) -> Self {
+        let cluster = K8sCluster::start(executors)
+            .await
+            .expect("kind cluster must start");
+
+        // Written into the shared mount, so the scheduler and executor pods see it.
+        let fixture = Fixture::write(cluster.shared_dir())
+            .await
+            .expect("fixture must be written to the shared mount");
+
+        let config = SessionConfig::new_with_ballista()
+            .set_bool(BALLISTA_ADAPTIVE_PLANNER_ENABLED, aqe);
+        let state = SessionStateBuilder::new()
+            .with_config(config)
+            .with_default_features()
+            .build();
+        let ctx = SessionContext::remote_with_state(&cluster.scheduler_url(), state)
+            .await
+            .expect("client must connect to the scheduler");
+
+        // Registered *after* `remote_with_state`: `upgrade_for_ballista` rebuilds
+        // the state with `with_scalar_functions(...)`, which replaces rather than
+        // merges the scalar-function map and would drop a UDF registered before.
+        // (Same subtlety documented in `ha.rs`'s `ChaosRun`.)
+        ctx.register_udf(chaos_testing::udf::chaos_fail_udf().as_ref().clone());
+        ctx.register_udf(chaos_testing::udf::chaos_delay_udf().as_ref().clone());
+
+        for stmt in fixture.register_sql() {
+            ctx.sql(&stmt).await.unwrap().collect().await.unwrap();
+        }
+
+        Self {
+            cluster,
+            fixture,
+            ctx,
+        }
     }
-    let batches = ctx
-        .sql(Fixture::baseline_query())
-        .await
-        .unwrap()
-        .collect()
-        .await
-        .unwrap();
-    pretty_format_batches(&batches).unwrap().to_string()
+
+    /// A clone of the session context, for running a query concurrently with a
+    /// fault (the query is spawned while the main task kills executors).
+    fn clone_ctx(&self) -> SessionContext {
+        self.ctx.clone()
+    }
+
+    /// Run a query on the cluster, returning the formatted result.
+    async fn sql(&self, sql: &str) -> Result<String, String> {
+        let df = self.ctx.sql(sql).await.map_err(|e| e.to_string())?;
+        let batches = df.collect().await.map_err(|e| e.to_string())?;
+        Ok(pretty_format_batches(&batches)
+            .map_err(|e| e.to_string())?
+            .to_string())
+    }
+
+    /// The expected answer, computed by plain local DataFusion over the same
+    /// fixture — the reference the cluster must reproduce exactly.
+    async fn local_baseline(&self) -> String {
+        let ctx = SessionContext::new();
+        for stmt in self.fixture.register_sql() {
+            ctx.sql(&stmt).await.unwrap().collect().await.unwrap();
+        }
+        let batches = ctx
+            .sql(Fixture::baseline_query())
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        pretty_format_batches(&batches).unwrap().to_string()
+    }
 }
 
 /// Smoke test: a real query on a real kind cluster returns the same result as
 /// plain local DataFusion. Exercises the whole path — client → scheduler → pods
 /// → shuffle → result — with the fixture shared through the `hostPath` mount.
+///
+/// Single planner: the wiring this smoke-tests (mount, port-forward, flight
+/// proxy, shuffle) does not vary by planner, so there is nothing to gain from
+/// running it under both.
 #[tokio::test]
 async fn baseline_matches_local_datafusion_on_k8s() {
     if !kind_backend_selected() {
         return;
     }
 
-    let cluster = K8sCluster::start(2).await.expect("kind cluster must start");
-
-    // Written into the shared mount, so the scheduler and executor pods see it.
-    let fixture = Fixture::write(cluster.shared_dir())
-        .await
-        .expect("fixture must be written to the shared mount");
-
-    let expected = local_baseline(&fixture).await;
-
-    let config = SessionConfig::new_with_ballista();
-    let state = SessionStateBuilder::new()
-        .with_config(config)
-        .with_default_features()
-        .build();
-    let ctx = SessionContext::remote_with_state(&cluster.scheduler_url(), state)
-        .await
-        .expect("client must connect to the scheduler");
-
-    for stmt in fixture.register_sql() {
-        ctx.sql(&stmt).await.unwrap().collect().await.unwrap();
-    }
-    let batches = ctx
+    let run = K8sRun::start(false, 2).await;
+    let expected = run.local_baseline().await;
+    let actual = run
         .sql(Fixture::baseline_query())
         .await
-        .unwrap()
-        .collect()
-        .await
-        .unwrap();
-    let actual = pretty_format_batches(&batches).unwrap().to_string();
+        .expect("cluster must serve the baseline query");
 
     assert_eq!(
         actual, expected,
         "cluster result must match plain local DataFusion"
     );
+}
+
+/// Scenario G (#2029) on k8s: every executor is lost mid-query.
+///
+/// The kill force-deletes every executor pod while holding the Deployment at
+/// zero replicas (`kill_all_executors_hard`). Scaling to zero alone is not
+/// enough: it is a graceful SIGTERM, so the executors drain the in-flight query
+/// to completion and it *succeeds*. Force-deleting the pods SIGKILLs them so the
+/// work is genuinely lost, and holding the Deployment at zero means the
+/// controller will not reschedule replacements. With no executor left, the job
+/// cannot succeed: once the last one is reaped the scheduler waits the bounded
+/// no-executors grace period and then fails the job rather than hanging forever.
+///
+/// Both AQE settings: #2029 had an AQE-on-only second hang path (a task-launch
+/// failure that removed the last executor without arming the grace timer), so
+/// the planner genuinely changes the code path here.
+#[rstest]
+#[case::aqe_off(false)]
+#[case::aqe_on(true)]
+#[tokio::test]
+async fn killing_every_executor_terminates_the_job_on_k8s(#[case] aqe: bool) {
+    if !kind_backend_selected() {
+        return;
+    }
+
+    let run = K8sRun::start(aqe, 2).await;
+    // A long per-batch delay keeps the query in flight while the hard kill runs
+    // its two kubectl round-trips (scale to zero, then force-delete), so the
+    // pods die mid-query rather than after it would have finished.
+    let sql = Fixture::chaos_query("chaos_delay(f.key >= 0, 2000)");
+
+    let query = tokio::spawn({
+        let ctx = run.clone_ctx();
+        async move { ctx.sql(&sql).await?.collect().await }
+    });
+
+    let job_id = run.cluster.running_job_id().await.expect("job must appear");
+    run.cluster
+        .await_any_stage_running(&job_id)
+        .await
+        .expect("the job must start running a task before we remove its executors");
+
+    // Total loss that stays lost and is not drained: force-kill every pod and
+    // hold the Deployment at zero so no replacement is scheduled.
+    run.cluster
+        .kill_all_executors_hard()
+        .await
+        .expect("force-kill every executor");
+
+    let result = tokio::time::timeout(Duration::from_secs(120), query)
+        .await
+        .expect("job must terminate, not hang, after every executor is lost")
+        .expect("query task should not panic");
+    let err = result.expect_err("query must fail once every executor is lost");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("executor"),
+        "failure should name the executor loss, got: {err}"
+    );
+}
+
+/// Scenario F on k8s: an executor pod is killed and the cluster reabsorbs its
+/// replacement.
+///
+/// Unlike the process harness — where the test spawns a fresh executor itself —
+/// deleting a pod lets the Deployment reschedule a replacement automatically,
+/// with a brand-new executor id. That is the k8s-unique behaviour this asserts:
+/// after a forced pod delete, the scheduler settles back to two executors, one
+/// of which is genuinely new (an id not present before), and the cluster still
+/// serves queries.
+///
+/// Single planner (aqe off): rescheduling and re-registration are
+/// planner-independent, and the post-restart query correctness is already
+/// covered by the baseline scenario.
+#[tokio::test]
+async fn restarted_executor_rejoins_and_serves_queries_on_k8s() {
+    if !kind_backend_selected() {
+        return;
+    }
+
+    let run = K8sRun::start(false, 2).await;
+    let expected = run.local_baseline().await;
+
+    let before = run
+        .cluster
+        .executor_ids()
+        .await
+        .expect("must list executors before the kill");
+    assert_eq!(before.len(), 2, "expected two executors to start");
+
+    run.cluster
+        .kill_one_executor(KillMode::Forced)
+        .await
+        .expect("force-delete one executor pod");
+
+    // Wait for steady state: exactly two executors again, one of which is new
+    // (a fresh id). A plain count==2 wait is not enough — the killed executor's
+    // heartbeat lingers, so the count passes transiently through 2 (ghost +
+    // survivor) and 3 (ghost + survivor + replacement) before settling.
+    let after = await_replacement(&run.cluster, &before).await;
+    assert_eq!(after.len(), 2, "cluster must settle back to two executors");
+    assert!(
+        after.iter().any(|id| !before.contains(id)),
+        "a rescheduled executor with a new id must have joined; before={before:?} after={after:?}"
+    );
+
+    let actual = run
+        .sql(Fixture::baseline_query())
+        .await
+        .expect("cluster must serve queries after an executor is rescheduled");
+    assert_eq!(actual, expected);
+}
+
+/// Poll until the scheduler lists exactly two executors and at least one is not
+/// in `before` — i.e. the killed executor has been reaped and its rescheduled
+/// replacement (new id) has registered.
+async fn await_replacement(cluster: &K8sCluster, before: &[String]) -> Vec<String> {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        if let Ok(ids) = cluster.executor_ids().await
+            && ids.len() == 2
+            && ids.iter().any(|id| !before.contains(id))
+        {
+            return ids;
+        }
+        if Instant::now() > deadline {
+            cluster.dump_diagnostics().await;
+            panic!(
+                "timed out waiting for a rescheduled executor to replace the killed one"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }


### PR DESCRIPTION
Add the two failure scenarios with kind cluster backend

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #. N/A - follow-up test coverage for #2029

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The #2029 scheduler fix (#2212) was only covered by the process-based chaos harness. The two failure modes that matter can't be reproduced without a real cluster: total executor loss (a Deployment scaled to zero, not a transient process/pod kill) and pod rescheduling-with-new-id.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Test-only, within chaos-testing. Adds the two scenarios that genuinely need a cluster to the kind backend:

  - G (#2029) — every executor is lost mid-query and the job must fail (not hang), under both AQE settings. The loss is a hard kill: scale the Deployment to 0 (so no replacement is rescheduled) then force-delete the pods (--grace-period=0 --force). A graceful scale 0 alone sends SIGTERM, and the executors drain their in-flight tasks to completion, so the query would succeed — not the condition #2029 is about. New K8sCluster::kill_all_executors_hard() primitive.
  - F — a force-deleted executor pod is rescheduled with a new id; the cluster reabsorbs it and keeps serving queries. AQE-off only (planner-independent).

  Plus:
  - Dedupe the scheduler REST polling shared by both backends into src/rest.rs (registered_executors, running_job_id, await_any_stage_running, await_executor_count, executor_ids); TestCluster and K8sCluster delegate to it. 
  - Add a K8sRun test helper mirroring ha.rs's ChaosRun.
  
  All k8s scenarios stay gated behind the k8s feature and CHAOS_BACKEND=kind.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No — test/harness code only, no public API or runtime changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
