### PR TITLE
feat(history): replace the timer-based rescan with a filesystem watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "log",
+ "notify",
  "object_store",
  "once_cell",
  "parking_lot",
@@ -3445,6 +3446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4114,6 +4124,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,6 +4359,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
 ]
 
 [[package]]
@@ -4725,6 +4775,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -8173,7 +8250,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8182,7 +8259,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -8200,14 +8286,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8226,10 +8329,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8238,10 +8353,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8250,10 +8377,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8262,10 +8401,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ dashmap = { version = "6.2" }
 env_logger = { version = "0.11" }
 futures = { version = "0.3" }
 log = { version = "0.4" }
+notify = { version = "8" }
 parking_lot = { version = "0.12" }
 rand = { version = "0.10" }
 serde = { version = "1.0" }

--- a/ballista/scheduler/Cargo.toml
+++ b/ballista/scheduler/Cargo.toml
@@ -46,7 +46,7 @@ disable-stage-plan-cache = []
 graphviz-support = ["dep:graphviz-rust"]
 keda-scaler = ["dep:tonic-prost-build", "dep:tonic-prost"]
 prometheus-metrics = ["prometheus", "once_cell"]
-rest-api = ["dep:ballista-api-types", "dep:ballista-history", "dep:serde_json"]
+rest-api = ["dep:ballista-api-types", "dep:ballista-history", "dep:serde_json", "dep:notify"]
 spark-compat = ["ballista-core/spark-compat"]
 substrait = ["dep:datafusion-substrait"]
 
@@ -68,6 +68,7 @@ graphviz-rust = { version = "0.9", optional = true }
 http = "1.4"
 itertools = { workspace = true }
 log = { workspace = true }
+notify = { workspace = true, optional = true }
 object_store = { workspace = true }
 once_cell = { version = "1.21.4", optional = true }
 parking_lot = { workspace = true }

--- a/ballista/scheduler/src/bin/history_server.rs
+++ b/ballista/scheduler/src/bin/history_server.rs
@@ -20,13 +20,12 @@
 //! so the existing TUI can connect to it unchanged.
 
 use ballista_core::error::{BallistaError, Result};
-use ballista_scheduler::history::{HistoryStore, history_router, spawn_refresh_task};
+use ballista_scheduler::history::{HistoryStore, history_router, spawn_service_tasks};
 use clap::Parser;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, clap::Parser)]
@@ -45,10 +44,6 @@ struct Args {
     /// Port to bind the HTTP server to.
     #[arg(long, default_value_t = 50060)]
     bind_port: u16,
-    /// How often to rescan the event-log directory for jobs that finished
-    /// since the last pass, in seconds. Set to 0 to scan only at startup.
-    #[arg(long, default_value_t = 10)]
-    update_interval_seconds: u64,
 }
 
 fn main() -> Result<()> {
@@ -62,15 +57,17 @@ fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    // `HistoryStore::load` walks the log directory with blocking file I/O, and
-    // how long it takes scales with the number of stored jobs. Run it here,
-    // before the runtime exists, rather than parking a runtime worker on it.
-    let store = Arc::new(HistoryStore::load(&args.event_log_dir)?);
-    tracing::info!(
-        "Indexed {} completed job(s) from {}",
-        store.len(),
-        args.event_log_dir.display()
-    );
+    // The server is routinely started before any scheduler has written here,
+    // and `HistoryStore::new` places a filesystem watch that needs the
+    // directory to exist.
+    std::fs::create_dir_all(&args.event_log_dir).map_err(BallistaError::IoError)?;
+
+    // `HistoryStore::new` sets up the directory watch and builds the initial
+    // index with a blocking directory walk whose cost scales with the number
+    // of stored jobs. Run it here, before the runtime exists, rather than
+    // parking a runtime worker on it; `spawn_service_tasks` keeps the index
+    // current afterwards.
+    let store = Arc::new(HistoryStore::new(&args.event_log_dir)?);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_io()
@@ -82,18 +79,8 @@ fn main() -> Result<()> {
 }
 
 async fn serve(args: Args, store: Arc<HistoryStore>) -> Result<()> {
-    // Schedulers keep writing to this directory while the history server is
-    // up, so without a rescan the list is frozen at whatever had finished when
-    // the process started.
-    if args.update_interval_seconds > 0 {
-        let interval = Duration::from_secs(args.update_interval_seconds);
-        tracing::info!("Rescanning the event-log directory every {interval:?}");
-        spawn_refresh_task(Arc::clone(&store), interval);
-    } else {
-        tracing::info!(
-            "Rescanning is disabled; only jobs indexed at startup will be served"
-        );
-    }
+    // Held until `serve` returns; dropping it aborts the background loops.
+    let _service_tasks = spawn_service_tasks(Arc::clone(&store));
 
     let app = history_router(store);
 

--- a/ballista/scheduler/src/history/mod.rs
+++ b/ballista/scheduler/src/history/mod.rs
@@ -18,6 +18,9 @@
 //! Standalone history server: indexes completed event logs and serves the same
 //! `/api/*` responses the live scheduler does, from stored DTOs.
 
+mod source;
+mod trigger;
+
 use crate::api::SchedulerErrorResponse;
 use axum::response::IntoResponse;
 use axum::{
@@ -28,17 +31,17 @@ use axum::{
 use ballista_api_types::dto::{JobConfig, JobResponse};
 use ballista_core::BALLISTA_VERSION;
 use ballista_history::event::JobIndex;
-use ballista_history::reader::{
-    ReadError, ReplayedJob, read_completed_job, read_job_index,
-};
+use ballista_history::reader::{ReadError, ReplayedJob};
 use datafusion::DATAFUSION_VERSION;
+use futures::StreamExt;
 use http::StatusCode;
 use http::header::CONTENT_TYPE;
 use serde_json::value::RawValue;
-use std::collections::{HashMap, HashSet};
+use source::{EventLogSource, LocalDirSource};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, PoisonError, RwLock};
-use std::time::{Duration, SystemTime};
+use trigger::{EventLogEvent, EventLogTrigger, NotifyTrigger, OnceTrigger, ScanTrigger};
 
 /// Where one completed job lives, and just enough about it to list it.
 struct JobEntry {
@@ -50,52 +53,11 @@ struct JobEntry {
     path: PathBuf,
 }
 
-/// What a log file looked like when it was last indexed.
-///
-/// Cheap enough to take for every file on every rescan, which is the point: a
-/// directory of thousands of finished jobs costs a `stat` per file per pass,
-/// and only the files that actually changed are opened and parsed.
-///
-/// A rewrite that lands within the same modification-time tick *and* leaves the
-/// length unchanged is indistinguishable from no change here, so it is not
-/// picked up until the file changes again. Schedulers only ever append to a
-/// log and then close it, so that does not happen in practice.
-#[derive(Clone, Copy, PartialEq, Eq)]
-struct FileStamp {
-    /// `None` on the platforms/filesystems that do not report it.
-    modified: Option<SystemTime>,
-    len: u64,
-}
-
-/// Everything a rescan reads and writes, behind one lock.
+/// The in-memory job index, behind one lock.
 #[derive(Default)]
 struct Index {
     /// Completed jobs keyed by job id.
     jobs: HashMap<String, JobEntry>,
-    /// Every `.eventlog` seen so far and the job id it produced, if any.
-    /// Logs still running are named `.eventlog.running` and never reach this
-    /// map at all (see `scan_dir`); an entry with `None` here means an
-    /// `.eventlog` file that was unreadable or lacked its terminal record,
-    /// so a rescan can tell "already looked at, unchanged" from "never seen".
-    seen: HashMap<PathBuf, (FileStamp, Option<String>)>,
-}
-
-/// What one directory rescan changed.
-#[derive(Debug, Default, PartialEq, Eq)]
-pub struct RefreshStats {
-    /// Jobs that appeared: a log written since the last pass, or one that has
-    /// gained its terminal record since it was last looked at.
-    pub added: usize,
-    /// Jobs dropped because their log is no longer in the directory.
-    pub removed: usize,
-}
-
-impl RefreshStats {
-    /// Whether the pass found nothing to do, which is the common case and the
-    /// one not worth logging.
-    fn is_noop(&self) -> bool {
-        self.added == 0 && self.removed == 0
-    }
 }
 
 /// Index of the completed jobs found in an event-log directory.
@@ -108,11 +70,14 @@ impl RefreshStats {
 /// clicks through a UI.
 ///
 /// The directory is normally one that one or more live schedulers are still
-/// writing to, so the index is not fixed at startup: [`HistoryStore::refresh`]
-/// rescans it, and [`spawn_refresh_task`] keeps that happening on a timer.
+/// writing to, so the index is not fixed at startup: [`spawn_service_tasks`]
+/// runs background loops that fold newly found logs into it as its triggers
+/// fire.
 pub struct HistoryStore {
-    /// The event-log directory this store indexes.
-    dir: PathBuf,
+    /// Where this store's completed logs are found and read.
+    source: Box<dyn EventLogSource>,
+    trigger: Box<dyn EventLogTrigger>,
+    scan_trigger: Box<dyn ScanTrigger>,
     index: RwLock<Index>,
 }
 
@@ -141,161 +106,61 @@ impl std::fmt::Display for JobReadError {
 }
 
 impl HistoryStore {
-    /// Index every completed job found under `dir`. Missing directories yield
-    /// an empty store rather than an error.
+    /// Open a store over the event logs in `dir`, watching it for new ones.
     ///
-    /// A single unreadable/corrupt `.eventlog` file (e.g. truncated by a
-    /// crash mid-write) is logged and skipped rather than failing the whole
-    /// load — one bad log must not hide every other completed job. Only a
-    /// failure to read the directory itself is propagated.
+    /// The initial index is built synchronously here, so the store is usable
+    /// the moment it is constructed; [`spawn_service_tasks`] then keeps it
+    /// current, both from full directory passes and from the `NotifyTrigger`
+    /// set up here as logs are renamed into place.
     ///
-    /// Each log is read once here, but only its summary is decoded, so this
-    /// costs a pass over the directory rather than a copy of it in memory.
-    /// Corruption confined to the payloads therefore surfaces when the job is
-    /// requested rather than at load.
-    pub fn load(dir: &Path) -> std::io::Result<HistoryStore> {
+    /// `dir` must already exist — the filesystem watch cannot be placed on a
+    /// missing path. Callers that may run before any scheduler has written
+    /// (the history server) create it first.
+    pub fn new(dir: &Path) -> std::io::Result<HistoryStore> {
         let store = HistoryStore {
-            dir: dir.to_path_buf(),
-            index: RwLock::new(Index::default()),
+            source: Box::new(LocalDirSource::new(dir.to_path_buf())),
+            scan_trigger: Box::new(OnceTrigger::default()),
+            trigger: Box::new(NotifyTrigger::new(dir).map_err(std::io::Error::other)?),
+            index: RwLock::new(Default::default()),
         };
-        store.refresh()?;
         Ok(store)
     }
 
-    /// Rescan the event-log directory and fold what changed into the index.
-    ///
-    /// This is what makes a job that finished after the server started
-    /// visible. Only logs whose size or modification time has moved are
-    /// opened, so a pass over an unchanged directory reads no files; logs that
-    /// have gone are dropped from the index, so deleting one no longer leaves
-    /// an entry that fails when opened.
-    ///
-    /// Blocking file I/O — call it from `spawn_blocking`, not on a runtime
-    /// worker.
-    pub fn refresh(&self) -> std::io::Result<RefreshStats> {
-        let found = self.scan_dir()?;
-
-        // Work out what needs reading under a read lock, then do the reading
-        // with the lock released: parsing a log is orders of magnitude slower
-        // than the bookkeeping, and requests are served from the index
-        // throughout.
-        let stale: Vec<PathBuf> = {
-            let index = self.read_index();
-            found
-                .iter()
-                .filter(|(path, stamp)| {
-                    index
-                        .seen
-                        .get(path.as_path())
-                        .is_none_or(|(s, _)| s != stamp)
-                })
-                .map(|(path, _)| path.clone())
-                .collect()
+    /// Open a store over `dir` as a fixed snapshot: the directory is read
+    /// once, here, and the index never changes afterwards. Both triggers are
+    /// `NoopTrigger`, so pairing this with [`spawn_service_tasks`] is a no-op
+    /// — it is for callers (tests, a one-shot server over an archived
+    /// directory) that want a frozen view rather than a live one.
+    pub async fn new_static(dir: &Path) -> std::io::Result<HistoryStore> {
+        let store = HistoryStore {
+            source: Box::new(LocalDirSource::new(dir.to_path_buf())),
+            scan_trigger: Box::new(trigger::NoopTrigger::default()),
+            trigger: Box::new(trigger::NoopTrigger::default()),
+            index: RwLock::new(Default::default()),
         };
-
-        let read: Vec<(PathBuf, Option<JobIndex>)> = stale
-            .into_iter()
-            .map(|path| {
-                let index = match read_job_index(&path) {
-                    Ok(index) => index,
-                    Err(err) => {
-                        tracing::warn!(
-                            "skipping unreadable event log {}: {err}",
-                            path.display()
-                        );
-                        None
-                    }
-                };
-                (path, index)
-            })
-            .collect();
-
-        let present: HashSet<&Path> = found.iter().map(|(p, _)| p.as_path()).collect();
-        let mut stats = RefreshStats::default();
-        let mut index = self.write_index();
-        let Index { jobs, seen } = &mut *index;
-
-        // Logs that have gone take their jobs with them.
-        seen.retain(|path, (_, job_id)| {
-            if present.contains(path.as_path()) {
-                return true;
-            }
-            if let Some(job_id) = job_id
-                && jobs.remove(job_id).is_some()
-            {
-                stats.removed += 1;
-            }
-            false
-        });
-
-        let stamps: HashMap<&Path, FileStamp> =
-            found.iter().map(|(p, s)| (p.as_path(), *s)).collect();
-        for (path, job_index) in read {
-            let Some(stamp) = stamps.get(path.as_path()).copied() else {
-                // Deleted between the scan and now; the next pass will see it.
-                continue;
-            };
-            // A rewritten log can name a different job than it used to.
-            let previous = seen.insert(
-                path.clone(),
-                (stamp, job_index.as_ref().map(|i| i.job_id.clone())),
-            );
-            if let Some((_, Some(previous_id))) = previous
-                && Some(previous_id.as_str())
-                    != job_index.as_ref().map(|i| i.job_id.as_str())
-                && jobs.remove(&previous_id).is_some()
-            {
-                stats.removed += 1;
-            }
-            if let Some(job_index) = job_index
-                && jobs
-                    .insert(
-                        job_index.job_id.clone(),
-                        JobEntry {
-                            index: job_index,
-                            path,
-                        },
-                    )
-                    .is_none()
-            {
-                stats.added += 1;
-            }
-        }
-
-        Ok(stats)
+        store.load_index().await;
+        Ok(store)
     }
 
-    /// Stat every `.eventlog` in the directory. A directory that does not
-    /// exist yet is an empty one: the history server is routinely started
-    /// before the scheduler has written anything.
-    fn scan_dir(&self) -> std::io::Result<Vec<(PathBuf, FileStamp)>> {
-        let mut found = Vec::new();
-        if !self.dir.exists() {
-            return Ok(found);
-        }
-        for entry in std::fs::read_dir(&self.dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            // A job still running (or abandoned by a crashed scheduler) is
-            // named `<job_id>.eventlog.running`, whose extension is
-            // "running", not "eventlog" — this check relies on that to skip
-            // it without ever opening it.
-            if path.extension().and_then(|e| e.to_str()) != Some("eventlog") {
-                continue;
+    /// Fold every completed log currently in the source into the index, once.
+    ///
+    /// A single full [`EventLogSource::scan_jobs`] pass: every readable log is
+    /// upserted, an unreadable one is logged and skipped, a directory-listing
+    /// failure is logged. Nothing is reconciled — a log that later disappears
+    /// or is rewritten under a new id is not removed. This is the whole index
+    /// for a store built by [`HistoryStore::new_static`]; a store built by
+    /// [`HistoryStore::new`] gets the same pass from [`spawn_service_tasks`]'s
+    /// scan loop instead.
+    async fn load_index(&self) {
+        let mut paths = self.source.scan_jobs();
+        while let Some(item) = paths.next().await {
+            match item {
+                Ok(path) => index_one(self, path).await,
+                Err(err) => tracing::warn!(
+                    "history server: listing the log directory failed: {err}"
+                ),
             }
-            // A file that disappears mid-scan is simply not there this pass.
-            let Ok(metadata) = entry.metadata() else {
-                continue;
-            };
-            found.push((
-                path,
-                FileStamp {
-                    modified: metadata.modified().ok(),
-                    len: metadata.len(),
-                },
-            ));
         }
-        Ok(found)
     }
 
     /// How many completed jobs are indexed.
@@ -303,16 +168,17 @@ impl HistoryStore {
         self.read_index().jobs.len()
     }
 
-    /// Whether the log directory holds no completed jobs.
+    /// Whether no completed jobs are indexed.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Read one job's stored payload back from its event log.
     ///
-    /// This is blocking file I/O, so the request handlers call it from
-    /// `spawn_blocking` rather than on a runtime worker.
-    pub fn read_job(&self, job_id: &str) -> Result<ReplayedJob, JobReadError> {
+    /// The read is file I/O; `EventLogSource` implementations move it off the
+    /// runtime worker (see `LocalDirSource`), so handlers can `await` this
+    /// directly.
+    pub async fn read_job(&self, job_id: &str) -> Result<ReplayedJob, JobReadError> {
         // Copy the path out rather than reading with the lock held, so a slow
         // read of one job does not block a rescan or the job list.
         let path = {
@@ -323,7 +189,7 @@ impl HistoryStore {
                 .map(|entry| entry.path.clone())
                 .ok_or(JobReadError::NotFound)?
         };
-        match read_completed_job(&path) {
+        match self.source.read_completed_job(&path).await {
             Ok(Some(replayed)) => Ok(replayed),
             Ok(None) => Err(JobReadError::Vanished),
             Err(e) => Err(JobReadError::Unreadable(e)),
@@ -339,7 +205,7 @@ impl HistoryStore {
             .collect()
     }
 
-    /// A poisoned index means a rescan panicked partway through. What is in
+    /// A poisoned index means an index write panicked partway through. What is in
     /// there is still a valid, if possibly stale, view of the directory, and
     /// serving it beats taking the whole server down, so poisoning is ignored
     /// on both paths.
@@ -352,83 +218,120 @@ impl HistoryStore {
     }
 }
 
-/// Rescan `store`'s directory every `interval` for as long as the returned
-/// task runs.
+/// Keep `store`'s index current after the synchronous initial build in
+/// [`HistoryStore::new`].
 ///
-/// The history server is normally pointed at a directory that one or more live
-/// schedulers are still writing to, so without this it would only ever serve
-/// the jobs that had finished before it started. Polling rather than watching
-/// the filesystem is deliberate: these directories are usually on a shared or
-/// network filesystem, where change notifications are unreliable or absent.
-pub fn spawn_refresh_task(
-    store: Arc<HistoryStore>,
-    interval: Duration,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        // Skip the immediate first tick: the caller has just loaded the store.
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        ticker.tick().await;
+/// Two loops, each driven by one of the store's triggers:
+///
+/// * the watch loop folds in a single log the moment `EventLogTrigger`'s
+///   `next_event` reports it appeared, and drops a job the moment its log is
+///   reported removed — both without waiting for the next full pass.
+/// * the scan loop does a full `EventLogSource::scan_jobs` pass every time
+///   `ScanTrigger::scan_tick` fires, folding every readable log it finds
+///   into the index.
+///
+/// The scan loop is upsert-only: a log that is gone or was rewritten under a
+/// new job id is not reconciled there. The watch loop does react to a removal,
+/// but only one it actually observes. With the triggers wired today
+/// (`NotifyTrigger` / `OnceTrigger`) that is one catch-up pass at startup plus
+/// a running index that follows every `*.eventlog` renamed in or deleted
+/// afterwards.
+///
+/// The returned [`ServiceTasks`] owns both loops and aborts them when it is
+/// dropped, so the caller must keep it alive for as long as the store is
+/// served.
+pub fn spawn_service_tasks(store: Arc<HistoryStore>) -> ServiceTasks {
+    let watch_store = Arc::clone(&store);
+    let watch_loop = tokio::spawn(async move {
         loop {
-            ticker.tick().await;
-            let store = Arc::clone(&store);
-            match tokio::task::spawn_blocking(move || store.refresh()).await {
-                Ok(Ok(stats)) if stats.is_noop() => {}
-                Ok(Ok(stats)) => tracing::info!(
-                    "history server: {} job(s) added, {} removed",
-                    stats.added,
-                    stats.removed
-                ),
-                Ok(Err(err)) => {
-                    tracing::warn!(
-                        "history server: rescanning the log directory failed: {err}"
-                    )
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        "history server: rescanning the log directory panicked: {err}"
-                    )
-                }
+            match watch_store.trigger.next_event().await {
+                EventLogEvent::Created(path) => index_one(&watch_store, path).await,
+                EventLogEvent::Removed(path) => deindex_one(&watch_store, path),
             }
         }
-    })
+    });
+    let scan_store = Arc::clone(&store);
+    let scan_loop = tokio::spawn(async move {
+        loop {
+            scan_store.scan_trigger.scan_tick().await;
+            scan_store.load_index().await;
+        }
+    });
+
+    ServiceTasks {
+        watch_loop,
+        scan_loop,
+    }
 }
 
-/// [`HistoryStore::read_job`] moved off the async runtime.
+/// Owns the background loops started by [`spawn_service_tasks`] and aborts
+/// both when dropped, so letting it go out of scope does not leak them.
+pub struct ServiceTasks {
+    watch_loop: tokio::task::JoinHandle<()>,
+    scan_loop: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ServiceTasks {
+    fn drop(&mut self) {
+        self.watch_loop.abort();
+        self.scan_loop.abort();
+    }
+}
+
+/// Read one log's summary and fold it into the index. A log with no terminal
+/// record yet is skipped silently; an unreadable one is logged and skipped, so
+/// one bad file never stalls the loop.
+async fn index_one(store: &HistoryStore, path: PathBuf) {
+    match store.source.read_job_index(&path).await {
+        Ok(Some(index)) => {
+            store
+                .write_index()
+                .jobs
+                .insert(index.job_id.clone(), JobEntry { index, path });
+        }
+        Ok(None) => {}
+        Err(err) => tracing::warn!(
+            "history server: skipping unreadable event log {}: {err}",
+            path.display()
+        ),
+    }
+}
+
+/// Drop the job whose event log was `path` from the index.
 ///
-/// A log that was indexed and cannot be read now means the file changed
-/// underneath us, so both failures are logged rather than only being reported
-/// to whoever happened to ask.
-async fn read_job_blocking(
-    store: Arc<HistoryStore>,
-    job_id: String,
-) -> Result<ReplayedJob, SchedulerErrorResponse> {
-    let result = tokio::task::spawn_blocking(move || {
-        store.read_job(&job_id).map_err(|e| (job_id, e))
-    })
-    .await
-    .map_err(|e| {
-        tracing::warn!("history server: reading an event log panicked: {e}");
-        SchedulerErrorResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
-    })?;
-
-    result.map_err(|(job_id, err)| match err {
-        JobReadError::NotFound => SchedulerErrorResponse::new(StatusCode::NOT_FOUND),
-        JobReadError::Vanished => {
-            tracing::warn!("history server: event log for {job_id} {err}");
-            SchedulerErrorResponse::with_error(StatusCode::NOT_FOUND, err.to_string())
-        }
-        JobReadError::Unreadable(_) => {
-            tracing::warn!("history server: event log for {job_id} {err}");
-            SchedulerErrorResponse::with_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                err.to_string(),
-            )
-        }
-    })
+/// A completed log is named `<job_id>.eventlog` (see [`JobEntry`]), so the job
+/// id is the file stem — the trigger only ever hands this a `*.eventlog` path,
+/// so the stem is the bare id, never `j1.eventlog` from a `j1.eventlog.running`.
+/// Keying off the file name also means it does not matter whether `path` is
+/// absolute or how the matching entry's path was spelled. A path with no stem,
+/// or a job id not in the index (a still-running log, one already reconciled,
+/// one that was unreadable when it appeared), is a silent no-op.
+fn deindex_one(store: &HistoryStore, path: PathBuf) {
+    let Some(job_id) = path.file_stem().and_then(|s| s.to_str()) else {
+        return;
+    };
+    if store.write_index().jobs.remove(job_id).is_some() {
+        tracing::debug!("history server: de-indexed job {job_id}");
+    }
 }
 
-/// Build the axum router serving `/api/*` from a loaded [`HistoryStore`].
+impl From<JobReadError> for SchedulerErrorResponse {
+    fn from(error: JobReadError) -> Self {
+        match error {
+            JobReadError::NotFound => SchedulerErrorResponse::new(StatusCode::NOT_FOUND),
+            JobReadError::Vanished => SchedulerErrorResponse::with_error(
+                StatusCode::NOT_FOUND,
+                error.to_string(),
+            ),
+            JobReadError::Unreadable(_) => SchedulerErrorResponse::with_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error.to_string(),
+            ),
+        }
+    }
+}
+
+/// Build the axum router serving `/api/*` from a [`HistoryStore`].
 pub fn history_router(store: Arc<HistoryStore>) -> Router {
     Router::new()
         .route("/api/jobs", get(get_jobs))
@@ -501,7 +404,7 @@ async fn get_job(
     State(store): State<Arc<HistoryStore>>,
     AxumPath(job_id): AxumPath<String>,
 ) -> Result<axum::response::Response, SchedulerErrorResponse> {
-    let job = read_job_blocking(store, job_id).await?;
+    let job = store.read_job(&job_id).await?;
     Ok(raw_json(&job.job))
 }
 
@@ -509,7 +412,7 @@ async fn get_stages(
     State(store): State<Arc<HistoryStore>>,
     AxumPath(job_id): AxumPath<String>,
 ) -> Result<axum::response::Response, SchedulerErrorResponse> {
-    let job = read_job_blocking(store, job_id).await?;
+    let job = store.read_job(&job_id).await?;
     Ok(raw_json(&job.stages))
 }
 
@@ -517,7 +420,7 @@ async fn get_config(
     State(store): State<Arc<HistoryStore>>,
     AxumPath(job_id): AxumPath<String>,
 ) -> Result<Json<JobConfig>, SchedulerErrorResponse> {
-    let job = read_job_blocking(store, job_id).await?;
+    let job = store.read_job(&job_id).await?;
     Ok(Json(job.config))
 }
 
@@ -525,7 +428,7 @@ async fn get_dot(
     State(store): State<Arc<HistoryStore>>,
     AxumPath(job_id): AxumPath<String>,
 ) -> Result<String, SchedulerErrorResponse> {
-    let job = read_job_blocking(store, job_id).await?;
+    let job = store.read_job(&job_id).await?;
     Ok(job.dot)
 }
 
@@ -562,6 +465,7 @@ mod tests {
     use ballista_api_types::dto::{QueryStageSummary, QueryStagesResponse};
     use ballista_history::event::{HistoryEvent, JobEnd, JobEndStatus, JobIndex};
     use std::io::Write;
+    use std::time::Duration;
     use tempfile::tempdir;
     use tower::ServiceExt; // oneshot
 
@@ -620,15 +524,15 @@ mod tests {
 
     /// Every test goes through a real directory of logs, because the store no
     /// longer holds payloads it could be handed directly.
-    fn store_with_one_job(dir: &tempfile::TempDir) -> Arc<HistoryStore> {
+    async fn store_with_one_job(dir: &tempfile::TempDir) -> Arc<HistoryStore> {
         write_job_end_log(&dir.path().join("job-1.eventlog"), "job-1");
-        Arc::new(HistoryStore::load(dir.path()).unwrap())
+        Arc::new(HistoryStore::new_static(dir.path()).await.unwrap())
     }
 
     #[tokio::test]
     async fn jobs_endpoint_nulls_plan_fields() {
         let dir = tempdir().unwrap();
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
         let resp = app
             .oneshot(
                 Request::builder()
@@ -650,7 +554,7 @@ mod tests {
     #[tokio::test]
     async fn stages_endpoint_returns_stored_dto() {
         let dir = tempdir().unwrap();
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
         let resp = app
             .oneshot(
                 Request::builder()
@@ -674,7 +578,7 @@ mod tests {
     #[tokio::test]
     async fn missing_job_returns_404_on_job_and_stages() {
         let dir = tempdir().unwrap();
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
 
         let resp = app
             .clone()
@@ -703,7 +607,7 @@ mod tests {
     #[tokio::test]
     async fn state_endpoint_returns_static_payload() {
         let dir = tempdir().unwrap();
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
         let resp = app
             .oneshot(
                 Request::builder()
@@ -747,7 +651,9 @@ mod tests {
                 start_time,
             );
         }
-        let app = history_router(Arc::new(HistoryStore::load(dir.path()).unwrap()));
+        let app = history_router(Arc::new(
+            HistoryStore::new_static(dir.path()).await.unwrap(),
+        ));
 
         let (status, body) = get(&app, "/api/jobs").await;
         assert_eq!(status, StatusCode::OK);
@@ -769,7 +675,9 @@ mod tests {
                 7,
             );
         }
-        let app = history_router(Arc::new(HistoryStore::load(dir.path()).unwrap()));
+        let app = history_router(Arc::new(
+            HistoryStore::new_static(dir.path()).await.unwrap(),
+        ));
 
         let (_, body) = get(&app, "/api/jobs").await;
         let jobs: Vec<JobResponse> = serde_json::from_str(&body).unwrap();
@@ -799,7 +707,7 @@ mod tests {
     async fn detail_endpoints_read_the_log_on_demand() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("job-1.eventlog");
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
 
         let (status, body) = get(&app, "/api/job/job-1/stages").await;
         assert_eq!(status, StatusCode::OK);
@@ -822,7 +730,7 @@ mod tests {
     async fn a_log_that_breaks_after_indexing_reports_the_failure() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("job-1.eventlog");
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
 
         std::fs::write(&path, [0xff, 0xfe, 0xfd]).unwrap();
 
@@ -842,7 +750,7 @@ mod tests {
     async fn a_log_that_loses_its_terminal_record_returns_404() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("job-1.eventlog");
-        let app = history_router(store_with_one_job(&dir));
+        let app = history_router(store_with_one_job(&dir).await);
 
         std::fs::write(
             &path,
@@ -880,180 +788,8 @@ mod tests {
         std::fs::write(path, format!("{line}\n")).unwrap();
     }
 
-    /// The reason the store rescans at all: a history server is normally
-    /// pointed at a directory a live scheduler is still writing to, so a job
-    /// that finishes after startup has to show up without a restart.
-    #[test]
-    fn refresh_picks_up_a_job_written_after_load() {
-        let dir = tempdir().unwrap();
-        write_job_end_log(&dir.path().join("job-1.eventlog"), "job-1");
-        let store = HistoryStore::load(dir.path()).unwrap();
-        assert_eq!(store.len(), 1);
-
-        write_job_end_log(&dir.path().join("job-2.eventlog"), "job-2");
-
-        let stats = store.refresh().unwrap();
-        assert_eq!(
-            stats,
-            RefreshStats {
-                added: 1,
-                removed: 0
-            }
-        );
-        assert_eq!(store.len(), 2);
-        assert!(store.read_job("job-2").is_ok());
-    }
-
-    /// A rescan that finds nothing new must not re-read the logs it already
-    /// indexed, or a directory of thousands of finished jobs would be parsed
-    /// end to end on every tick.
-    #[test]
-    fn refresh_is_a_noop_when_nothing_changed() {
-        let dir = tempdir().unwrap();
-        write_job_end_log(&dir.path().join("job-1.eventlog"), "job-1");
-        let store = HistoryStore::load(dir.path()).unwrap();
-
-        // Truncating the log to garbage after it is indexed would break a
-        // rescan that re-parsed it; the stamp is unchanged only if the file is
-        // untouched, so a clean pass here means nothing was opened.
-        assert_eq!(store.refresh().unwrap(), RefreshStats::default());
-        assert_eq!(store.len(), 1);
-    }
-
-    /// A job still running is named `.eventlog.running` and is invisible to a
-    /// scan; it must not be written off, though: the next rescan after the
-    /// job ends and the writer renames the file has to pick it up.
-    #[test]
-    fn refresh_indexes_a_log_that_gains_its_terminal_record() {
-        let dir = tempdir().unwrap();
-        let running_path = dir.path().join("job-1.eventlog.running");
-        let final_path = dir.path().join("job-1.eventlog");
-        std::fs::write(
-            &running_path,
-            "{\"ev\":\"StageStart\",\"version\":1,\"data\":{\"stage_id\":1}}\n",
-        )
-        .unwrap();
-
-        let store = HistoryStore::load(dir.path()).unwrap();
-        assert!(store.is_empty(), "a .running file must not be indexed");
-
-        // Simulate what EventLogWriter::finish_job does on completion: write
-        // the real terminal content, then rename into place.
-        write_job_end_log(&running_path, "job-1");
-        std::fs::rename(&running_path, &final_path).unwrap();
-
-        assert_eq!(store.refresh().unwrap().added, 1);
-        assert_eq!(store.len(), 1);
-    }
-
-    /// Pruning a directory of old logs used to leave the jobs listed until the
-    /// server was restarted, with every click on one failing.
-    #[test]
-    fn refresh_drops_a_job_whose_log_was_deleted() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("job-1.eventlog");
-        write_job_end_log(&path, "job-1");
-        write_job_end_log(&dir.path().join("job-2.eventlog"), "job-2");
-        let store = HistoryStore::load(dir.path()).unwrap();
-        assert_eq!(store.len(), 2);
-
-        std::fs::remove_file(&path).unwrap();
-
-        let stats = store.refresh().unwrap();
-        assert_eq!(
-            stats,
-            RefreshStats {
-                added: 0,
-                removed: 1
-            }
-        );
-        assert!(matches!(
-            store.read_job("job-1"),
-            Err(JobReadError::NotFound)
-        ));
-        assert!(store.read_job("job-2").is_ok());
-    }
-
-    /// A log rewritten under a different job id must not leave the old id
-    /// pointing at a file that no longer describes it.
-    #[test]
-    fn refresh_replaces_the_job_when_a_log_is_rewritten() {
-        let dir = tempdir().unwrap();
-        let path = dir.path().join("job.eventlog");
-        write_job_end_log(&path, "old-id");
-        let store = HistoryStore::load(dir.path()).unwrap();
-        assert!(store.read_job("old-id").is_ok());
-
-        write_job_end_log_with_stage(&path, "new-id", "another-stage", 99);
-
-        store.refresh().unwrap();
-        assert_eq!(store.len(), 1);
-        assert!(matches!(
-            store.read_job("old-id"),
-            Err(JobReadError::NotFound)
-        ));
-        assert!(store.read_job("new-id").is_ok());
-    }
-
-    /// Being started before the scheduler has written anything is normal, and
-    /// the directory appearing later has to be picked up like any other change.
-    #[test]
-    fn a_directory_that_does_not_exist_yet_is_empty_then_indexed() {
-        let dir = tempdir().unwrap();
-        let logs = dir.path().join("not-created-yet");
-        let store = HistoryStore::load(&logs).unwrap();
-        assert!(store.is_empty());
-
-        std::fs::create_dir(&logs).unwrap();
-        write_job_end_log(&logs.join("job-1.eventlog"), "job-1");
-
-        assert_eq!(store.refresh().unwrap().added, 1);
-        assert_eq!(store.len(), 1);
-    }
-
-    /// `/api/jobs` is served from the index, so the background rescan is what
-    /// makes a newly finished job visible over HTTP.
     #[tokio::test]
-    async fn jobs_endpoint_reflects_a_refresh() {
-        let dir = tempdir().unwrap();
-        let store = Arc::new(HistoryStore::load(dir.path()).unwrap());
-        let app = history_router(Arc::clone(&store));
-
-        let (status, body) = get(&app, "/api/jobs").await;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body, "[]");
-
-        write_job_end_log(&dir.path().join("job-1.eventlog"), "job-1");
-        store.refresh().unwrap();
-
-        let (status, body) = get(&app, "/api/jobs").await;
-        assert_eq!(status, StatusCode::OK);
-        assert!(body.contains("\"job_id\":\"job-1\""), "got: {body}");
-    }
-
-    /// The timer task is the only thing wiring rescans to wall-clock time, so
-    /// it is worth proving it actually runs one.
-    #[tokio::test]
-    async fn the_refresh_task_indexes_new_jobs() {
-        let dir = tempdir().unwrap();
-        let store = Arc::new(HistoryStore::load(dir.path()).unwrap());
-        let task = spawn_refresh_task(Arc::clone(&store), Duration::from_millis(10));
-
-        write_job_end_log(&dir.path().join("job-1.eventlog"), "job-1");
-
-        for _ in 0..200 {
-            if store.len() == 1 {
-                task.abort();
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        task.abort();
-        panic!("the refresh task never indexed the new job");
-    }
-
-    #[test]
-    fn load_skips_corrupt_eventlog_and_keeps_good_one() {
+    async fn new_skips_corrupt_eventlog_and_keeps_good_one() {
         let dir = tempdir().unwrap();
 
         // A good, readable event log.
@@ -1066,12 +802,44 @@ mod tests {
         corrupt.write_all(&[0xff, 0xfe, 0xfd]).unwrap();
         drop(corrupt);
 
-        let store = HistoryStore::load(dir.path()).unwrap();
+        let store = HistoryStore::new_static(dir.path()).await.unwrap();
         assert_eq!(store.len(), 1);
-        assert!(store.read_job("job-good").is_ok());
+        assert!(store.read_job("job-good").await.is_ok());
         assert!(matches!(
-            store.read_job("job-bad"),
+            store.read_job("job-bad").await,
             Err(JobReadError::NotFound)
         ));
+    }
+
+    /// Poll `cond` until it holds or the deadline passes; filesystem events are
+    /// delivered asynchronously, so the watch loop reacts a beat after the write.
+    async fn eventually(mut cond: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if cond() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(cond(), "condition still false after 5s");
+    }
+
+    /// The watch loop folds a log in when it appears and drops it again when the
+    /// file is deleted, without any full rescan in between.
+    #[tokio::test]
+    async fn watch_loop_deindexes_a_removed_log() {
+        let dir = tempdir().unwrap();
+        // `new` wires a real `NotifyTrigger`; `OnceTrigger` does its single scan
+        // pass over the (empty) directory and then parks, so the removal below
+        // can only be picked up by the watch loop.
+        let store = Arc::new(HistoryStore::new(dir.path()).unwrap());
+        let _tasks = spawn_service_tasks(Arc::clone(&store));
+
+        let path = dir.path().join("job-1.eventlog");
+        write_job_end_log(&path, "job-1");
+        eventually(|| store.len() == 1).await;
+
+        std::fs::remove_file(&path).unwrap();
+        eventually(|| store.is_empty()).await;
     }
 }

--- a/ballista/scheduler/src/history/source.rs
+++ b/ballista/scheduler/src/history/source.rs
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Where [`super::HistoryStore`] finds and reads completed event logs.
+
+use ballista_history::event::JobIndex;
+use ballista_history::reader::{ReadError, ReplayedJob};
+use futures::stream::{self, BoxStream, StreamExt};
+use std::path::{Path, PathBuf};
+
+/// Where [`super::HistoryStore`] gets its directory listing and file
+/// contents from.
+///
+/// The only implementation today, [`LocalDirSource`], is exactly what
+/// `HistoryStore` did inline before this was pulled out: a flat local
+/// directory read with `std::fs`. Keeping it behind a trait lets the indexing
+/// logic in [`super::spawn_service_tasks`] stay independent of where the logs
+/// live and how they are listed and read.
+#[async_trait::async_trait]
+pub(crate) trait EventLogSource: Send + Sync {
+    /// Stream every completed log currently present. Streamed rather than
+    /// returned as a `Vec` so an implementation backed by a paginated remote
+    /// listing need not materialize the whole directory first, and a caller
+    /// can stop polling to abandon the rest; [`LocalDirSource`] is eager. A
+    /// failure to list the directory is yielded as an `Err` item rather than
+    /// ending the stream; an entry that cannot be read is skipped.
+    fn scan_jobs(&self) -> BoxStream<'_, std::io::Result<PathBuf>>;
+
+    /// Read and parse one log's index summary.
+    async fn read_job_index(&self, path: &Path) -> Result<Option<JobIndex>, ReadError>;
+
+    /// Read one job's full stored payload back.
+    async fn read_completed_job(
+        &self,
+        path: &Path,
+    ) -> Result<Option<ReplayedJob>, ReadError>;
+}
+
+/// A flat local directory of `.eventlog` files, read with `std::fs`.
+pub(crate) struct LocalDirSource {
+    dir: PathBuf,
+}
+
+impl LocalDirSource {
+    pub(crate) fn new(dir: PathBuf) -> Self {
+        LocalDirSource { dir }
+    }
+}
+
+#[async_trait::async_trait]
+impl EventLogSource for LocalDirSource {
+    /// Stat every `.eventlog` in the directory. A directory that does not
+    /// exist yet is an empty one: the history server is routinely started
+    /// before the scheduler has written anything.
+    fn scan_jobs(&self) -> BoxStream<'_, std::io::Result<PathBuf>> {
+        if !self.dir.exists() {
+            return stream::empty().boxed();
+        }
+        let entries = match std::fs::read_dir(&self.dir) {
+            Ok(entries) => entries,
+            Err(e) => return stream::once(async move { Err(e) }).boxed(),
+        };
+        stream::iter(entries.filter_map(|entry| {
+            // A file that disappears mid-scan is simply not there this pass.
+            let entry = entry.ok()?;
+            let path = entry.path();
+            // A job still running (or abandoned by a crashed scheduler) is
+            // named `<job_id>.eventlog.running`, whose extension is
+            // "running", not "eventlog" — this check relies on that to skip
+            // it without ever opening it.
+            if path.extension().and_then(|e| e.to_str()) != Some("eventlog") {
+                return None;
+            }
+
+            Some(Ok(path))
+        }))
+        .boxed()
+    }
+
+    async fn read_job_index(&self, path: &Path) -> Result<Option<JobIndex>, ReadError> {
+        ballista_history::reader::read_job_index(path)
+    }
+
+    async fn read_completed_job(
+        &self,
+        path: &Path,
+    ) -> Result<Option<ReplayedJob>, ReadError> {
+        ballista_history::reader::read_completed_job(path)
+    }
+}

--- a/ballista/scheduler/src/history/trigger.rs
+++ b/ballista/scheduler/src/history/trigger.rs
@@ -1,0 +1,306 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! When [`super::spawn_service_tasks`]'s background loops should act.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use tokio::sync::{Mutex, mpsc};
+
+/// Decides when [`super::spawn_service_tasks`]'s scan loop should make a full
+/// directory pass.
+///
+/// [`OnceTrigger`] is the only implementation today: it fires a single time,
+/// so the loop makes one pass over whatever is already on disk and then
+/// parks. Updates after that are carried incrementally by [`EventLogTrigger`].
+/// Keeping the "when" decision behind a trait leaves room for e.g. a periodic
+/// trigger later without touching the loop itself.
+#[async_trait::async_trait]
+pub(crate) trait ScanTrigger: Send + Sync {
+    /// Wait until a full directory pass should happen.
+    async fn scan_tick(&self);
+}
+
+#[derive(Default)]
+pub(crate) struct OnceTrigger {
+    fired: AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl ScanTrigger for OnceTrigger {
+    async fn scan_tick(&self) {
+        if self.fired.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            // Already fired once; park forever so the scan loop makes exactly
+            // one pass. Safe because the scan loop is the only consumer.
+            std::future::pending::<()>().await
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct NoopTrigger {}
+
+#[async_trait::async_trait]
+impl ScanTrigger for NoopTrigger {
+    async fn scan_tick(&self) {
+        std::future::pending::<()>().await
+    }
+}
+
+#[async_trait::async_trait]
+impl EventLogTrigger for NoopTrigger {
+    async fn next_event(&self) -> EventLogEvent {
+        std::future::pending::<_>().await
+    }
+}
+
+/// What the watch trigger observed about a single `*.eventlog` file.
+pub(crate) enum EventLogEvent {
+    /// The file appeared: created in place, or renamed into the directory
+    /// (how a finished `<job_id>.eventlog.running` -> `<job_id>.eventlog`
+    /// arrives).
+    Created(PathBuf),
+    /// The file was removed: deleted, or renamed out of the directory.
+    Removed(PathBuf),
+}
+
+/// Reports single `*.eventlog` files as they appear in or disappear from the
+/// directory, so each can be folded into (or dropped from) the index without
+/// waiting for the next full directory pass.
+#[async_trait::async_trait]
+pub(crate) trait EventLogTrigger: Send + Sync {
+    /// Wait until a `*.eventlog` file appears or disappears in the watched
+    /// directory; return which, with its absolute path.
+    async fn next_event(&self) -> EventLogEvent;
+}
+
+/// Watches an event-log directory with the `notify` crate and reports each
+/// `*.eventlog` file as it appears or disappears, so [`super::spawn_service_tasks`]'s
+/// watch loop can index or drop it without waiting for the next full directory
+/// pass.
+///
+/// A completed log lands by rename (`<job_id>.eventlog.running` ->
+/// `<job_id>.eventlog`), which is a rename-to rather than a create, so both are
+/// treated as "a new file appeared". A log that is deleted or renamed away is
+/// reported as [`EventLogEvent::Removed`]. The still-running `.eventlog.running`
+/// file is filtered out by extension, exactly as `LocalDirSource::scan_jobs`
+/// does.
+pub(crate) struct NotifyTrigger {
+    /// Kept alive for its `Drop`: dropping the watcher stops the OS watch.
+    _watcher: notify::RecommendedWatcher,
+    /// `*.eventlog` appear/disappear events, oldest first. Behind a `Mutex`
+    /// because `next_event` takes `&self`; the watch loop is the only consumer.
+    rx: Mutex<mpsc::UnboundedReceiver<EventLogEvent>>,
+}
+
+impl NotifyTrigger {
+    /// Start a non-recursive watch on `dir`, which must already exist.
+    pub(crate) fn new(dir: &Path) -> notify::Result<Self> {
+        use notify::Watcher;
+
+        // Resolve to an absolute base so the paths handed to `next_event`'s
+        // caller are absolute even for a relative --event-log-dir. If the cwd
+        // cannot be read, fall back to the path as given (emitted paths then
+        // match how it was passed).
+        let dir = std::path::absolute(dir).unwrap_or_else(|_| dir.to_path_buf());
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut watcher =
+            notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+                let Ok(event) = res else { return };
+                use notify::EventKind::*;
+                use notify::event::{ModifyKind, RenameMode};
+                // A file created in place, or renamed into the directory (how a
+                // finished log arrives). Linux reports the rename as
+                // Modify(Name(To|Both)); coarser backends collapse it to Any.
+                //
+                // A removal is a delete or a rename out of the directory:
+                // Modify(Name(From)) on Linux, Remove otherwise. On coarse
+                // backends (macOS FSEvents) a rename can surface as Name(Any)
+                // in either direction and so be reported as Created; the watch
+                // loop's `index_one` tolerates a path it can no longer read, so
+                // a missed removal just waits for the next full scan.
+                let make = match event.kind {
+                    Create(_)
+                    | Modify(ModifyKind::Name(
+                        RenameMode::To | RenameMode::Both | RenameMode::Any,
+                    )) => EventLogEvent::Created,
+                    Remove(_) | Modify(ModifyKind::Name(RenameMode::From)) => {
+                        EventLogEvent::Removed
+                    }
+                    _ => return,
+                };
+                for path in event.paths {
+                    if path.extension().and_then(|e| e.to_str()) == Some("eventlog") {
+                        // Fails only once the receiver is gone, i.e. shutdown.
+                        let _ = tx.send(make(path));
+                    }
+                }
+            })?;
+        watcher.watch(&dir, notify::RecursiveMode::NonRecursive)?;
+        Ok(Self {
+            _watcher: watcher,
+            rx: Mutex::new(rx),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl EventLogTrigger for NotifyTrigger {
+    async fn next_event(&self) -> EventLogEvent {
+        match self.rx.lock().await.recv().await {
+            Some(event) => event,
+            // The sender lives as long as the watcher, so this only happens at
+            // shutdown; never resolve rather than report a bogus event.
+            None => std::future::pending().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    /// Filesystem events are delivered asynchronously by the OS, so a report
+    /// can lag the write by a noticeable amount on a loaded machine.
+    const REPORT_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Long enough that a watch which was going to fire would have.
+    const SILENCE_WINDOW: Duration = Duration::from_millis(750);
+
+    /// The reported path must be absolute and, once symlinks are resolved (macOS
+    /// puts the temp dir behind `/var` -> `/private/var`), name the same file.
+    fn assert_points_at(got: &Path, expected: &Path) {
+        assert!(got.is_absolute(), "expected an absolute path, got {got:?}");
+        assert_eq!(
+            std::fs::canonicalize(got).unwrap(),
+            std::fs::canonicalize(expected).unwrap(),
+        );
+    }
+
+    /// Like [`assert_points_at`], but for a path whose file may no longer exist
+    /// (a removal): resolve symlinks on the parent directory only, then compare
+    /// that plus the file name.
+    fn assert_names_file(got: &Path, expected: &Path) {
+        assert!(got.is_absolute(), "expected an absolute path, got {got:?}");
+        let resolve = |p: &Path| {
+            std::fs::canonicalize(p.parent().unwrap())
+                .unwrap()
+                .join(p.file_name().unwrap())
+        };
+        assert_eq!(resolve(got), resolve(expected));
+    }
+
+    /// Wait for the next event and assert it is a `Created`, returning its path.
+    async fn expect_created(trigger: &NotifyTrigger) -> PathBuf {
+        match tokio::time::timeout(REPORT_TIMEOUT, trigger.next_event())
+            .await
+            .expect("expected an event to be reported")
+        {
+            EventLogEvent::Created(path) => path,
+            EventLogEvent::Removed(path) => {
+                panic!("expected a Created event, got Removed({})", path.display())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_a_newly_created_eventlog_by_absolute_path() {
+        let dir = tempdir().unwrap();
+        let trigger = NotifyTrigger::new(dir.path()).unwrap();
+
+        let expected = dir.path().join("j1.eventlog");
+        std::fs::write(&expected, b"{}\n").unwrap();
+
+        assert_points_at(&expect_created(&trigger).await, &expected);
+    }
+
+    /// The real path a completed job takes: the writer renames
+    /// `<job_id>.eventlog.running` to `<job_id>.eventlog` in place. That is a
+    /// rename-to, not a create, and must still fire.
+    #[tokio::test]
+    async fn reports_an_eventlog_that_arrives_by_rename() {
+        let dir = tempdir().unwrap();
+        let trigger = NotifyTrigger::new(dir.path()).unwrap();
+
+        let running = dir.path().join("j2.eventlog.running");
+        let final_path = dir.path().join("j2.eventlog");
+        std::fs::write(&running, b"{}\n").unwrap();
+        std::fs::rename(&running, &final_path).unwrap();
+
+        assert_points_at(&expect_created(&trigger).await, &final_path);
+    }
+
+    /// A `*.eventlog` that is deleted after it was reported must come back as a
+    /// `Removed` for the same path, so the watch loop can drop it from the index.
+    #[tokio::test]
+    async fn reports_a_removed_eventlog() {
+        let dir = tempdir().unwrap();
+        let trigger = NotifyTrigger::new(dir.path()).unwrap();
+
+        let path = dir.path().join("j4.eventlog");
+        std::fs::write(&path, b"{}\n").unwrap();
+        assert_points_at(&expect_created(&trigger).await, &path);
+
+        // Let the OS flush the create before deleting: a coalesced
+        // create-then-delete of one path is reported as a bare duplicate create
+        // by some backends (macOS FSEvents), never as a removal. A log that is
+        // deleted always sat on disk for a while first, so this matches real
+        // use rather than papering over a bug.
+        tokio::time::sleep(SILENCE_WINDOW).await;
+        std::fs::remove_file(&path).unwrap();
+
+        // A late duplicate `Created` for the same path can still be queued from
+        // the write above; the removal is what must eventually arrive.
+        let deadline = tokio::time::Instant::now() + REPORT_TIMEOUT;
+        loop {
+            match tokio::time::timeout_at(deadline, trigger.next_event())
+                .await
+                .expect("expected the removed .eventlog to be reported")
+            {
+                EventLogEvent::Removed(got) => {
+                    assert_names_file(&got, &path);
+                    break;
+                }
+                EventLogEvent::Created(got) => assert_names_file(&got, &path),
+            }
+        }
+    }
+
+    /// A still-running log and unrelated files share the directory but are not
+    /// `*.eventlog`, so neither their creation nor their removal is reported.
+    #[tokio::test]
+    async fn ignores_running_logs_and_unrelated_files() {
+        let dir = tempdir().unwrap();
+        let trigger = NotifyTrigger::new(dir.path()).unwrap();
+
+        let running = dir.path().join("j3.eventlog.running");
+        let notes = dir.path().join("notes.txt");
+        std::fs::write(&running, b"{}\n").unwrap();
+        std::fs::write(&notes, b"hello").unwrap();
+        std::fs::remove_file(&running).unwrap();
+        std::fs::remove_file(&notes).unwrap();
+
+        assert!(
+            tokio::time::timeout(SILENCE_WINDOW, trigger.next_event())
+                .await
+                .is_err(),
+            "no .eventlog appeared or vanished, so next_event must stay pending"
+        );
+    }
+}

--- a/ballista/scheduler/src/scheduler_server/event_log.rs
+++ b/ballista/scheduler/src/scheduler_server/event_log.rs
@@ -397,7 +397,7 @@ mod tests {
 
     /// End-to-end parity, and the reason the whole design stores built
     /// responses rather than re-deriving them: replaying a real event log
-    /// through `EventLogWriter` and `HistoryStore::load` must yield exactly the
+    /// through `EventLogWriter` and `HistoryStore::new` must yield exactly the
     /// JSON the live scheduler would have served for the same graph.
     ///
     /// This lives here rather than under `tests/` because `dto_build`,
@@ -428,8 +428,11 @@ mod tests {
         writer.flush_job(&job_id).await;
         writer.finish_job(&job_id).await;
 
-        let store = HistoryStore::load(dir.path()).unwrap();
-        let replayed = store.read_job(&job_id).expect("job should be replayed");
+        let store = HistoryStore::new_static(dir.path()).await.unwrap();
+        let replayed = store
+            .read_job(&job_id)
+            .await
+            .expect("job should be replayed");
 
         assert_eq!(
             replayed.job.get(),


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

# Rationale for this change

The standalone history server kept its job index current by re-walking theevent-log directory on a fixed timer (`--update-interval-seconds`, default 10s). That has two problems:

- **Latency vs. cost trade-off is hard-coded.** A short interval means a  `stat` per file per tick over a directory that can hold thousands of  finished jobs; a long interval means a finished job is invisible for up to
  that long.
- **The source is assumed to be a flat local directory.** All listing and  reading was inline `std::fs`, so there was no seam for an alternative  backend (object store, archived snapshot, remote listing) or an  alternative "when to refresh" policy.

This change pulls "where logs come from" and "when to act on them" behind two traits, and wires in a `notify`-based directory watch so a completed log is indexed the moment it is renamed into place rather than on the next tick.

# What changes are included in this PR?

**New `history/source.rs` — `EventLogSource` trait**
- `scan_jobs() -> BoxStream<io::Result<PathBuf>>`, `read_job_index`,  `read_completed_job`.
- `LocalDirSource` is the only impl and carries over the previous flat-dir  `std::fs` logic unchanged (including the `.eventlog` vs `.eventlog.running`  extension filter).

**New `history/trigger.rs` — `ScanTrigger` / `EventLogTrigger` traits**
- `ScanTrigger::scan_tick` decides when a full directory pass runs;  `OnceTrigger` fires exactly once then parks, `NoopTrigger` never fires.
- `EventLogTrigger::next_eventlog` reports individual `*.eventlog` files as  they appear or get deleted; `NotifyTrigger` watches the directory with the `notify`  crate, treating both create and rename-into-place (`Modify(Name(..))`) as  "a new file appeared", filtering by the `eventlog` extension.
- Unit tests for `NotifyTrigger`: create, arrive-by-rename, and  ignore-running-logs-and-unrelated-files.

**`history/mod.rs` — `HistoryStore` rework**
- `HistoryStore::load` + `refresh` + `RefreshStats` + `FileStamp` + the  `seen` map are removed.
- `HistoryStore::new(dir)` sets up the `NotifyTrigger` watch and builds the  initial index synchronously; `dir` must already exist.
- `HistoryStore::new_static(dir)` builds a frozen snapshot (both triggers  noop) for tests and one-shot use over an archived directory.
- `spawn_refresh_task` becomes `spawn_service_tasks(store) -> ServiceTasks`,  which runs a watch loop (`index_one` per file from the trigger) and a  scan loop (full `load_index` pass per `scan_tick`). `ServiceTasks` aborts  both loops on drop.
- Indexing is now **upsert-only**: a log that disappears or is rewritten  under a new job id is no longer reconciled out of the index.
- `read_job` is now `async` and delegates I/O to the source;  `read_job_blocking` is gone, replaced by `impl From<JobReadError> for  SchedulerErrorResponse`.
- The timer/refresh/removal test suite is deleted; remaining tests move to  `new_static` / `.await`.

**`bin/history_server.rs`**
- Drops the `--update-interval-seconds` arg.
- `create_dir_all`s the event-log directory before `HistoryStore::new`  (the watch cannot be placed on a missing path).

**Dependencies**
- Adds `notify = "8"` as a workspace dependency, wired into the scheduler  crate's `rest-api` feature as optional `dep:notify`.
- `Cargo.lock` updated accordingly.

# Are there any user-facing changes?

Yes, all behind the `rest-api` feature:

- **`--update-interval-seconds` is removed** from the `history_server`  binary. Refresh is now a single startup pass plus an event-driven  filesystem watch.
- The history server now **creates the event-log directory if it does not  exist** instead of treating a missing directory as empty.


