### PR TITLE
fix(scheduler): repair test broken by a stale-base merge

### DIFF
--- a/ballista/scheduler/src/scheduler_server/mod.rs
+++ b/ballista/scheduler/src/scheduler_server/mod.rs
@@ -1129,12 +1129,12 @@ mod test {
         .await?;
 
         let plan = test_plan();
-        let job_id = test.submit("", &plan).await?;
 
+        // `run` submits the job and polls until it reaches a terminal state.
         // Hard wall-clock bound so a stuck job fails the test instead of hanging.
-        let status = tokio::time::timeout(
+        let (status, _job_id) = tokio::time::timeout(
             std::time::Duration::from_secs(10),
-            test.await_completion(&job_id),
+            test.run("", &plan),
         )
         .await
         .expect(


### PR DESCRIPTION
# Which issue does this PR close?

No issue filed. `main` is currently red and this unblocks it.

# Rationale for this change

`cargo test -p ballista-scheduler` has not compiled since #2016 merged.
`deterministic_launch_rejection_fails_job` calls `SchedulerTest::await_completion`,
which #2354 removed.

Neither PR was wrong on its own:

| Date | Event |
| --- | --- |
| 2026-08-18 | #2016's branch last merges `main` |
| 2026-08-30 | #2354 removes `await_completion`, which had no callers |
| 2026-09-09 | #2016 merges, 10 days stale, adding a call to it |

The two edits touch different files, so git merged them cleanly. Nothing ever
compiled the combination until the post-merge run on `main`.

# What changes are included in this PR?

Use the existing `SchedulerTest::run` instead of restoring the deleted helper.
`run` is `submit` plus a poll to a terminal state, which is what the test was
doing by hand, so this adds no test surface. It also drains the task-status
channel, which `submit` alone does not.

Verified: the test passes, inverting its assertion to expect a successful job
makes it fail, and the full `ballista-scheduler` suite is green at 402 passed.

# Are there any user-facing changes?

No. Test-only, three lines.

# Preventing this class of failure

AI suggestion:

`.asf.yaml` protects `main` with `required_approving_review_count: 1` and
nothing else, so a two-month-old branch can merge without re-testing against
current `main`. Review cannot catch this: there is no conflict to see, and both
sides are individually correct.

The fix is to require branches to be up to date before merging, either via
strict status checks or a merge queue. A merge queue is the better fit here:
strict checks force every contributor to rebase whenever `main` moves, which on
a repo with this much CI is a real tax, whereas a queue tests the merge result
once, at merge time, without pushing work onto contributors.

Worth noting detection did work, just late. The post-merge run went red
immediately. The gap is that it went red on `main` rather than on the PR.
