### PR TITLE
fix(ci): pull the MinIO test image from quay.io

### DIFF
--- a/examples/tests/common/mod.rs
+++ b/examples/tests/common/mod.rs
@@ -34,6 +34,14 @@ pub const BUCKET: &str = "ballista";
 pub const ACCESS_KEY_ID: &str = "MINIO";
 pub const SECRET_KEY: &str = "MINIOMINIO";
 
+/// Registry override for the image pinned by `testcontainers-modules`.
+///
+/// MinIO withdrew `minio/minio` from Docker Hub on 2026-09-11, so the image the
+/// crate pins no longer resolves and every test that starts a container panics.
+/// quay.io still serves the same tag, so only the registry changes here.
+/// See <https://github.com/apache/datafusion/issues/25215>.
+const MINIO_IMAGE_NAME: &str = "quay.io/minio/minio";
+
 #[allow(dead_code)]
 pub fn create_s3_store(
     host: &str,
@@ -53,6 +61,7 @@ pub fn create_s3_store(
 #[allow(dead_code)]
 pub fn create_minio_container() -> ContainerRequest<minio::MinIO> {
     MinIO::default()
+        .with_name(MINIO_IMAGE_NAME)
         .with_env_var("MINIO_ACCESS_KEY", ACCESS_KEY_ID)
         .with_env_var("MINIO_SECRET_KEY", SECRET_KEY)
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2446.

 # Rationale for this change

MinIO withdrew the `minio/minio` repository from Docker Hub on 2026-09-11. The repository itself 404s, so the image that `testcontainers-modules` pins no longer resolves and the object store integration tests in `examples/tests/object_store.rs` panic on startup:

```
failed to pull the image 'minio/minio:RELEASE.2025-02-28T09-55-16Z', error: Docker responded with status code 404: pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

That is what fails the `test linux crates` job, which runs `cargo test --profile ci --features=testcontainers`.

Every `testcontainers-modules` version pins the identical tag, so downgrading the crate does not help. quay.io still serves that tag.

This is an unblock rather than a fix. If MinIO stops publishing to quay.io too, the image will need replacing outright.

# What changes are included in this PR?

`create_minio_container()` in `examples/tests/common/mod.rs` now calls `.with_name("quay.io/minio/minio")`. Only the registry is overridden, the tag still comes from `testcontainers-modules`, so routine crate bumps keep working.

`examples/examples/custom-client.rs` already documents `quay.io/minio/minio` in its `docker run` instructions, so this makes the tests consistent with the docs.

DataFusion hit the same breakage and took the same approach: apache/datafusion#25215 / apache/datafusion#25216. Its `cargo test datafusion-cli (amd64)` job, which runs the MinIO storage integration tests, passes with the quay.io override.

# Are there any user-facing changes?

No. Test-only change.